### PR TITLE
feat(v2): w0-ffi-client - @ax/lib/duckdb typed FFI client, ingest lock, snapshot publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ community/.gist-etag-cache.json
 
 /BRIEF.md
 /REPORT.md
+
+# DuckDB dylib cache used by @ax/lib/duckdb tests (downloaded, never committed)
+vendor/duckdb/

--- a/docs/superpowers/plans/2026-08-14-w0-ffi-client.md
+++ b/docs/superpowers/plans/2026-08-14-w0-ffi-client.md
@@ -1,0 +1,2267 @@
+# `@ax/lib/duckdb` - typed DuckDB FFI client (chunk w0-ffi-client)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `@ax/lib/duckdb` - the Effect-native, layer-testable DuckDB client (open / query
+with typed row decode / exec / close, snapshot publish + open, ingest lockfile, dylib resolution)
+that every later chunk of the v2-duckdb epic builds on.
+
+**Architecture:** A thin, dependency-free FFI layer (`ffi.ts`) wraps `libduckdb`'s C API through
+`bun:ffi`, using the by-value-u64-handle convention proven in `scripts/duckdb-spike/ffi/`. Pure
+modules on top (`row-decode.ts`, `dylib.ts`, `lock-state.ts`) hold every decision that can be
+tested without a database. Two `Context.Service` seams (`DuckDb`, `IngestLock`) expose the
+capability to callers; their `Live` layers are the only place FFI and the filesystem meet, and the
+dylib path is injectable so the custom static dylib from chunk `w0-dylib-ci` drops in later.
+
+**Tech Stack:** bun ≥ 1.3 · `bun:ffi` · libduckdb v1.5.5 (official prebuilt for tests) ·
+`effect@4.0.0-beta.78` (`Context.Service` / `Layer` / `Schema.TaggedErrorClass`) · `bun:test`.
+
+**Spec:** `docs/superpowers/plans/2026-08-14-v2-duckdb-backlog.md` (chunk `w0-ffi-client`, wave 0)
+plus `BRIEF.md` at the worktree root.
+
+## Global Constraints
+
+- Worktree ONLY: `/Users/necmttn/Projects/ax/.claude/worktrees/w0-ffi-client`. Never `cd` to or
+  commit in the primary checkout.
+- Tests import from `"bun:test"` - **never** vitest.
+- Effect v4 beta idioms as used in this repo: `Context.Service<Tag, Shape>()("ax/Name")`,
+  `Layer.effect(Tag)(effect)` / `Layer.succeed(Tag)(shape)`,
+  `Schema.TaggedErrorClass<E>("Tag")("Tag", { …fields })`, `Schema.decodeUnknownEffect`.
+- `packages/lib/src` uses **4-space** indentation. Match it.
+- **No `node:fs` / `node:path` in any RUNTIME module under `packages/lib/src/duckdb/`.** The CI-wired
+  `check:no-node-fs` gate (`scripts/check-no-node-fs.ts`, `.github/workflows/ci.yml:110`) scans
+  `packages/*/src/**/*.ts` and hard-fails on them. Use `FileSystem` from `effect` (its
+  `PlatformError` failures get mapped into this module's tagged errors) and `posixPath` from
+  `@ax/lib/shared/path` for path math. `node:os` is NOT banned - `homedir()` / `tmpdir()` are fine.
+  `*.test.ts` files are excluded from the gate, so tests may use `node:fs` freely.
+  `packages/lib/src/testing/duckdb-dylib.ts` is the ONE exempt runtime-path file (it sits in the
+  gate's `EXCLUDED_FILES`, being a test-only fixture called from a plain `beforeAll`).
+- Gate list, all four run from the worktree with real exit codes: `bun run typecheck`,
+  `bunx tsc --noEmit -p tsconfig.json`, `bun run check:no-node-fs`, `bun test <touched areas>`.
+- No `BRIEF.md` / `REPORT.md` in the commit.
+- ONE conventional commit at the very end of the whole chunk (the per-task "commit" step of the
+  generic TDD loop is deliberately **omitted** here - the brief mandates a single commit).
+- Gates, run FROM the worktree, real exit codes: `bun run typecheck` → 0;
+  `bunx tsc --noEmit -p tsconfig.json` → 0; `bun test` over touched areas green.
+
+## Locked technical decisions (verified against the real `duckdb.h` v1.5.5, do not re-litigate)
+
+1. **Row extraction uses the row-major `duckdb_value_*` API, not the chunk API.**
+   `duckdb_fetch_chunk(duckdb_result result)`, `duckdb_result_chunk_count(duckdb_result)` and
+   `duckdb_result_return_type(duckdb_result)` all take the 48-byte `duckdb_result` struct **by
+   value**, and `bun:ffi` cannot pass structs by value. Every `duckdb_value_*` accessor takes
+   `duckdb_result *` (a pointer) and is therefore reachable. Verified present in the official
+   v1.5.5 prebuilt via `nm -gU libduckdb.dylib` (`_duckdb_value_int64`, `_duckdb_value_varchar`,
+   `_duckdb_value_is_null`, `_duckdb_value_uint64`, `_duckdb_value_double`,
+   `_duckdb_value_boolean`, `_duckdb_row_count`). They are marked deprecated in the header but
+   are still exported; Task 3 asserts their presence so a dylib built with
+   `DUCKDB_API_NO_DEPRECATED` fails loudly instead of silently.
+2. **Opaque handles pass by value as `u64`; out-params pass as real pointers.**
+   `duckdb_database`, `duckdb_connection`, `duckdb_config`, `duckdb_prepared_statement` are
+   `void *` typedefs. Argument position → `FFIType.u64` reading `BigUint64Array[0]`. Out-param
+   position → `FFIType.ptr` of a `BigUint64Array(1)`. This is the gotcha the spike solved.
+3. **Read-only open goes through `duckdb_open_ext` + a config with `access_mode=READ_ONLY`.**
+   `duckdb_open` has no config argument.
+4. **Params go through prepared statements** (`duckdb_prepare` → `duckdb_bind_*` →
+   `duckdb_execute_prepared`). Bind indices are **1-based**.
+5. **BLOB / nested (LIST/STRUCT/MAP/UNION/ARRAY) columns are not decoded.** `duckdb_value_blob`
+   returns a struct by value (unreachable); nested types have no row-major accessor. These raise a
+   typed `DuckDbUnsupportedTypeError` naming the column and type, telling the caller to project
+   the column (e.g. `hex(col)`, `to_json(col)`) in SQL.
+6. **Snapshot publish** = `CHECKPOINT` on the live connection → `ATTACH '<tmp>' AS ax_snapshot`
+   → `COPY FROM DATABASE "<current_database()>" TO ax_snapshot` → `DETACH ax_snapshot` →
+   `rename(tmp, snapshotPath)`. The tmp file is a sibling of `snapshotPath` so the rename is a
+   same-filesystem atomic swap and a reader holding the old inode keeps reading.
+
+## File Structure
+
+All new files live under `packages/lib/src/duckdb/` except the test fixture helper.
+
+| File | Responsibility |
+|---|---|
+| `packages/lib/src/duckdb/errors.ts` | Every tagged error the module can fail with. |
+| `packages/lib/src/duckdb/types.ts` | `DuckDbTypeId`, `DuckDbValue`, `DuckDbRow`, `QueryResult`, `DuckDbParam`. |
+| `packages/lib/src/duckdb/row-decode.ts` | PURE: type-id → accessor kind mapping + raw-value → JS-value coercion. No FFI. |
+| `packages/lib/src/duckdb/ffi.ts` | `dlopen` symbol table, struct sizes, handle helpers. No Effect. |
+| `packages/lib/src/duckdb/dylib.ts` | `resolveDylibPath` - source path vs `$bunfs` extract-to-content-hash with reuse. |
+| `packages/lib/src/duckdb/client.ts` | `DuckDb` service + `DuckDbLive` / `DuckDbLayer(dylibPath)`. open / openSnapshot / publishSnapshot. |
+| `packages/lib/src/duckdb/lock.ts` | `IngestLock` service + `IngestLockLive` / `IngestLockLayer(path)`. |
+| `packages/lib/src/duckdb/lock-state.ts` | PURE: lock-file payload codec + "is this holder alive / stale?" decision. |
+| `packages/lib/src/duckdb/index.ts` | Barrel re-export - the `@ax/lib/duckdb` public surface. |
+| `packages/lib/src/testing/duckdb-dylib.ts` | Test fixture: resolve-or-download the official v1.5.5 dylib; report a skip reason when impossible. |
+
+Test files sit beside their subject as `<name>.test.ts`.
+
+---
+
+### Task 1: Errors, types, package wiring, and the test-dylib fixture
+
+Everything downstream imports from here, and no later task can run an e2e test without the
+fixture, so these ship together.
+
+**Files:**
+- Create: `packages/lib/src/duckdb/errors.ts`
+- Create: `packages/lib/src/duckdb/types.ts`
+- Create: `packages/lib/src/testing/duckdb-dylib.ts`
+- Create: `packages/lib/src/duckdb/errors.test.ts`
+- Create: `packages/lib/src/testing/duckdb-dylib.test.ts`
+- Modify: `packages/lib/package.json` (exports map)
+- Modify: `.gitignore` (vendor cache)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `DuckDbOpenError`, `DuckDbQueryError`, `DuckDbDecodeError`, `DuckDbUnsupportedTypeError`,
+    `DuckDbDylibError`, `IngestLockHeldError`, `IngestLockError`, `SnapshotPublishError`
+  - `DuckDbTypeId` (const object + type), `DuckDbValue`, `DuckDbRow`, `QueryResult`, `DuckDbParam`
+  - `resolveTestDylib(): Promise<TestDylib>` where
+    `type TestDylib = { readonly ok: true; readonly path: string } | { readonly ok: false; readonly reason: string }`
+
+- [ ] **Step 1: Add the vendor cache to `.gitignore`**
+
+Append to `.gitignore`:
+
+```gitignore
+# DuckDB dylib cache used by @ax/lib/duckdb tests (downloaded, never committed)
+vendor/duckdb/
+```
+
+- [ ] **Step 2: Wire the package exports**
+
+In `packages/lib/package.json`, add these two entries to `"exports"` immediately after
+`"./shared/team-fetch"` (keep the trailing `"./*"` glob last):
+
+```json
+    "./duckdb": "./src/duckdb/index.ts",
+    "./testing/duckdb-dylib": "./src/testing/duckdb-dylib.ts",
+```
+
+- [ ] **Step 3: Write the failing error/type test**
+
+Create `packages/lib/src/duckdb/errors.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+    DuckDbDecodeError,
+    DuckDbDylibError,
+    DuckDbOpenError,
+    DuckDbQueryError,
+    DuckDbUnsupportedTypeError,
+    IngestLockHeldError,
+    SnapshotPublishError,
+} from "./errors.ts";
+
+describe("duckdb errors", () => {
+    test("each error carries its discriminating tag", () => {
+        expect(new DuckDbOpenError({ path: "/tmp/x.db", readOnly: true, message: "boom" })._tag)
+            .toBe("DuckDbOpenError");
+        expect(new DuckDbQueryError({ sql: "SELECT 1", message: "boom" })._tag)
+            .toBe("DuckDbQueryError");
+        expect(new DuckDbDecodeError({ sql: "SELECT 1", message: "bad row" })._tag)
+            .toBe("DuckDbDecodeError");
+        expect(new DuckDbUnsupportedTypeError({ column: "payload", typeId: 18 })._tag)
+            .toBe("DuckDbUnsupportedTypeError");
+        expect(new DuckDbDylibError({ message: "not found" })._tag).toBe("DuckDbDylibError");
+        expect(
+            new IngestLockHeldError({
+                path: "/tmp/ingest.lock",
+                pid: 42,
+                startedAt: "2026-08-14T00:00:00.000Z",
+            })._tag,
+        ).toBe("IngestLockHeldError");
+        expect(new SnapshotPublishError({ snapshotPath: "/tmp/s.db", message: "boom" })._tag)
+            .toBe("SnapshotPublishError");
+    });
+
+    test("the unsupported-type error names the column and how to work around it", () => {
+        const err = new DuckDbUnsupportedTypeError({ column: "payload", typeId: 18 });
+        expect(err.message).toContain("payload");
+        expect(err.message).toContain("BLOB");
+    });
+});
+```
+
+- [ ] **Step 4: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/errors.test.ts`
+Expected: FAIL - `Cannot find module './errors.ts'`.
+
+- [ ] **Step 5: Write `types.ts`**
+
+Create `packages/lib/src/duckdb/types.ts`:
+
+```ts
+/**
+ * `duckdb_type` enum values from duckdb.h (v1.5.5). Only the ids this client
+ * can decode are named; anything else surfaces as a raw number in
+ * `DuckDbUnsupportedTypeError`.
+ */
+export const DuckDbTypeId = {
+    INVALID: 0,
+    BOOLEAN: 1,
+    TINYINT: 2,
+    SMALLINT: 3,
+    INTEGER: 4,
+    BIGINT: 5,
+    UTINYINT: 6,
+    USMALLINT: 7,
+    UINTEGER: 8,
+    UBIGINT: 9,
+    FLOAT: 10,
+    DOUBLE: 11,
+    TIMESTAMP: 12,
+    DATE: 13,
+    TIME: 14,
+    INTERVAL: 15,
+    HUGEINT: 16,
+    VARCHAR: 17,
+    BLOB: 18,
+    DECIMAL: 19,
+    TIMESTAMP_S: 20,
+    TIMESTAMP_MS: 21,
+    TIMESTAMP_NS: 22,
+    ENUM: 23,
+    LIST: 24,
+    STRUCT: 25,
+    MAP: 26,
+    UUID: 27,
+    UNION: 28,
+    BIT: 29,
+    TIME_TZ: 30,
+    TIMESTAMP_TZ: 31,
+    UHUGEINT: 32,
+    ARRAY: 33,
+    SQLNULL: 36,
+} as const;
+
+export type DuckDbTypeId = (typeof DuckDbTypeId)[keyof typeof DuckDbTypeId];
+
+/** Human name for a duckdb type id, for error messages. */
+export const duckDbTypeName = (id: number): string =>
+    Object.entries(DuckDbTypeId).find(([, v]) => v === id)?.[0] ?? `TYPE_${id}`;
+
+/** Every JS value a decoded cell can take. */
+export type DuckDbValue = string | number | bigint | boolean | Date | null;
+
+export type DuckDbRow = Readonly<Record<string, DuckDbValue>>;
+
+export interface DuckDbColumn {
+    readonly name: string;
+    readonly typeId: number;
+}
+
+export interface QueryResult {
+    readonly columns: ReadonlyArray<DuckDbColumn>;
+    readonly rows: ReadonlyArray<DuckDbRow>;
+    /** Rows changed by a DML statement; 0 for SELECTs. */
+    readonly rowsChanged: number;
+}
+
+/** Values accepted as prepared-statement parameters. */
+export type DuckDbParam = string | number | bigint | boolean | Date | null | undefined;
+```
+
+- [ ] **Step 6: Write `errors.ts`**
+
+Create `packages/lib/src/duckdb/errors.ts`:
+
+```ts
+import { Schema } from "effect";
+import { duckDbTypeName } from "./types.ts";
+
+/** `duckdb_open` / `duckdb_open_ext` / `duckdb_connect` failure. */
+export class DuckDbOpenError extends Schema.TaggedErrorClass<DuckDbOpenError>(
+    "DuckDbOpenError",
+)("DuckDbOpenError", {
+    path: Schema.String,
+    readOnly: Schema.Boolean,
+    message: Schema.String,
+}) {}
+
+/** A statement failed to prepare, bind, or execute. `sql` is a short excerpt. */
+export class DuckDbQueryError extends Schema.TaggedErrorClass<DuckDbQueryError>(
+    "DuckDbQueryError",
+)("DuckDbQueryError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Rows came back fine but did not match the caller's schema. */
+export class DuckDbDecodeError extends Schema.TaggedErrorClass<DuckDbDecodeError>(
+    "DuckDbDecodeError",
+)("DuckDbDecodeError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/**
+ * A result column has a type this client cannot read through the row-major
+ * `duckdb_value_*` API (BLOB and the nested types have no pointer-based
+ * accessor). Project the column in SQL instead - `hex(col)` / `to_json(col)`.
+ */
+export class DuckDbUnsupportedTypeError extends Schema.TaggedErrorClass<DuckDbUnsupportedTypeError>(
+    "DuckDbUnsupportedTypeError",
+)("DuckDbUnsupportedTypeError", {
+    column: Schema.String,
+    typeId: Schema.Number,
+}) {
+    override get message(): string {
+        const name = duckDbTypeName(this.typeId);
+        return `column "${this.column}" has type ${name}, which this client cannot decode; project it in SQL instead (e.g. hex(${this.column}) for BLOB, to_json(${this.column}) for nested types)`;
+    }
+}
+
+/** The libduckdb shared library could not be located, extracted, or opened. */
+export class DuckDbDylibError extends Schema.TaggedErrorClass<DuckDbDylibError>(
+    "DuckDbDylibError",
+)("DuckDbDylibError", {
+    message: Schema.String,
+}) {}
+
+/** Another process holds the ingest lock. Carries who, so the CLI can say so. */
+export class IngestLockHeldError extends Schema.TaggedErrorClass<IngestLockHeldError>(
+    "IngestLockHeldError",
+)("IngestLockHeldError", {
+    path: Schema.String,
+    pid: Schema.Number,
+    startedAt: Schema.String,
+}) {}
+
+/** The lock file itself could not be read/written (permissions, bad dir, ...). */
+export class IngestLockError extends Schema.TaggedErrorClass<IngestLockError>(
+    "IngestLockError",
+)("IngestLockError", {
+    path: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Snapshot publication failed before the atomic rename landed. */
+export class SnapshotPublishError extends Schema.TaggedErrorClass<SnapshotPublishError>(
+    "SnapshotPublishError",
+)("SnapshotPublishError", {
+    snapshotPath: Schema.String,
+    message: Schema.String,
+}) {}
+```
+
+- [ ] **Step 7: Run the error test to green**
+
+Run: `bun test packages/lib/src/duckdb/errors.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Write the failing fixture test**
+
+Create `packages/lib/src/testing/duckdb-dylib.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { resolveTestDylib } from "./duckdb-dylib.ts";
+
+describe("resolveTestDylib", () => {
+    test("either resolves to a real file on disk or explains why it cannot", async () => {
+        const found = await resolveTestDylib();
+        if (found.ok) {
+            expect(existsSync(found.path)).toBe(true);
+        } else {
+            expect(found.reason.length).toBeGreaterThan(0);
+        }
+    });
+
+    test("honours AX_DUCKDB_DYLIB when it points at an existing file", async () => {
+        const first = await resolveTestDylib();
+        if (!first.ok) return; // nothing on disk to point at; covered by the test above
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        process.env.AX_DUCKDB_DYLIB = first.path;
+        try {
+            const second = await resolveTestDylib();
+            expect(second).toEqual({ ok: true, path: first.path });
+        } finally {
+            if (prev === undefined) delete process.env.AX_DUCKDB_DYLIB;
+            else process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+});
+```
+
+- [ ] **Step 9: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/testing/duckdb-dylib.test.ts`
+Expected: FAIL - `Cannot find module './duckdb-dylib.ts'`.
+
+- [ ] **Step 10: Write the fixture helper**
+
+Create `packages/lib/src/testing/duckdb-dylib.ts`:
+
+```ts
+/**
+ * Test-only resolution of a libduckdb shared library.
+ *
+ * Order: `AX_DUCKDB_DYLIB` (the injection point the custom static dylib from
+ * chunk w0-dylib-ci will use) -> the gitignored `vendor/duckdb/<version>/`
+ * cache -> a one-time download of the official prebuilt release. When the
+ * download is impossible (offline CI, unsupported platform) this returns a
+ * REASON rather than throwing, so suites can skip with a notice instead of
+ * failing red for an environment problem.
+ */
+import { existsSync, mkdirSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DUCKDB_VERSION = "v1.5.5";
+
+export type TestDylib =
+    | { readonly ok: true; readonly path: string }
+    | { readonly ok: false; readonly reason: string };
+
+/** Repo root, found by walking up from this file to the dir holding `turbo.json`. */
+const repoRoot = (): string => {
+    let dir = dirname(new URL(import.meta.url).pathname);
+    for (let i = 0; i < 10; i += 1) {
+        if (existsSync(join(dir, "turbo.json"))) return dir;
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    return process.cwd();
+};
+
+const libFileName = (): string => (platform() === "darwin" ? "libduckdb.dylib" : "libduckdb.so");
+
+/** Official release asset for this platform, or null when unsupported. */
+const releaseAsset = (): string | null => {
+    if (platform() === "darwin") return "libduckdb-osx-universal.zip";
+    if (platform() === "linux") {
+        return arch() === "arm64" ? "libduckdb-linux-arm64.zip" : "libduckdb-linux-amd64.zip";
+    }
+    return null;
+};
+
+export const vendorDir = (): string => join(repoRoot(), "vendor", "duckdb", DUCKDB_VERSION);
+
+export const resolveTestDylib = async (): Promise<TestDylib> => {
+    const injected = process.env.AX_DUCKDB_DYLIB?.trim();
+    if (injected) {
+        return existsSync(injected)
+            ? { ok: true, path: injected }
+            : { ok: false, reason: `AX_DUCKDB_DYLIB points at a missing file: ${injected}` };
+    }
+
+    const cached = join(vendorDir(), libFileName());
+    if (existsSync(cached)) return { ok: true, path: cached };
+
+    const asset = releaseAsset();
+    if (asset === null) {
+        return { ok: false, reason: `no official libduckdb build for ${platform()}/${arch()}` };
+    }
+
+    const url = `https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/${asset}`;
+    try {
+        mkdirSync(vendorDir(), { recursive: true });
+        const zipPath = join(vendorDir(), asset);
+        const response = await fetch(url);
+        if (!response.ok) {
+            return { ok: false, reason: `download failed: ${url} -> HTTP ${response.status}` };
+        }
+        await Bun.write(zipPath, await response.arrayBuffer());
+        const unzip = Bun.spawnSync(["unzip", "-o", "-q", zipPath, "-d", vendorDir()], {
+            stdout: "ignore",
+            stderr: "pipe",
+        });
+        if (unzip.exitCode !== 0) {
+            return { ok: false, reason: `unzip failed: ${unzip.stderr.toString().trim()}` };
+        }
+        if (!existsSync(cached)) {
+            return { ok: false, reason: `archive ${asset} did not contain ${libFileName()}` };
+        }
+        return { ok: true, path: cached };
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, reason: `download failed: ${url} -> ${message}` };
+    }
+};
+
+/** Prints a uniform notice so a skipped suite is visible in test output. */
+export const noteSkippedDylib = (suite: string, reason: string): void => {
+    console.warn(`[skip] ${suite}: no libduckdb available (${reason})`);
+};
+```
+
+- [ ] **Step 11: Run the fixture test to green**
+
+Run: `bun test packages/lib/src/testing/duckdb-dylib.test.ts`
+Expected: PASS (2 tests). A `vendor/duckdb/v1.5.5/libduckdb.dylib` already staged in this
+worktree makes it instant; on a clean machine the first run downloads ~36MB.
+
+---
+
+### Task 2: Pure row decode
+
+The whole "typed row decode" promise lives here, and none of it needs a database. Everything this
+module decides - which accessor a column type needs, how a raw accessor result becomes a JS value -
+is a pure function under test.
+
+**Files:**
+- Create: `packages/lib/src/duckdb/row-decode.ts`
+- Create: `packages/lib/src/duckdb/row-decode.test.ts`
+
+**Interfaces:**
+- Consumes: `DuckDbTypeId`, `DuckDbValue`, `duckDbTypeName` from Task 1's `types.ts`;
+  `DuckDbUnsupportedTypeError` from Task 1's `errors.ts`.
+- Produces:
+  - `type AccessorKind = "boolean" | "int64" | "uint64" | "double" | "varchar"`
+  - `accessorFor(typeId: number): AccessorKind | null` - `null` means unsupported.
+  - `coerceValue(typeId: number, raw: boolean | bigint | number | string): DuckDbValue`
+  - `unsupportedColumns(columns: ReadonlyArray<DuckDbColumn>): ReadonlyArray<DuckDbColumn>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/duckdb/row-decode.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { accessorFor, coerceValue, unsupportedColumns } from "./row-decode.ts";
+import { DuckDbTypeId } from "./types.ts";
+
+describe("accessorFor", () => {
+    test("maps each integer width to the widest safe row-major accessor", () => {
+        for (const id of [
+            DuckDbTypeId.TINYINT,
+            DuckDbTypeId.SMALLINT,
+            DuckDbTypeId.INTEGER,
+            DuckDbTypeId.BIGINT,
+        ]) {
+            expect(accessorFor(id)).toBe("int64");
+        }
+        for (const id of [
+            DuckDbTypeId.UTINYINT,
+            DuckDbTypeId.USMALLINT,
+            DuckDbTypeId.UINTEGER,
+            DuckDbTypeId.UBIGINT,
+        ]) {
+            expect(accessorFor(id)).toBe("uint64");
+        }
+    });
+
+    test("maps booleans, floats and text", () => {
+        expect(accessorFor(DuckDbTypeId.BOOLEAN)).toBe("boolean");
+        expect(accessorFor(DuckDbTypeId.FLOAT)).toBe("double");
+        expect(accessorFor(DuckDbTypeId.DOUBLE)).toBe("double");
+        expect(accessorFor(DuckDbTypeId.VARCHAR)).toBe("varchar");
+    });
+
+    test("reads temporal, uuid, decimal and hugeint columns as text", () => {
+        for (const id of [
+            DuckDbTypeId.DATE,
+            DuckDbTypeId.TIME,
+            DuckDbTypeId.TIMESTAMP,
+            DuckDbTypeId.TIMESTAMP_S,
+            DuckDbTypeId.TIMESTAMP_MS,
+            DuckDbTypeId.TIMESTAMP_NS,
+            DuckDbTypeId.TIMESTAMP_TZ,
+            DuckDbTypeId.UUID,
+            DuckDbTypeId.DECIMAL,
+            DuckDbTypeId.HUGEINT,
+            DuckDbTypeId.ENUM,
+            DuckDbTypeId.INTERVAL,
+        ]) {
+            expect(accessorFor(id)).toBe("varchar");
+        }
+    });
+
+    test("refuses BLOB and the nested types", () => {
+        for (const id of [
+            DuckDbTypeId.BLOB,
+            DuckDbTypeId.LIST,
+            DuckDbTypeId.STRUCT,
+            DuckDbTypeId.MAP,
+            DuckDbTypeId.UNION,
+            DuckDbTypeId.ARRAY,
+        ]) {
+            expect(accessorFor(id)).toBeNull();
+        }
+    });
+});
+
+describe("coerceValue", () => {
+    test("narrows small integers to number and keeps BIGINT as bigint", () => {
+        expect(coerceValue(DuckDbTypeId.INTEGER, 7n)).toBe(7);
+        expect(coerceValue(DuckDbTypeId.SMALLINT, -3n)).toBe(-3);
+        expect(coerceValue(DuckDbTypeId.BIGINT, 9007199254740993n)).toBe(9007199254740993n);
+    });
+
+    test("keeps BIGINT values inside the safe range as bigint for a stable row type", () => {
+        expect(coerceValue(DuckDbTypeId.BIGINT, 5n)).toBe(5n);
+        expect(coerceValue(DuckDbTypeId.UBIGINT, 5n)).toBe(5n);
+    });
+
+    test("passes booleans, doubles and strings through", () => {
+        expect(coerceValue(DuckDbTypeId.BOOLEAN, true)).toBe(true);
+        expect(coerceValue(DuckDbTypeId.DOUBLE, 1.5)).toBe(1.5);
+        expect(coerceValue(DuckDbTypeId.VARCHAR, "hi")).toBe("hi");
+    });
+
+    test("turns timestamp text into a Date and leaves DATE/TIME as text", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP, "2026-08-14 10:11:12.5");
+        expect(ts).toBeInstanceOf(Date);
+        expect((ts as Date).toISOString()).toBe("2026-08-14T10:11:12.500Z");
+        expect(coerceValue(DuckDbTypeId.DATE, "2026-08-14")).toBe("2026-08-14");
+        expect(coerceValue(DuckDbTypeId.TIME, "10:11:12")).toBe("10:11:12");
+    });
+
+    test("parses a TZ timestamp without double-applying the offset", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "2026-08-14 10:11:12+02");
+        expect((ts as Date).toISOString()).toBe("2026-08-14T08:11:12.000Z");
+    });
+
+    test("leaves an unparseable timestamp as its original text rather than an Invalid Date", () => {
+        expect(coerceValue(DuckDbTypeId.TIMESTAMP, "infinity")).toBe("infinity");
+    });
+});
+
+describe("unsupportedColumns", () => {
+    test("returns only the columns with no row-major accessor", () => {
+        const columns = [
+            { name: "id", typeId: DuckDbTypeId.BIGINT },
+            { name: "payload", typeId: DuckDbTypeId.BLOB },
+            { name: "tags", typeId: DuckDbTypeId.LIST },
+        ];
+        expect(unsupportedColumns(columns).map((c) => c.name)).toEqual(["payload", "tags"]);
+    });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/row-decode.test.ts`
+Expected: FAIL - `Cannot find module './row-decode.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/lib/src/duckdb/row-decode.ts`:
+
+```ts
+/**
+ * Pure decode rules for the row-major `duckdb_value_*` accessors.
+ *
+ * `bun:ffi` cannot pass structs by value, which rules out `duckdb_fetch_chunk`
+ * (it takes the 48-byte `duckdb_result` by value), so every cell is read
+ * through a pointer-based `duckdb_value_*` accessor. This module holds the two
+ * decisions that follow from that - WHICH accessor a column type needs, and how
+ * the raw accessor result becomes a JS value - so both are testable without a
+ * database.
+ */
+import { DuckDbTypeId, type DuckDbColumn, type DuckDbValue } from "./types.ts";
+
+export type AccessorKind = "boolean" | "int64" | "uint64" | "double" | "varchar";
+
+const INT64_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.TINYINT,
+    DuckDbTypeId.SMALLINT,
+    DuckDbTypeId.INTEGER,
+    DuckDbTypeId.BIGINT,
+]);
+
+const UINT64_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.UTINYINT,
+    DuckDbTypeId.USMALLINT,
+    DuckDbTypeId.UINTEGER,
+    DuckDbTypeId.UBIGINT,
+]);
+
+const DOUBLE_TYPES: ReadonlySet<number> = new Set([DuckDbTypeId.FLOAT, DuckDbTypeId.DOUBLE]);
+
+/**
+ * Types with no fixed-width row-major accessor that DuckDB will still render
+ * faithfully as text: temporals, uuid, decimal, 128-bit ints, enums, intervals,
+ * bit strings. Reading them as VARCHAR is lossless for our purposes and keeps
+ * the FFI surface small.
+ */
+const VARCHAR_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.VARCHAR,
+    DuckDbTypeId.DATE,
+    DuckDbTypeId.TIME,
+    DuckDbTypeId.TIME_TZ,
+    DuckDbTypeId.TIMESTAMP,
+    DuckDbTypeId.TIMESTAMP_S,
+    DuckDbTypeId.TIMESTAMP_MS,
+    DuckDbTypeId.TIMESTAMP_NS,
+    DuckDbTypeId.TIMESTAMP_TZ,
+    DuckDbTypeId.INTERVAL,
+    DuckDbTypeId.HUGEINT,
+    DuckDbTypeId.UHUGEINT,
+    DuckDbTypeId.DECIMAL,
+    DuckDbTypeId.UUID,
+    DuckDbTypeId.ENUM,
+    DuckDbTypeId.BIT,
+    DuckDbTypeId.SQLNULL,
+]);
+
+/** Which `duckdb_value_*` accessor reads this column, or null when none can. */
+export const accessorFor = (typeId: number): AccessorKind | null => {
+    if (typeId === DuckDbTypeId.BOOLEAN) return "boolean";
+    if (INT64_TYPES.has(typeId)) return "int64";
+    if (UINT64_TYPES.has(typeId)) return "uint64";
+    if (DOUBLE_TYPES.has(typeId)) return "double";
+    if (VARCHAR_TYPES.has(typeId)) return "varchar";
+    return null;
+};
+
+/** Types read as text but handed back as a Date. */
+const TIMESTAMP_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.TIMESTAMP,
+    DuckDbTypeId.TIMESTAMP_S,
+    DuckDbTypeId.TIMESTAMP_MS,
+    DuckDbTypeId.TIMESTAMP_NS,
+    DuckDbTypeId.TIMESTAMP_TZ,
+]);
+
+/**
+ * DuckDB prints timestamps as `YYYY-MM-DD HH:MM:SS[.ffffff][+HH[:MM]]`.
+ * `TIMESTAMP` is offset-free and means UTC here, so it gets a `Z`;
+ * `TIMESTAMP WITH TIME ZONE` already carries an offset, which must be kept
+ * (appending `Z` on top of it would shift the instant twice).
+ */
+const parseTimestamp = (text: string): Date | string => {
+    const hasOffset = /(?:[+-]\d{2}(?::?\d{2})?|Z)$/.test(text);
+    const iso = text.replace(" ", "T") + (hasOffset ? "" : "Z");
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? text : date;
+};
+
+/** Raw accessor output -> the JS value callers see. */
+export const coerceValue = (
+    typeId: number,
+    raw: boolean | bigint | number | string,
+): DuckDbValue => {
+    if (typeof raw === "string") {
+        return TIMESTAMP_TYPES.has(typeId) ? parseTimestamp(raw) : raw;
+    }
+    if (typeof raw === "bigint") {
+        // 64-bit columns stay bigint so a row's TS type never depends on the
+        // magnitude of the value it happens to hold. Narrower widths cannot
+        // overflow a JS number, so they come back as number.
+        if (typeId === DuckDbTypeId.BIGINT || typeId === DuckDbTypeId.UBIGINT) return raw;
+        return Number(raw);
+    }
+    return raw;
+};
+
+/** Result columns this client cannot decode. */
+export const unsupportedColumns = (
+    columns: ReadonlyArray<DuckDbColumn>,
+): ReadonlyArray<DuckDbColumn> => columns.filter((c) => accessorFor(c.typeId) === null);
+```
+
+- [ ] **Step 4: Run the test to green**
+
+Run: `bun test packages/lib/src/duckdb/row-decode.test.ts`
+Expected: PASS (9 tests).
+
+---
+
+### Task 3: The FFI symbol table
+
+**Files:**
+- Create: `packages/lib/src/duckdb/ffi.ts`
+- Create: `packages/lib/src/duckdb/ffi.test.ts`
+
+**Interfaces:**
+- Consumes: the Task 1 fixture (`resolveTestDylib`, `noteSkippedDylib`).
+- Produces:
+  - `openLibDuckDb(dylibPath: string): LibDuckDb` where `LibDuckDb = { symbols, close }`
+  - `DUCKDB_RESULT_SIZE = 64`, `DUCKDB_SUCCESS = 0`
+  - `handleBuffer(): BigUint64Array` and `cstr(s: string): Buffer`
+  - `readCString(p: number | bigint | null): string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/duckdb/ffi.test.ts`:
+
+```ts
+import { beforeAll, describe, expect, test } from "bun:test";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { cstr, DUCKDB_RESULT_SIZE, DUCKDB_SUCCESS, handleBuffer, openLibDuckDb, readCString } from "./ffi.ts";
+import { ptr } from "bun:ffi";
+
+let dylib: string | null = null;
+let skipReason = "";
+
+beforeAll(async () => {
+    const found = await resolveTestDylib();
+    if (found.ok) dylib = found.path;
+    else {
+        skipReason = found.reason;
+        noteSkippedDylib("duckdb ffi", found.reason);
+    }
+});
+
+describe("openLibDuckDb", () => {
+    test("binds every symbol the client needs, including the row-major value accessors", () => {
+        if (dylib === null) return expect(skipReason.length).toBeGreaterThan(0);
+        const lib = openLibDuckDb(dylib);
+        try {
+            for (const name of [
+                "duckdb_open_ext",
+                "duckdb_close",
+                "duckdb_connect",
+                "duckdb_disconnect",
+                "duckdb_query",
+                "duckdb_prepare",
+                "duckdb_bind_varchar",
+                "duckdb_bind_int64",
+                "duckdb_bind_double",
+                "duckdb_bind_boolean",
+                "duckdb_bind_null",
+                "duckdb_execute_prepared",
+                "duckdb_destroy_prepare",
+                "duckdb_prepare_error",
+                "duckdb_destroy_result",
+                "duckdb_result_error",
+                "duckdb_row_count",
+                "duckdb_rows_changed",
+                "duckdb_column_count",
+                "duckdb_column_name",
+                "duckdb_column_type",
+                "duckdb_value_boolean",
+                "duckdb_value_int64",
+                "duckdb_value_uint64",
+                "duckdb_value_double",
+                "duckdb_value_varchar",
+                "duckdb_value_is_null",
+                "duckdb_free",
+                "duckdb_create_config",
+                "duckdb_set_config",
+                "duckdb_destroy_config",
+            ]) {
+                expect(typeof (lib.symbols as Record<string, unknown>)[name]).toBe("function");
+            }
+        } finally {
+            lib.close();
+        }
+    });
+
+    test("runs an in-memory round trip through the bound symbols", () => {
+        if (dylib === null) return expect(skipReason.length).toBeGreaterThan(0);
+        const lib = openLibDuckDb(dylib);
+        const db = handleBuffer();
+        const conn = handleBuffer();
+        try {
+            expect(lib.symbols.duckdb_open_ext(cstr(":memory:"), ptr(db), 0n, null)).toBe(DUCKDB_SUCCESS);
+            expect(lib.symbols.duckdb_connect(db[0]!, ptr(conn))).toBe(DUCKDB_SUCCESS);
+            const result = new Uint8Array(DUCKDB_RESULT_SIZE);
+            expect(lib.symbols.duckdb_query(conn[0]!, cstr("SELECT 41 + 1 AS answer"), ptr(result)))
+                .toBe(DUCKDB_SUCCESS);
+            expect(lib.symbols.duckdb_row_count(ptr(result))).toBe(1n);
+            expect(readCString(lib.symbols.duckdb_column_name(ptr(result), 0n))).toBe("answer");
+            expect(lib.symbols.duckdb_value_int64(ptr(result), 0n, 0n)).toBe(42n);
+            lib.symbols.duckdb_destroy_result(ptr(result));
+        } finally {
+            lib.symbols.duckdb_disconnect(ptr(conn));
+            lib.symbols.duckdb_close(ptr(db));
+            lib.close();
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/ffi.test.ts`
+Expected: FAIL - `Cannot find module './ffi.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/lib/src/duckdb/ffi.ts`:
+
+```ts
+/**
+ * Raw `bun:ffi` bindings for the libduckdb C API. No Effect, no policy - the
+ * bare symbol table plus the handle conventions the rest of the module relies
+ * on.
+ *
+ * THE HANDLE GOTCHA (solved in scripts/duckdb-spike/ffi/duckdb-ffi.ts):
+ * `duckdb_database`, `duckdb_connection`, `duckdb_config` and
+ * `duckdb_prepared_statement` are opaque `void *` typedefs. In ARGUMENT
+ * position they are passed BY VALUE, so they bind as `u64` and are read out of
+ * a `BigUint64Array`. In OUT-PARAM position they are real pointers and bind as
+ * `ptr`. Mixing the two up corrupts the handle and segfaults.
+ *
+ * Everything here takes `duckdb_result *`. The chunk API
+ * (`duckdb_fetch_chunk`, `duckdb_result_chunk_count`) takes the 48-byte
+ * `duckdb_result` struct BY VALUE, which `bun:ffi` cannot express, so the
+ * row-major `duckdb_value_*` accessors are the only reachable read path.
+ */
+import { CString, dlopen, FFIType } from "bun:ffi";
+
+const { i32, u64, f64, bool, ptr: PTR, cstring, void: VOID } = FFIType;
+
+/** `duckdb_result` is 48 bytes in duckdb.h; 64 leaves headroom. */
+export const DUCKDB_RESULT_SIZE = 64;
+/** `DuckDBSuccess` from `duckdb_state`. */
+export const DUCKDB_SUCCESS = 0;
+
+const SYMBOLS = {
+    // --- lifecycle -------------------------------------------------------
+    duckdb_open_ext: { args: [cstring, PTR, u64, PTR], returns: i32 },
+    duckdb_close: { args: [PTR], returns: VOID },
+    duckdb_connect: { args: [u64, PTR], returns: i32 },
+    duckdb_disconnect: { args: [PTR], returns: VOID },
+    // --- config ----------------------------------------------------------
+    duckdb_create_config: { args: [PTR], returns: i32 },
+    duckdb_set_config: { args: [u64, cstring, cstring], returns: i32 },
+    duckdb_destroy_config: { args: [PTR], returns: VOID },
+    // --- statements ------------------------------------------------------
+    duckdb_query: { args: [u64, cstring, PTR], returns: i32 },
+    duckdb_prepare: { args: [u64, cstring, PTR], returns: i32 },
+    duckdb_prepare_error: { args: [u64], returns: cstring },
+    duckdb_destroy_prepare: { args: [PTR], returns: VOID },
+    duckdb_execute_prepared: { args: [u64, PTR], returns: i32 },
+    duckdb_bind_boolean: { args: [u64, u64, bool], returns: i32 },
+    duckdb_bind_int64: { args: [u64, u64, FFIType.i64], returns: i32 },
+    duckdb_bind_double: { args: [u64, u64, f64], returns: i32 },
+    duckdb_bind_varchar: { args: [u64, u64, cstring], returns: i32 },
+    duckdb_bind_null: { args: [u64, u64], returns: i32 },
+    // --- results ---------------------------------------------------------
+    duckdb_destroy_result: { args: [PTR], returns: VOID },
+    duckdb_result_error: { args: [PTR], returns: PTR },
+    duckdb_row_count: { args: [PTR], returns: u64 },
+    duckdb_rows_changed: { args: [PTR], returns: u64 },
+    duckdb_column_count: { args: [PTR], returns: u64 },
+    duckdb_column_name: { args: [PTR, u64], returns: PTR },
+    duckdb_column_type: { args: [PTR, u64], returns: i32 },
+    // --- row-major value accessors --------------------------------------
+    duckdb_value_boolean: { args: [PTR, u64, u64], returns: bool },
+    duckdb_value_int64: { args: [PTR, u64, u64], returns: FFIType.i64 },
+    duckdb_value_uint64: { args: [PTR, u64, u64], returns: u64 },
+    duckdb_value_double: { args: [PTR, u64, u64], returns: f64 },
+    duckdb_value_varchar: { args: [PTR, u64, u64], returns: PTR },
+    duckdb_value_is_null: { args: [PTR, u64, u64], returns: bool },
+    duckdb_free: { args: [PTR], returns: VOID },
+} as const;
+
+export type LibDuckDb = ReturnType<typeof dlopen<typeof SYMBOLS>>;
+
+/** `dlopen` libduckdb with the full symbol table. Throws on a missing symbol. */
+export const openLibDuckDb = (dylibPath: string): LibDuckDb => dlopen(dylibPath, SYMBOLS);
+
+/** Backing store for one opaque handle (database / connection / statement). */
+export const handleBuffer = (): BigUint64Array => new BigUint64Array(1);
+
+/** NUL-terminated buffer for a `const char *` argument. */
+export const cstr = (s: string): Buffer => Buffer.from(`${s}\0`, "utf8");
+
+/** Read a `char *` return value, or null when the pointer is null. */
+export const readCString = (p: number | bigint | null | undefined): string | null => {
+    if (p === null || p === undefined || p === 0 || p === 0n) return null;
+    return new CString(p as never).toString();
+};
+```
+
+- [ ] **Step 4: Run the test to green**
+
+Run: `bun test packages/lib/src/duckdb/ffi.test.ts`
+Expected: PASS (2 tests). If `dlopen` throws on a symbol name, the dylib was built with
+`DUCKDB_API_NO_DEPRECATED` - that is the loud failure this test exists to produce.
+
+---
+
+### Task 4: Dylib resolution (source vs `$bunfs`)
+
+**Files:**
+- Create: `packages/lib/src/duckdb/dylib.ts`
+- Create: `packages/lib/src/duckdb/dylib.test.ts`
+
+**Interfaces:**
+- Consumes: `DuckDbDylibError` from Task 1.
+- Produces:
+  - `isEmbeddedPath(p: string): boolean`
+  - `extractDylib(embeddedPath: string, cacheDir: string): Effect.Effect<string, DuckDbDylibError, FileSystem.FileSystem>`
+    - content-hash path, reuse-if-present.
+  - `resolveDylibPath(options?: ResolveDylibOptions): Effect.Effect<string, DuckDbDylibError, FileSystem.FileSystem>`
+    where `interface ResolveDylibOptions { readonly assetPath?: string; readonly cacheDir?: string }`
+  - `dylibCacheDir(): string`
+
+**RULING R6 APPLIES - this supersedes the code sketch below wherever they disagree.** `dylib.ts` is
+a runtime module under `packages/lib/src/`, so `node:fs` and `node:path` are BANNED (the CI-wired
+`check:no-node-fs` gate hard-fails on them). The sketch in Step 3 was written against `node:fs`;
+port it:
+
+- `existsSync(p)` -> `yield* fs.exists(p)` (`const fs = yield* FileSystem.FileSystem`)
+- `mkdirSync(d, { recursive: true })` -> `yield* fs.makeDirectory(d, { recursive: true })`
+- `join(a, b)` -> `posixPath.join(a, b)` from `@ax/lib/shared/path`
+- the staging rename -> `yield* fs.rename(staging, out)` (NOT `Bun.$\`mv\``)
+- `homedir()` from `node:os` STAYS - `node:os` is not banned.
+- Map any `PlatformError` into `DuckDbDylibError` so the failure channel stays this module's own.
+- `extractDylib` becomes an `Effect.gen`, not an `async` function; `Bun.file(p).arrayBuffer()` and
+  `Bun.CryptoHasher` stay (they are not `node:fs`) - wrap them in `Effect.tryPromise` /
+  `Effect.sync`.
+
+Both exported effects therefore carry `FileSystem.FileSystem` in their requirements channel. The
+test provides it with `BunFileSystem.layer` from `@effect/platform-bun`:
+`Effect.runPromise(resolveDylibPath({ … }).pipe(Effect.provide(BunFileSystem.layer)))`. The TEST
+file may keep using `node:fs` directly (`*.test.ts` is excluded from the gate), so the Step 1 test
+body needs only its `Effect.runPromise` calls updated to provide the layer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/duckdb/dylib.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { existsSync, mkdtempSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { extractDylib, isEmbeddedPath, resolveDylibPath } from "./dylib.ts";
+
+const tempDir = () => mkdtempSync(join(tmpdir(), "ax-duckdb-dylib-"));
+
+describe("isEmbeddedPath", () => {
+    test("recognises the compiled-binary virtual filesystem", () => {
+        expect(isEmbeddedPath("/$bunfs/root/libduckdb.dylib")).toBe(true);
+        expect(isEmbeddedPath("B:/~BUN/root/libduckdb.dylib")).toBe(true);
+        expect(isEmbeddedPath("/Users/x/vendor/libduckdb.dylib")).toBe(false);
+    });
+});
+
+describe("extractDylib", () => {
+    test("writes the bytes to a content-hash path under the cache dir", async () => {
+        const dir = tempDir();
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "duckdb-bytes");
+        const cache = join(dir, "cache");
+
+        const out = await extractDylib(source, cache);
+
+        expect(out.startsWith(cache)).toBe(true);
+        expect(existsSync(out)).toBe(true);
+        expect(await Bun.file(out).text()).toBe("duckdb-bytes");
+    });
+
+    test("different bytes land on different paths", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const a = join(dir, "a.bin");
+        const b = join(dir, "b.bin");
+        await Bun.write(a, "aaaa");
+        await Bun.write(b, "bbbb");
+
+        expect(await extractDylib(a, cache)).not.toBe(await extractDylib(b, cache));
+    });
+
+    test("reuses an already-extracted file instead of rewriting it", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "duckdb-bytes");
+
+        const first = await extractDylib(source, cache);
+        const firstMtime = statSync(first).mtimeMs;
+        await Bun.sleep(15);
+        const second = await extractDylib(source, cache);
+
+        expect(second).toBe(first);
+        expect(statSync(second).mtimeMs).toBe(firstMtime);
+        expect(readdirSync(cache).length).toBe(1);
+    });
+});
+
+describe("resolveDylibPath", () => {
+    test("prefers AX_DUCKDB_DYLIB when it exists", async () => {
+        const dir = tempDir();
+        const injected = join(dir, "injected.dylib");
+        await Bun.write(injected, "x");
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        process.env.AX_DUCKDB_DYLIB = injected;
+        try {
+            expect(await Effect.runPromise(resolveDylibPath())).toBe(injected);
+        } finally {
+            if (prev === undefined) delete process.env.AX_DUCKDB_DYLIB;
+            else process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+
+    test("returns a real on-disk asset path unchanged (source mode)", async () => {
+        const dir = tempDir();
+        const asset = join(dir, "libduckdb.dylib");
+        await Bun.write(asset, "x");
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        delete process.env.AX_DUCKDB_DYLIB;
+        try {
+            expect(await Effect.runPromise(resolveDylibPath({ assetPath: asset }))).toBe(asset);
+        } finally {
+            if (prev !== undefined) process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+
+    test("fails with a typed error when nothing resolves", async () => {
+        const dir = tempDir();
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        delete process.env.AX_DUCKDB_DYLIB;
+        try {
+            const exit = await Effect.runPromise(
+                Effect.either(resolveDylibPath({ assetPath: join(dir, "missing.dylib") })),
+            );
+            expect(exit._tag).toBe("Left");
+            if (exit._tag === "Left") expect(exit.left._tag).toBe("DuckDbDylibError");
+        } finally {
+            if (prev !== undefined) process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/dylib.test.ts`
+Expected: FAIL - `Cannot find module './dylib.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/lib/src/duckdb/dylib.ts`:
+
+```ts
+/**
+ * Where libduckdb comes from at runtime.
+ *
+ * Source mode (`bun run`): the asset path is already a real file, hand it back.
+ * Compiled mode (`bun build --compile`): the asset lives in the binary's
+ * virtual filesystem, and `dlopen` cannot open a `$bunfs` path - the bytes must
+ * be materialised on disk first. They go to a CONTENT-HASH path so a given
+ * binary extracts once and every later run (and every concurrent process)
+ * reuses the same file. Mirrors the studio-embed pattern in
+ * `scripts/gen-studio-embed.ts`.
+ *
+ * `AX_DUCKDB_DYLIB` overrides everything - it is how tests, and later the
+ * custom static dylib from chunk w0-dylib-ci, inject their own build.
+ */
+import { Effect } from "effect";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DuckDbDylibError } from "./errors.ts";
+
+export interface ResolveDylibOptions {
+    /** The bundled asset path (a `{ type: "file" }` import in compiled mode). */
+    readonly assetPath?: string;
+    /** Where extracted copies land. Defaults to {@link dylibCacheDir}. */
+    readonly cacheDir?: string;
+}
+
+/** `~/.ax/cache/duckdb` (honours `AX_DATA_DIR`, like the serve pidfile). */
+export const dylibCacheDir = (): string => {
+    const base = process.env.AX_DATA_DIR?.trim();
+    return base ? join(base, "duckdb") : join(homedir(), ".ax", "cache", "duckdb");
+};
+
+/** Is this path inside a compiled binary's virtual filesystem? */
+export const isEmbeddedPath = (p: string): boolean =>
+    p.startsWith("/$bunfs/") || p.startsWith("B:/~BUN/") || p.startsWith("/~BUN/");
+
+/**
+ * Materialise `embeddedPath`'s bytes at `<cacheDir>/<sha256-16>-libduckdb`,
+ * reusing an existing extraction. The hash is over the CONTENT, so a rebuilt
+ * binary with a new dylib gets a new path instead of racing the old one.
+ */
+export const extractDylib = async (embeddedPath: string, cacheDir: string): Promise<string> => {
+    const bytes = await Bun.file(embeddedPath).arrayBuffer();
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(new Uint8Array(bytes));
+    const digest = hasher.digest("hex").slice(0, 16);
+    const out = join(cacheDir, `${digest}-libduckdb`);
+    if (existsSync(out)) return out;
+    mkdirSync(cacheDir, { recursive: true });
+    // Stage in a pid-suffixed sibling and rename, so two processes extracting
+    // concurrently can never observe a half-written dylib.
+    const staging = `${out}.${process.pid}.tmp`;
+    await Bun.write(staging, bytes);
+    await Bun.$`mv -f ${staging} ${out}`.quiet();
+    return out;
+};
+
+export const resolveDylibPath = (
+    options?: ResolveDylibOptions,
+): Effect.Effect<string, DuckDbDylibError> =>
+    Effect.gen(function* () {
+        const injected = process.env.AX_DUCKDB_DYLIB?.trim();
+        if (injected) {
+            if (existsSync(injected)) return injected;
+            return yield* Effect.fail(
+                new DuckDbDylibError({
+                    message: `AX_DUCKDB_DYLIB points at a missing file: ${injected}`,
+                }),
+            );
+        }
+
+        const asset = options?.assetPath;
+        if (asset === undefined) {
+            return yield* Effect.fail(
+                new DuckDbDylibError({
+                    message:
+                        "no libduckdb available: set AX_DUCKDB_DYLIB, or pass assetPath from the embedded build",
+                }),
+            );
+        }
+
+        if (!isEmbeddedPath(asset)) {
+            if (existsSync(asset)) return asset;
+            return yield* Effect.fail(
+                new DuckDbDylibError({ message: `libduckdb not found at ${asset}` }),
+            );
+        }
+
+        return yield* Effect.tryPromise({
+            try: () => extractDylib(asset, options?.cacheDir ?? dylibCacheDir()),
+            catch: (err) =>
+                new DuckDbDylibError({
+                    message: `failed to extract the embedded libduckdb: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                }),
+        });
+    });
+```
+
+- [ ] **Step 4: Run the test to green**
+
+Run: `bun test packages/lib/src/duckdb/dylib.test.ts`
+Expected: PASS (7 tests).
+
+---
+
+### Task 5: The `DuckDb` service - open, query, exec, close
+
+The load-bearing task. Tests run against real temp DB files through the real FFI; nothing here is
+mocked.
+
+**Files:**
+- Create: `packages/lib/src/duckdb/client.ts`
+- Create: `packages/lib/src/duckdb/client.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces:
+  - `interface DuckDbConnection { readonly path: string; readonly readOnly: boolean; readonly query: (sql: string, params?: ReadonlyArray<DuckDbParam>) => Effect.Effect<QueryResult, DuckDbQueryError | DuckDbUnsupportedTypeError>; readonly queryAs: <S extends Schema.Top>(schema: S, sql: string, params?: ReadonlyArray<DuckDbParam>) => Effect.Effect<ReadonlyArray<S["Type"]>, DuckDbQueryError | DuckDbUnsupportedTypeError | DuckDbDecodeError, S["DecodingServices"]>; readonly exec: (sql: string, params?: ReadonlyArray<DuckDbParam>) => Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError>; readonly close: Effect.Effect<void> }`
+  - `interface DuckDbService { readonly open: (path: string, options?: { readonly readOnly?: boolean }) => Effect.Effect<DuckDbConnection, DuckDbOpenError>; readonly scoped: (path: string, options?: { readonly readOnly?: boolean }) => Effect.Effect<DuckDbConnection, DuckDbOpenError, Scope.Scope> }`
+  - `class DuckDb extends Context.Service<DuckDb, DuckDbService>()("ax/DuckDb")`
+  - `const DuckDbLayer: (dylibPath: string) => Layer.Layer<DuckDb>`
+  - `const DuckDbLive: Layer.Layer<DuckDb, DuckDbDylibError>` (resolves the dylib itself)
+
+**RULING R6 APPLIES - this supersedes the code sketch below wherever they disagree.** `client.ts` is
+a runtime module under `packages/lib/src/`, so `node:fs` and `node:path` are BANNED (the CI-wired
+`check:no-node-fs` gate hard-fails on them; `*.test.ts` is exempt, so the test file may keep them).
+Concretely:
+
+- The read-only "database must already exist" guard uses `yield* fs.exists(path)`, NOT `existsSync`.
+- `join(...)` -> `posixPath.join(...)` from `@ax/lib/shared/path`; `homedir()` from `node:os` stays.
+- **Acquire `FileSystem` in the LAYER, not in the method signatures.** Build the service with
+  `Layer.effect(DuckDb)(Effect.gen(function* () { const fs = yield* FileSystem.FileSystem; … }))`
+  so `fs` is closed over and every `DuckDbService` / `DuckDbConnection` method keeps `R = never` -
+  the signatures in the Produces list above are exact and must not grow a requirements channel.
+- Then provide the platform INSIDE this module so callers stay clean:
+  `export const DuckDbLayer = (dylibPath: string): Layer.Layer<DuckDb> => baseLayer(dylibPath).pipe(Layer.provide(BunFileSystem.layer))`
+  (`BunFileSystem` from `@effect/platform-bun`, already a dependency of `@ax/lib`). This module is
+  Bun-only regardless - it loads `bun:ffi`.
+- Map any `PlatformError` from `fs` into this module's own tagged errors; never let it leak.
+- **`DuckDbLive` must wrap `openLibDuckDb` in `Effect.try`** mapping the throw to
+  `DuckDbDylibError` (ruling R2). `dlopen` throws on a missing symbol; the sketch's `Effect.map`
+  would turn that into an unhandled defect instead of a typed failure.
+- **RULING R9 - `Effect.either` DOES NOT EXIST in `effect@4.0.0-beta.78`.** The Step 1 test snippet
+  uses it repeatedly; it does not compile. The v4 equivalent is `Effect.result`, which returns
+  `Result.Result<A, E>` (verified in `node_modules/effect/src/Effect.ts:3454` and
+  `node_modules/effect/src/Result.ts:159`). Rewrite every occurrence as:
+  ```ts
+  const r = yield* Effect.result(conn.query("SELECT * FROM nope"));
+  expect(r._tag).toBe("Failure");            // NOT "Left"
+  if (r._tag === "Failure") expect(r.failure._tag).toBe("DuckDbQueryError");  // .failure, NOT .left
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/duckdb/client.test.ts`:
+
+```ts
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { DuckDb, DuckDbLayer } from "./client.ts";
+import { DuckDbTypeId } from "./types.ts";
+
+let layer: ReturnType<typeof DuckDbLayer> | null = null;
+let skipReason = "";
+
+beforeAll(async () => {
+    const found = await resolveTestDylib();
+    if (found.ok) layer = DuckDbLayer(found.path);
+    else {
+        skipReason = found.reason;
+        noteSkippedDylib("duckdb client", found.reason);
+    }
+});
+
+const tempDb = (name = "test.db") => join(mkdtempSync(join(tmpdir(), "ax-duckdb-client-")), name);
+
+/** Runs `body` with the DuckDb service, or no-ops when there is no dylib. */
+const withDuckDb = <A>(body: (db: DuckDbService) => Effect.Effect<A, unknown>) => async () => {
+    if (layer === null) return expect(skipReason.length).toBeGreaterThan(0);
+    await Effect.runPromise(
+        Effect.gen(function* () {
+            const db = yield* DuckDb;
+            yield* body(db);
+        }).pipe(Effect.provide(layer)) as Effect.Effect<void>,
+    );
+};
+type DuckDbService = Effect.Effect.Success<typeof DuckDb.asEffect extends never ? never : never>;
+
+describe("DuckDb", () => {
+    test(
+        "creates a database file and round-trips a typed row",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                const conn = yield* db.open(path);
+                yield* conn.exec("CREATE TABLE t (id BIGINT, note VARCHAR, ok BOOLEAN, score DOUBLE)");
+                const changed = yield* conn.exec(
+                    "INSERT INTO t VALUES (1, 'hello', true, 1.5), (2, NULL, false, 2.5)",
+                );
+                expect(changed).toBe(2);
+
+                const result = yield* conn.query("SELECT id, note, ok, score FROM t ORDER BY id");
+                expect(result.columns.map((c) => c.name)).toEqual(["id", "note", "ok", "score"]);
+                expect(result.columns[0]!.typeId).toBe(DuckDbTypeId.BIGINT);
+                expect(result.rows).toEqual([
+                    { id: 1n, note: "hello", ok: true, score: 1.5 },
+                    { id: 2n, note: null, ok: false, score: 2.5 },
+                ]);
+
+                yield* conn.close;
+                expect(existsSync(path)).toBe(true);
+            }),
+        ),
+    );
+
+    test(
+        "binds prepared-statement parameters instead of interpolating them",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES (?, ?)", [1, "o'brien; DROP TABLE t;--"]);
+                const result = yield* conn.query("SELECT note FROM t WHERE id = ?", [1]);
+                expect(result.rows).toEqual([{ note: "o'brien; DROP TABLE t;--" }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "decodes rows through an Effect schema with queryAs",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES (7, 'seven')");
+                const Row = Schema.Struct({ id: Schema.Number, note: Schema.String });
+                const rows = yield* conn.queryAs(Row, "SELECT id, note FROM t");
+                expect(rows).toEqual([{ id: 7, note: "seven" }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "fails with DuckDbDecodeError when rows do not match the schema",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES ('not a number')");
+                const Row = Schema.Struct({ note: Schema.Number });
+                const either = yield* Effect.either(conn.queryAs(Row, "SELECT note FROM t"));
+                expect(either._tag).toBe("Left");
+                if (either._tag === "Left") expect(either.left._tag).toBe("DuckDbDecodeError");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "surfaces a SQL error as DuckDbQueryError carrying duckdb's message",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const either = yield* Effect.either(conn.query("SELECT * FROM nope"));
+                expect(either._tag).toBe("Left");
+                if (either._tag === "Left") {
+                    expect(either.left._tag).toBe("DuckDbQueryError");
+                    expect((either.left as { message: string }).message).toContain("nope");
+                }
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "refuses to decode a BLOB column instead of returning garbage",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const either = yield* Effect.either(conn.query("SELECT 'abc'::BLOB AS payload"));
+                expect(either._tag).toBe("Left");
+                if (either._tag === "Left") {
+                    expect(either.left._tag).toBe("DuckDbUnsupportedTypeError");
+                }
+                // the documented workaround works
+                const ok = yield* conn.query("SELECT hex('abc'::BLOB) AS payload");
+                expect(ok.rows[0]!.payload).toBe("616263");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "reads timestamps back as Date",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* conn.query(
+                    "SELECT TIMESTAMP '2026-08-14 10:11:12' AS ts, DATE '2026-08-14' AS d",
+                );
+                expect(result.rows[0]!.ts).toBeInstanceOf(Date);
+                expect((result.rows[0]!.ts as Date).toISOString()).toBe("2026-08-14T10:11:12.000Z");
+                expect(result.rows[0]!.d).toBe("2026-08-14");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    test(
+        "a read-only open cannot write, and refuses a database that does not exist",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                const rw = yield* db.open(path);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.close;
+
+                const ro = yield* db.open(path, { readOnly: true });
+                expect(ro.readOnly).toBe(true);
+                expect((yield* ro.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(0n);
+                const either = yield* Effect.either(ro.exec("INSERT INTO t VALUES (1)"));
+                expect(either._tag).toBe("Left");
+                yield* ro.close;
+
+                const missing = yield* Effect.either(
+                    db.open(join(tempDb(), "..", "absent.db"), { readOnly: true }),
+                );
+                expect(missing._tag).toBe("Left");
+                if (missing._tag === "Left") expect(missing.left._tag).toBe("DuckDbOpenError");
+            }),
+        ),
+    );
+
+    test(
+        "scoped closes the connection when the scope closes",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                yield* Effect.scoped(
+                    Effect.gen(function* () {
+                        const conn = yield* db.scoped(path);
+                        yield* conn.exec("CREATE TABLE t (id INTEGER)");
+                    }),
+                );
+                // the file is closed and reopenable read-only, which a leaked
+                // write handle on the same path would not allow
+                const ro = yield* db.open(path, { readOnly: true });
+                yield* ro.close;
+            }),
+        ),
+    );
+});
+```
+
+> Note for the implementer: the `withDuckDb` helper above carries a placeholder
+> `DuckDbService` type alias that will not compile. Replace it with a direct
+> `import type { DuckDbService } from "./client.ts";` - the alias is only in this plan to keep the
+> test readable before `client.ts` exists.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/client.test.ts`
+Expected: FAIL - `Cannot find module './client.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/lib/src/duckdb/client.ts`. The shape (write it in full; the sketch below is the
+contract, not a stub - every branch shown must exist):
+
+```ts
+import { Context, Effect, Layer, Schema, Scope } from "effect";
+import { ptr } from "bun:ffi";
+import { existsSync } from "node:fs";
+import {
+    DuckDbDecodeError,
+    DuckDbDylibError,
+    DuckDbOpenError,
+    DuckDbQueryError,
+    DuckDbUnsupportedTypeError,
+} from "./errors.ts";
+import {
+    cstr,
+    DUCKDB_RESULT_SIZE,
+    DUCKDB_SUCCESS,
+    handleBuffer,
+    openLibDuckDb,
+    readCString,
+    type LibDuckDb,
+} from "./ffi.ts";
+import { accessorFor, coerceValue, unsupportedColumns } from "./row-decode.ts";
+import { resolveDylibPath } from "./dylib.ts";
+import type { DuckDbColumn, DuckDbParam, DuckDbRow, DuckDbValue, QueryResult } from "./types.ts";
+```
+
+Implementation rules the code must follow:
+
+1. **`sqlExcerpt(sql)`** - first 200 chars + `…`, mirroring `packages/lib/src/db.ts`. Every
+   `DuckDbQueryError` uses it so a huge statement never bloats the error.
+2. **`openDatabase(lib, path, readOnly)`** (private, sync):
+   - `readOnly === true` and `!existsSync(path)` → throw a `DuckDbOpenError`; DuckDB would create
+     an empty database otherwise, which silently hides a missing snapshot.
+   - build a config: `duckdb_create_config(ptr(cfgBuf))`, then when read-only
+     `duckdb_set_config(cfgBuf[0], cstr("access_mode"), cstr("READ_ONLY"))`; always
+     `duckdb_destroy_config(ptr(cfgBuf))` after `duckdb_open_ext` returns.
+   - `duckdb_open_ext(cstr(path), ptr(dbBuf), cfgBuf[0], ptr(errBuf))`; on non-success read
+     `readCString(errBuf[0])`, `duckdb_free`, and throw `DuckDbOpenError`.
+   - `duckdb_connect(dbBuf[0], ptr(connBuf))`; on non-success close the db and throw.
+3. **`runStatement(lib, connHandle, sql, params)`** (private, sync) returns
+   `{ resultPtr, resultBuf }` or throws `DuckDbQueryError`:
+   - no params → `duckdb_query(connHandle, cstr(sql), ptr(resultBuf))`.
+   - with params → `duckdb_prepare`, then per param (1-based index):
+     `null`/`undefined` → `duckdb_bind_null`; `boolean` → `duckdb_bind_boolean`;
+     `bigint` → `duckdb_bind_int64`; `number` → integer-valued and within
+     `Number.isSafeInteger` → `duckdb_bind_int64(BigInt(v))`, else `duckdb_bind_double`;
+     `Date` → `duckdb_bind_varchar(v.toISOString())`; `string` → `duckdb_bind_varchar`.
+     Then `duckdb_execute_prepared`, and `duckdb_destroy_prepare` in a `finally`.
+   - On a prepare failure read `duckdb_prepare_error(stmtHandle)`; on an execute/query failure read
+     `duckdb_result_error(ptr(resultBuf))`, destroy the result, and throw.
+4. **`readResult(lib, resultPtr, sql)`** (private, sync) → `QueryResult`:
+   - columns: `duckdb_column_count`, then per index `duckdb_column_name` (via `readCString`) and
+     `duckdb_column_type`.
+   - `unsupportedColumns(columns)` non-empty → throw `DuckDbUnsupportedTypeError` for the FIRST one
+     BEFORE reading any cell.
+   - rows: `duckdb_row_count`, then per (row, col): `duckdb_value_is_null` → `null`; else dispatch
+     on `accessorFor(typeId)` - `boolean`/`int64`/`uint64`/`double` call their accessor directly,
+     `varchar` calls `duckdb_value_varchar`, `readCString`s it and **`duckdb_free`s the pointer**
+     (leaking it leaks per cell). Feed the raw value through `coerceValue(typeId, raw)`.
+   - `rowsChanged: Number(duckdb_rows_changed(resultPtr))`.
+   - The caller always `duckdb_destroy_result`s in a `finally`.
+5. **`makeConnection(lib, path, readOnly, dbBuf, connBuf)`** builds the `DuckDbConnection`:
+   - `query` = `Effect.try({ try: … , catch: … })` wrapping runStatement + readResult +
+     destroy-result, re-raising `DuckDbQueryError` / `DuckDbUnsupportedTypeError` as-is and wrapping
+     anything else in `DuckDbQueryError`.
+   - `exec` = same but returns `rowsChanged` and does not decode rows (still runs the
+     unsupported-column check via `readResult`; DDL/DML results have no columns so it is free).
+   - `queryAs(schema, sql, params)` = `query(...)` then
+     `Schema.decodeUnknownEffect(Schema.Array(schema))(result.rows)` mapped to a
+     `DuckDbDecodeError` carrying the schema failure message.
+   - `close` = `Effect.sync` that is idempotent (a `closed` flag), calling `duckdb_disconnect` then
+     `duckdb_close`.
+6. **Service + layers**:
+
+```ts
+export class DuckDb extends Context.Service<DuckDb, DuckDbService>()("ax/DuckDb") {}
+
+/** Layer over an explicit dylib path - the injection point for tests and for
+ *  the custom static dylib from chunk w0-dylib-ci. */
+export const DuckDbLayer = (dylibPath: string): Layer.Layer<DuckDb> =>
+    Layer.effect(DuckDb)(
+        Effect.sync(() => {
+            const lib = openLibDuckDb(dylibPath);
+            return makeService(lib);
+        }),
+    );
+
+/** Layer that resolves the dylib itself (env override / bundled asset). */
+export const DuckDbLive: Layer.Layer<DuckDb, DuckDbDylibError> = Layer.effect(DuckDb)(
+    Effect.map(resolveDylibPath(), (path) => makeService(openLibDuckDb(path))),
+);
+```
+
+  `scoped` = `Effect.acquireRelease(open(path, options), (conn) => conn.close)`.
+
+- [ ] **Step 4: Run the test to green**
+
+Run: `bun test packages/lib/src/duckdb/client.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Check the FFI does not leak varchar cells**
+
+Run: `bun test packages/lib/src/duckdb/client.test.ts` and confirm no crash; then eyeball
+`readResult` - every `duckdb_value_varchar` pointer must reach `duckdb_free` on both the value and
+the null path.
+
+---
+
+### Task 6: The ingest lockfile
+
+**Files:**
+- Create: `packages/lib/src/duckdb/lock-state.ts`
+- Create: `packages/lib/src/duckdb/lock-state.test.ts`
+- Create: `packages/lib/src/duckdb/lock.ts`
+- Create: `packages/lib/src/duckdb/lock.test.ts`
+
+**Interfaces:**
+- Consumes: `IngestLockError`, `IngestLockHeldError` from Task 1.
+- Produces:
+  - `interface LockPayload { readonly pid: number; readonly started_at: string }`
+  - `encodeLockPayload(p: LockPayload): string`, `decodeLockPayload(text: string): LockPayload | null`
+  - `interface LockDecision { readonly kind: "free" | "held" | "stale"; readonly holder?: LockPayload }`
+  - `decideLock(text: string | null, isAlive: (pid: number) => boolean, selfPid: number): LockDecision`
+  - `interface IngestLockHandle { readonly path: string; readonly release: Effect.Effect<void> }`
+  - `interface IngestLockService { readonly acquire: (options?: AcquireOptions) => Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError>; readonly holder: Effect.Effect<LockPayload | null, IngestLockError> }`
+    with `interface AcquireOptions { readonly wait?: boolean; readonly timeoutMs?: number; readonly pollMs?: number }`
+  - `class IngestLock extends Context.Service<IngestLock, IngestLockService>()("ax/IngestLock")`
+  - `ingestLockPath(): string`, `IngestLockLayer(path: string): Layer.Layer<IngestLock>`,
+    `IngestLockLive: Layer.Layer<IngestLock>`
+
+**RULING R6 APPLIES - this supersedes the implementation rules below wherever they disagree.**
+`lock.ts` and `lock-state.ts` are runtime modules under `packages/lib/src/`, so `node:fs` and
+`node:path` are BANNED (`*.test.ts` is exempt, so `lock.test.ts` may keep them). `lock-state.ts` is
+already pure and touches no filesystem - leave it alone. In `lock.ts`:
+
+- `mkdirSync(dirname(path), { recursive: true })` -> `yield* fs.makeDirectory(posixPath.dirname(path), { recursive: true })`
+- reading the lock file -> `yield* fs.readFileString(path)`, catching the not-found failure into
+  `null` (`Effect.catchAll` / `Effect.option`), since "no file" is the `free` case, not an error
+- **the exclusive create** -> `yield* fs.writeFileString(path, payload, { flag: "wx" })`. `"wx"` is a
+  supported `OpenFlag` in effect's `FileSystem`, so the atomic create-or-fail semantics survive the
+  port intact; a racing writer's failure loops back to the decide step exactly as specified.
+- `unlinkSync` -> `yield* fs.remove(path)`
+- `homedir()` from `node:os` STAYS; `join` -> `posixPath.join`
+- Map every unexpected `PlatformError` into `IngestLockError`; never let it leak.
+- **Acquire `FileSystem` in the LAYER, not in the method signatures:**
+  `Layer.effect(IngestLock)(Effect.gen(function* () { const fs = yield* FileSystem.FileSystem; … }))`,
+  then `export const IngestLockLayer = (path: string): Layer.Layer<IngestLock> => base(path).pipe(Layer.provide(BunFileSystem.layer))`.
+  The `IngestLockService` signatures above are exact and must not grow a requirements channel.
+- **RULING R9 - `Effect.either` DOES NOT EXIST in `effect@4.0.0-beta.78`.** The Step 5 test snippet
+  uses it; it does not compile. The v4 equivalent is `Effect.result`, returning `Result.Result<A, E>`
+  (verified in `node_modules/effect/src/Effect.ts:3454`, `node_modules/effect/src/Result.ts:159`):
+  ```ts
+  const r = yield* Effect.result(lock.acquire());
+  expect(r._tag).toBe("Failure");            // NOT "Left"
+  if (r._tag === "Failure") expect(r.failure._tag).toBe("IngestLockHeldError");  // .failure, NOT .left
+  ```
+
+- [ ] **Step 1: Write the failing pure-state test**
+
+Create `packages/lib/src/duckdb/lock-state.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { decideLock, decodeLockPayload, encodeLockPayload } from "./lock-state.ts";
+
+const alive = () => true;
+const dead = () => false;
+
+describe("lock payload codec", () => {
+    test("round-trips pid and started_at", () => {
+        const payload = { pid: 4242, started_at: "2026-08-14T10:00:00.000Z" };
+        expect(decodeLockPayload(encodeLockPayload(payload))).toEqual(payload);
+    });
+
+    test("rejects junk and partial payloads instead of guessing", () => {
+        expect(decodeLockPayload("not json")).toBeNull();
+        expect(decodeLockPayload("{}")).toBeNull();
+        expect(decodeLockPayload('{"pid":"x","started_at":"y"}')).toBeNull();
+    });
+});
+
+describe("decideLock", () => {
+    test("no file means free", () => {
+        expect(decideLock(null, alive, 1).kind).toBe("free");
+    });
+
+    test("a live foreign holder means held, and the holder comes back with it", () => {
+        const text = encodeLockPayload({ pid: 999, started_at: "2026-08-14T10:00:00.000Z" });
+        const decision = decideLock(text, alive, 1);
+        expect(decision.kind).toBe("held");
+        expect(decision.holder?.pid).toBe(999);
+    });
+
+    test("a dead holder means stale, so the next run can take over", () => {
+        const text = encodeLockPayload({ pid: 999, started_at: "2026-08-14T10:00:00.000Z" });
+        expect(decideLock(text, dead, 1).kind).toBe("stale");
+    });
+
+    test("an unreadable lock file is stale, not a permanent wedge", () => {
+        expect(decideLock("garbage", alive, 1).kind).toBe("stale");
+    });
+
+    test("our own pid is stale - a leftover from a crashed run of this process", () => {
+        const text = encodeLockPayload({ pid: 7, started_at: "2026-08-14T10:00:00.000Z" });
+        expect(decideLock(text, alive, 7).kind).toBe("stale");
+    });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/lock-state.test.ts`
+Expected: FAIL - `Cannot find module './lock-state.ts'`.
+
+- [ ] **Step 3: Write `lock-state.ts`**
+
+```ts
+/**
+ * Pure lock-file reasoning: what the file says, and what to do about it.
+ * Kept away from the filesystem so every branch (live holder, dead holder,
+ * corrupt file, our own leftover) is testable without spawning a process.
+ */
+export interface LockPayload {
+    readonly pid: number;
+    readonly started_at: string;
+}
+
+export const encodeLockPayload = (payload: LockPayload): string =>
+    `${JSON.stringify(payload)}\n`;
+
+export const decodeLockPayload = (text: string): LockPayload | null => {
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (typeof parsed !== "object" || parsed === null) return null;
+        const { pid, started_at } = parsed as Record<string, unknown>;
+        if (typeof pid !== "number" || !Number.isInteger(pid)) return null;
+        if (typeof started_at !== "string" || started_at.length === 0) return null;
+        return { pid, started_at };
+    } catch {
+        return null;
+    }
+};
+
+export interface LockDecision {
+    readonly kind: "free" | "held" | "stale";
+    readonly holder?: LockPayload;
+}
+
+/**
+ * `stale` covers three cases that all mean "take it": the holder process is
+ * gone, the file is unparseable, or the pid is US (a leftover from a crashed
+ * run - a live process never contends with itself here because acquire is the
+ * only writer).
+ */
+export const decideLock = (
+    text: string | null,
+    isAlive: (pid: number) => boolean,
+    selfPid: number,
+): LockDecision => {
+    if (text === null) return { kind: "free" };
+    const holder = decodeLockPayload(text);
+    if (holder === null) return { kind: "stale" };
+    if (holder.pid === selfPid) return { kind: "stale", holder };
+    return isAlive(holder.pid) ? { kind: "held", holder } : { kind: "stale", holder };
+};
+```
+
+- [ ] **Step 4: Run to green**
+
+Run: `bun test packages/lib/src/duckdb/lock-state.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Write the failing lock-service test**
+
+Create `packages/lib/src/duckdb/lock.test.ts`. This exercises the REAL filesystem - contention is
+proven by a second acquire against the same real file, and cross-process contention by a real
+`bun` subprocess, not by a stubbed lock.
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { IngestLock, IngestLockLayer } from "./lock.ts";
+import { encodeLockPayload } from "./lock-state.ts";
+
+const lockPath = () => join(mkdtempSync(join(tmpdir(), "ax-ingest-lock-")), "ingest.lock");
+
+const withLock = <A>(path: string, body: (lock: IngestLockService) => Effect.Effect<A, unknown>) =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const lock = yield* IngestLock;
+            return yield* body(lock);
+        }).pipe(Effect.provide(IngestLockLayer(path))) as Effect.Effect<A>,
+    );
+
+describe("IngestLock", () => {
+    test("acquire writes a lock file holding our pid, release removes it", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const handle = yield* lock.acquire();
+                expect(existsSync(path)).toBe(true);
+                expect((yield* lock.holder)?.pid).toBe(process.pid);
+                yield* handle.release;
+                expect(existsSync(path)).toBe(false);
+            }),
+        );
+    });
+
+    test("a second acquire while a LIVE holder owns the lock fails fast", async () => {
+        const path = lockPath();
+        // A live foreign holder: pid 1 always exists and is never us.
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        const started = Date.now();
+        const either = await withLock(path, (lock) => Effect.either(lock.acquire()));
+        expect(either._tag).toBe("Left");
+        if (either._tag === "Left") {
+            expect(either.left._tag).toBe("IngestLockHeldError");
+            expect((either.left as { pid: number }).pid).toBe(1);
+        }
+        expect(Date.now() - started).toBeLessThan(1000); // fail-fast, not a wait
+    });
+
+    test("wait mode gives up with the same typed error after the timeout", async () => {
+        const path = lockPath();
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        const started = Date.now();
+        const either = await withLock(path, (lock) =>
+            Effect.either(lock.acquire({ wait: true, timeoutMs: 250, pollMs: 25 })),
+        );
+        expect(either._tag).toBe("Left");
+        if (either._tag === "Left") expect(either.left._tag).toBe("IngestLockHeldError");
+        expect(Date.now() - started).toBeGreaterThanOrEqual(200);
+    });
+
+    test("wait mode succeeds once the holder releases", async () => {
+        const path = lockPath();
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        setTimeout(() => {
+            try {
+                require("node:fs").unlinkSync(path);
+            } catch {
+                /* already gone */
+            }
+        }, 120);
+        const handle = await withLock(path, (lock) =>
+            lock.acquire({ wait: true, timeoutMs: 3000, pollMs: 25 }),
+        );
+        expect(existsSync(path)).toBe(true);
+        await Effect.runPromise(handle.release);
+    });
+
+    test("takes over a lock whose holder is dead", async () => {
+        const path = lockPath();
+        // A pid that cannot be running: spawn a process and let it exit.
+        const proc = Bun.spawnSync(["true"]);
+        expect(proc.exitCode).toBe(0);
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        const handle = await withLock(path, (lock) => lock.acquire());
+        expect(existsSync(path)).toBe(true);
+        await Effect.runPromise(handle.release);
+        expect(existsSync(path)).toBe(false);
+    });
+
+    test("release is idempotent and never removes someone else's lock", async () => {
+        const path = lockPath();
+        const handle = await withLock(path, (lock) => lock.acquire());
+        await Effect.runPromise(handle.release);
+        // someone else takes it
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        await Effect.runPromise(handle.release);
+        expect(existsSync(path)).toBe(true);
+    });
+});
+```
+
+> Implementer note: add `import type { IngestLockService } from "./lock.ts";` and drop the local
+> alias; and prefer `unlinkSync` imported at the top over the inline `require`.
+
+- [ ] **Step 6: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/lock.test.ts`
+Expected: FAIL - `Cannot find module './lock.ts'`.
+
+- [ ] **Step 7: Write `lock.ts`**
+
+Rules the implementation must follow:
+
+- `ingestLockPath()` = `process.env.AX_INGEST_LOCK?.trim()` or `join(homedir(), ".ax", "ingest.lock")`.
+- `acquire`:
+  1. `mkdirSync(dirname(path), { recursive: true })`.
+  2. Read the file (`null` when `ENOENT`), run `decideLock(text, isAlive, process.pid)`.
+  3. `held` → fail `IngestLockHeldError({ path, pid, startedAt })` when not waiting; when waiting,
+     sleep `pollMs` (default 100) and retry until `timeoutMs` (default 30_000) elapses, then fail
+     with the SAME error.
+  4. `free`/`stale` → write with `openSync(path, "wx")` (exclusive create; a `stale` decision
+     `unlinkSync`s first). `EEXIST` from a racing writer loops back to step 2 rather than throwing.
+  5. Return a handle whose `release` re-reads the file and only unlinks when the payload's pid is
+     ours - so a late release never deletes a successor's lock. Idempotent.
+- `isAlive(pid)` = `try { process.kill(pid, 0); return true } catch (e) { return (e as NodeJS.ErrnoException).code === "EPERM" }`
+  (EPERM means the process exists but belongs to another user).
+- Filesystem failures other than the expected `ENOENT`/`EEXIST` become `IngestLockError`.
+- Service/layers mirror Task 5: `IngestLock` tag, `IngestLockLayer(path)`, and
+  `IngestLockLive = IngestLockLayer(ingestLockPath())`.
+
+- [ ] **Step 8: Run to green**
+
+Run: `bun test packages/lib/src/duckdb/lock.test.ts`
+Expected: PASS (6 tests).
+
+---
+
+### Task 7: Snapshot publish + snapshot open
+
+**Files:**
+- Modify: `packages/lib/src/duckdb/client.ts` (add `publishSnapshot` + `openSnapshot` to the service)
+- Create: `packages/lib/src/duckdb/snapshot.test.ts`
+
+**Interfaces:**
+- Consumes: `DuckDbConnection` / `DuckDbService` from Task 5, `SnapshotPublishError` from Task 1.
+- Produces, added to `DuckDbService`:
+  - `readonly publishSnapshot: (livePath: string, snapshotPath: string) => Effect.Effect<void, SnapshotPublishError | DuckDbOpenError>`
+  - `readonly openSnapshot: (snapshotPath?: string) => Effect.Effect<DuckDbConnection, DuckDbOpenError>`
+  - `snapshotPath(): string` - `AX_DUCKDB_SNAPSHOT` or `~/.ax/cache/ax-snapshot.duckdb`.
+
+**RULING R6 APPLIES - this supersedes the implementation rules below wherever they disagree.** You
+are editing `client.ts`, a runtime module: `node:fs` and `node:path` are BANNED (`snapshot.test.ts`
+is exempt). Task 5 already closed a `FileSystem` instance over the service inside its layer - use
+that same `fs`, and do NOT add a requirements channel to the two new method signatures above.
+
+- the "livePath must exist" guard -> `yield* fs.exists(livePath)`
+- removing a leftover temp file -> `yield* fs.remove(tmp)` (ignore a not-found failure)
+- **the atomic swap** -> `yield* fs.rename(tmp, snapshotPath)`. `tmp` stays a SIBLING of
+  `snapshotPath`, so the rename is same-filesystem and therefore atomic; that is the whole point of
+  the test that proves a reader on the old inode keeps reading.
+- Map every `PlatformError` into `SnapshotPublishError`.
+- **RULING R9 - `Effect.either` DOES NOT EXIST in `effect@4.0.0-beta.78`.** The Step 1 test snippet
+  uses it; it does not compile. The v4 equivalent is `Effect.result`, returning `Result.Result<A, E>`
+  (verified in `node_modules/effect/src/Effect.ts:3454`, `node_modules/effect/src/Result.ts:159`):
+  ```ts
+  const r = yield* Effect.result(db.publishSnapshot(missing, snap));
+  expect(r._tag).toBe("Failure");   // NOT "Left"; the failure value is `r.failure`, NOT `r.left`
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/duckdb/snapshot.test.ts`:
+
+```ts
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { existsSync, mkdtempSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { DuckDb, DuckDbLayer } from "./client.ts";
+import type { DuckDbService } from "./client.ts";
+
+let layer: ReturnType<typeof DuckDbLayer> | null = null;
+let skipReason = "";
+
+beforeAll(async () => {
+    const found = await resolveTestDylib();
+    if (found.ok) layer = DuckDbLayer(found.path);
+    else {
+        skipReason = found.reason;
+        noteSkippedDylib("duckdb snapshot", found.reason);
+    }
+});
+
+const workDir = () => mkdtempSync(join(tmpdir(), "ax-duckdb-snapshot-"));
+
+const withDuckDb = <A>(body: (db: DuckDbService) => Effect.Effect<A, unknown>) => async () => {
+    if (layer === null) return expect(skipReason.length).toBeGreaterThan(0);
+    await Effect.runPromise(
+        Effect.gen(function* () {
+            const db = yield* DuckDb;
+            yield* body(db);
+        }).pipe(Effect.provide(layer)) as Effect.Effect<void>,
+    );
+};
+
+describe("publishSnapshot", () => {
+    test(
+        "copies the live database to the snapshot path and leaves no temp files",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'first')");
+                yield* rw.close;
+
+                yield* db.publishSnapshot(live, snap);
+                expect(existsSync(snap)).toBe(true);
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+
+                const reader = yield* db.openSnapshot(snap);
+                expect(reader.readOnly).toBe(true);
+                expect((yield* reader.query("SELECT note FROM t")).rows).toEqual([
+                    { note: "first" },
+                ]);
+                yield* reader.close;
+            }),
+        ),
+    );
+
+    test(
+        "a reader holding the OLD snapshot keeps reading while a new one is renamed into place",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'v1')");
+                yield* rw.close;
+                yield* db.publishSnapshot(live, snap);
+
+                // A reader opens v1 and HOLDS it open across the republish.
+                const reader = yield* db.openSnapshot(snap);
+                const inodeBefore = statSync(snap).ino;
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1);
+
+                const rw2 = yield* db.open(live);
+                yield* rw2.exec("INSERT INTO t VALUES (2, 'v2')");
+                yield* rw2.close;
+                yield* db.publishSnapshot(live, snap);
+
+                // the path now points at a NEW inode ...
+                expect(statSync(snap).ino).not.toBe(inodeBefore);
+                // ... while the held reader still sees the OLD contents.
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1);
+                yield* reader.close;
+
+                // a fresh reader sees the new snapshot
+                const fresh = yield* db.openSnapshot(snap);
+                expect((yield* fresh.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(2);
+                yield* fresh.close;
+            }),
+        ),
+    );
+
+    test(
+        "a failed publish leaves the previous snapshot intact",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+                yield* rw.close;
+                yield* db.publishSnapshot(live, snap);
+
+                const either = yield* Effect.either(
+                    db.publishSnapshot(join(dir, "does-not-exist.duckdb"), snap),
+                );
+                expect(either._tag).toBe("Left");
+
+                const reader = yield* db.openSnapshot(snap);
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1);
+                yield* reader.close;
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+            }),
+        ),
+    );
+});
+```
+
+> Note: `count(*)` comes back as `BIGINT`, so the expected value is `1n`/`2n` under the Task 2
+> rule that BIGINT stays `bigint`. Fix the literals in these assertions to `1n` / `2n` when you
+> write the test - they are shown unsuffixed here only to make the intent readable.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/snapshot.test.ts`
+Expected: FAIL - `db.publishSnapshot is not a function`.
+
+- [ ] **Step 3: Implement `publishSnapshot` / `openSnapshot` in `client.ts`**
+
+Rules:
+
+- `snapshotPath()` = `process.env.AX_DUCKDB_SNAPSHOT?.trim()` or
+  `join(homedir(), ".ax", "cache", "ax-snapshot.duckdb")`.
+- `openSnapshot(p?)` = `open(p ?? snapshotPath(), { readOnly: true })`.
+- `publishSnapshot(livePath, snapshotPath)`:
+  1. Fail `SnapshotPublishError` when `livePath` does not exist (do not create an empty database).
+  2. `tmp = ${snapshotPath}.${process.pid}.tmp` - a SIBLING, so the rename is same-filesystem and
+     therefore atomic (never `EXDEV`). `unlink` any leftover tmp first.
+  3. Open `livePath` read-write, then in order:
+     `CHECKPOINT`, `ATTACH '<tmp>' AS ax_snapshot`,
+     `COPY FROM DATABASE "<name>" TO ax_snapshot` where `<name>` is
+     `(yield* conn.query("SELECT current_database() AS n")).rows[0].n`,
+     `DETACH ax_snapshot`. Single-quote-escape `tmp` (`replace(/'/g, "''")`) inside the ATTACH.
+  4. Close the connection BEFORE the rename so the tmp file has no open writer.
+  5. `renameSync(tmp, snapshotPath)`.
+  6. Wrap the whole thing so ANY failure removes `tmp` (`Effect.ensuring` + `unlink … ignore`) and
+     surfaces as `SnapshotPublishError` - the previous snapshot is untouched because nothing
+     writes to `snapshotPath` until the rename.
+
+- [ ] **Step 4: Run to green**
+
+Run: `bun test packages/lib/src/duckdb/snapshot.test.ts`
+Expected: PASS (3 tests).
+
+---
+
+### Task 8: Barrel, gates, single commit
+
+**Files:**
+- Create: `packages/lib/src/duckdb/index.ts`
+- Create: `packages/lib/src/duckdb/index.test.ts`
+
+- [ ] **Step 1: Write the failing surface test**
+
+Create `packages/lib/src/duckdb/index.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import * as duckdb from "./index.ts";
+
+describe("@ax/lib/duckdb public surface", () => {
+    test("exports the services, layers and helpers callers need", () => {
+        for (const name of [
+            "DuckDb",
+            "DuckDbLayer",
+            "DuckDbLive",
+            "IngestLock",
+            "IngestLockLayer",
+            "IngestLockLive",
+            "ingestLockPath",
+            "snapshotPath",
+            "resolveDylibPath",
+            "dylibCacheDir",
+            "DuckDbTypeId",
+        ]) {
+            expect((duckdb as Record<string, unknown>)[name]).toBeDefined();
+        }
+    });
+
+    test("exports every tagged error so callers can catch by tag", () => {
+        for (const name of [
+            "DuckDbOpenError",
+            "DuckDbQueryError",
+            "DuckDbDecodeError",
+            "DuckDbUnsupportedTypeError",
+            "DuckDbDylibError",
+            "IngestLockHeldError",
+            "IngestLockError",
+            "SnapshotPublishError",
+        ]) {
+            expect((duckdb as Record<string, unknown>)[name]).toBeDefined();
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/lib/src/duckdb/index.test.ts`
+Expected: FAIL - `Cannot find module './index.ts'`.
+
+- [ ] **Step 3: Write the barrel**
+
+```ts
+/**
+ * `@ax/lib/duckdb` - the typed DuckDB client the v2 architecture stands on.
+ *
+ * Reads go through a read-only handle on the published snapshot
+ * (`openSnapshot`); writes only happen inside ingest, under the ingest lock
+ * (`IngestLock`), against the live database; `publishSnapshot` is how the two
+ * meet - CHECKPOINT, copy to a sibling temp file, atomic rename.
+ */
+export * from "./errors.ts";
+export * from "./types.ts";
+export * from "./row-decode.ts";
+export * from "./dylib.ts";
+export * from "./client.ts";
+export * from "./lock-state.ts";
+export * from "./lock.ts";
+```
+
+(`ffi.ts` is deliberately NOT re-exported - it is the internal FFI seam, not public surface.)
+
+- [ ] **Step 4: Run to green**
+
+Run: `bun test packages/lib/src/duckdb/index.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run every gate from the worktree and capture real exit codes**
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/w0-ffi-client
+bun run typecheck; echo "typecheck exit=$?"
+bunx tsc --noEmit -p tsconfig.json; echo "tsc exit=$?"
+bun test packages/lib/src/duckdb packages/lib/src/testing/duckdb-dylib.test.ts; echo "test exit=$?"
+```
+
+Expected: all three `exit=0`. Never pipe `tsc` through `tail`/`grep` before reading `$?`.
+
+- [ ] **Step 6: Single conventional commit**
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/w0-ffi-client
+git add -A ':!BRIEF.md' ':!REPORT.md'
+git status --short
+git commit -m "feat(duckdb): typed DuckDB FFI client, ingest lock, snapshot publisher"
+```
+
+Confirm `vendor/duckdb/` is NOT in `git status --short` (Task 1 Step 1 ignores it) and that the
+117MB dylib is not staged.
+
+---
+
+## Self-Review
+
+**Spec coverage** (chunk `w0-ffi-client` in the backlog + BRIEF.md):
+
+| Requirement | Task |
+|---|---|
+| `open(path, {readOnly})` | 5 |
+| `query(sql, params?)` with typed row decode | 2 (rules) + 5 (`query`/`queryAs`) |
+| `exec` | 5 |
+| `close` | 5 |
+| `openSnapshot()` | 7 |
+| `publishSnapshot()` = CHECKPOINT + COPY FROM DATABASE → tmp → atomic rename | 7 |
+| ingest lockfile `~/.ax/ingest.lock` (pid + started_at, fail-fast default, wait option) | 6 |
+| `resolveDylib()` real path in source mode, `$bunfs` extract to content-hash path, reuse-if-present | 4 |
+| Effect-native service, layer-testable, heavily typed | 5, 6 (`Context.Service` + injectable-path layers) |
+| Start from the working spike | 3 (the by-value-u64 handle convention is carried over verbatim) |
+| Dylib downloaded into a gitignored vendor cache in test setup; skip with a notice when impossible | 1 |
+| Dylib path injectable for chunk w0-dylib-ci | 1 (`AX_DUCKDB_DYLIB`), 4, 5 (`DuckDbLayer(path)`) |
+| unit + e2e against a real temp DB file | 3, 5, 7 |
+| lock contention test (second acquire fails fast) | 6 |
+| snapshot publish test: reader on the old inode keeps reading while the rename lands | 7 |
+
+No gaps.
+
+**Seam rule check:** nothing mocks DuckDB, the filesystem, or the lock - every e2e runs against a
+real dylib, real temp `.duckdb` files, and real lock files. The only injected values are *paths*
+(`AX_DUCKDB_DYLIB`, the layer's `dylibPath`, the lock path), which is configuration, not a mock.
+Delete-the-mock heuristic: there is no mock to delete.
+
+**Placeholder scan:** every code step carries real code; the two "rules the implementation must
+follow" blocks (Tasks 5 step 3, 6 step 7, 7 step 3) enumerate concrete C calls, argument forms and
+error branches rather than saying "handle errors".
+
+**Type consistency:** `DuckDbColumn`/`QueryResult`/`DuckDbValue`/`DuckDbParam` are defined once in
+Task 1 and used unchanged in Tasks 2, 5, 7. `accessorFor`/`coerceValue`/`unsupportedColumns`
+(Task 2) are called with exactly those signatures in Task 5. `LockPayload`/`decideLock` (Task 6
+`lock-state.ts`) are consumed with the same names in `lock.ts` and both test files.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,6 +12,8 @@
     "./shared/path": "./src/shared/path.ts",
     "./shared/team-community": "./src/shared/team-community.ts",
     "./shared/team-fetch": "./src/shared/team-fetch.ts",
+    "./duckdb": "./src/duckdb/index.ts",
+    "./testing/duckdb-dylib": "./src/testing/duckdb-dylib.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",
     "./testing/surreal": "./src/testing/surreal.ts",
     "./*": {

--- a/packages/lib/src/duckdb/canonical-path.ts
+++ b/packages/lib/src/duckdb/canonical-path.ts
@@ -1,0 +1,45 @@
+/**
+ * One canonical spelling for a filesystem path, so two names for the SAME
+ * file compare equal.
+ *
+ * Both consumers in this module were bitten by the same class of bug (found
+ * in cross-review): `lock.ts` keyed its process-local "do we hold this lock"
+ * state by the caller-supplied STRING, so `ingest.lock`, `/abs/ingest.lock`
+ * and a symlinked alias of the directory looked like three different locks
+ * and the second name stole the first one's live lock (P1-5); `client.ts`
+ * compared `options.from.path` to `livePath` not at all, and would have been
+ * fooled by the same aliasing had it compared them naively (P1-6/P2-4).
+ *
+ * The file itself usually does NOT exist yet (a lock about to be created, a
+ * snapshot about to be published), so `realPath` is applied to the PARENT
+ * DIRECTORY and the basename is appended. That resolves `.`/`..`, a relative
+ * spelling, and every symlink ABOVE the file, which is the whole aliasing
+ * surface that matters here. A symlink AT the leaf is deliberately not
+ * followed: for a lock file that would resolve to the target the writer never
+ * created, and for a snapshot the publish rename replaces the link itself.
+ *
+ * Canonicalization NEVER fails the caller. When the parent directory cannot
+ * be resolved (it does not exist yet, or is unreadable) the input is returned
+ * unchanged - the comparison then degrades to a plain string compare, which
+ * is exactly the behavior these call sites had before, so a probe failure can
+ * never turn a working publish or acquire into an error.
+ *
+ * RULING R6: runtime module under `packages/lib/src/`, so `node:fs`/
+ * `node:path` are banned - `FileSystem.FileSystem` and `posixPath` only.
+ */
+import { Effect, type FileSystem } from "effect";
+import { orAbsent } from "../shared/fs-error.ts";
+import { posixPath } from "../shared/path.ts";
+
+export const canonicalPath = (
+    fs: FileSystem.FileSystem,
+    path: string,
+): Effect.Effect<string> =>
+    Effect.suspend(() => {
+        const dir = posixPath.dirname(path);
+        const base = posixPath.basename(path);
+        return fs.realPath(dir).pipe(
+            Effect.map((real) => (base === "" || base === "." ? real : posixPath.join(real, base))),
+            orAbsent(path),
+        );
+    });

--- a/packages/lib/src/duckdb/client.test.ts
+++ b/packages/lib/src/duckdb/client.test.ts
@@ -1,0 +1,442 @@
+import { ptr } from "bun:ffi";
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { DuckDb, DuckDbLayer, makeConnection, readResult } from "./client.ts";
+import type { DuckDbService } from "./client.ts";
+import type { LibDuckDb } from "./ffi.ts";
+import { DuckDbTypeId } from "./types.ts";
+
+// Resolved at module load (top-level await), not in `beforeAll`, so
+// `test.skipIf` below sees a real boolean at test-registration time and bun
+// reports a SKIP status - distinct from a PASS - when no dylib is available.
+// Finding 3 (final fix round): the previous `beforeAll` + runtime
+// `expect(skipReason.length).toBeGreaterThan(0)` guard reported PASS for
+// every one of these tests on a dylib-less box, with only a console.warn as
+// the signal - mirrors ffi.test.ts's convention exactly.
+const found = await resolveTestDylib();
+const dylibPath = found.ok ? found.path : null;
+if (!found.ok) noteSkippedDylib("duckdb client", found.reason);
+const layer = dylibPath !== null ? DuckDbLayer(dylibPath) : null;
+
+/** `test`, bound to skip (not pass) every dylib-dependent case below when no
+ *  dylib is available. */
+const dtest = test.skipIf(dylibPath === null);
+
+// Finding 4 (final fix round): every dir this suite creates is collected
+// here and removed in one afterAll - see dylib.test.ts for the measured
+// leak this closes.
+const createdTempDirs: string[] = [];
+const tempDb = (name = "test.db") => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-duckdb-client-"));
+    createdTempDirs.push(dir);
+    return join(dir, name);
+};
+
+afterAll(() => {
+    for (const dir of createdTempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Runs `body` with the DuckDb service. Only ever invoked via `dtest`, which
+ *  skips registration entirely when `layer` is null - the non-null assertion
+ *  is safe by construction. */
+const withDuckDb = <A>(body: (db: DuckDbService) => Effect.Effect<A, unknown>) => async () => {
+    await Effect.runPromise(
+        Effect.gen(function* () {
+            const db = yield* DuckDb;
+            yield* body(db);
+        }).pipe(Effect.provide(layer as NonNullable<typeof layer>)) as Effect.Effect<void>,
+    );
+};
+
+describe("DuckDb", () => {
+    dtest(
+        "creates a database file and round-trips a typed row",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                const conn = yield* db.open(path);
+                yield* conn.exec("CREATE TABLE t (id BIGINT, note VARCHAR, ok BOOLEAN, score DOUBLE)");
+                const changed = yield* conn.exec(
+                    "INSERT INTO t VALUES (1, 'hello', true, 1.5), (2, NULL, false, 2.5)",
+                );
+                expect(changed).toBe(2);
+
+                const result = yield* conn.query("SELECT id, note, ok, score FROM t ORDER BY id");
+                expect(result.columns.map((c) => c.name)).toEqual(["id", "note", "ok", "score"]);
+                expect(result.columns[0]!.typeId).toBe(DuckDbTypeId.BIGINT);
+                expect(result.rows).toEqual([
+                    { id: 1n, note: "hello", ok: true, score: 1.5 },
+                    { id: 2n, note: null, ok: false, score: 2.5 },
+                ]);
+
+                yield* conn.close;
+                expect(existsSync(path)).toBe(true);
+            }),
+        ),
+    );
+
+    dtest(
+        "binds prepared-statement parameters instead of interpolating them",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES (?, ?)", [1, "o'brien; DROP TABLE t;--"]);
+                const result = yield* conn.query("SELECT note FROM t WHERE id = ?", [1]);
+                expect(result.rows).toEqual([{ note: "o'brien; DROP TABLE t;--" }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "decodes rows through an Effect schema with queryAs",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES (7, 'seven')");
+                const Row = Schema.Struct({ id: Schema.Number, note: Schema.String });
+                const rows = yield* conn.queryAs(Row, "SELECT id, note FROM t");
+                expect(rows).toEqual([{ id: 7, note: "seven" }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "fails with DuckDbDecodeError when rows do not match the schema",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (note VARCHAR)");
+                yield* conn.exec("INSERT INTO t VALUES ('not a number')");
+                const Row = Schema.Struct({ note: Schema.Number });
+                const result = yield* Effect.result(conn.queryAs(Row, "SELECT note FROM t"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") expect(result.failure._tag).toBe("DuckDbDecodeError");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "surfaces a SQL error as DuckDbQueryError carrying duckdb's message",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* Effect.result(conn.query("SELECT * FROM nope"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbQueryError");
+                    expect((result.failure as { message: string }).message).toContain("nope");
+                }
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "refuses to decode a BLOB column instead of returning garbage",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* Effect.result(conn.query("SELECT 'abc'::BLOB AS payload"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbUnsupportedTypeError");
+                }
+                // the documented workaround works
+                const ok = yield* conn.query("SELECT hex('abc'::BLOB) AS payload");
+                expect(ok.rows[0]!.payload).toBe("616263");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "reads timestamps back as Date",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* conn.query(
+                    "SELECT TIMESTAMP '2026-08-14 10:11:12' AS ts, DATE '2026-08-14' AS d",
+                );
+                expect(result.rows[0]!.ts).toBeInstanceOf(Date);
+                expect((result.rows[0]!.ts as Date).toISOString()).toBe("2026-08-14T10:11:12.000Z");
+                expect(result.rows[0]!.d).toBe("2026-08-14");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Fix round 1 (ruling R10), Part A: duckdb_value_varchar returns a NULL
+    // pointer for TIMESTAMP WITH TIME ZONE (verified against libduckdb
+    // v1.5.5 directly, on both a literal and a real table column), so it is
+    // now excluded from row-decode.ts's VARCHAR_TYPES - querying it raises
+    // DuckDbUnsupportedTypeError naming the column instead of silently
+    // decoding to "". The documented workaround (CAST ... AS VARCHAR) works.
+    dtest(
+        "refuses to decode TIMESTAMP WITH TIME ZONE instead of returning an empty string",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* Effect.result(
+                    conn.query("SELECT TIMESTAMP WITH TIME ZONE '2026-08-14 10:11:12+02' AS ts_tz"),
+                );
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbUnsupportedTypeError");
+                    expect((result.failure as { message: string }).message).toContain(
+                        "CAST(ts_tz AS VARCHAR)",
+                    );
+                }
+                // the documented workaround works
+                const ok = yield* conn.query(
+                    "SELECT CAST(TIMESTAMP WITH TIME ZONE '2026-08-14 10:11:12+02' AS VARCHAR) AS ts_tz",
+                );
+                expect(typeof ok.rows[0]!.ts_tz).toBe("string");
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Fix round 1 (ruling R10): UUID showed the exact same accessor failure
+    // as TIMESTAMP_TZ during the investigation (duckdb_value_varchar -> NULL
+    // for a real, non-SQL-NULL value) and is excluded from VARCHAR_TYPES the
+    // same way - confirmed structurally here, mirroring the TZ test above.
+    dtest(
+        "refuses to decode UUID instead of returning an empty string",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE u (id UUID)");
+                yield* conn.exec("INSERT INTO u VALUES ('11111111-1111-1111-1111-111111111111')");
+                const result = yield* Effect.result(conn.query("SELECT id FROM u"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbUnsupportedTypeError");
+                    expect((result.failure as { message: string }).message).toContain("CAST(id AS VARCHAR)");
+                }
+                // the documented workaround works, including for a NULL row
+                yield* conn.exec("INSERT INTO u VALUES (NULL)");
+                const ok = yield* conn.query("SELECT CAST(id AS VARCHAR) AS id FROM u ORDER BY id");
+                expect(ok.rows).toEqual([
+                    { id: "11111111-1111-1111-1111-111111111111" },
+                    { id: null },
+                ]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "a read-only open cannot write, and refuses a database that does not exist",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                const rw = yield* db.open(path);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.close;
+
+                const ro = yield* db.open(path, { readOnly: true });
+                expect(ro.readOnly).toBe(true);
+                expect((yield* ro.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(0n);
+                const result = yield* Effect.result(ro.exec("INSERT INTO t VALUES (1)"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    // Assert the specific tag and a read-only-mode message,
+                    // not just "some failure" - a differently-broken INSERT
+                    // (e.g. a typo'd table name) would also satisfy a bare
+                    // _tag === "Failure" check without proving read-only
+                    // actually blocked the write.
+                    expect(result.failure._tag).toBe("DuckDbQueryError");
+                    expect((result.failure as { message: string }).message.toLowerCase()).toContain(
+                        "read-only",
+                    );
+                }
+                yield* ro.close;
+
+                const missingPath = join(tempDb(), "..", "absent.db");
+                const missing = yield* Effect.result(db.open(missingPath, { readOnly: true }));
+                expect(missing._tag).toBe("Failure");
+                if (missing._tag === "Failure") expect(missing.failure._tag).toBe("DuckDbOpenError");
+                // The guarantee under test is "fails rather than silently
+                // creating an empty database" - assert the file was in fact
+                // never created, not just that open() reported failure.
+                expect(existsSync(missingPath)).toBe(false);
+            }),
+        ),
+    );
+
+    // Fix round 2 (ruling R11): this test previously "proved" close ran by
+    // reopening the path read-only afterward. The reviewer disproved that as
+    // evidence - opening the same dylib read-only WHILE a write handle is
+    // still open on the same path SUCCEEDS, so the reopen would pass whether
+    // or not close ever ran. This is now a light integration smoke test only
+    // (scoped composes correctly and the scope exits without throwing); the
+    // actual guarantee - close disconnects/closes exactly once, and a second
+    // close is a no-op - is unit-tested directly below against a fake
+    // LibDuckDb, where the FFI calls can be counted.
+    dtest(
+        "scoped opens a usable connection and the scope exits cleanly",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const path = tempDb();
+                yield* Effect.scoped(
+                    Effect.gen(function* () {
+                        const conn = yield* db.scoped(path);
+                        yield* conn.exec("CREATE TABLE t (id INTEGER)");
+                        const result = yield* conn.query("SELECT count(*) AS n FROM t");
+                        expect(result.rows[0]!.n).toBe(0n);
+                    }),
+                );
+            }),
+        ),
+    );
+
+    dtest(
+        "round-trips 2000 varchar rows correctly",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (note VARCHAR)");
+                // Volume evidence that decoding stays correct at scale; this
+                // is NOT leak-detection instrumentation (no RSS/heap
+                // measurement here) - see the task report for the reviewer's
+                // independent RSS measurement proving duckdb_free is
+                // load-bearing (101->198MB with the free vs 109->411MB
+                // without it, over 400k cells in two fresh processes).
+                yield* conn.exec(
+                    `INSERT INTO t SELECT 'row-' || i FROM range(2000) t(i)`,
+                );
+                const result = yield* conn.query("SELECT note FROM t ORDER BY note");
+                expect(result.rows.length).toBe(2000);
+                expect(result.rows[0]!.note).toBe("row-0");
+                yield* conn.close;
+            }),
+        ),
+    );
+});
+
+// Fix round 1 (ruling R10), Part B: direct unit test of readResult's general
+// accessor-failure guard (duckdb_value_is_null false + a NULL varchar
+// pointer -> DuckDbUnsupportedTypeError). Part A now excludes every
+// currently-known trigger of this guard from VARCHAR_TYPES structurally, so
+// no real SQL type reaches it any more via the client.open()/query() path
+// above - this is the "unit-test the read helper directly" fallback,
+// exercising readResult with a hand-built fake LibDuckDb instead of a
+// vacuous SQL assertion that could never fail. DATE is used as the column's
+// reported type (still a real "varchar"-accessor type) purely so the
+// structural unsupportedColumns() pre-check does not reject the column
+// before the per-cell guard even runs - the fake's duckdb_value_varchar is
+// what actually returns NULL, standing in for the accessor failure.
+describe("readResult (Part B unit test)", () => {
+    test("a not-null cell with a NULL duckdb_value_varchar pointer raises DuckDbUnsupportedTypeError, not an empty string", () => {
+        const resultPtr = ptr(new Uint8Array(8));
+        const fakeLib = {
+            symbols: {
+                duckdb_column_count: () => 1n,
+                duckdb_column_name: () => null, // -> readResult falls back to "column_0"
+                duckdb_column_type: () => DuckDbTypeId.DATE,
+                duckdb_row_count: () => 1n,
+                duckdb_rows_changed: () => 0n,
+                duckdb_value_is_null: () => false, // the cell is NOT SQL NULL
+                duckdb_value_varchar: () => null, // ...yet the accessor returns NULL anyway
+                duckdb_value_boolean: () => {
+                    throw new Error("not expected to be called for a DATE column");
+                },
+                duckdb_value_int64: () => {
+                    throw new Error("not expected to be called for a DATE column");
+                },
+                duckdb_value_uint64: () => {
+                    throw new Error("not expected to be called for a DATE column");
+                },
+                duckdb_value_double: () => {
+                    throw new Error("not expected to be called for a DATE column");
+                },
+                duckdb_free: () => {
+                    throw new Error("must not be called - there is no pointer to free");
+                },
+            },
+        } as unknown as LibDuckDb;
+
+        expect(() => readResult(fakeLib, resultPtr)).toThrow();
+        try {
+            readResult(fakeLib, resultPtr);
+            throw new Error("expected readResult to throw");
+        } catch (err) {
+            expect((err as { _tag?: string })._tag).toBe("DuckDbUnsupportedTypeError");
+            expect((err as { message: string }).message).toContain("column_0");
+        }
+    });
+});
+
+// Fix round 2 (ruling R11), IMPORTANT 1 + 2: direct unit test of
+// makeConnection's `close`. The previous "scoped" test's evidence for
+// "close actually releases the file" was a read-only reopen of the same
+// path - disproved as evidence (opening read-only while a write handle is
+// still open on the same path SUCCEEDS against this dylib, so that
+// assertion was true whether or not close ever ran). This counts the
+// duckdb_disconnect/duckdb_close calls directly against a fake LibDuckDb,
+// which is the only reliable way to prove (a) close actually calls them and
+// (b) a second close does not call them again - the `closed` flag guard is
+// the only thing standing between an idempotent close and a double-free of
+// the same handle buffers.
+// Final fix round, finding 1: `baseLayer` used to call `openLibDuckDb`
+// bare inside `Effect.gen`, so a bad dylib path threw a raw, unhandled
+// defect straight through `DuckDbLayer` - which is declared
+// `Layer.Layer<DuckDb, DuckDbDylibError>` and is the seam the w0-dylib-ci
+// chunk consumes directly. This never touches a real dylib (the path does
+// not exist), so it runs unconditionally - no `withDuckDb`/skip needed.
+describe("DuckDbLayer (finding 1)", () => {
+    test("a bad dylib path surfaces DuckDbDylibError through Effect.result, not a rejected promise", async () => {
+        const layer = DuckDbLayer("/definitely/not/a/dylib.so");
+        const prog = Effect.asVoid(DuckDb).pipe(Effect.provide(layer)) as Effect.Effect<void, unknown>;
+
+        const result = await Effect.runPromise(Effect.result(prog));
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+            expect((result.failure as { _tag?: string })._tag).toBe("DuckDbDylibError");
+        }
+    });
+});
+
+describe("makeConnection.close (Part B-style unit test)", () => {
+    test("close disconnects and closes exactly once; a second close is a no-op", () => {
+        let disconnectCalls = 0;
+        let closeCalls = 0;
+        const fakeLib = {
+            symbols: {
+                duckdb_disconnect: () => {
+                    disconnectCalls += 1;
+                },
+                duckdb_close: () => {
+                    closeCalls += 1;
+                },
+            },
+        } as unknown as LibDuckDb;
+
+        const conn = makeConnection(
+            fakeLib,
+            "/fake/path.db",
+            false,
+            new BigUint64Array(1),
+            new BigUint64Array(1),
+        );
+
+        Effect.runSync(conn.close);
+        expect(disconnectCalls).toBe(1);
+        expect(closeCalls).toBe(1);
+
+        // Idempotency: the second close must not re-invoke either FFI call.
+        Effect.runSync(conn.close);
+        Effect.runSync(conn.close);
+        expect(disconnectCalls).toBe(1);
+        expect(closeCalls).toBe(1);
+    });
+});

--- a/packages/lib/src/duckdb/client.test.ts
+++ b/packages/lib/src/duckdb/client.test.ts
@@ -1,11 +1,12 @@
 import { ptr } from "bun:ffi";
+import { BunFileSystem } from "@effect/platform-bun";
 import { afterAll, describe, expect, test } from "bun:test";
-import { Effect, Schema } from "effect";
+import { Effect, Layer, Schema } from "effect";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
-import { DuckDb, DuckDbLayer, makeConnection, readResult } from "./client.ts";
+import { DuckDb, DuckDbLayer, layerFromLib, makeConnection, openDatabase, readResult } from "./client.ts";
 import type { DuckDbService } from "./client.ts";
 import type { LibDuckDb } from "./ffi.ts";
 import { DuckDbTypeId } from "./types.ts";
@@ -299,6 +300,135 @@ describe("DuckDb", () => {
         ),
     );
 
+    // Cross-review P1-1: `makeConnection` captured the connection pointer up
+    // front and no operation re-checked `closed`, so a query issued after
+    // `close` handed a freed pointer to `duckdb_query` - reproduced as a Bun
+    // SEGMENTATION FAULT, i.e. a process kill with no catchable error at all.
+    // Every operation now fails with a typed `DuckDbQueryError` instead.
+    dtest(
+        "a query after close fails with a typed error instead of segfaulting",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (id INTEGER)");
+                yield* conn.close;
+
+                const queried = yield* Effect.result(conn.query("SELECT 1 AS n"));
+                expect(queried._tag).toBe("Failure");
+                if (queried._tag === "Failure") {
+                    expect(queried.failure._tag).toBe("DuckDbQueryError");
+                    expect((queried.failure as { message: string }).message.toLowerCase()).toContain(
+                        "closed",
+                    );
+                }
+
+                const executed = yield* Effect.result(conn.exec("INSERT INTO t VALUES (1)"));
+                expect(executed._tag).toBe("Failure");
+                if (executed._tag === "Failure") expect(executed.failure._tag).toBe("DuckDbQueryError");
+
+                // close itself stays idempotent (no double free).
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Cross-review P1-2: every `bigint` parameter went through
+    // `duckdb_bind_int64`, which SILENTLY WRAPS - `2n**63n` was reproduced
+    // arriving as `-2n**63n`, and `2n**100n` as `0n`. Corrupt data with no
+    // signal is the worst possible outcome for a store, so out-of-range
+    // values are now a typed failure naming the value and the i64 limit.
+    dtest(
+        "refuses a bigint parameter outside the signed 64-bit range instead of wrapping it",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+
+                for (const value of [2n ** 63n, 2n ** 100n, -(2n ** 63n) - 1n]) {
+                    const result = yield* Effect.result(
+                        conn.query("SELECT CAST(? AS BIGINT) AS v", [value]),
+                    );
+                    expect(result._tag).toBe("Failure");
+                    if (result._tag === "Failure") {
+                        expect(result.failure._tag).toBe("DuckDbQueryError");
+                        const message = (result.failure as { message: string }).message;
+                        expect(message).toContain(value.toString());
+                        expect(message).toContain("9223372036854775807");
+                    }
+                }
+
+                // ... while both boundary values still bind exactly.
+                const max = yield* conn.query("SELECT CAST(? AS BIGINT) AS v", [2n ** 63n - 1n]);
+                expect(max.rows[0]!.v).toBe(9223372036854775807n);
+                const min = yield* conn.query("SELECT CAST(? AS BIGINT) AS v", [-(2n ** 63n)]);
+                expect(min.rows[0]!.v).toBe(-9223372036854775808n);
+
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Cross-review P2-1: rows were built on a normal `{}`, so a `__proto__`
+    // column vanished (the setter swallows the assignment) and a duplicate
+    // column name silently overwrote the earlier value - data loss with no
+    // signal either way.
+    dtest(
+        "a __proto__ column round-trips instead of vanishing into the prototype setter",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* conn.query(`SELECT 42 AS "__proto__"`);
+                const row = result.rows[0]!;
+                expect(Object.getPrototypeOf(row)).toBe(null);
+                // 42 (not 42n): an untyped integer literal is INTEGER, which
+                // row-decode narrows to a JS number - the point here is that
+                // the KEY survives at all.
+                expect(row["__proto__"]).toBe(42);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "duplicate column names fail loudly instead of silently overwriting",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE a (v INTEGER)");
+                yield* conn.exec("CREATE TABLE b (v INTEGER)");
+                yield* conn.exec("INSERT INTO a VALUES (1)");
+                yield* conn.exec("INSERT INTO b VALUES (2)");
+                const result = yield* Effect.result(conn.query("SELECT a.v, b.v FROM a, b"));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbQueryError");
+                    expect((result.failure as { message: string }).message).toContain("alias");
+                }
+                // the documented workaround works
+                const ok = yield* conn.query("SELECT a.v AS av, b.v AS bv FROM a, b");
+                expect(ok.rows).toEqual([{ av: 1, bv: 2 }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Cross-review P2-2: DuckDB stores TIMESTAMP at MICROSECOND grain; a JS
+    // `Date` is millisecond-grain, so the last three digits are dropped. ax
+    // data is millisecond-grain, so this is the accepted trade - PINNED here
+    // so it stays a documented contract rather than an accident.
+    dtest(
+        "TIMESTAMP microseconds truncate to milliseconds (documented, pinned)",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                const result = yield* conn.query(
+                    "SELECT TIMESTAMP '2026-08-14 10:11:12.999999' AS ts",
+                );
+                expect((result.rows[0]!.ts as Date).toISOString()).toBe("2026-08-14T10:11:12.999Z");
+                yield* conn.close;
+            }),
+        ),
+    );
+
     dtest(
         "round-trips 2000 varchar rows correctly",
         withDuckDb((db) =>
@@ -437,6 +567,95 @@ describe("makeConnection.close (Part B-style unit test)", () => {
         Effect.runSync(conn.close);
         Effect.runSync(conn.close);
         expect(disconnectCalls).toBe(1);
+        expect(closeCalls).toBe(1);
+    });
+
+    // Cross-review P1-1, unit half: prove NO native symbol is reached after
+    // close. The e2e half (above) proves the process survives; this proves
+    // WHY - the guard short-circuits before any pointer is dereferenced.
+    test("no operation touches a native symbol after close", () => {
+        const boom = () => {
+            throw new Error("native call after close");
+        };
+        const fakeLib = {
+            symbols: {
+                duckdb_disconnect: () => {},
+                duckdb_close: () => {},
+                duckdb_query: boom,
+                duckdb_prepare: boom,
+                duckdb_column_count: boom,
+                duckdb_row_count: boom,
+            },
+        } as unknown as LibDuckDb;
+
+        const conn = makeConnection(
+            fakeLib,
+            "/fake/path.db",
+            false,
+            new BigUint64Array(1),
+            new BigUint64Array(1),
+        );
+        Effect.runSync(conn.close);
+
+        const ops: ReadonlyArray<Effect.Effect<unknown, unknown>> = [
+            conn.query("SELECT 1"),
+            conn.exec("SELECT 1"),
+            conn.queryAs(Schema.Struct({ n: Schema.Number }), "SELECT 1 AS n"),
+        ];
+        for (const op of ops) {
+            const result = Effect.runSync(Effect.result(op));
+            expect(result._tag).toBe("Failure");
+            if (result._tag === "Failure") {
+                expect((result.failure as { _tag: string })._tag).toBe("DuckDbQueryError");
+                expect((result.failure as { message: string }).message.toLowerCase()).toContain(
+                    "closed",
+                );
+            }
+        }
+    });
+});
+
+// Cross-review P3-1: duckdb.h requires `duckdb_destroy_config` even when
+// `duckdb_create_config` FAILS (duckdb.h:1018-1023) - the failure path threw
+// without it, leaking whatever the call had already allocated.
+describe("openDatabase (P3-1)", () => {
+    test("destroys the config even when duckdb_create_config fails", () => {
+        let destroyCalls = 0;
+        const fakeLib = {
+            symbols: {
+                duckdb_create_config: () => 1, // != DUCKDB_SUCCESS
+                duckdb_destroy_config: () => {
+                    destroyCalls += 1;
+                },
+            },
+        } as unknown as LibDuckDb;
+
+        expect(() => openDatabase(fakeLib, "/fake/path.db", false)).toThrow();
+        expect(destroyCalls).toBe(1);
+    });
+});
+
+// Cross-review P3-2: the layers held the `dlopen` handle for the life of the
+// process - repeated layer construction (a fresh AppLayer per run, the shape
+// this repo already builds) retained one dylib handle each. The layer is now
+// scoped: releasing it calls `lib.close()`.
+describe("layerFromLib (P3-2)", () => {
+    test("closing the layer scope releases the dynamic library handle", async () => {
+        let closeCalls = 0;
+        const fakeLib = {
+            symbols: {},
+            close: () => {
+                closeCalls += 1;
+            },
+        } as unknown as LibDuckDb;
+
+        await Effect.runPromise(
+            Effect.asVoid(DuckDb).pipe(
+                Effect.provide(
+                    layerFromLib(Effect.succeed(fakeLib)).pipe(Layer.provide(BunFileSystem.layer)),
+                ),
+            ) as Effect.Effect<void>,
+        );
         expect(closeCalls).toBe(1);
     });
 });

--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -32,6 +32,7 @@ import { BunFileSystem } from "@effect/platform-bun";
 import { Context, Effect, FileSystem, Layer, Schema, type Scope } from "effect";
 import { homedir } from "node:os";
 import { posixPath } from "../shared/path.ts";
+import { canonicalPath } from "./canonical-path.ts";
 import { resolveDylibPath } from "./dylib.ts";
 import {
     DuckDbDecodeError,
@@ -145,7 +146,10 @@ const duckdbFree = (lib: LibDuckDb, p: number | bigint | null | undefined): void
  * than here, so this function can stay a plain sync throw-on-failure helper
  * with no `R` channel to thread through.
  */
-const openDatabase = (
+// Exported (not part of the DuckDbService product surface) so the P3-1
+// config-destruction guarantee can be unit-tested against a fake LibDuckDb -
+// a failing `duckdb_create_config` cannot be provoked through a real dylib.
+export const openDatabase = (
     lib: LibDuckDb,
     path: string,
     readOnly: boolean,
@@ -153,6 +157,11 @@ const openDatabase = (
     const cfgBuf = handleBuffer();
     const createState = lib.symbols.duckdb_create_config(ptr(cfgBuf));
     if (createState !== DUCKDB_SUCCESS) {
+        // Cross-review P3-1: duckdb.h (v1.5.5, lines 1018-1023) documents
+        // that `duckdb_destroy_config` must run even when creation FAILS -
+        // the out-param can already hold a partially-initialised config. The
+        // throw used to skip it, leaking that allocation on every failure.
+        lib.symbols.duckdb_destroy_config(ptr(cfgBuf));
         throw new DuckDbOpenError({ path, readOnly, message: "duckdb_create_config failed" });
     }
 
@@ -193,6 +202,28 @@ const openDatabase = (
 
     return { dbBuf, connBuf };
 };
+
+/**
+ * The inclusive bounds of DuckDB's `BIGINT` / C `int64_t`, which is the only
+ * integer width `duckdb_bind_int64` (the sole integer bind this client binds)
+ * can carry.
+ */
+const I64_MIN = -(2n ** 63n);
+const I64_MAX = 2n ** 63n - 1n;
+
+/**
+ * Cross-review P1-2: every `bigint` parameter went straight to
+ * `duckdb_bind_int64`, and `bun:ffi`'s `i64` marshalling WRAPS silently -
+ * `2n**63n` was reproduced arriving as `-2n**63n`, and `2n**100n` as `0n`.
+ * Corrupt data with no signal is the worst failure mode a store can have, so
+ * an out-of-range value is refused BEFORE it reaches the FFI boundary. The
+ * caller keeps the exact value in the message, plus the limit it broke, so
+ * the fix (store it as VARCHAR/HUGEINT text) is obvious from the error alone.
+ */
+export const bindableBigInt = (value: bigint): boolean => value >= I64_MIN && value <= I64_MAX;
+
+const bigintRangeMessage = (idx: number, value: bigint): string =>
+    `parameter ${idx} (${value}) is outside the range this client can bind: DuckDB binds integers as a signed 64-bit int64 (${I64_MIN} to ${I64_MAX}), and a wider value would silently wrap. Pass it as text (and store the column as VARCHAR or HUGEINT) instead.`;
 
 /** Bind one prepared-statement parameter (1-based `idx`). Returns the
  *  `duckdb_state` from the underlying bind call so the caller can check it. */
@@ -257,6 +288,13 @@ const runStatement = (
     try {
         const stmtHandle = stmtBuf[0]!;
         for (let i = 0; i < params.length; i += 1) {
+            const param = params[i];
+            if (typeof param === "bigint" && !bindableBigInt(param)) {
+                throw new DuckDbQueryError({
+                    sql: sqlExcerpt(sql),
+                    message: bigintRangeMessage(i + 1, param),
+                });
+            }
             const bindState = bindParam(lib, stmtHandle, BigInt(i + 1), params[i]);
             if (bindState !== DUCKDB_SUCCESS) {
                 throw new DuckDbQueryError({
@@ -321,7 +359,11 @@ const runStatement = (
 // LibDuckDb: Part A now excludes every currently-known trigger of the guard
 // from VARCHAR_TYPES structurally, so no real SQL type reaches it any more -
 // see client.test.ts.
-export const readResult = (lib: LibDuckDb, resultPtr: ReturnType<typeof ptr>): QueryResult => {
+export const readResult = (
+    lib: LibDuckDb,
+    resultPtr: ReturnType<typeof ptr>,
+    sql = "",
+): QueryResult => {
     const columnCount = Number(lib.symbols.duckdb_column_count(resultPtr));
     const columns: DuckDbColumn[] = [];
     for (let c = 0; c < columnCount; c += 1) {
@@ -329,6 +371,19 @@ export const readResult = (lib: LibDuckDb, resultPtr: ReturnType<typeof ptr>): Q
         const name = readCString(lib.symbols.duckdb_column_name(resultPtr, idx)) ?? `column_${c}`;
         const typeId = lib.symbols.duckdb_column_type(resultPtr, idx);
         columns.push({ name, typeId });
+    }
+
+    // Cross-review P2-1, half one: a row is keyed BY COLUMN NAME, so two
+    // columns sharing a name (`SELECT a.v, b.v FROM a, b` - DuckDB permits
+    // it) used to overwrite each other and hand the caller one value where it
+    // asked for two. That is silent data loss on a read path, so it is a
+    // typed refusal naming the fix.
+    const duplicate = columns.find((c, i) => columns.findIndex((o) => o.name === c.name) !== i);
+    if (duplicate !== undefined) {
+        throw new DuckDbQueryError({
+            sql: sqlExcerpt(sql),
+            message: `the result has more than one column named "${duplicate.name}"; rows are keyed by column name, so alias them (e.g. SELECT a.${duplicate.name} AS a_${duplicate.name}, b.${duplicate.name} AS b_${duplicate.name}) to keep both values`,
+        });
     }
 
     const unsupported = unsupportedColumns(columns);
@@ -345,7 +400,13 @@ export const readResult = (lib: LibDuckDb, resultPtr: ReturnType<typeof ptr>): Q
     const rows: DuckDbRow[] = [];
     for (let r = 0; r < rowCount; r += 1) {
         const rowIdx = BigInt(r);
-        const row: Record<string, DuckDbValue> = {};
+        // Cross-review P2-1, half two: on a normal `{}` the assignment
+        // `row["__proto__"] = v` hits Object.prototype's `__proto__` SETTER,
+        // which ignores a non-object value - so a `__proto__` column silently
+        // vanished from every row. A null-prototype object has no inherited
+        // accessors at all, so every column name (`__proto__`, `constructor`,
+        // `toString`) round-trips as plain data.
+        const row: Record<string, DuckDbValue> = Object.create(null) as Record<string, DuckDbValue>;
         for (let c = 0; c < columnCount; c += 1) {
             const colIdx = BigInt(c);
             const column = columns[c]!;
@@ -431,22 +492,51 @@ export const makeConnection = (
         // use of that address. Never read directly; it exists to be held.
         const { resultPtr, resultBuf } = runStatement(lib, connHandle, sql, params);
         try {
-            return readResult(lib, resultPtr);
+            return readResult(lib, resultPtr, sql);
         } finally {
             lib.symbols.duckdb_destroy_result(resultPtr);
             void resultBuf;
         }
     };
 
-    const query: DuckDbConnection["query"] = (sql, params = []) =>
-        Effect.try({
-            try: () => runQuery(sql, params),
-            catch: (err) =>
-                err instanceof DuckDbQueryError || err instanceof DuckDbUnsupportedTypeError
-                    ? err
-                    : new DuckDbQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
-        });
+    /**
+     * Cross-review P1-1: `connHandle` is captured ONCE, above, and `close`
+     * frees the database and connection behind it - so every operation issued
+     * after `close` handed a DANGLING pointer to libduckdb. That is not a
+     * catchable error: it was reproduced as a Bun SEGMENTATION FAULT, the
+     * process gone with no stack, no Effect failure, and nothing written to
+     * the caller's log. Use-after-close is a caller bug either way, but this
+     * client's job is to make it a typed failure the caller can see, so every
+     * operation re-checks the flag first and NO native symbol is reached.
+     *
+     * `Effect.suspend` matters: the check has to run when the effect RUNS,
+     * not when it is built - a `query(...)` value constructed before `close`
+     * and run after it must still refuse.
+     */
+    const refuseIfClosed = (sql: string): Effect.Effect<never, DuckDbQueryError> =>
+        Effect.fail(
+            new DuckDbQueryError({
+                sql: sqlExcerpt(sql),
+                message: `the connection to ${path} is closed; open a new one (a statement on a closed connection would dereference a freed native handle)`,
+            }),
+        );
 
+    const query: DuckDbConnection["query"] = (sql, params = []) =>
+        Effect.suspend(() =>
+            closed
+                ? refuseIfClosed(sql)
+                : Effect.try({
+                      try: () => runQuery(sql, params),
+                      catch: (err) =>
+                          err instanceof DuckDbQueryError || err instanceof DuckDbUnsupportedTypeError
+                              ? err
+                              : new DuckDbQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+                  }),
+        );
+
+    // `exec` and `queryAs` both run THROUGH `query`, so the closed-connection
+    // guard above covers all three - there is no second path to the native
+    // handle to forget.
     const exec: DuckDbConnection["exec"] = (sql, params = []) =>
         Effect.map(query(sql, params), (result) => result.rowsChanged);
 
@@ -562,7 +652,21 @@ const makeService = (lib: LibDuckDb, fs: FileSystem.FileSystem): DuckDbService =
      */
     const publishSnapshot: DuckDbService["publishSnapshot"] = (livePath, targetPath, options) => {
         const tmp = `${targetPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
-        const removeTmp = fs.remove(tmp, { force: true, recursive: true }).pipe(Effect.ignore);
+        // Cross-review P3-6: this used to be `Effect.ignore`, so a temp file
+        // that could NOT be removed vanished from the record entirely - and
+        // the temp file here is a COMPLETE COPY of the database, i.e. the
+        // largest piece of litter this module can leave. `force: true`
+        // already tolerates "already gone", so anything reaching this handler
+        // is a real failure and is worth one line in the log. It still must
+        // not fail the publish: this runs as an `Effect.ensuring` finalizer,
+        // where masking the primary error would be worse than the leak.
+        const removeTmp = fs.remove(tmp, { force: true, recursive: true }).pipe(
+            Effect.catch((err) =>
+                Effect.logWarning(
+                    `ax duckdb: could not remove the temporary snapshot copy at ${tmp}: ${err.message}`,
+                ),
+            ),
+        );
 
         const copyThrough = (conn: DuckDbConnection) => {
             // A per-call alias, not a fixed constant. Fix round 1's `from`
@@ -576,12 +680,22 @@ const makeService = (lib: LibDuckDb, fs: FileSystem.FileSystem): DuckDbService =
             // silently, since the connection stays otherwise usable. A
             // randomized alias means the next publish simply never collides.
             const alias = `ax_snapshot_${crypto.randomUUID().replace(/-/g, "")}`;
-            // Best-effort only: DETACHing an alias that was never actually
-            // attached (e.g. this call's OWN `ATTACH` below is what failed)
-            // is expected to fail, and a finalizer passed to
-            // `Effect.ensuring` must be `Effect<X, never, R>` - it can never
-            // fail, and must never mask the real error with a cleanup error.
-            const detach = conn.exec(`DETACH "${alias}"`).pipe(Effect.ignore);
+            // A finalizer passed to `Effect.ensuring` must be
+            // `Effect<X, never, R>` - it can never fail, and must never mask
+            // the real error with a cleanup error. Cross-review P3-7: it used
+            // to be `Effect.ignore`, which is stronger than "do not mask" -
+            // it erased the event. This finalizer only ever runs on a span
+            // whose `ATTACH` ALREADY SUCCEEDED, so a failing DETACH means the
+            // caller's own long-lived connection is still carrying an
+            // attached database (the exact leak `from` was built to avoid),
+            // and the caller has nothing else to go on. Log it, do not fail.
+            const detach = conn.exec(`DETACH "${alias}"`).pipe(
+                Effect.catch((err) =>
+                    Effect.logWarning(
+                        `ax duckdb: could not DETACH the temporary snapshot database "${alias}" after publishing to ${targetPath}: ${err.message}`,
+                    ),
+                ),
+            );
 
             return Effect.gen(function* () {
                 yield* conn.exec("CHECKPOINT");
@@ -615,6 +729,40 @@ const makeService = (lib: LibDuckDb, fs: FileSystem.FileSystem): DuckDbService =
         };
 
         const attempt = Effect.gen(function* () {
+            // Cross-review P1-6 + P2-4, both checked BEFORE anything is
+            // created or opened, and both compared on the CANONICAL path so
+            // `./x`, a relative spelling, or a symlinked directory cannot
+            // fool them (see canonical-path.ts).
+            const canonicalLive = yield* canonicalPath(fs, livePath);
+            const canonicalTarget = yield* canonicalPath(fs, targetPath);
+
+            // P2-4: publishing a database onto ITSELF is never what the
+            // caller means. The rename would replace the live pathname with
+            // the copy, leaving any writer that still holds the original open
+            // on an unlinked inode - its later commits going to a file
+            // nothing can ever read again.
+            if (canonicalLive === canonicalTarget) {
+                return yield* new SnapshotPublishError({
+                    snapshotPath: targetPath,
+                    message: `cannot publish a database onto itself: the live path ${livePath} and the snapshot path ${targetPath} are the same file`,
+                });
+            }
+
+            // P1-6: `from` exists so the copy runs through the connection
+            // that owns the live database (RULING R14). A connection open on
+            // a DIFFERENT database would copy THAT one and publish it under
+            // this snapshot's name - wrong data, no error, indistinguishable
+            // downstream from a successful publish.
+            if (options?.from) {
+                const canonicalFrom = yield* canonicalPath(fs, options.from.path);
+                if (canonicalFrom !== canonicalLive) {
+                    return yield* new SnapshotPublishError({
+                        snapshotPath: targetPath,
+                        message: `options.from is open on a different database (${options.from.path}) than the live path being published (${livePath}); pass the connection that owns the live database`,
+                    });
+                }
+            }
+
             const liveExists = yield* fs.exists(livePath).pipe(
                 Effect.mapError(
                     (err) =>
@@ -704,28 +852,58 @@ const openLibOrFail = (dylibPath: string): Effect.Effect<LibDuckDb, DuckDbDylibE
             }),
     });
 
-const baseLayer = (
-    dylibPath: string,
+/**
+ * The one place a `DuckDb` layer is built, over whatever effect produces the
+ * `LibDuckDb`.
+ *
+ * Cross-review P3-2: `Layer.effect` runs its effect IN THE LAYER'S SCOPE, so
+ * an `Effect.addFinalizer` here is released when the layer is - and `dlopen`
+ * handles are a per-process resource this repo hands out repeatedly (a fresh
+ * `AppLayer` per `run(provide(...))` call is the established shape), so
+ * never calling `lib.close()` retained one dylib handle per layer for the
+ * life of the process. Bun documents `close()` as the release operation.
+ *
+ * Closing is best-effort by design: the finalizer must not fail, and a dylib
+ * that refuses to unload is not a reason to fail a program that has already
+ * finished its work.
+ *
+ * Exported (not on the barrel) so the release is unit-testable against a fake
+ * `LibDuckDb` - a real `dlopen` handle has no observable "was I closed".
+ */
+export const layerFromLib = (
+    openLib: Effect.Effect<LibDuckDb, DuckDbDylibError, FileSystem.FileSystem>,
 ): Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> =>
     Layer.effect(DuckDb)(
         Effect.gen(function* () {
             const fs = yield* FileSystem.FileSystem;
-            const lib = yield* openLibOrFail(dylibPath);
+            const lib = yield* openLib;
+            yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                    try {
+                        lib.close();
+                    } catch {
+                        /* an unloadable dylib must not fail teardown */
+                    }
+                }),
+            );
             return makeService(lib, fs);
         }),
     );
+
+const baseLayer = (
+    dylibPath: string,
+): Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> =>
+    layerFromLib(openLibOrFail(dylibPath));
 
 /** Layer over an explicit dylib path - the injection point for tests and for
  *  the custom static dylib from chunk w0-dylib-ci. */
 export const DuckDbLayer = (dylibPath: string): Layer.Layer<DuckDb, DuckDbDylibError> =>
     baseLayer(dylibPath).pipe(Layer.provide(BunFileSystem.layer));
 
-const baseLive: Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> = Layer.effect(DuckDb)(
+const baseLive: Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> = layerFromLib(
     Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
         const dylibPath = yield* resolveDylibPath();
-        const lib = yield* openLibOrFail(dylibPath);
-        return makeService(lib, fs);
+        return yield* openLibOrFail(dylibPath);
     }),
 );
 

--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -1,0 +1,735 @@
+/**
+ * The `DuckDb` service: open a database, run queries/exec through it, and
+ * close it. Everything downstream in the v2 architecture reads and writes
+ * through this module, so its two jobs are non-negotiable: never leak a
+ * native allocation, and never turn a missing/corrupt database into a silent
+ * empty result.
+ *
+ * Layered on top of ffi.ts's raw symbol table (see that module's docstring
+ * for the handle-convention gotchas) and row-decode.ts's pure accessor/coerce
+ * rules. This module owns:
+ *   - the open/connect/close lifecycle, including the config dance needed to
+ *     force read-only mode and the guard that refuses to silently create a
+ *     database when a read-only caller expected one to already exist,
+ *   - translating every C-level failure into one of this package's tagged
+ *     errors (`DuckDbOpenError` / `DuckDbQueryError` / `DuckDbUnsupportedTypeError`),
+ *   - the parameter-binding dispatch for prepared statements,
+ *   - freeing every `duckdb_value_varchar` pointer and every `duckdb_result` /
+ *     `duckdb_prepared_statement` handle, on every path (success, SQL error,
+ *     decode error) via `try/finally`.
+ *
+ * RULING R6: this is a runtime module under `packages/lib/src/`, so
+ * `node:fs` / `node:path` are banned (`check:no-node-fs`). The read-only
+ * existence guard goes through `FileSystem.FileSystem`, acquired once in the
+ * layer and closed over by every service/connection method - so every method
+ * below keeps `R = never`, exactly as the interfaces declare. `node:os`
+ * `homedir()` is not banned, and `snapshotPath()`'s default
+ * (`~/.ax/cache/ax-snapshot.duckdb`) uses it. `bun:ffi` is fine - this module
+ * is Bun-only regardless.
+ */
+import { ptr } from "bun:ffi";
+import { BunFileSystem } from "@effect/platform-bun";
+import { Context, Effect, FileSystem, Layer, Schema, type Scope } from "effect";
+import { homedir } from "node:os";
+import { posixPath } from "../shared/path.ts";
+import { resolveDylibPath } from "./dylib.ts";
+import {
+    DuckDbDecodeError,
+    DuckDbDylibError,
+    DuckDbOpenError,
+    DuckDbQueryError,
+    DuckDbUnsupportedTypeError,
+    SnapshotPublishError,
+} from "./errors.ts";
+import {
+    cstr,
+    DUCKDB_RESULT_SIZE,
+    DUCKDB_SUCCESS,
+    handleBuffer,
+    openLibDuckDb,
+    readCString,
+    type LibDuckDb,
+} from "./ffi.ts";
+import { accessorFor, coerceValue, unsupportedColumns } from "./row-decode.ts";
+import type { DuckDbColumn, DuckDbParam, DuckDbRow, DuckDbValue, QueryResult } from "./types.ts";
+
+export interface DuckDbConnection {
+    readonly path: string;
+    readonly readOnly: boolean;
+    readonly query: (
+        sql: string,
+        params?: ReadonlyArray<DuckDbParam>,
+    ) => Effect.Effect<QueryResult, DuckDbQueryError | DuckDbUnsupportedTypeError>;
+    readonly queryAs: <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+        params?: ReadonlyArray<DuckDbParam>,
+    ) => Effect.Effect<
+        ReadonlyArray<S["Type"]>,
+        DuckDbQueryError | DuckDbUnsupportedTypeError | DuckDbDecodeError,
+        S["DecodingServices"]
+    >;
+    readonly exec: (
+        sql: string,
+        params?: ReadonlyArray<DuckDbParam>,
+    ) => Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError>;
+    readonly close: Effect.Effect<void>;
+}
+
+export interface DuckDbService {
+    readonly open: (
+        path: string,
+        options?: { readonly readOnly?: boolean },
+    ) => Effect.Effect<DuckDbConnection, DuckDbOpenError>;
+    readonly scoped: (
+        path: string,
+        options?: { readonly readOnly?: boolean },
+    ) => Effect.Effect<DuckDbConnection, DuckDbOpenError, Scope.Scope>;
+    /**
+     * Copy `livePath`'s current contents to `snapshotPath` via an atomic
+     * rename - readers holding the previous snapshot keep reading it
+     * uninterrupted until they reopen. See the docstring above
+     * `makeService`'s `publishSnapshot` for the mechanism, and RULING R14
+     * (same docstring) for why `options.from` is load-bearing whenever a
+     * writer on `livePath` is already open in this process.
+     */
+    readonly publishSnapshot: (
+        livePath: string,
+        snapshotPath: string,
+        options?: { readonly from?: DuckDbConnection },
+    ) => Effect.Effect<void, SnapshotPublishError | DuckDbOpenError>;
+    /** Open a published snapshot read-only. Defaults to {@link snapshotPath}. */
+    readonly openSnapshot: (snapshotPath?: string) => Effect.Effect<DuckDbConnection, DuckDbOpenError>;
+    /** `AX_DUCKDB_SNAPSHOT`, or `~/.ax/cache/ax-snapshot.duckdb`. Pure - same
+     *  value as the module-level {@link snapshotPath} export. */
+    readonly snapshotPath: () => string;
+}
+
+/** `AX_DUCKDB_SNAPSHOT`, or `~/.ax/cache/ax-snapshot.duckdb` - mirrors the
+ *  `AX_DATA_DIR`-less default used by `dylib.ts`/`lock.ts`. */
+export const snapshotPath = (): string => {
+    const override = process.env.AX_DUCKDB_SNAPSHOT?.trim();
+    return override ? override : posixPath.join(homedir(), ".ax", "cache", "ax-snapshot.duckdb");
+};
+
+/** First 200 chars of a statement, mirroring `packages/lib/src/db.ts`'s
+ *  `sqlExcerpt` - every `DuckDbQueryError`/`DuckDbDecodeError` uses it so a
+ *  huge statement never bloats the error. */
+const SQL_EXCERPT_LEN = 200;
+const sqlExcerpt = (sql: string): string =>
+    sql.length > SQL_EXCERPT_LEN ? `${sql.slice(0, SQL_EXCERPT_LEN)}…` : sql;
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/** True for a null/zero pointer - both the `Pointer` shape from a
+ *  `PTR`-typed return and the `bigint` shape read out of a `BigUint64Array`
+ *  out-param show up here. */
+const isNullPointer = (p: number | bigint | null | undefined): boolean =>
+    p === null || p === undefined || p === 0 || p === 0n;
+
+/** Free a `char *` this client owns, tolerating a null pointer. */
+const duckdbFree = (lib: LibDuckDb, p: number | bigint | null | undefined): void => {
+    if (isNullPointer(p)) return;
+    lib.symbols.duckdb_free(Number(p) as never);
+};
+
+/**
+ * Open the database file and connect. Always builds a `duckdb_config` (even
+ * for a read-write open) so the read-only branch is just one extra
+ * `duckdb_set_config` call; the config is always destroyed before returning,
+ * on every path. Throws `DuckDbOpenError` - the caller (`makeService.open`)
+ * wraps this in `Effect.try`.
+ *
+ * The "does the file already exist" check for a read-only open happens
+ * BEFORE this is called (in the effectful `open`, via `FileSystem`) rather
+ * than here, so this function can stay a plain sync throw-on-failure helper
+ * with no `R` channel to thread through.
+ */
+const openDatabase = (
+    lib: LibDuckDb,
+    path: string,
+    readOnly: boolean,
+): { readonly dbBuf: BigUint64Array; readonly connBuf: BigUint64Array } => {
+    const cfgBuf = handleBuffer();
+    const createState = lib.symbols.duckdb_create_config(ptr(cfgBuf));
+    if (createState !== DUCKDB_SUCCESS) {
+        throw new DuckDbOpenError({ path, readOnly, message: "duckdb_create_config failed" });
+    }
+
+    if (readOnly) {
+        const setState = lib.symbols.duckdb_set_config(
+            cfgBuf[0]!,
+            cstr("access_mode"),
+            cstr("READ_ONLY"),
+        );
+        if (setState !== DUCKDB_SUCCESS) {
+            lib.symbols.duckdb_destroy_config(ptr(cfgBuf));
+            throw new DuckDbOpenError({
+                path,
+                readOnly,
+                message: "duckdb_set_config(access_mode, READ_ONLY) failed",
+            });
+        }
+    }
+
+    const dbBuf = handleBuffer();
+    const errBuf = handleBuffer();
+    const openState = lib.symbols.duckdb_open_ext(cstr(path), ptr(dbBuf), cfgBuf[0]!, ptr(errBuf));
+    // Always destroyed, on both the success and failure path.
+    lib.symbols.duckdb_destroy_config(ptr(cfgBuf));
+
+    if (openState !== DUCKDB_SUCCESS) {
+        const message = readCString(errBuf[0]) ?? "duckdb_open_ext failed with no message";
+        duckdbFree(lib, errBuf[0]);
+        throw new DuckDbOpenError({ path, readOnly, message });
+    }
+
+    const connBuf = handleBuffer();
+    const connectState = lib.symbols.duckdb_connect(dbBuf[0]!, ptr(connBuf));
+    if (connectState !== DUCKDB_SUCCESS) {
+        lib.symbols.duckdb_close(ptr(dbBuf));
+        throw new DuckDbOpenError({ path, readOnly, message: "duckdb_connect failed" });
+    }
+
+    return { dbBuf, connBuf };
+};
+
+/** Bind one prepared-statement parameter (1-based `idx`). Returns the
+ *  `duckdb_state` from the underlying bind call so the caller can check it. */
+const bindParam = (lib: LibDuckDb, stmtHandle: bigint, idx: bigint, param: DuckDbParam): number => {
+    if (param === null || param === undefined) return lib.symbols.duckdb_bind_null(stmtHandle, idx);
+    if (typeof param === "boolean") return lib.symbols.duckdb_bind_boolean(stmtHandle, idx, param);
+    if (typeof param === "bigint") return lib.symbols.duckdb_bind_int64(stmtHandle, idx, param);
+    if (typeof param === "number") {
+        return Number.isSafeInteger(param)
+            ? lib.symbols.duckdb_bind_int64(stmtHandle, idx, BigInt(param))
+            : lib.symbols.duckdb_bind_double(stmtHandle, idx, param);
+    }
+    if (param instanceof Date) {
+        return lib.symbols.duckdb_bind_varchar(stmtHandle, idx, cstr(param.toISOString()));
+    }
+    return lib.symbols.duckdb_bind_varchar(stmtHandle, idx, cstr(param));
+};
+
+/** Read the borrowed (result-owned) error message off a just-failed result,
+ *  destroy the result, and build the typed failure. */
+const queryError = (
+    lib: LibDuckDb,
+    sql: string,
+    resultPtr: ReturnType<typeof ptr>,
+): DuckDbQueryError => {
+    const message = readCString(lib.symbols.duckdb_result_error(resultPtr)) ?? "query failed with no message";
+    lib.symbols.duckdb_destroy_result(resultPtr);
+    return new DuckDbQueryError({ sql: sqlExcerpt(sql), message });
+};
+
+/**
+ * Run one statement (query or prepared+bound+execute) and hand back the raw
+ * result buffer. Throws `DuckDbQueryError`. The prepared statement, when one
+ * is created, is always destroyed in a `finally` - on the bind-failure,
+ * execute-failure, and success paths alike.
+ */
+const runStatement = (
+    lib: LibDuckDb,
+    connHandle: bigint,
+    sql: string,
+    params: ReadonlyArray<DuckDbParam>,
+): { readonly resultPtr: ReturnType<typeof ptr>; readonly resultBuf: Uint8Array } => {
+    const resultBuf = new Uint8Array(DUCKDB_RESULT_SIZE);
+    const resultPtr = ptr(resultBuf);
+
+    if (params.length === 0) {
+        const state = lib.symbols.duckdb_query(connHandle, cstr(sql), resultPtr);
+        if (state !== DUCKDB_SUCCESS) throw queryError(lib, sql, resultPtr);
+        return { resultPtr, resultBuf };
+    }
+
+    const stmtBuf = handleBuffer();
+    const prepareState = lib.symbols.duckdb_prepare(connHandle, cstr(sql), ptr(stmtBuf));
+    if (prepareState !== DUCKDB_SUCCESS) {
+        const message =
+            readCString(lib.symbols.duckdb_prepare_error(stmtBuf[0]!)) ??
+            "duckdb_prepare failed with no message";
+        lib.symbols.duckdb_destroy_prepare(ptr(stmtBuf));
+        throw new DuckDbQueryError({ sql: sqlExcerpt(sql), message });
+    }
+
+    try {
+        const stmtHandle = stmtBuf[0]!;
+        for (let i = 0; i < params.length; i += 1) {
+            const bindState = bindParam(lib, stmtHandle, BigInt(i + 1), params[i]);
+            if (bindState !== DUCKDB_SUCCESS) {
+                throw new DuckDbQueryError({
+                    sql: sqlExcerpt(sql),
+                    message: `failed to bind parameter ${i + 1}`,
+                });
+            }
+        }
+
+        const execState = lib.symbols.duckdb_execute_prepared(stmtHandle, resultPtr);
+        if (execState !== DUCKDB_SUCCESS) throw queryError(lib, sql, resultPtr);
+    } finally {
+        lib.symbols.duckdb_destroy_prepare(ptr(stmtBuf));
+    }
+
+    return { resultPtr, resultBuf };
+};
+
+/**
+ * Decode a successful result into `QueryResult`. Throws
+ * `DuckDbUnsupportedTypeError` for the FIRST undecodable column BEFORE
+ * reading any cell - a BLOB (or other unsupported) column must never let a
+ * garbage value through. Every `duckdb_value_varchar` pointer is freed in a
+ * `try/finally` immediately wrapping `readCString`, on every row - freeing
+ * happens whether or not decoding the string itself throws, by construction
+ * rather than by the two calls merely sitting next to each other.
+ *
+ * Fix round 1 (ruling R10, Part B): a column can pass the structural
+ * `unsupportedColumns` check above (it has an accessor kind) and STILL fail
+ * per-cell - `duckdb_value_varchar` returns a NULL `char *` for a handful of
+ * types (`TIME_TZ`/`TIMESTAMP_TZ` confirmed, plus `TIMESTAMP_S`/`_MS`/`_NS`,
+ * `UUID`, `ENUM`, `BIT` in this dylib build - see the comment on
+ * `VARCHAR_TYPES` in row-decode.ts) even though `duckdb_value_is_null`
+ * reports the cell is NOT SQL NULL. That combination - not-null cell, NULL
+ * varchar pointer - is an ACCESSOR FAILURE, not an empty string and not a
+ * real NULL, so it raises `DuckDbUnsupportedTypeError` naming the column
+ * instead of silently decoding to `""`. This is the general guard: it is
+ * what would have caught `TIMESTAMP_TZ` before it shipped, and it is what
+ * catches every other type in the list above today plus whatever DuckDB
+ * adds next. It keys on duckdb.h's own documented contract for
+ * `duckdb_value_varchar` (duckdb.h:1579-1581): "returns the char* value...
+ * NULL if the value cannot be converted" - the NULL return IS the failure
+ * signal, not an implementation quirk being worked around.
+ *
+ * Fix round 2 (ruling R11) - KNOWN, UNFIXED LIMITATION: `duckdb_value_varchar`
+ * returns a plain NUL-terminated `char *` with no accompanying length, and
+ * `readCString` (ffi.ts) decodes it with `new CString(ptr)`, which stops at
+ * the first NUL byte. A VARCHAR value containing an embedded NUL byte (e.g.
+ * `SELECT 'a' || chr(0) || 'b'`) is silently TRUNCATED to `"a"` - no error,
+ * no signal, on the load-bearing read path every v2 caller uses. This is NOT
+ * fixable within this design: the length-carrying accessor
+ * (`duckdb_value_string`, returning `duckdb_string { char *data; idx_t size;
+ * }`) returns that struct BY VALUE, which `bun:ffi` cannot express (no
+ * struct-typed `FFIType` exists at all - the same constraint already
+ * documented in ffi.ts for `duckdb_fetch_chunk`/`duckdb_result`). Callers
+ * storing arbitrary text (e.g. JSON transcripts, which can carry `\0`)
+ * through this client must reject or escape NUL bytes before writing, since
+ * this client cannot detect the truncation on the way back out.
+ */
+// Exported (not part of the DuckDbService/DuckDbConnection product surface)
+// so fix round 1's Part B guard can be unit-tested directly against a fake
+// LibDuckDb: Part A now excludes every currently-known trigger of the guard
+// from VARCHAR_TYPES structurally, so no real SQL type reaches it any more -
+// see client.test.ts.
+export const readResult = (lib: LibDuckDb, resultPtr: ReturnType<typeof ptr>): QueryResult => {
+    const columnCount = Number(lib.symbols.duckdb_column_count(resultPtr));
+    const columns: DuckDbColumn[] = [];
+    for (let c = 0; c < columnCount; c += 1) {
+        const idx = BigInt(c);
+        const name = readCString(lib.symbols.duckdb_column_name(resultPtr, idx)) ?? `column_${c}`;
+        const typeId = lib.symbols.duckdb_column_type(resultPtr, idx);
+        columns.push({ name, typeId });
+    }
+
+    const unsupported = unsupportedColumns(columns);
+    if (unsupported.length > 0) {
+        const first = unsupported[0]!;
+        throw new DuckDbUnsupportedTypeError({ column: first.name, typeId: first.typeId });
+    }
+
+    // Hoisted out of the row loop: every column's accessor kind is invariant
+    // across rows, and `unsupportedColumns` above already proved none is null.
+    const columnKinds = columns.map((c) => accessorFor(c.typeId));
+
+    const rowCount = Number(lib.symbols.duckdb_row_count(resultPtr));
+    const rows: DuckDbRow[] = [];
+    for (let r = 0; r < rowCount; r += 1) {
+        const rowIdx = BigInt(r);
+        const row: Record<string, DuckDbValue> = {};
+        for (let c = 0; c < columnCount; c += 1) {
+            const colIdx = BigInt(c);
+            const column = columns[c]!;
+
+            if (lib.symbols.duckdb_value_is_null(resultPtr, colIdx, rowIdx)) {
+                row[column.name] = null;
+                continue;
+            }
+
+            const kind = columnKinds[c];
+            let raw: boolean | bigint | number | string;
+            switch (kind) {
+                case "boolean":
+                    raw = lib.symbols.duckdb_value_boolean(resultPtr, colIdx, rowIdx);
+                    break;
+                case "int64":
+                    raw = lib.symbols.duckdb_value_int64(resultPtr, colIdx, rowIdx);
+                    break;
+                case "uint64":
+                    raw = lib.symbols.duckdb_value_uint64(resultPtr, colIdx, rowIdx);
+                    break;
+                case "double":
+                    raw = lib.symbols.duckdb_value_double(resultPtr, colIdx, rowIdx);
+                    break;
+                case "varchar": {
+                    const strPtr = lib.symbols.duckdb_value_varchar(resultPtr, colIdx, rowIdx);
+                    if (isNullPointer(strPtr)) {
+                        // duckdb_value_is_null already said this cell is NOT
+                        // SQL NULL, so a NULL char* here means the row-major
+                        // accessor cannot render this type at all - see the
+                        // fix-round-1 note on this function.
+                        throw new DuckDbUnsupportedTypeError({
+                            column: column.name,
+                            typeId: column.typeId,
+                        });
+                    }
+                    try {
+                        raw = readCString(strPtr) ?? "";
+                    } finally {
+                        duckdbFree(lib, strPtr);
+                    }
+                    break;
+                }
+                default:
+                    // unreachable: unsupportedColumns() above already excluded
+                    // every column whose accessorFor() is null.
+                    throw new DuckDbUnsupportedTypeError({ column: column.name, typeId: column.typeId });
+            }
+            row[column.name] = coerceValue(column.typeId, raw);
+        }
+        rows.push(row);
+    }
+
+    const rowsChanged = Number(lib.symbols.duckdb_rows_changed(resultPtr));
+    return { columns, rows, rowsChanged };
+};
+
+// Exported (not part of the DuckDbService/DuckDbConnection product surface,
+// same rationale as readResult above) so fix round 2's close/idempotency
+// tests can drive a connection against a fake LibDuckDb and count
+// duckdb_disconnect/duckdb_close calls directly, instead of relying on an
+// indirect, unreliable proxy (a read-only reopen of the same path does NOT
+// prove the write handle was released - opening a path read-only while a
+// write handle is still open on it succeeds against this dylib).
+/** Build the `DuckDbConnection` for one open database handle. */
+export const makeConnection = (
+    lib: LibDuckDb,
+    path: string,
+    readOnly: boolean,
+    dbBuf: BigUint64Array,
+    connBuf: BigUint64Array,
+): DuckDbConnection => {
+    const connHandle = connBuf[0]!;
+    let closed = false;
+
+    /** Run `sql`, always destroying the native result exactly once, whether
+     *  decoding succeeds, fails with `DuckDbUnsupportedTypeError`, or a lower
+     *  layer throws something unexpected. */
+    const runQuery = (sql: string, params: ReadonlyArray<DuckDbParam>): QueryResult => {
+        // `resultBuf` is bound (not discarded) so it stays a live local
+        // reference for the duration of this call - `resultPtr` is a raw
+        // address into its backing store, so the buffer must outlive every
+        // use of that address. Never read directly; it exists to be held.
+        const { resultPtr, resultBuf } = runStatement(lib, connHandle, sql, params);
+        try {
+            return readResult(lib, resultPtr);
+        } finally {
+            lib.symbols.duckdb_destroy_result(resultPtr);
+            void resultBuf;
+        }
+    };
+
+    const query: DuckDbConnection["query"] = (sql, params = []) =>
+        Effect.try({
+            try: () => runQuery(sql, params),
+            catch: (err) =>
+                err instanceof DuckDbQueryError || err instanceof DuckDbUnsupportedTypeError
+                    ? err
+                    : new DuckDbQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+        });
+
+    const exec: DuckDbConnection["exec"] = (sql, params = []) =>
+        Effect.map(query(sql, params), (result) => result.rowsChanged);
+
+    const queryAs: DuckDbConnection["queryAs"] = (schema, sql, params) =>
+        query(sql, params).pipe(
+            Effect.flatMap((result) =>
+                Schema.decodeUnknownEffect(Schema.Array(schema))(result.rows).pipe(
+                    Effect.mapError(
+                        (issue) => new DuckDbDecodeError({ sql: sqlExcerpt(sql), message: issue.message }),
+                    ),
+                ),
+            ),
+        );
+
+    const close: Effect.Effect<void> = Effect.sync(() => {
+        if (closed) return;
+        closed = true;
+        lib.symbols.duckdb_disconnect(ptr(connBuf));
+        lib.symbols.duckdb_close(ptr(dbBuf));
+    });
+
+    return { path, readOnly, query, queryAs, exec, close };
+};
+
+/** Build the `DuckDbService` over an already-opened `LibDuckDb`. `fs` is
+ *  closed over from the layer so `open`/`scoped` stay `R = never`. */
+const makeService = (lib: LibDuckDb, fs: FileSystem.FileSystem): DuckDbService => {
+    const open: DuckDbService["open"] = (path, options) => {
+        const readOnly = options?.readOnly ?? false;
+        return Effect.gen(function* () {
+            if (readOnly) {
+                // DuckDB happily creates an empty database on open when one
+                // doesn't exist - fine for read-write, but for a read-only
+                // open that would silently turn "the snapshot is missing"
+                // into an empty result set instead of a legible error.
+                const exists = yield* fs.exists(path).pipe(
+                    Effect.mapError(
+                        (err) =>
+                            new DuckDbOpenError({
+                                path,
+                                readOnly,
+                                message: `failed to check whether the database file exists: ${err.message}`,
+                            }),
+                    ),
+                );
+                if (!exists) {
+                    return yield* new DuckDbOpenError({
+                        path,
+                        readOnly,
+                        message: `cannot open read-only: no database file at ${path}`,
+                    });
+                }
+            }
+
+            const { dbBuf, connBuf } = yield* Effect.try({
+                try: () => openDatabase(lib, path, readOnly),
+                catch: (err) =>
+                    err instanceof DuckDbOpenError
+                        ? err
+                        : new DuckDbOpenError({ path, readOnly, message: errorMessage(err) }),
+            });
+
+            return makeConnection(lib, path, readOnly, dbBuf, connBuf);
+        });
+    };
+
+    const scoped: DuckDbService["scoped"] = (path, options) =>
+        Effect.acquireRelease(open(path, options), (conn) => conn.close);
+
+    /**
+     * Copy `livePath`'s current contents to `targetPath` via DuckDB's own
+     * `COPY FROM DATABASE ... TO` (which snapshots the live catalog, not
+     * merely the file bytes), landing the copy at a TEMP PATH THAT IS A
+     * SIBLING OF `targetPath` and only then `fs.rename`-ing it into place.
+     * Same directory -> same filesystem -> the rename is atomic (never
+     * `EXDEV`), which is the entire point: a reader that already has
+     * `targetPath` open keeps reading the OLD inode uninterrupted for as long
+     * as it holds that handle, even while this swaps in a new one.
+     *
+     * The writer connection doing the copy is closed BEFORE the rename
+     * (inside the `Effect.ensuring` guarding the copy - or, with
+     * `options.from`, simply never closed at all, see below), so the temp
+     * file never has an open writer at the moment it becomes the published
+     * snapshot. The whole operation is wrapped in an outer `Effect.ensuring`
+     * that removes the temp file unconditionally - on success it is already
+     * gone (renamed away) so the removal is a harmless no-op; on any failure
+     * it deletes the half-written temp file, so `targetPath` - which nothing
+     * touches until the final rename - is left exactly as it was.
+     *
+     * RULING R14 - READ THIS BEFORE CALLING WITHOUT `options.from`:
+     * without `options.from`, this function opens its OWN, SEPARATE
+     * `duckdb_open_ext` handle on `livePath`. If another handle on that same
+     * path is ALREADY OPEN IN THIS PROCESS - e.g. an ingest writer, which is
+     * exactly the epic's intended call site ("writes happen inside ingest
+     * against the live database... publish is the hand-off at the end of
+     * that ingest") - this second handle is NOT guaranteed to observe the
+     * first handle's later commits. Confirmed empirically: a writer that
+     * inserted rows up to a count of 5 while a bare (no-`from`)
+     * `publishSnapshot` call ran concurrently produced a published snapshot
+     * frozen at 3 - two committed rows silently missing, no error anywhere.
+     * The `CHECKPOINT` this function issues runs on ITS OWN instance, so it
+     * cannot flush a DIFFERENT open instance's state.
+     *
+     * The fix is `options.from`: pass the writer's own already-open
+     * `DuckDbConnection` and this function runs `CHECKPOINT` / `ATTACH` /
+     * `COPY FROM DATABASE` / `DETACH` on THAT connection instead of opening a
+     * second one - so it always sees exactly what the writer has committed.
+     * This function never closes a connection handed in via `options.from`;
+     * the caller owns its lifecycle. Calling without `options.from` is only
+     * safe when no writer on `livePath` is open in this process (e.g. a
+     * standalone snapshot command run after ingest has fully exited) - do
+     * not use it as the ingest-time publish path.
+     */
+    const publishSnapshot: DuckDbService["publishSnapshot"] = (livePath, targetPath, options) => {
+        const tmp = `${targetPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+        const removeTmp = fs.remove(tmp, { force: true, recursive: true }).pipe(Effect.ignore);
+
+        const copyThrough = (conn: DuckDbConnection) => {
+            // A per-call alias, not a fixed constant. Fix round 1's `from`
+            // hands publishSnapshot a caller-owned, LONG-LIVED connection
+            // that is reused across repeated publishes - the whole point of
+            // R14. If a mid-copy failure somehow left this call's ATTACH
+            // un-DETACHed despite the `Effect.ensuring` below (e.g. an
+            // interruption racing the finalizer itself), a FIXED alias would
+            // permanently poison every later publish on that same
+            // connection with "database ax_snapshot already exists" -
+            // silently, since the connection stays otherwise usable. A
+            // randomized alias means the next publish simply never collides.
+            const alias = `ax_snapshot_${crypto.randomUUID().replace(/-/g, "")}`;
+            // Best-effort only: DETACHing an alias that was never actually
+            // attached (e.g. this call's OWN `ATTACH` below is what failed)
+            // is expected to fail, and a finalizer passed to
+            // `Effect.ensuring` must be `Effect<X, never, R>` - it can never
+            // fail, and must never mask the real error with a cleanup error.
+            const detach = conn.exec(`DETACH "${alias}"`).pipe(Effect.ignore);
+
+            return Effect.gen(function* () {
+                yield* conn.exec("CHECKPOINT");
+                const escapedTmp = tmp.replace(/'/g, "''");
+                yield* conn.exec(`ATTACH '${escapedTmp}' AS "${alias}"`);
+                // RULING R14 fix round 2: from here on, whatever happens -
+                // success, a typed query failure, a defect, or interruption -
+                // DETACH is guaranteed to run (`Effect.ensuring`), so a
+                // long-lived `from` connection is never left with a
+                // permanently attached database after a mid-copy failure.
+                yield* Effect.gen(function* () {
+                    const nameRow = (yield* conn.query("SELECT current_database() AS n")).rows[0];
+                    if (nameRow === undefined) {
+                        return yield* new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: "SELECT current_database() returned no rows",
+                        });
+                    }
+                    const dbName = String(nameRow.n).replace(/"/g, '""');
+                    yield* conn.exec(`COPY FROM DATABASE "${dbName}" TO "${alias}"`);
+                }).pipe(Effect.ensuring(detach));
+            }).pipe(
+                Effect.mapError(
+                    (err) =>
+                        new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: `failed to copy live database to snapshot: ${err.message}`,
+                        }),
+                ),
+            );
+        };
+
+        const attempt = Effect.gen(function* () {
+            const liveExists = yield* fs.exists(livePath).pipe(
+                Effect.mapError(
+                    (err) =>
+                        new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: `failed to check whether the live database exists: ${err.message}`,
+                        }),
+                ),
+            );
+            if (!liveExists) {
+                return yield* new SnapshotPublishError({
+                    snapshotPath: targetPath,
+                    message: `cannot publish snapshot: no live database at ${livePath}`,
+                });
+            }
+
+            // A leftover temp file from a prior crashed/interrupted publish
+            // must not collide with this run's ATTACH.
+            yield* removeTmp;
+
+            yield* fs.makeDirectory(posixPath.dirname(targetPath), { recursive: true }).pipe(
+                Effect.mapError(
+                    (err) =>
+                        new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: `failed to create the snapshot directory: ${err.message}`,
+                        }),
+                ),
+            );
+
+            if (options?.from) {
+                // Caller-owned connection - copy through it directly (RULING
+                // R14) and never close it, we don't own its lifecycle.
+                yield* copyThrough(options.from);
+            } else {
+                // Finding 6 (final fix round): `open` then `copyThrough` used
+                // to be two separate `yield*`s, so an interrupt landing
+                // BETWEEN them leaked the write handle on the live database
+                // for the life of the process - `conn.close` was never
+                // reached because `Effect.ensuring` was only attached to the
+                // SECOND yield. `acquireUseRelease` (the non-scoped sibling
+                // of the `Effect.acquireRelease` `scoped` already uses above)
+                // makes acquire+use+release one atomic unit: acquisition is
+                // uninterruptible, and release is guaranteed to run once
+                // acquisition succeeds, however `use` ends - success, typed
+                // failure, defect, or interruption. Close the writer BEFORE
+                // the rename below, on every path.
+                yield* Effect.acquireUseRelease(
+                    open(livePath, { readOnly: false }),
+                    (conn) => copyThrough(conn),
+                    (conn) => conn.close,
+                );
+            }
+
+            yield* fs.rename(tmp, targetPath).pipe(
+                Effect.mapError(
+                    (err) =>
+                        new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: `failed to rename the temp snapshot into place: ${err.message}`,
+                        }),
+                ),
+            );
+        });
+
+        return attempt.pipe(Effect.ensuring(removeTmp));
+    };
+
+    const openSnapshot: DuckDbService["openSnapshot"] = (path) =>
+        open(path ?? snapshotPath(), { readOnly: true });
+
+    return { open, scoped, publishSnapshot, openSnapshot, snapshotPath };
+};
+
+export class DuckDb extends Context.Service<DuckDb, DuckDbService>()("ax/DuckDb") {}
+
+/** `dlopen` throws synchronously - on a missing file AND on a missing symbol
+ *  (ruling R2) - never let that surface as an unhandled defect. Shared by
+ *  both layer constructors below so a bad dylib path is a typed
+ *  `DuckDbDylibError` through either one. */
+const openLibOrFail = (dylibPath: string): Effect.Effect<LibDuckDb, DuckDbDylibError> =>
+    Effect.try({
+        try: () => openLibDuckDb(dylibPath),
+        catch: (err) =>
+            new DuckDbDylibError({
+                message: `failed to open libduckdb at ${dylibPath}: ${errorMessage(err)}`,
+            }),
+    });
+
+const baseLayer = (
+    dylibPath: string,
+): Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> =>
+    Layer.effect(DuckDb)(
+        Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const lib = yield* openLibOrFail(dylibPath);
+            return makeService(lib, fs);
+        }),
+    );
+
+/** Layer over an explicit dylib path - the injection point for tests and for
+ *  the custom static dylib from chunk w0-dylib-ci. */
+export const DuckDbLayer = (dylibPath: string): Layer.Layer<DuckDb, DuckDbDylibError> =>
+    baseLayer(dylibPath).pipe(Layer.provide(BunFileSystem.layer));
+
+const baseLive: Layer.Layer<DuckDb, DuckDbDylibError, FileSystem.FileSystem> = Layer.effect(DuckDb)(
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dylibPath = yield* resolveDylibPath();
+        const lib = yield* openLibOrFail(dylibPath);
+        return makeService(lib, fs);
+    }),
+);
+
+/** Layer that resolves the dylib itself (env override / bundled asset). */
+export const DuckDbLive: Layer.Layer<DuckDb, DuckDbDylibError> = baseLive.pipe(
+    Layer.provide(BunFileSystem.layer),
+);

--- a/packages/lib/src/duckdb/dylib.test.ts
+++ b/packages/lib/src/duckdb/dylib.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { BunFileSystem } from "@effect/platform-bun";
+import { Effect } from "effect";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { extractDylib, isEmbeddedPath, resolveDylibPath } from "./dylib.ts";
+
+// Finding 4 (final fix round): every dir this suite creates is collected here
+// and removed in one afterAll - `mkdtempSync` with no cleanup was leaking
+// +43 dirs / +10 MB per full duckdb suite run (1,784 dirs / 670 MB measured
+// on the reviewer's machine). `force: true` tolerates a dir already gone.
+const createdTempDirs: string[] = [];
+const tempDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-duckdb-dylib-"));
+    createdTempDirs.push(dir);
+    return dir;
+};
+
+afterAll(() => {
+    for (const dir of createdTempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** RULING R6: both effects need `FileSystem.FileSystem` - run every call
+ *  through `BunFileSystem.layer`. */
+const runWithFs = <A, E>(eff: Effect.Effect<A, E, import("effect").FileSystem.FileSystem>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(BunFileSystem.layer)));
+
+describe("isEmbeddedPath", () => {
+    test("recognises the compiled-binary virtual filesystem", () => {
+        expect(isEmbeddedPath("/$bunfs/root/libduckdb.dylib")).toBe(true);
+        expect(isEmbeddedPath("B:/~BUN/root/libduckdb.dylib")).toBe(true);
+        expect(isEmbeddedPath("/Users/x/vendor/libduckdb.dylib")).toBe(false);
+    });
+});
+
+describe("extractDylib", () => {
+    test("writes the bytes to a content-hash path under the cache dir", async () => {
+        const dir = tempDir();
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "duckdb-bytes");
+        const cache = join(dir, "cache");
+
+        const out = await runWithFs(extractDylib(source, cache));
+
+        expect(out.startsWith(cache)).toBe(true);
+        expect(existsSync(out)).toBe(true);
+        expect(await Bun.file(out).text()).toBe("duckdb-bytes");
+    });
+
+    test("different bytes land on different paths", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const a = join(dir, "a.bin");
+        const b = join(dir, "b.bin");
+        await Bun.write(a, "aaaa");
+        await Bun.write(b, "bbbb");
+
+        expect(await runWithFs(extractDylib(a, cache))).not.toBe(await runWithFs(extractDylib(b, cache)));
+    });
+
+    test("reuses an already-extracted file instead of rewriting it", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "duckdb-bytes");
+
+        const first = await runWithFs(extractDylib(source, cache));
+        const firstMtime = statSync(first).mtimeMs;
+        await Bun.sleep(15);
+        const second = await runWithFs(extractDylib(source, cache));
+
+        expect(second).toBe(first);
+        expect(statSync(second).mtimeMs).toBe(firstMtime);
+        // The reuse path must never leave a staging file behind either.
+        expect(readdirSync(cache).length).toBe(1);
+    });
+});
+
+describe("resolveDylibPath", () => {
+    test("prefers AX_DUCKDB_DYLIB when it exists", async () => {
+        const dir = tempDir();
+        const injected = join(dir, "injected.dylib");
+        await Bun.write(injected, "x");
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        process.env.AX_DUCKDB_DYLIB = injected;
+        try {
+            expect(await runWithFs(resolveDylibPath())).toBe(injected);
+        } finally {
+            if (prev === undefined) delete process.env.AX_DUCKDB_DYLIB;
+            else process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+
+    test("returns a real on-disk asset path unchanged (source mode)", async () => {
+        const dir = tempDir();
+        const asset = join(dir, "libduckdb.dylib");
+        await Bun.write(asset, "x");
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        delete process.env.AX_DUCKDB_DYLIB;
+        try {
+            expect(await runWithFs(resolveDylibPath({ assetPath: asset }))).toBe(asset);
+        } finally {
+            if (prev !== undefined) process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+
+    test("fails with a typed error when nothing resolves", async () => {
+        const dir = tempDir();
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        delete process.env.AX_DUCKDB_DYLIB;
+        try {
+            // effect@4 beta: `Effect.either` is gone; `Effect.result` produces
+            // a `Result` (`_tag: "Success" | "Failure"`, not Either's Left/Right).
+            const result = await runWithFs(
+                Effect.result(resolveDylibPath({ assetPath: join(dir, "missing.dylib") })),
+            );
+            expect(result._tag).toBe("Failure");
+            if (result._tag === "Failure") expect(result.failure._tag).toBe("DuckDbDylibError");
+        } finally {
+            if (prev !== undefined) process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+});

--- a/packages/lib/src/duckdb/dylib.ts
+++ b/packages/lib/src/duckdb/dylib.ts
@@ -1,0 +1,169 @@
+/**
+ * Where libduckdb comes from at runtime.
+ *
+ * Source mode (`bun run`): the asset path is already a real file, hand it back.
+ * Compiled mode (`bun build --compile`): the asset lives in the binary's
+ * virtual filesystem, and `dlopen` cannot open a `$bunfs` path - the bytes must
+ * be materialised on disk first. They go to a CONTENT-HASH path so a given
+ * binary extracts once and every later run (and every concurrent process)
+ * reuses the same file. Mirrors the studio-embed pattern in
+ * `scripts/gen-studio-embed.ts`.
+ *
+ * `AX_DUCKDB_DYLIB` overrides everything - it is how tests, and later the
+ * custom static dylib from chunk w0-dylib-ci, inject their own build.
+ *
+ * RULING R6: this is a runtime module under `packages/lib/src/`, so
+ * `node:fs` / `node:path` are banned (`check:no-node-fs`). Filesystem access
+ * goes through `FileSystem.FileSystem`; path joins go through `posixPath`
+ * (`@ax/lib/shared/path`). `node:os#homedir` is not banned and stays.
+ */
+import { Effect, FileSystem, type PlatformError } from "effect";
+import { homedir } from "node:os";
+import { posixPath } from "../shared/path.ts";
+import { DuckDbDylibError } from "./errors.ts";
+
+export interface ResolveDylibOptions {
+    /** The bundled asset path (a `{ type: "file" }` import in compiled mode). */
+    readonly assetPath?: string;
+    /** Where extracted copies land. Defaults to {@link dylibCacheDir}. */
+    readonly cacheDir?: string;
+}
+
+/** `~/.ax/cache/duckdb` (honours `AX_DATA_DIR`, like the serve pidfile). */
+export const dylibCacheDir = (): string => {
+    const base = process.env.AX_DATA_DIR?.trim();
+    return base
+        ? posixPath.join(base, "duckdb")
+        : posixPath.join(homedir(), ".ax", "cache", "duckdb");
+};
+
+/** Is this path inside a compiled binary's virtual filesystem? */
+export const isEmbeddedPath = (p: string): boolean =>
+    p.startsWith("/$bunfs/") || p.startsWith("B:/~BUN/") || p.startsWith("/~BUN/");
+
+/** Map a `PlatformError` into this module's own typed failure. */
+const toDylibError =
+    (context: string) =>
+    (err: PlatformError.PlatformError): DuckDbDylibError =>
+        new DuckDbDylibError({ message: `${context}: ${err.message}` });
+
+/**
+ * Materialise `embeddedPath`'s bytes at `<cacheDir>/<sha256-16>-libduckdb`,
+ * reusing an existing extraction. The hash is over the CONTENT, so a rebuilt
+ * binary with a new dylib gets a new path instead of racing the old one.
+ *
+ * Concurrency: the reuse check (`fs.exists`) runs BEFORE anything is staged,
+ * so a process that finds the file already present never touches the
+ * filesystem again - no staging file, no leaked temp entry. When extraction
+ * IS needed, the bytes are staged at a pid-suffixed sibling and published with
+ * `fs.rename` (same directory, so the rename is atomic on every platform this
+ * runs on) - two processes racing the same content hash both stage under
+ * distinct names and both rename onto the same `out` path; since the bytes
+ * are identical (same content hash), whichever rename lands last still
+ * produces the correct file, and neither process can observe a partially
+ * written dylib.
+ */
+export const extractDylib = (
+    embeddedPath: string,
+    cacheDir: string,
+): Effect.Effect<string, DuckDbDylibError, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+
+        const bytes = yield* Effect.tryPromise({
+            try: () => Bun.file(embeddedPath).arrayBuffer(),
+            catch: (err) =>
+                new DuckDbDylibError({
+                    message: `failed to read the embedded dylib bytes at ${embeddedPath}: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                }),
+        });
+
+        const digest = yield* Effect.sync(() => {
+            const hasher = new Bun.CryptoHasher("sha256");
+            hasher.update(new Uint8Array(bytes));
+            return hasher.digest("hex").slice(0, 16);
+        });
+
+        const out = posixPath.join(cacheDir, `${digest}-libduckdb`);
+
+        const alreadyExtracted = yield* fs
+            .exists(out)
+            .pipe(Effect.mapError(toDylibError(`failed to check for an existing extraction at ${out}`)));
+        if (alreadyExtracted) return out;
+
+        yield* fs
+            .makeDirectory(cacheDir, { recursive: true })
+            .pipe(Effect.mapError(toDylibError(`failed to create the dylib cache dir ${cacheDir}`)));
+
+        // Stage in a pid-suffixed sibling and rename, so a concurrent reader
+        // can never observe a half-written dylib. `Effect.ensuring` removes
+        // the staging file on ANY failure between write and rename (after a
+        // successful rename it is already gone, so the cleanup is a no-op) -
+        // same crash-safety shape as writeFileAtomic in atomic-write.ts.
+        const staging = `${out}.${process.pid}.tmp`;
+        const stageAndPublish = Effect.gen(function* () {
+            yield* Effect.tryPromise({
+                try: () => Bun.write(staging, bytes),
+                catch: (err) =>
+                    new DuckDbDylibError({
+                        message: `failed to stage the extracted dylib at ${staging}: ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    }),
+            });
+
+            yield* fs
+                .rename(staging, out)
+                .pipe(Effect.mapError(toDylibError(`failed to publish the extracted dylib to ${out}`)));
+        });
+
+        yield* stageAndPublish.pipe(Effect.ensuring(fs.remove(staging).pipe(Effect.ignore)));
+
+        return out;
+    });
+
+/**
+ * Resolve the libduckdb path to hand to `dlopen`. Order:
+ *   1. `AX_DUCKDB_DYLIB` - explicit override; fails if it points nowhere.
+ *   2. `options.assetPath` - the bundled asset. If it is a real on-disk file
+ *      (source mode), hand it back unchanged. If it lives in `$bunfs`
+ *      (compiled mode), extract it first.
+ *   3. Neither is set - a typed failure naming both knobs.
+ */
+export const resolveDylibPath = (
+    options?: ResolveDylibOptions,
+): Effect.Effect<string, DuckDbDylibError, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+
+        const injected = process.env.AX_DUCKDB_DYLIB?.trim();
+        if (injected) {
+            const exists = yield* fs
+                .exists(injected)
+                .pipe(Effect.mapError(toDylibError(`failed to check AX_DUCKDB_DYLIB at ${injected}`)));
+            if (exists) return injected;
+            return yield* new DuckDbDylibError({
+                message: `AX_DUCKDB_DYLIB points at a missing file: ${injected}`,
+            });
+        }
+
+        const asset = options?.assetPath;
+        if (asset === undefined) {
+            return yield* new DuckDbDylibError({
+                message:
+                    "no libduckdb available: set AX_DUCKDB_DYLIB, or pass assetPath from the embedded build",
+            });
+        }
+
+        if (!isEmbeddedPath(asset)) {
+            const exists = yield* fs
+                .exists(asset)
+                .pipe(Effect.mapError(toDylibError(`failed to check the bundled asset path ${asset}`)));
+            if (exists) return asset;
+            return yield* new DuckDbDylibError({ message: `libduckdb not found at ${asset}` });
+        }
+
+        return yield* extractDylib(asset, options?.cacheDir ?? dylibCacheDir());
+    });

--- a/packages/lib/src/duckdb/dylib.ts
+++ b/packages/lib/src/duckdb/dylib.ts
@@ -97,12 +97,22 @@ export const extractDylib = (
             .makeDirectory(cacheDir, { recursive: true })
             .pipe(Effect.mapError(toDylibError(`failed to create the dylib cache dir ${cacheDir}`)));
 
-        // Stage in a pid-suffixed sibling and rename, so a concurrent reader
-        // can never observe a half-written dylib. `Effect.ensuring` removes
-        // the staging file on ANY failure between write and rename (after a
-        // successful rename it is already gone, so the cleanup is a no-op) -
-        // same crash-safety shape as writeFileAtomic in atomic-write.ts.
-        const staging = `${out}.${process.pid}.tmp`;
+        // Stage in a UNIQUELY-suffixed sibling and rename, so a concurrent
+        // reader can never observe a half-written dylib. `Effect.ensuring`
+        // removes the staging file on ANY failure between write and rename
+        // (after a successful rename it is already gone, so the cleanup is a
+        // no-op) - same crash-safety shape as writeFileAtomic in
+        // atomic-write.ts.
+        //
+        // Cross-review P3-3: the suffix used to be the pid ALONE, which is
+        // not unique WITHIN a process - two fibers extracting the same
+        // content hash concurrently (a plausible shape: two layers built in
+        // parallel) shared one staging path, so one could rename or remove
+        // the file the other was still writing, and a caller could see
+        // truncated bytes or a bare NotFound. A random component makes the
+        // staging name unique per call, which is what the rename-to-publish
+        // dance already assumed.
+        const staging = `${out}.${process.pid}.${crypto.randomUUID()}.tmp`;
         const stageAndPublish = Effect.gen(function* () {
             yield* Effect.tryPromise({
                 try: () => Bun.write(staging, bytes),

--- a/packages/lib/src/duckdb/errors.test.ts
+++ b/packages/lib/src/duckdb/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+    DuckDbDecodeError,
+    DuckDbDylibError,
+    DuckDbOpenError,
+    DuckDbQueryError,
+    DuckDbUnsupportedTypeError,
+    IngestLockHeldError,
+    SnapshotPublishError,
+} from "./errors.ts";
+
+describe("duckdb errors", () => {
+    test("each error carries its discriminating tag", () => {
+        expect(new DuckDbOpenError({ path: "/tmp/x.db", readOnly: true, message: "boom" })._tag)
+            .toBe("DuckDbOpenError");
+        expect(new DuckDbQueryError({ sql: "SELECT 1", message: "boom" })._tag)
+            .toBe("DuckDbQueryError");
+        expect(new DuckDbDecodeError({ sql: "SELECT 1", message: "bad row" })._tag)
+            .toBe("DuckDbDecodeError");
+        expect(new DuckDbUnsupportedTypeError({ column: "payload", typeId: 18 })._tag)
+            .toBe("DuckDbUnsupportedTypeError");
+        expect(new DuckDbDylibError({ message: "not found" })._tag).toBe("DuckDbDylibError");
+        expect(
+            new IngestLockHeldError({
+                path: "/tmp/ingest.lock",
+                pid: 42,
+                startedAt: "2026-08-14T00:00:00.000Z",
+            })._tag,
+        ).toBe("IngestLockHeldError");
+        expect(new SnapshotPublishError({ snapshotPath: "/tmp/s.db", message: "boom" })._tag)
+            .toBe("SnapshotPublishError");
+    });
+
+    test("the unsupported-type error names the column and how to work around it", () => {
+        const err = new DuckDbUnsupportedTypeError({ column: "payload", typeId: 18 });
+        expect(err.message).toContain("payload");
+        expect(err.message).toContain("BLOB");
+        expect(err.message).toContain("hex(payload)");
+    });
+
+    test("nested types suggest to_json instead of hex", () => {
+        const err = new DuckDbUnsupportedTypeError({ column: "tags", typeId: 24 /* LIST */ });
+        expect(err.message).toContain("to_json(tags)");
+    });
+
+    // Fix round 1 (ruling R10): every accessor-failure type (the eight swept
+    // against libduckdb v1.5.5, plus whatever the general Part B guard
+    // catches next) wants a CAST suggestion, not hex()/to_json() - neither
+    // of those apply to a scalar type.
+    test("every accessor-failure type suggests CAST(col AS VARCHAR)", () => {
+        for (const [column, typeId] of [
+            ["t", 30 /* TIME_TZ */],
+            ["ts", 31 /* TIMESTAMP_TZ */],
+            ["id", 27 /* UUID */],
+            ["created", 20 /* TIMESTAMP_S */],
+        ] as const) {
+            const err = new DuckDbUnsupportedTypeError({ column, typeId });
+            expect(err.message).toContain(`CAST(${column} AS VARCHAR)`);
+        }
+    });
+});

--- a/packages/lib/src/duckdb/errors.ts
+++ b/packages/lib/src/duckdb/errors.ts
@@ -1,0 +1,103 @@
+import { Schema } from "effect";
+import { DuckDbTypeId, duckDbTypeName } from "./types.ts";
+
+const NESTED_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.LIST,
+    DuckDbTypeId.STRUCT,
+    DuckDbTypeId.MAP,
+    DuckDbTypeId.UNION,
+    DuckDbTypeId.ARRAY,
+]);
+
+/**
+ * The SQL to suggest projecting the column through instead, tailored to WHY
+ * this client can't decode `typeId`: BLOB and the nested types have no
+ * row-major accessor at all, while `TIME_TZ`/`TIMESTAMP_TZ` (and, as of fix
+ * round 1, several other types - see the comment on `VARCHAR_TYPES` in
+ * row-decode.ts) DO have an accessor kind assigned but the underlying
+ * `duckdb_value_varchar` call fails for them regardless - `CAST(col AS
+ * VARCHAR)` is the one workaround proven to render every case tried so far.
+ */
+const workaroundFor = (typeId: number, column: string): string => {
+    if (typeId === DuckDbTypeId.BLOB) return `hex(${column})`;
+    if (NESTED_TYPES.has(typeId)) return `to_json(${column})`;
+    return `CAST(${column} AS VARCHAR)`;
+};
+
+/** `duckdb_open` / `duckdb_open_ext` / `duckdb_connect` failure. */
+export class DuckDbOpenError extends Schema.TaggedErrorClass<DuckDbOpenError>(
+    "DuckDbOpenError",
+)("DuckDbOpenError", {
+    path: Schema.String,
+    readOnly: Schema.Boolean,
+    message: Schema.String,
+}) {}
+
+/** A statement failed to prepare, bind, or execute. `sql` is a short excerpt. */
+export class DuckDbQueryError extends Schema.TaggedErrorClass<DuckDbQueryError>(
+    "DuckDbQueryError",
+)("DuckDbQueryError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Rows came back fine but did not match the caller's schema. */
+export class DuckDbDecodeError extends Schema.TaggedErrorClass<DuckDbDecodeError>(
+    "DuckDbDecodeError",
+)("DuckDbDecodeError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/**
+ * A result column has a type this client cannot read through the row-major
+ * `duckdb_value_*` API. Two distinct reasons land here: BLOB and the nested
+ * types have no pointer-based accessor at all; TIME_TZ/TIMESTAMP_TZ and
+ * several other types (fix round 1 - see `VARCHAR_TYPES` in row-decode.ts)
+ * DO have an accessor assigned but `duckdb_value_varchar` fails for them
+ * regardless. Project the column in SQL instead - `hex(col)` / `to_json(col)`
+ * / `CAST(col AS VARCHAR)`, depending on which.
+ */
+export class DuckDbUnsupportedTypeError extends Schema.TaggedErrorClass<DuckDbUnsupportedTypeError>(
+    "DuckDbUnsupportedTypeError",
+)("DuckDbUnsupportedTypeError", {
+    column: Schema.String,
+    typeId: Schema.Number,
+}) {
+    override get message(): string {
+        const name = duckDbTypeName(this.typeId);
+        return `column "${this.column}" has type ${name}, which this client cannot decode; project it in SQL instead (e.g. ${workaroundFor(this.typeId, this.column)})`;
+    }
+}
+
+/** The libduckdb shared library could not be located, extracted, or opened. */
+export class DuckDbDylibError extends Schema.TaggedErrorClass<DuckDbDylibError>(
+    "DuckDbDylibError",
+)("DuckDbDylibError", {
+    message: Schema.String,
+}) {}
+
+/** Another process holds the ingest lock. Carries who, so the CLI can say so. */
+export class IngestLockHeldError extends Schema.TaggedErrorClass<IngestLockHeldError>(
+    "IngestLockHeldError",
+)("IngestLockHeldError", {
+    path: Schema.String,
+    pid: Schema.Number,
+    startedAt: Schema.String,
+}) {}
+
+/** The lock file itself could not be read/written (permissions, bad dir, ...). */
+export class IngestLockError extends Schema.TaggedErrorClass<IngestLockError>(
+    "IngestLockError",
+)("IngestLockError", {
+    path: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Snapshot publication failed before the atomic rename landed. */
+export class SnapshotPublishError extends Schema.TaggedErrorClass<SnapshotPublishError>(
+    "SnapshotPublishError",
+)("SnapshotPublishError", {
+    snapshotPath: Schema.String,
+    message: Schema.String,
+}) {}

--- a/packages/lib/src/duckdb/ffi.test.ts
+++ b/packages/lib/src/duckdb/ffi.test.ts
@@ -1,0 +1,118 @@
+import { ptr } from "bun:ffi";
+import { describe, expect, test } from "bun:test";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { cstr, DUCKDB_RESULT_SIZE, DUCKDB_SUCCESS, handleBuffer, openLibDuckDb, readCString } from "./ffi.ts";
+
+// Resolved at module load (top-level await), not in `beforeAll`, so
+// `test.skipIf` below sees a real boolean at test-registration time and bun
+// reports a SKIP status - distinct from a pass - when no dylib is available.
+// (`resolveTestDylib` never throws; it returns a `{ ok: false, reason }`
+// instead, so this await is safe even offline.)
+const found = await resolveTestDylib();
+const dylib = found.ok ? found.path : null;
+if (!found.ok) noteSkippedDylib("duckdb ffi", found.reason);
+
+describe("openLibDuckDb", () => {
+    test.skipIf(dylib === null)(
+        "binds every symbol the client needs, including the row-major value accessors",
+        () => {
+            const lib = openLibDuckDb(dylib as string);
+            try {
+                for (const name of [
+                    "duckdb_open_ext",
+                    "duckdb_close",
+                    "duckdb_connect",
+                    "duckdb_disconnect",
+                    "duckdb_query",
+                    "duckdb_prepare",
+                    "duckdb_bind_varchar",
+                    "duckdb_bind_int64",
+                    "duckdb_bind_double",
+                    "duckdb_bind_boolean",
+                    "duckdb_bind_null",
+                    "duckdb_execute_prepared",
+                    "duckdb_destroy_prepare",
+                    "duckdb_prepare_error",
+                    "duckdb_destroy_result",
+                    "duckdb_result_error",
+                    "duckdb_row_count",
+                    "duckdb_rows_changed",
+                    "duckdb_column_count",
+                    "duckdb_column_name",
+                    "duckdb_column_type",
+                    "duckdb_value_boolean",
+                    "duckdb_value_int64",
+                    "duckdb_value_uint64",
+                    "duckdb_value_double",
+                    "duckdb_value_varchar",
+                    "duckdb_value_is_null",
+                    "duckdb_free",
+                    "duckdb_create_config",
+                    "duckdb_set_config",
+                    "duckdb_destroy_config",
+                ]) {
+                    expect(typeof (lib.symbols as Record<string, unknown>)[name]).toBe("function");
+                }
+            } finally {
+                lib.close();
+            }
+        },
+    );
+
+    test.skipIf(dylib === null)("runs an in-memory round trip through the bound symbols", () => {
+        const lib = openLibDuckDb(dylib as string);
+        const db = handleBuffer();
+        const conn = handleBuffer();
+        try {
+            expect(lib.symbols.duckdb_open_ext(cstr(":memory:"), ptr(db), 0n, null)).toBe(DUCKDB_SUCCESS);
+            expect(lib.symbols.duckdb_connect(db[0]!, ptr(conn))).toBe(DUCKDB_SUCCESS);
+            const result = new Uint8Array(DUCKDB_RESULT_SIZE);
+            expect(lib.symbols.duckdb_query(conn[0]!, cstr("SELECT 41 + 1 AS answer"), ptr(result))).toBe(
+                DUCKDB_SUCCESS,
+            );
+            expect(lib.symbols.duckdb_row_count(ptr(result))).toBe(1n);
+            expect(readCString(lib.symbols.duckdb_column_name(ptr(result), 0n))).toBe("answer");
+            expect(lib.symbols.duckdb_value_int64(ptr(result), 0n, 0n)).toBe(42n);
+            lib.symbols.duckdb_destroy_result(ptr(result));
+        } finally {
+            lib.symbols.duckdb_disconnect(ptr(conn));
+            lib.symbols.duckdb_close(ptr(db));
+            lib.close();
+        }
+    });
+
+    // Regression test for readCString mishandling a bigint pointer. `char
+    // **out_error` (duckdb_open_ext's 4th arg) writes into a BigUint64Array
+    // we own, so reading `errorBuf[0]` back out gives a `bigint` pointer -
+    // exactly the shape `readCString` must decode correctly. Before the
+    // `Number(p)` coercion, `new CString(bigintValue)` silently returned the
+    // literal string "TypeError [ERR_INVALID_ARG_TYPE]: ptr must be a
+    // number." instead of throwing or decoding, so this assertion would have
+    // failed (message would equal that TypeError text) against the
+    // unfixed implementation.
+    test.skipIf(dylib === null)("readCString decodes a bigint pointer read out of a BigUint64Array", () => {
+        const lib = openLibDuckDb(dylib as string);
+        const db = handleBuffer();
+        const errorBuf = handleBuffer();
+        try {
+            const state = lib.symbols.duckdb_open_ext(
+                cstr("/nonexistent-dir-ax-duckdb-ffi-test/db.duckdb"),
+                ptr(db),
+                0n,
+                ptr(errorBuf),
+            );
+            expect(state).not.toBe(DUCKDB_SUCCESS);
+            const errorPtr = errorBuf[0]!;
+            expect(typeof errorPtr).toBe("bigint");
+            const message = readCString(errorPtr);
+            expect(message).not.toBeNull();
+            expect(message).not.toContain("ERR_INVALID_ARG_TYPE");
+            expect(message).toContain("nonexistent-dir-ax-duckdb-ffi-test");
+            // duckdb_open_ext's out_error is caller-owned, like duckdb_value_varchar.
+            lib.symbols.duckdb_free(Number(errorPtr) as never);
+        } finally {
+            lib.symbols.duckdb_close(ptr(db));
+            lib.close();
+        }
+    });
+});

--- a/packages/lib/src/duckdb/ffi.ts
+++ b/packages/lib/src/duckdb/ffi.ts
@@ -1,0 +1,110 @@
+/**
+ * Raw `bun:ffi` bindings for the libduckdb C API. No Effect, no policy - the
+ * bare symbol table plus the handle conventions the rest of the module relies
+ * on.
+ *
+ * THE HANDLE GOTCHA (solved in scripts/duckdb-spike/ffi/duckdb-ffi.ts):
+ * `duckdb_database`, `duckdb_connection`, `duckdb_config` and
+ * `duckdb_prepared_statement` are opaque `void *` typedefs. In ARGUMENT
+ * position they are passed BY VALUE, so they bind as `u64` and are read out of
+ * a `BigUint64Array`. In OUT-PARAM position they are real pointers and bind as
+ * `ptr`. Mixing the two up corrupts the handle and segfaults.
+ *
+ * Everything here takes `duckdb_result *`. The chunk API
+ * (`duckdb_fetch_chunk`, `duckdb_result_chunk_count`) takes the 48-byte
+ * `duckdb_result` struct BY VALUE, which `bun:ffi` cannot express, so the
+ * row-major `duckdb_value_*` accessors are the only reachable read path.
+ *
+ * DEPRECATED-SYMBOL GUARD: the `duckdb_value_*` accessors AND
+ * `duckdb_row_count` (duckdb.h `#ifndef DUCKDB_API_NO_DEPRECATED`) are marked
+ * deprecated in duckdb.h and are absent from a dylib built with
+ * `DUCKDB_API_NO_DEPRECATED`. `dlopen` resolves every symbol in `SYMBOLS`
+ * eagerly and throws synchronously the moment one is missing, so opening such
+ * a dylib fails loudly here (a plain JS `Error` naming the symbol) instead of
+ * segfaulting on first call.
+ */
+import { CString, dlopen, FFIType } from "bun:ffi";
+
+const { i32, u64, f64, bool, ptr: PTR, cstring, void: VOID } = FFIType;
+
+/** `duckdb_result` is 48 bytes in duckdb.h; 64 leaves headroom. */
+export const DUCKDB_RESULT_SIZE = 64;
+/** `DuckDBSuccess` from `duckdb_state`. */
+export const DUCKDB_SUCCESS = 0;
+
+const SYMBOLS = {
+    // --- lifecycle -------------------------------------------------------
+    duckdb_open_ext: { args: [cstring, PTR, u64, PTR], returns: i32 },
+    duckdb_close: { args: [PTR], returns: VOID },
+    duckdb_connect: { args: [u64, PTR], returns: i32 },
+    duckdb_disconnect: { args: [PTR], returns: VOID },
+    // --- config ----------------------------------------------------------
+    duckdb_create_config: { args: [PTR], returns: i32 },
+    duckdb_set_config: { args: [u64, cstring, cstring], returns: i32 },
+    duckdb_destroy_config: { args: [PTR], returns: VOID },
+    // --- statements ------------------------------------------------------
+    duckdb_query: { args: [u64, cstring, PTR], returns: i32 },
+    duckdb_prepare: { args: [u64, cstring, PTR], returns: i32 },
+    // `PTR`, not `cstring` (matches `duckdb_result_error`): `cstring` decodes
+    // to a `CString` object, and a NULL `cstring` return decodes to `""`
+    // rather than null - collapsing "no error" with "empty error". `PTR`
+    // keeps the raw pointer so `readCString` can tell the two apart.
+    duckdb_prepare_error: { args: [u64], returns: PTR },
+    duckdb_destroy_prepare: { args: [PTR], returns: VOID },
+    duckdb_execute_prepared: { args: [u64, PTR], returns: i32 },
+    duckdb_bind_boolean: { args: [u64, u64, bool], returns: i32 },
+    duckdb_bind_int64: { args: [u64, u64, FFIType.i64], returns: i32 },
+    duckdb_bind_double: { args: [u64, u64, f64], returns: i32 },
+    duckdb_bind_varchar: { args: [u64, u64, cstring], returns: i32 },
+    duckdb_bind_null: { args: [u64, u64], returns: i32 },
+    // --- results ---------------------------------------------------------
+    duckdb_destroy_result: { args: [PTR], returns: VOID },
+    duckdb_result_error: { args: [PTR], returns: PTR },
+    duckdb_row_count: { args: [PTR], returns: u64 },
+    duckdb_rows_changed: { args: [PTR], returns: u64 },
+    duckdb_column_count: { args: [PTR], returns: u64 },
+    duckdb_column_name: { args: [PTR, u64], returns: PTR },
+    duckdb_column_type: { args: [PTR, u64], returns: i32 },
+    // --- row-major value accessors (deprecated in duckdb.h - see guard note
+    // above) --------------------------------------------------------------
+    duckdb_value_boolean: { args: [PTR, u64, u64], returns: bool },
+    duckdb_value_int64: { args: [PTR, u64, u64], returns: FFIType.i64 },
+    duckdb_value_uint64: { args: [PTR, u64, u64], returns: u64 },
+    duckdb_value_double: { args: [PTR, u64, u64], returns: f64 },
+    // The returned `char *` is a fresh allocation OWNED BY THE CALLER - it
+    // must be released with `duckdb_free` after reading, or every decoded
+    // cell leaks. Bound `PTR` (not `cstring`) precisely so the caller gets
+    // the raw pointer back to free, instead of bun eagerly copying it into a
+    // `CString` and discarding the pointer.
+    duckdb_value_varchar: { args: [PTR, u64, u64], returns: PTR },
+    duckdb_value_is_null: { args: [PTR, u64, u64], returns: bool },
+    duckdb_free: { args: [PTR], returns: VOID },
+} as const;
+
+export type LibDuckDb = ReturnType<typeof dlopen<typeof SYMBOLS>>;
+
+/** `dlopen` libduckdb with the full symbol table. Throws on a missing symbol. */
+export const openLibDuckDb = (dylibPath: string): LibDuckDb => dlopen(dylibPath, SYMBOLS);
+
+/** Backing store for one opaque handle (database / connection / statement). */
+export const handleBuffer = (): BigUint64Array => new BigUint64Array(1);
+
+/** NUL-terminated buffer for a `const char *` argument. */
+export const cstr = (s: string): Buffer => Buffer.from(`${s}\0`, "utf8");
+
+/**
+ * Read a `char *` return value, or null when the pointer is null.
+ *
+ * `p` is typically a `Pointer` (number) from a `PTR`-typed return, but is
+ * also `bigint` when read out of a `BigUint64Array` (e.g. an out-param
+ * handle buffer, or `duckdb_open_ext`'s `char **out_error`). `CString`'s
+ * constructor only accepts its branded `Pointer` (number) type - handing it
+ * a `bigint` neither decodes nor throws, it silently returns
+ * `"TypeError [ERR_INVALID_ARG_TYPE]: ptr must be a number."` as if that
+ * were the string content. `Number(p)` is lossless here: real pointers are
+ * well under 2^53.
+ */
+export const readCString = (p: number | bigint | null | undefined): string | null => {
+    if (p === null || p === undefined || p === 0 || p === 0n) return null;
+    return new CString(Number(p) as never).toString();
+};

--- a/packages/lib/src/duckdb/index.test.ts
+++ b/packages/lib/src/duckdb/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import * as duckdb from "./index.ts";
+
+describe("@ax/lib/duckdb public surface", () => {
+    test("exports the services, layers and helpers callers need", () => {
+        for (const name of [
+            "DuckDb",
+            "DuckDbLayer",
+            "DuckDbLive",
+            "IngestLock",
+            "IngestLockLayer",
+            "IngestLockLive",
+            "ingestLockPath",
+            "snapshotPath",
+            "resolveDylibPath",
+            "dylibCacheDir",
+            "DuckDbTypeId",
+        ]) {
+            expect((duckdb as Record<string, unknown>)[name]).toBeDefined();
+        }
+    });
+
+    test("exports every tagged error so callers can catch by tag", () => {
+        for (const name of [
+            "DuckDbOpenError",
+            "DuckDbQueryError",
+            "DuckDbDecodeError",
+            "DuckDbUnsupportedTypeError",
+            "DuckDbDylibError",
+            "IngestLockHeldError",
+            "IngestLockError",
+            "SnapshotPublishError",
+        ]) {
+            expect((duckdb as Record<string, unknown>)[name]).toBeDefined();
+        }
+    });
+
+    // Finding 5 (final fix round): the barrel used to be five blind
+    // `export *`s, three names too many - `base` (lock.ts, a test-only
+    // decorated-FileSystem seam), `makeConnection`, and `readResult`
+    // (client.ts) leaked through even though `client.ts` deliberately keeps
+    // its own equivalent seam (`baseLayer`) private. A closed-set assertion
+    // pins the surface so it cannot silently regrow those three, or drift in
+    // either direction, without this test failing.
+    test("the runtime surface is exactly this closed set of 28 names", () => {
+        const names = Object.keys(duckdb as Record<string, unknown>).sort();
+        expect(names).toEqual(
+            [
+                "DuckDb",
+                "DuckDbDecodeError",
+                "DuckDbDylibError",
+                "DuckDbLayer",
+                "DuckDbLive",
+                "DuckDbOpenError",
+                "DuckDbQueryError",
+                "DuckDbTypeId",
+                "DuckDbUnsupportedTypeError",
+                "IngestLock",
+                "IngestLockError",
+                "IngestLockHeldError",
+                "IngestLockLayer",
+                "IngestLockLive",
+                "SnapshotPublishError",
+                "accessorFor",
+                "coerceValue",
+                "decideLock",
+                "decodeLockPayload",
+                "duckDbTypeName",
+                "dylibCacheDir",
+                "encodeLockPayload",
+                "extractDylib",
+                "ingestLockPath",
+                "isEmbeddedPath",
+                "resolveDylibPath",
+                "snapshotPath",
+                "unsupportedColumns",
+            ].sort(),
+        );
+    });
+});

--- a/packages/lib/src/duckdb/index.ts
+++ b/packages/lib/src/duckdb/index.ts
@@ -1,0 +1,25 @@
+/**
+ * `@ax/lib/duckdb` - the typed DuckDB client the v2 architecture stands on.
+ *
+ * Reads go through a read-only handle on the published snapshot
+ * (`openSnapshot`); writes only happen inside ingest, under the ingest lock
+ * (`IngestLock`), against the live database; `publishSnapshot` is how the two
+ * meet - CHECKPOINT, copy to a sibling temp file, atomic rename.
+ */
+export * from "./errors.ts";
+export * from "./types.ts";
+export * from "./row-decode.ts";
+export * from "./dylib.ts";
+export * from "./lock-state.ts";
+
+// `client.ts` and `lock.ts` each keep one internal test-only seam private to
+// this barrel - `makeConnection`/`readResult` (client.ts) and `base`
+// (lock.ts). Their own tests still import them directly by relative path;
+// only the PUBLIC surface is re-exported here, as an explicit named list so
+// it can never silently drift back to `export *` (see index.test.ts's
+// closed-set assertion).
+export type { DuckDbConnection, DuckDbService } from "./client.ts";
+export { DuckDb, DuckDbLayer, DuckDbLive, snapshotPath } from "./client.ts";
+
+export type { AcquireOptions, IngestLockHandle, IngestLockService } from "./lock.ts";
+export { IngestLock, IngestLockLayer, IngestLockLive, ingestLockPath } from "./lock.ts";

--- a/packages/lib/src/duckdb/lock-state.test.ts
+++ b/packages/lib/src/duckdb/lock-state.test.ts
@@ -15,6 +15,36 @@ describe("lock payload codec", () => {
         expect(decodeLockPayload("{}")).toBeNull();
         expect(decodeLockPayload('{"pid":"x","started_at":"y"}')).toBeNull();
     });
+
+    // Cross-review P3-5: pid 0 and negative pids are not process ids. Worse,
+    // `process.kill(0, 0)` targets the CALLER'S PROCESS GROUP - it succeeds -
+    // so a corrupt `"pid":0` payload read as a LIVE holder and wedged the
+    // lock. Corrupt input must decode as corrupt.
+    test("rejects a non-positive pid - it is corrupt, not a holder", () => {
+        expect(decodeLockPayload('{"pid":0,"started_at":"2026-08-14T10:00:00.000Z"}')).toBeNull();
+        expect(decodeLockPayload('{"pid":-5,"started_at":"2026-08-14T10:00:00.000Z"}')).toBeNull();
+    });
+
+    // Cross-review P1-4 / P2-3: the payload carries two more (optional)
+    // fields now - a per-acquire token, so a stale handle can tell its own
+    // lock from a successor's, and the holder's process start time, so a
+    // reused pid is not mistaken for a live holder.
+    test("round-trips the acquire token and the process start fingerprint", () => {
+        const payload = {
+            pid: 4242,
+            started_at: "2026-08-14T10:00:00.000Z",
+            token: "6f0b6f2c",
+            proc_started_at: "Thu Aug 14 10:00:00 2026",
+        };
+        expect(decodeLockPayload(encodeLockPayload(payload))).toEqual(payload);
+    });
+
+    test("tolerates a payload without the optional fields", () => {
+        const decoded = decodeLockPayload('{"pid":9,"started_at":"2026-08-14T10:00:00.000Z"}');
+        expect(decoded?.pid).toBe(9);
+        expect(decoded?.token).toBeUndefined();
+        expect(decoded?.proc_started_at).toBeUndefined();
+    });
 });
 
 describe("decideLock", () => {

--- a/packages/lib/src/duckdb/lock-state.test.ts
+++ b/packages/lib/src/duckdb/lock-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { decideLock, decodeLockPayload, encodeLockPayload } from "./lock-state.ts";
+
+const alive = () => true;
+const dead = () => false;
+
+describe("lock payload codec", () => {
+    test("round-trips pid and started_at", () => {
+        const payload = { pid: 4242, started_at: "2026-08-14T10:00:00.000Z" };
+        expect(decodeLockPayload(encodeLockPayload(payload))).toEqual(payload);
+    });
+
+    test("rejects junk and partial payloads instead of guessing", () => {
+        expect(decodeLockPayload("not json")).toBeNull();
+        expect(decodeLockPayload("{}")).toBeNull();
+        expect(decodeLockPayload('{"pid":"x","started_at":"y"}')).toBeNull();
+    });
+});
+
+describe("decideLock", () => {
+    test("no file means free", () => {
+        expect(decideLock(null, alive, 1, false).kind).toBe("free");
+    });
+
+    test("a live foreign holder means held, and the holder comes back with it", () => {
+        const text = encodeLockPayload({ pid: 999, started_at: "2026-08-14T10:00:00.000Z" });
+        const decision = decideLock(text, alive, 1, false);
+        expect(decision.kind).toBe("held");
+        expect(decision.holder?.pid).toBe(999);
+    });
+
+    test("a dead holder means stale, so the next run can take over", () => {
+        const text = encodeLockPayload({ pid: 999, started_at: "2026-08-14T10:00:00.000Z" });
+        expect(decideLock(text, dead, 1, false).kind).toBe("stale");
+    });
+
+    test("an unreadable lock file is stale, not a permanent wedge", () => {
+        expect(decideLock("garbage", alive, 1, false).kind).toBe("stale");
+    });
+
+    test("our own pid without selfHolds is stale - a leftover from a pid the OS reused, or a prior unreleased run", () => {
+        const text = encodeLockPayload({ pid: 7, started_at: "2026-08-14T10:00:00.000Z" });
+        expect(decideLock(text, alive, 7, false).kind).toBe("stale");
+    });
+
+    test("our own pid WITH selfHolds is held - a second in-process acquirer must not clobber the first", () => {
+        const text = encodeLockPayload({ pid: 7, started_at: "2026-08-14T10:00:00.000Z" });
+        const decision = decideLock(text, alive, 7, true);
+        expect(decision.kind).toBe("held");
+        expect(decision.holder?.pid).toBe(7);
+    });
+
+    test("selfHolds is ignored for a foreign pid - it only disambiguates our own pid", () => {
+        const text = encodeLockPayload({ pid: 999, started_at: "2026-08-14T10:00:00.000Z" });
+        expect(decideLock(text, alive, 1, true).kind).toBe("held");
+        expect(decideLock(text, dead, 1, true).kind).toBe("stale");
+    });
+});

--- a/packages/lib/src/duckdb/lock-state.ts
+++ b/packages/lib/src/duckdb/lock-state.ts
@@ -6,19 +6,61 @@
 export interface LockPayload {
     readonly pid: number;
     readonly started_at: string;
+    /**
+     * A random per-ACQUIRE token (cross-review P1-4). `pid` alone cannot tell
+     * one of this process's acquires from the next, so a late release of an
+     * already-released handle used to delete whatever this process had
+     * acquired SINCE. `release` compares the bytes it wrote - token included -
+     * against what is on disk, and removes the file only on an exact match.
+     * Optional so a payload written by an older build still decodes.
+     */
+    readonly token?: string;
+    /**
+     * The HOLDER PROCESS's start time, as reported by `ps -o lstart=`
+     * (cross-review P2-3). A pid is reused freely by the OS, so "the pid is
+     * alive" is not "the holder is alive"; a live pid whose start time no
+     * longer matches this value is a corpse. Best-effort - absent when `ps`
+     * is unavailable, in which case liveness falls back to the pid probe
+     * alone.
+     */
+    readonly proc_started_at?: string;
 }
 
 export const encodeLockPayload = (payload: LockPayload): string =>
     `${JSON.stringify(payload)}\n`;
 
+/** An optional string field: present-and-non-empty, or absent. Anything else
+ *  (a number, an empty string, null) makes the whole payload corrupt rather
+ *  than silently dropping the field. */
+const optionalText = (value: unknown): { readonly ok: true; readonly value: string | undefined } | { readonly ok: false } => {
+    if (value === undefined) return { ok: true, value: undefined };
+    if (typeof value === "string" && value.length > 0) return { ok: true, value };
+    return { ok: false };
+};
+
 export const decodeLockPayload = (text: string): LockPayload | null => {
     try {
         const parsed: unknown = JSON.parse(text);
         if (typeof parsed !== "object" || parsed === null) return null;
-        const { pid, started_at } = parsed as Record<string, unknown>;
+        const { pid, started_at, token, proc_started_at } = parsed as Record<string, unknown>;
         if (typeof pid !== "number" || !Number.isInteger(pid)) return null;
+        // Cross-review P3-5: pid 0 and negative pids are not process ids, and
+        // they are not harmless either - `process.kill(0, 0)` signals the
+        // CALLER'S OWN process group and succeeds, so a corrupt `"pid": 0`
+        // read back as a LIVE holder and wedged the lock permanently. Corrupt
+        // input must decode as corrupt (`null` -> `stale`), never as a holder.
+        if (pid <= 0) return null;
         if (typeof started_at !== "string" || started_at.length === 0) return null;
-        return { pid, started_at };
+        const decodedToken = optionalText(token);
+        if (!decodedToken.ok) return null;
+        const decodedStart = optionalText(proc_started_at);
+        if (!decodedStart.ok) return null;
+        return {
+            pid,
+            started_at,
+            ...(decodedToken.value === undefined ? {} : { token: decodedToken.value }),
+            ...(decodedStart.value === undefined ? {} : { proc_started_at: decodedStart.value }),
+        };
     } catch {
         return null;
     }
@@ -38,6 +80,12 @@ export interface LockDecision {
  * a genuine second in-process acquirer, because our own pid is by definition
  * always alive - hence `selfHolds`, which the caller tracks per-process (see
  * `lock.ts`), not derived from anything on disk.
+ *
+ * `isAlive` is "is the RECORDED HOLDER still running", not merely "does this
+ * pid exist": `lock.ts` passes a probe that also compares the payload's
+ * `proc_started_at` fingerprint when there is one, so a REUSED pid answers
+ * false here (cross-review P2-3). This module stays pure and knows nothing
+ * about how that is measured.
  *
  * When the pid IS ours and `selfHolds` is true, the file names a lock we
  * ourselves currently hold open - that is `held`, not `stale`, so a second

--- a/packages/lib/src/duckdb/lock-state.ts
+++ b/packages/lib/src/duckdb/lock-state.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure lock-file reasoning: what the file says, and what to do about it.
+ * Kept away from the filesystem so every branch (live holder, dead holder,
+ * corrupt file, our own leftover) is testable without spawning a process.
+ */
+export interface LockPayload {
+    readonly pid: number;
+    readonly started_at: string;
+}
+
+export const encodeLockPayload = (payload: LockPayload): string =>
+    `${JSON.stringify(payload)}\n`;
+
+export const decodeLockPayload = (text: string): LockPayload | null => {
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (typeof parsed !== "object" || parsed === null) return null;
+        const { pid, started_at } = parsed as Record<string, unknown>;
+        if (typeof pid !== "number" || !Number.isInteger(pid)) return null;
+        if (typeof started_at !== "string" || started_at.length === 0) return null;
+        return { pid, started_at };
+    } catch {
+        return null;
+    }
+};
+
+export interface LockDecision {
+    readonly kind: "free" | "held" | "stale";
+    readonly holder?: LockPayload;
+}
+
+/**
+ * `stale` covers three cases that all mean "take it": the holder process is
+ * gone, the file is unparseable, or the pid is US but we are NOT currently
+ * holding it in THIS process (`selfHolds`) - a leftover from a pid our OS
+ * happened to reuse, or a leftover from a prior run of this same pid that
+ * never released. `isAlive` alone cannot distinguish that leftover case from
+ * a genuine second in-process acquirer, because our own pid is by definition
+ * always alive - hence `selfHolds`, which the caller tracks per-process (see
+ * `lock.ts`), not derived from anything on disk.
+ *
+ * When the pid IS ours and `selfHolds` is true, the file names a lock we
+ * ourselves currently hold open - that is `held`, not `stale`, so a second
+ * concurrent `acquire()` call in the same process (e.g. two in-process
+ * ingest requests) is correctly rejected instead of clobbering the first.
+ */
+export const decideLock = (
+    text: string | null,
+    isAlive: (pid: number) => boolean,
+    selfPid: number,
+    selfHolds: boolean,
+): LockDecision => {
+    if (text === null) return { kind: "free" };
+    const holder = decodeLockPayload(text);
+    if (holder === null) return { kind: "stale" };
+    if (holder.pid === selfPid) return { kind: selfHolds ? "held" : "stale", holder };
+    return isAlive(holder.pid) ? { kind: "held", holder } : { kind: "stale", holder };
+};

--- a/packages/lib/src/duckdb/lock.test.ts
+++ b/packages/lib/src/duckdb/lock.test.ts
@@ -7,6 +7,7 @@ import {
     readdirSync,
     readFileSync,
     rmSync,
+    symlinkSync,
     unlinkSync,
     utimesSync,
     writeFileSync,
@@ -14,7 +15,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decodeLockPayload, encodeLockPayload } from "./lock-state.ts";
-import { base, IngestLock, IngestLockLayer, type IngestLockService } from "./lock.ts";
+import {
+    base,
+    IngestLock,
+    IngestLockLayer,
+    type IngestLockHandle,
+    type IngestLockService,
+} from "./lock.ts";
 
 // Finding 4 (final fix round): every dir this suite creates - via the two
 // helpers below AND the one inline `mkdtempSync` further down - is collected
@@ -44,7 +51,7 @@ const lockDir = () => newTempDir();
  */
 const HANG_GUARD_MS = 2_000;
 
-type AcquiredHandle = { readonly path: string; readonly release: Effect.Effect<void> };
+type AcquiredHandle = IngestLockHandle;
 
 const boundedAcquire = (lock: IngestLockService, options?: Parameters<IngestLockService["acquire"]>[0]) =>
     Effect.timeoutOption(Effect.result(lock.acquire(options)), HANG_GUARD_MS);
@@ -570,6 +577,282 @@ describe("IngestLock", () => {
         expect(failure._tag).toBe("IngestLockError");
         expect(failure.path).toBe(path);
         expect(readFileSync(path, "utf8")).toBe(""); // untouched - not seized
+    });
+
+    // ---------------------------------------------------------------------
+    // Cross-review fixes: P1-3 (create/register race), P1-4 (a stale handle
+    // deleting its successor), P1-5 (path aliasing), P2-3 (pid reuse), P2-5
+    // (release errors reported as success).
+    // ---------------------------------------------------------------------
+
+    // P1-3: `createExclusive` wrote the lock file and only THEN registered
+    // `selfHolds`. A second fiber scheduled in that gap read a file naming
+    // OUR pid with `selfHolds` still false - which `decideLock` calls `stale`
+    // - and stole the lock the first fiber had just won. Both fibers ended up
+    // with a handle. The decorated `writeFileString` below makes that gap
+    // deterministic by holding the first winner inside the write for 50ms.
+    test("two concurrent same-process acquires: exactly one wins, the other is told it is held", async () => {
+        const path = lockPath();
+        let delayedWrite = false;
+        const results = await withDecoratedLock(
+            path,
+            (real) => ({
+                writeFileString: (
+                    target: string,
+                    data: string,
+                    options?: {
+                        readonly flag?: FileSystem.OpenFlag | undefined;
+                        readonly mode?: number | undefined;
+                    },
+                ) =>
+                    Effect.suspend(() => {
+                        const write = real.writeFileString(target, data, options);
+                        if (target !== path || options?.flag !== "wx" || delayedWrite) return write;
+                        delayedWrite = true;
+                        // The winner is descheduled AFTER its file exists but
+                        // BEFORE it can return - the exact interleave.
+                        return write.pipe(Effect.tap(() => Effect.sleep(50)));
+                    }),
+            }),
+            (lock) =>
+                Effect.all([Effect.result(lock.acquire()), Effect.result(lock.acquire())], {
+                    concurrency: "unbounded",
+                }),
+        );
+
+        const outcomes = results as ReadonlyArray<{
+            readonly _tag: string;
+            readonly failure?: { readonly _tag: string; readonly pid: number };
+            readonly success?: AcquiredHandle;
+        }>;
+        const winners = outcomes.filter((r) => r._tag === "Success");
+        expect(winners.length).toBe(1);
+        const loser = outcomes.find((r) => r._tag === "Failure")!;
+        expect(loser.failure?._tag).toBe("IngestLockHeldError");
+        expect(loser.failure?.pid).toBe(process.pid);
+        expect(existsSync(path)).toBe(true);
+
+        await Effect.runPromise(Effect.orDie(winners[0]!.success!.release));
+        expect(existsSync(path)).toBe(false);
+    });
+
+    // P1-4: release checked only "does the file name my pid". Every handle
+    // from THIS process passes that check, so a late release of an already
+    // released handle deleted whatever this process had acquired SINCE -
+    // unlocking a live ingest run without anyone noticing. Each acquire now
+    // stamps a random token into the payload and release removes the file
+    // only when the bytes on disk are still exactly the ones it wrote.
+    test("releasing a stale handle does not delete the successor's lock", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const first = yield* lock.acquire();
+                yield* first.release;
+
+                const second = yield* lock.acquire();
+                const secondText = readFileSync(path, "utf8");
+
+                // The stale handle releases again - a no-op success.
+                yield* first.release;
+
+                expect(existsSync(path)).toBe(true);
+                expect(readFileSync(path, "utf8")).toBe(secondText);
+                // ... and the successor is still the registered in-process
+                // holder, so a third acquire is still correctly rejected.
+                const third = yield* Effect.result(lock.acquire());
+                expect(third._tag).toBe("Failure");
+                if (third._tag === "Failure") {
+                    expect((third.failure as { _tag: string })._tag).toBe("IngestLockHeldError");
+                }
+
+                yield* second.release;
+                expect(existsSync(path)).toBe(false);
+            }),
+        );
+    });
+
+    test("two acquires of the same path never write the same payload bytes", async () => {
+        const path = lockPath();
+        const texts = await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const first = yield* lock.acquire();
+                const a = readFileSync(path, "utf8");
+                yield* first.release;
+                const second = yield* lock.acquire();
+                const b = readFileSync(path, "utf8");
+                yield* second.release;
+                return [a, b] as const;
+            }),
+        );
+        expect(texts[0]).not.toBe(texts[1]);
+    });
+
+    // P1-5: process-local state was keyed by the STRING the caller passed, so
+    // the same file under two names (symlinked dir, relative vs absolute)
+    // looked like two different locks - and the second name stole the first
+    // one's live lock. State is now keyed by the canonical path.
+    test("a symlinked alias of the lock directory is recognised as the SAME lock", async () => {
+        const realDir = newTempDir();
+        const aliasDir = join(newTempDir(), "alias");
+        symlinkSync(realDir, aliasDir, "dir");
+
+        const realPath = join(realDir, "ingest.lock");
+        const aliasPath = join(aliasDir, "ingest.lock");
+
+        const first = await Effect.runPromise(
+            Effect.gen(function* () {
+                const lock = yield* IngestLock;
+                return yield* lock.acquire();
+            }).pipe(Effect.provide(IngestLockLayer(realPath))) as Effect.Effect<AcquiredHandle>,
+        );
+
+        const result = await Effect.runPromise(
+            Effect.gen(function* () {
+                const lock = yield* IngestLock;
+                return yield* Effect.result(lock.acquire());
+            }).pipe(Effect.provide(IngestLockLayer(aliasPath))) as Effect.Effect<unknown>,
+        );
+
+        expect((result as { _tag: string })._tag).toBe("Failure");
+        const failure = (result as { failure: { _tag: string; pid: number } }).failure;
+        expect(failure._tag).toBe("IngestLockHeldError");
+        expect(failure.pid).toBe(process.pid);
+        expect(existsSync(realPath)).toBe(true);
+
+        await Effect.runPromise(Effect.orDie(first.release));
+    });
+
+    test("a relative spelling of the lock path is recognised as the SAME lock", async () => {
+        const dir = newTempDir();
+        const absolute = join(dir, "ingest.lock");
+        const cwd = process.cwd();
+        try {
+            process.chdir(dir);
+            const first = await Effect.runPromise(
+                Effect.gen(function* () {
+                    const lock = yield* IngestLock;
+                    return yield* lock.acquire();
+                }).pipe(Effect.provide(IngestLockLayer("ingest.lock"))) as Effect.Effect<AcquiredHandle>,
+            );
+
+            const result = await Effect.runPromise(
+                Effect.gen(function* () {
+                    const lock = yield* IngestLock;
+                    return yield* Effect.result(lock.acquire());
+                }).pipe(Effect.provide(IngestLockLayer(absolute))) as Effect.Effect<unknown>,
+            );
+            expect((result as { _tag: string })._tag).toBe("Failure");
+            expect((result as { failure: { _tag: string } }).failure._tag).toBe("IngestLockHeldError");
+
+            await Effect.runPromise(Effect.orDie(first.release));
+        } finally {
+            process.chdir(cwd);
+        }
+    });
+
+    // P2-3: pid liveness alone cannot tell "the holder is still running" from
+    // "the OS handed that pid to something unrelated". The payload now
+    // carries the holder's process start time (best effort); a live pid whose
+    // start time no longer matches is a corpse, not a holder.
+    test("a live pid whose recorded start time no longer matches is stale, not held", async () => {
+        const path = lockPath();
+        writeFileSync(
+            path,
+            encodeLockPayload({
+                pid: 1,
+                started_at: new Date().toISOString(),
+                proc_started_at: "Thu Jan  1 00:00:00 1970",
+            }),
+        );
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; success: AcquiredHandle }>);
+        expect(result._tag).toBe("Success");
+        expect(decodeLockPayload(readFileSync(path, "utf8"))?.pid).toBe(process.pid);
+        await Effect.runPromise(Effect.orDie(result.success.release));
+    });
+
+    test("a live pid whose recorded start time still matches stays held", async () => {
+        const path = lockPath();
+        const ps = Bun.spawnSync(["ps", "-o", "lstart=", "-p", "1"]);
+        const fingerprint = ps.stdout.toString().trim();
+        expect(fingerprint.length).toBeGreaterThan(0); // ps must work for this test to mean anything
+        writeFileSync(
+            path,
+            encodeLockPayload({
+                pid: 1,
+                started_at: new Date().toISOString(),
+                proc_started_at: fingerprint,
+            }),
+        );
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; failure: unknown }>);
+        expect(result._tag).toBe("Failure");
+        expect((result.failure as { _tag: string })._tag).toBe("IngestLockHeldError");
+    });
+
+    test("an acquired lock records the holder's process start time", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const handle = yield* lock.acquire();
+                const payload = decodeLockPayload(readFileSync(path, "utf8"));
+                expect(payload?.proc_started_at?.length ?? 0).toBeGreaterThan(0);
+                yield* handle.release;
+            }),
+        );
+    });
+
+    // P2-5: release swallowed EVERY error, so a permission failure on the
+    // unlink reported success while the lock file stayed on disk - every
+    // other process then saw a live holder forever. Only the benign
+    // already-gone case is silent now.
+    test("a failing removal during release surfaces as IngestLockError", async () => {
+        const path = lockPath();
+        const outcome = await withDecoratedLock(
+            path,
+            (real) => ({
+                remove: (
+                    target: string,
+                    options?: { readonly recursive?: boolean | undefined; readonly force?: boolean | undefined },
+                ) =>
+                    target === path
+                        ? Effect.fail(
+                              PlatformError.systemError({
+                                  _tag: "PermissionDenied",
+                                  module: "FileSystem",
+                                  method: "remove",
+                                  pathOrDescriptor: target,
+                              }),
+                          )
+                        : real.remove(target, options),
+            }),
+            (lock) =>
+                Effect.gen(function* () {
+                    const handle = yield* lock.acquire();
+                    return yield* Effect.result(handle.release);
+                }),
+        );
+
+        expect((outcome as { _tag: string })._tag).toBe("Failure");
+        expect((outcome as { failure: { _tag: string } }).failure._tag).toBe("IngestLockError");
+        // the file really is still there - which is exactly why the caller
+        // has to hear about it.
+        expect(existsSync(path)).toBe(true);
+        unlinkSync(path);
+    });
+
+    test("releasing an already-removed lock is a silent success", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const handle = yield* lock.acquire();
+                unlinkSync(path); // somebody cleaned up behind us
+                const result = yield* Effect.result(handle.release);
+                expect(result._tag).toBe("Success");
+            }),
+        );
     });
 
     // ...but an empty lock file that has aged out IS a genuine corpse, and

--- a/packages/lib/src/duckdb/lock.test.ts
+++ b/packages/lib/src/duckdb/lock.test.ts
@@ -1,0 +1,594 @@
+import { BunFileSystem } from "@effect/platform-bun";
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, FileSystem, Layer, Option, PlatformError } from "effect";
+import {
+    existsSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    unlinkSync,
+    utimesSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeLockPayload, encodeLockPayload } from "./lock-state.ts";
+import { base, IngestLock, IngestLockLayer, type IngestLockService } from "./lock.ts";
+
+// Finding 4 (final fix round): every dir this suite creates - via the two
+// helpers below AND the one inline `mkdtempSync` further down - is collected
+// here and removed in one afterAll. See dylib.test.ts for the measured leak
+// this closes.
+const createdTempDirs: string[] = [];
+const newTempDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-ingest-lock-"));
+    createdTempDirs.push(dir);
+    return dir;
+};
+
+afterAll(() => {
+    for (const dir of createdTempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+const lockPath = () => join(newTempDir(), "ingest.lock");
+
+const lockDir = () => newTempDir();
+
+/**
+ * Every terminating path in `lock.ts` is bounded by an absolute deadline that
+ * these tests keep well under a second, so an acquire still running after this
+ * window is a HANG, not a slow machine. `Effect.timeoutOption` INTERRUPTS the
+ * source fiber and yields `Option.none`, so a regression fails an assertion
+ * instead of wedging the whole suite the way the real bug wedged `ax ingest`.
+ */
+const HANG_GUARD_MS = 2_000;
+
+type AcquiredHandle = { readonly path: string; readonly release: Effect.Effect<void> };
+
+const boundedAcquire = (lock: IngestLockService, options?: Parameters<IngestLockService["acquire"]>[0]) =>
+    Effect.timeoutOption(Effect.result(lock.acquire(options)), HANG_GUARD_MS);
+
+/** Unwrap a `boundedAcquire` outcome, asserting first that it TERMINATED. */
+const terminated = <A>(outcome: Option.Option<A>): A => {
+    expect(outcome._tag).toBe("Some"); // None here means acquire() never returned.
+    return Option.getOrThrow(outcome);
+};
+
+const withLock = <A>(
+    path: string,
+    body: (lock: IngestLockService) => Effect.Effect<A, unknown>,
+) =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const lock = yield* IngestLock;
+            return yield* body(lock);
+        }).pipe(Effect.provide(IngestLockLayer(path))) as Effect.Effect<A>,
+    );
+
+/**
+ * Like `withLock`, but the `FileSystem` underneath is Bun's real
+ * implementation with ONE operation intercepted by `decorate` - the seam
+ * `base` (exported from `lock.ts` for exactly this reason) makes available.
+ * This is what makes the steal-token race deterministically testable: a
+ * decorated `readFileString`/`rename` can inject "what another racer would
+ * have done at this exact instant" without a real multi-process harness or
+ * timing-dependent sleeps.
+ */
+const withDecoratedLock = <A>(
+    path: string,
+    decorate: (real: FileSystem.FileSystem) => Partial<FileSystem.FileSystem>,
+    body: (lock: IngestLockService) => Effect.Effect<A, unknown>,
+) => {
+    const decoratedFsLayer = Layer.effect(FileSystem.FileSystem)(
+        Effect.map(FileSystem.FileSystem, (real) => ({ ...real, ...decorate(real) })),
+    ).pipe(Layer.provide(BunFileSystem.layer));
+
+    return Effect.runPromise(
+        Effect.gen(function* () {
+            const lock = yield* IngestLock;
+            return yield* body(lock);
+        }).pipe(Effect.provide(base(path).pipe(Layer.provide(decoratedFsLayer)))) as Effect.Effect<A>,
+    );
+};
+
+describe("IngestLock", () => {
+    test("acquire writes a lock file holding our pid, release removes it", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const handle = yield* lock.acquire();
+                expect(existsSync(path)).toBe(true);
+                expect((yield* lock.holder)?.pid).toBe(process.pid);
+                yield* handle.release;
+                expect(existsSync(path)).toBe(false);
+            }),
+        );
+    });
+
+    test("a second acquire while a LIVE holder owns the lock fails fast", async () => {
+        const path = lockPath();
+        // A live foreign holder: pid 1 always exists and is never us.
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        const started = Date.now();
+        const result = await withLock(path, (lock) => Effect.result(lock.acquire()));
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+            const failure = result.failure as { _tag: string; pid: number };
+            expect(failure._tag).toBe("IngestLockHeldError");
+            expect(failure.pid).toBe(1);
+        }
+        expect(Date.now() - started).toBeLessThan(1000); // fail-fast, not a wait
+    });
+
+    test("wait mode gives up with the same typed error after the timeout", async () => {
+        const path = lockPath();
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        const started = Date.now();
+        const result = await withLock(path, (lock) =>
+            Effect.result(lock.acquire({ wait: true, timeoutMs: 250, pollMs: 25 })),
+        );
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+            expect((result.failure as { _tag: string })._tag).toBe("IngestLockHeldError");
+        }
+        expect(Date.now() - started).toBeGreaterThanOrEqual(200);
+    });
+
+    test("wait mode succeeds once the holder releases", async () => {
+        const path = lockPath();
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        setTimeout(() => {
+            try {
+                unlinkSync(path);
+            } catch {
+                /* already gone */
+            }
+        }, 120);
+        const handle = await withLock(path, (lock) =>
+            lock.acquire({ wait: true, timeoutMs: 3000, pollMs: 25 }),
+        );
+        expect(existsSync(path)).toBe(true);
+        await Effect.runPromise(handle.release);
+    });
+
+    test("takes over a lock whose holder is dead", async () => {
+        const path = lockPath();
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        const handle = await withLock(path, (lock) => lock.acquire());
+        expect(existsSync(path)).toBe(true);
+        await Effect.runPromise(handle.release);
+        expect(existsSync(path)).toBe(false);
+    });
+
+    test("release is idempotent and never removes someone else's lock", async () => {
+        const path = lockPath();
+        const handle = await withLock(path, (lock) => lock.acquire());
+        await Effect.runPromise(handle.release);
+        // someone else takes it
+        writeFileSync(path, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+        await Effect.runPromise(handle.release);
+        expect(existsSync(path)).toBe(true);
+    });
+
+    // IMPORTANT 1 (review, fix rounds 1-2): what actually arbitrates a stale
+    // takeover is the STEAL TOKEN plus the confirm-then-act re-read
+    // (`stealStale`/`confirmAndTakeOver` in lock.ts) - NOT the rename by
+    // itself. A bare `rename` (round 1's mistake, corrected by ruling R13)
+    // moves whatever currently sits at the source path with no identity
+    // check, so it does not arbitrate anything on its own; it is only safe
+    // here because only the token holder ever reaches it for a `stale`
+    // takeover, after confirming the payload has not changed underneath it.
+    // This particular test does NOT exercise a second racer at all - it
+    // pins the single-acquirer MECHANISM only: the token+rename+cleanup
+    // leaves no `<path>.steal` or `<path>.stale.<pid>.<nonce>` sibling
+    // behind, and the file left at `path` is provably the successor's own
+    // payload. The actual multi-racer arbitration claim is pinned
+    // deterministically below, via a decorated `FileSystem` that injects a
+    // second racer's write at the exact instant that matters (see
+    // "the interleave that matters" and "the loser branch" further down).
+    test("stale takeover leaves no token or staging file behind", async () => {
+        const dir = newTempDir();
+        const path = join(dir, "ingest.lock");
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        const handle = await withLock(path, (lock) => lock.acquire());
+        // exactly one file remains in the lock dir - no leaked staging sibling.
+        expect(readdirSync(dir)).toEqual(["ingest.lock"]);
+        const onDisk = decodeLockPayload(readFileSync(path, "utf8"));
+        expect(onDisk?.pid).toBe(process.pid);
+        await Effect.runPromise(handle.release);
+    });
+
+    // IMPORTANT 2 (review, fix round 1; hoisting confirmed fix round 2): two
+    // `acquire()` calls for the SAME path must not let the second call
+    // silently steal the first's still-open lock - even across separate
+    // `IngestLock` layer instances, since `ax` may build a fresh `AppLayer`
+    // per `run(provide(...))` call (the `ax serve`-forking-`runIngest`
+    // shape). The in-process holding state lives in a module-level map keyed
+    // by the resolved path (`inProcessHolders` in lock.ts), not a per-layer
+    // `Ref`, so it is shared here too even though both `.acquire()` calls
+    // happen to go through the one `lock` the `withLock` body receives.
+    test("a second acquire on the SAME in-process service, while the first handle is open, fails instead of clobbering it", async () => {
+        const path = lockPath();
+        await withLock(path, (lock) =>
+            Effect.gen(function* () {
+                const first = yield* lock.acquire();
+                const result = yield* Effect.result(lock.acquire());
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    const failure = result.failure as { _tag: string; pid: number };
+                    expect(failure._tag).toBe("IngestLockHeldError");
+                    expect(failure.pid).toBe(process.pid);
+                }
+                // the second attempt must not have touched the first's lock.
+                expect(existsSync(path)).toBe(true);
+                expect((yield* lock.holder)?.pid).toBe(process.pid);
+
+                yield* first.release;
+                // releasing clears the in-process holding state, so the same
+                // service can legitimately acquire again afterward - the fix
+                // must not permanently wedge a process against itself.
+                const second = yield* lock.acquire();
+                expect(existsSync(path)).toBe(true);
+                yield* second.release;
+            }),
+        );
+    });
+
+    // "Also fix" (review, fix round 2): the in-process holding state must be
+    // PROCESS-scoped, not per-layer-instance - `ax` can build a fresh
+    // `AppLayer` (and hence a fresh `IngestLock` layer) per
+    // `run(provide(...))` call, so two SEPARATE layer instances for the SAME
+    // path must still see each other. This is the test the prior round's
+    // single-layer-instance test could not have caught.
+    test("a second acquire through a SEPARATE layer instance for the SAME path still fails instead of clobbering it", async () => {
+        const path = lockPath();
+        const firstLayer = IngestLockLayer(path);
+        const secondLayer = IngestLockLayer(path);
+
+        const first = await Effect.runPromise(
+            Effect.gen(function* () {
+                const lock = yield* IngestLock;
+                return yield* lock.acquire();
+            }).pipe(Effect.provide(firstLayer)) as Effect.Effect<{
+                readonly path: string;
+                readonly release: Effect.Effect<void>;
+            }>,
+        );
+
+        const result = await Effect.runPromise(
+            Effect.gen(function* () {
+                const lock = yield* IngestLock;
+                return yield* Effect.result(lock.acquire());
+            }).pipe(Effect.provide(secondLayer)) as Effect.Effect<unknown>,
+        );
+        expect((result as { _tag: string })._tag).toBe("Failure");
+        const failure = (result as { failure: { _tag: string; pid: number } }).failure;
+        expect(failure._tag).toBe("IngestLockHeldError");
+        expect(failure.pid).toBe(process.pid);
+        expect(existsSync(path)).toBe(true);
+
+        await Effect.runPromise(first.release);
+        // after release, a THIRD, also-separate layer instance for the same
+        // path can legitimately acquire - the process-scoped state must not
+        // wedge every future layer instance against this one forever.
+        const third = await Effect.runPromise(
+            Effect.gen(function* () {
+                const lock = yield* IngestLock;
+                return yield* lock.acquire();
+            }).pipe(Effect.provide(IngestLockLayer(path))) as Effect.Effect<{
+                readonly path: string;
+                readonly release: Effect.Effect<void>;
+            }>,
+        );
+        expect(existsSync(path)).toBe(true);
+        await Effect.runPromise(third.release);
+    });
+
+    // IMPORTANT 1, ruling R13 - "the loser branch": force the rename inside
+    // `confirmAndTakeOver` to fail with `NotFound` on its first call (a
+    // TOCTOU the confirm-read alone cannot close), and - as part of that same
+    // injected failure - write a LIVE foreign-pid payload to `path` for real.
+    // Pins the actual claim (the loop-back correctly detects the new live
+    // holder and fails with `IngestLockHeldError`), not just "it does not
+    // crash" or "it does not throw an unhandled defect".
+    test("stale takeover: losing the confirmed rename to NotFound re-decides and correctly detects the winner", async () => {
+        const path = lockPath();
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+
+        let renameCalls = 0;
+        const result = await withDecoratedLock(
+            path,
+            (real) => ({
+                rename: (from: string, to: string) => {
+                    renameCalls += 1;
+                    if (renameCalls === 1 && from === path) {
+                        // Simulate the confirmed-stale file vanishing out from
+                        // under this exact rename, AND a live foreign holder
+                        // showing up for real, on disk, at `path`.
+                        writeFileSync(
+                            path,
+                            encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }),
+                        );
+                        return Effect.fail(
+                            PlatformError.systemError({
+                                _tag: "NotFound",
+                                module: "FileSystem",
+                                method: "rename",
+                                pathOrDescriptor: from,
+                            }),
+                        );
+                    }
+                    return real.rename(from, to);
+                },
+            }),
+            (lock) => Effect.result(lock.acquire()),
+        );
+
+        expect((result as { _tag: string })._tag).toBe("Failure");
+        const failure = (result as { failure: { _tag: string; pid: number } }).failure;
+        expect(failure._tag).toBe("IngestLockHeldError");
+        expect(failure.pid).toBe(1);
+        expect(renameCalls).toBe(1); // the loop-back re-decided as `held`, never attempting a second rename.
+    });
+
+    // IMPORTANT 1, ruling R13 - "the interleave that matters": this is the
+    // ACTUAL bug from round 1 (rename-only) reproduced deterministically.
+    // The classify-read (inside `attempt`) sees the real stale payload; every
+    // SUBSEQUENT read of `path` is intercepted to report a live foreign
+    // holder instead - simulating a second racer's `"wx"`-create having
+    // ALREADY completed between our classify-read and our confirm re-read,
+    // without physically touching disk (so it is provable that the
+    // classify-read really did see the stale payload, and only the
+    // confirm-read saw the swap).
+    //
+    // This test is RED against the round-1 (bare-rename, no token, no
+    // confirm-read) implementation: that code renames whatever is REALLY on
+    // disk (still the untouched stale payload, since this decorator never
+    // writes to disk) without ever re-reading `path` first, so it wins the
+    // takeover and returns a Success handle - clobbering the "winner" this
+    // test is modeling. Under the current (R13) implementation, the
+    // confirm-read (call #2) sees the swapped live payload, does not match
+    // the originally-classified stale text, and loops back - the fresh
+    // classify-read on that loop (call #3+) also sees the (still-swapped)
+    // live payload and correctly reports `held`.
+    test("stale takeover: a live lock installed between classify-read and confirm re-read is detected, not clobbered", async () => {
+        const path = lockPath();
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        const liveForeignText = encodeLockPayload({ pid: 1, started_at: new Date().toISOString() });
+
+        let readCallsOnPath = 0;
+        const result = await withDecoratedLock(
+            path,
+            (real) => ({
+                // `lock.ts`'s `readLockText` is a single hoisted `const`,
+                // built from ONE call to `fs.readFileString(path)` at service
+                // construction time - so a plain-function override here would
+                // only ever be INVOKED once (its branch baked permanently
+                // into the returned Effect value) even though that value is
+                // legitimately RE-RUN once per logical read. `Effect.suspend`
+                // defers the branching itself into the run, so it
+                // re-evaluates - and the counter genuinely advances - on
+                // every actual read, matching how the real (Bun) FileSystem
+                // implementation behaves.
+                readFileString: (target: string, encoding?: string) =>
+                    Effect.suspend(() => {
+                        if (target !== path) return real.readFileString(target, encoding);
+                        readCallsOnPath += 1;
+                        if (readCallsOnPath === 1) return real.readFileString(target, encoding);
+                        return Effect.succeed(liveForeignText);
+                    }),
+            }),
+            (lock) => Effect.result(lock.acquire()),
+        );
+
+        expect((result as { _tag: string })._tag).toBe("Failure");
+        const failure = (result as { failure: { _tag: string; pid: number } }).failure;
+        expect(failure._tag).toBe("IngestLockHeldError");
+        expect(failure.pid).toBe(1);
+        expect(readCallsOnPath).toBeGreaterThanOrEqual(2); // classify-read, then the confirm re-read that catches the swap.
+    });
+
+    // ---------------------------------------------------------------------
+    // Fix round 4: three REACHABLE HANGS in the steal-token paths. Each one
+    // was reproduced against the round-3 code as an acquire() that never
+    // returned - a hot loop at roughly 8,000 syscalls/second with no sleep,
+    // no deadline, and no error. `<path>.steal` is ONE machine-wide path, so
+    // a single leaked token wedged every later `ax ingest` on the box with
+    // nothing naming the file to delete. `boundedAcquire` turns each of these
+    // into an assertion instead of a wedged suite.
+    // ---------------------------------------------------------------------
+
+    // HANG 1: a leaked token whose pid is ALIVE. A stealer crashes between
+    // token-create and token-remove and the OS later reuses its pid (or the
+    // token-remove failed for a reason other than NotFound, which the code
+    // swallows). The dead-pid reclaim then declines FOREVER, because the pid
+    // genuinely reads alive. Bounding it needs an AGE fallback plus a
+    // fail-fast on real contention - `pid: 1` is alive on every unix box, so
+    // no pid check can ever free this path on its own.
+    test("token contention: a leaked steal token whose pid is ALIVE fails fast naming the token, not forever", async () => {
+        const path = lockPath();
+        const tokenPath = `${path}.steal`;
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        writeFileSync(tokenPath, encodeLockPayload({ pid: 1, started_at: new Date().toISOString() }));
+
+        const started = Date.now();
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; failure: unknown }>);
+
+        expect(result._tag).toBe("Failure");
+        const failure = result.failure as { _tag: string; path: string };
+        expect(failure._tag).toBe("IngestLockError");
+        // The operator has to be told WHICH file to delete - a bare "lock
+        // busy" is what made this wedge undiagnosable in the first place.
+        expect(failure.path).toBe(tokenPath);
+        expect(Date.now() - started).toBeLessThan(1000); // no-wait means no polling
+    });
+
+    // HANG 2: a leaked token that is EMPTY. `writeFileString(..., {flag:"wx"})`
+    // is create-then-write, so a crash in that window leaves a zero-byte
+    // token. `decodeLockPayload` returns null, so there is no pid to probe and
+    // the dead-pid reclaim can never fire at all - a permanent wedge with no
+    // pid reuse needed. Bounded here by the same fail-fast.
+    test("token contention: a leaked EMPTY steal token fails fast naming the token, not forever", async () => {
+        const path = lockPath();
+        const tokenPath = `${path}.steal`;
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        writeFileSync(tokenPath, ""); // crashed between the wx open and the write
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; failure: unknown }>);
+
+        expect(result._tag).toBe("Failure");
+        const failure = result.failure as { _tag: string; path: string };
+        expect(failure._tag).toBe("IngestLockError");
+        expect(failure.path).toBe(tokenPath);
+    });
+
+    // The other half of the HANG 2 fix: failing fast is only acceptable
+    // because the wedge SELF-HEALS. An unparseable token older than
+    // STALE_RECLAIM_AGE_MS is reclaimed by age (removed tolerantly, then the
+    // caller loops back and re-races the token create), so a crash costs the
+    // machine one threshold, not every future `ax ingest`.
+    test("token contention: an AGED leaked steal token is reclaimed by age, so a crash cannot wedge the path forever", async () => {
+        const dir = lockDir();
+        const path = join(dir, "ingest.lock");
+        const tokenPath = `${path}.steal`;
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+        writeFileSync(tokenPath, "");
+        const longAgo = new Date(Date.now() - 10 * 60_000);
+        utimesSync(tokenPath, longAgo, longAgo);
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; success: AcquiredHandle }>);
+
+        expect(result._tag).toBe("Success");
+        expect(decodeLockPayload(readFileSync(path, "utf8"))?.pid).toBe(process.pid);
+        // the reclaimed token and the staging sibling are both gone.
+        expect(readdirSync(dir)).toEqual(["ingest.lock"]);
+        await Effect.runPromise(result.success.release);
+    });
+
+    // HANG 3: `createExclusive`'s AlreadyExists branch re-DECIDED under our
+    // own token. Sequence: confirm matches -> rename -> a THIRD acquirer wins
+    // the wx create in that window -> the old code looped straight back into
+    // `attempt` WHILE our token was still held -> that acquirer's lock reads
+    // back stale -> `stealStale` -> wx on OUR OWN token fails AlreadyExists ->
+    // reclaim declines its own live pid -> forever. The fix returns the same
+    // "retry" sentinel `confirmAndTakeOver` already used, so the token is
+    // released by `Effect.ensuring` BEFORE any loop-back runs - and the second
+    // pass then legitimately succeeds.
+    test("createExclusive losing the wx create UNDER the steal token releases it before looping back", async () => {
+        const dir = lockDir();
+        const path = join(dir, "ingest.lock");
+        writeFileSync(
+            path,
+            encodeLockPayload({ pid: 2 ** 22 - 1, started_at: "2020-01-01T00:00:00.000Z" }),
+        );
+
+        let exclusiveCreates = 0;
+        const outcome = await withDecoratedLock(
+            path,
+            (real) => ({
+                writeFileString: (
+                    target: string,
+                    data: string,
+                    options?: { readonly flag?: FileSystem.OpenFlag | undefined; readonly mode?: number | undefined },
+                ) =>
+                    Effect.suspend(() => {
+                        if (target !== path || options?.flag !== "wx") {
+                            return real.writeFileString(target, data, options);
+                        }
+                        exclusiveCreates += 1;
+                        if (exclusiveCreates > 1) return real.writeFileString(target, data, options);
+                        // A third acquirer wins this create - and its own
+                        // holder is ALREADY dead, so the loop-back re-decides
+                        // `stale` and re-enters the steal path, which is the
+                        // only way to reach the self-block.
+                        writeFileSync(
+                            path,
+                            encodeLockPayload({ pid: 2 ** 22 - 2, started_at: "2020-01-01T00:00:00.000Z" }),
+                        );
+                        return Effect.fail(
+                            PlatformError.systemError({
+                                _tag: "AlreadyExists",
+                                module: "FileSystem",
+                                method: "writeFileString",
+                                pathOrDescriptor: target,
+                            }),
+                        );
+                    }),
+            }),
+            (lock) => boundedAcquire(lock),
+        );
+        const result = terminated(outcome as Option.Option<{ _tag: string; success: AcquiredHandle }>);
+
+        expect(result._tag).toBe("Success");
+        expect(exclusiveCreates).toBe(2); // the injected loss, then the real win
+        expect(decodeLockPayload(readFileSync(path, "utf8"))?.pid).toBe(process.pid);
+        expect(readdirSync(dir)).toEqual(["ingest.lock"]); // no leaked token
+        await Effect.runPromise(result.success.release);
+    });
+
+    // The empty/unparseable-lock confirm gate. `writeFileString(..., "wx")` is
+    // create-then-write, so a LIVE holder is briefly a zero-byte file.
+    // `decideLock` calls that `stale`, and two racers reading inside that
+    // window would both compare "" === "" and both confirm-and-take-over a
+    // live lock. Empty/unparseable content is therefore NOT confirmable until
+    // it has aged past STALE_RECLAIM_AGE_MS - below that, the token is
+    // released and the acquire loops back rather than seizing.
+    test("an empty lock file younger than the reclaim age is NOT confirmable", async () => {
+        const path = lockPath();
+        writeFileSync(path, ""); // a live holder's wx-create, mid-write
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; failure: unknown }>);
+
+        expect(result._tag).toBe("Failure");
+        const failure = result.failure as { _tag: string; path: string };
+        expect(failure._tag).toBe("IngestLockError");
+        expect(failure.path).toBe(path);
+        expect(readFileSync(path, "utf8")).toBe(""); // untouched - not seized
+    });
+
+    // ...but an empty lock file that has aged out IS a genuine corpse, and
+    // must not be a permanent wedge either (this is what `decideLock`'s
+    // "an unreadable lock file is stale, not a permanent wedge" test means
+    // once it reaches the filesystem).
+    test("an empty lock file older than the reclaim age IS taken over", async () => {
+        const dir = lockDir();
+        const path = join(dir, "ingest.lock");
+        writeFileSync(path, "");
+        const longAgo = new Date(Date.now() - 10 * 60_000);
+        utimesSync(path, longAgo, longAgo);
+
+        const outcome = await withLock(path, (lock) => boundedAcquire(lock));
+        const result = terminated(outcome as Option.Option<{ _tag: string; success: AcquiredHandle }>);
+
+        expect(result._tag).toBe("Success");
+        expect(decodeLockPayload(readFileSync(path, "utf8"))?.pid).toBe(process.pid);
+        expect(readdirSync(dir)).toEqual(["ingest.lock"]);
+        await Effect.runPromise(result.success.release);
+    });
+});

--- a/packages/lib/src/duckdb/lock.ts
+++ b/packages/lib/src/duckdb/lock.ts
@@ -1,0 +1,773 @@
+/**
+ * The ingest lockfile: the thing that stops two `ax ingest` runs from
+ * corrupting the live database. In the v2 architecture, reads go through a
+ * read-only handle on a published snapshot; WRITES only ever happen inside
+ * ingest, under this lock.
+ *
+ * The lock is a small JSON file (`lock-state.ts`'s `LockPayload`) holding the
+ * writer's pid and start time. `decideLock` (pure, tested in isolation)
+ * classifies what's on disk into `free` / `held` / `stale` given a liveness
+ * probe; this module supplies that probe (`process.kill(pid, 0)`), the real
+ * filesystem operations, and the acquire/release lifecycle around them.
+ *
+ * The exclusive create (`"wx"`) is what actually breaks a race between two
+ * simultaneous acquirers: `decideLock` can agree "free"/"stale" for both, but
+ * only one `"wx"` write wins - the loser's failure is `AlreadyExists`, and
+ * `createExclusive` (below) reports it back as a `"retry"` sentinel rather
+ * than throwing or looping itself.
+ *
+ * WHAT IS BOUNDED, precisely (fix round 4). Every loop-back in this module is
+ * one of exactly two kinds, and each kind has ONE bound. Nothing else loops.
+ *
+ *  - POLL loop-backs, for a condition only somebody ELSE can clear: the main
+ *    lock is `held`; a live, young steal token holds the takeover; the lock
+ *    file is empty-but-too-young to be a corpse. Three sites, all guarded by
+ *    `ctx.waitUntil !== null && Date.now() < ctx.waitUntil` and all sleeping
+ *    `ctx.pollMs` first. In no-wait mode `waitUntil` is `null`, so they do not
+ *    loop AT ALL - they fail immediately, with a typed error naming the file.
+ *  - RETRY loop-backs, for a condition that has already CHANGED under us: a
+ *    lost `"wx"` create, a reclaimed leaked token, a confirm mismatch, a
+ *    rename TOCTOU. Three sites, and all three go through `retryOrGiveUp`,
+ *    which checks `ctx.deadline` and backs off `RETRY_BACKOFF_MS`.
+ *    `acquire()` sets that deadline unconditionally - `timeoutMs` in wait
+ *    mode, `NO_WAIT_RETRY_BUDGET_MS` otherwise - so a NO-WAIT acquire is
+ *    bounded too, which is what rounds 2-3 lacked.
+ *
+ * So the guarantee is a DEADLINE, not a structural argument. Earlier drafts of
+ * this comment argued instead that the loop "cannot spin ... each iteration
+ * either wins the write, or lands on a decision of 'held'"; that was true only
+ * of the plain `"wx"`-on-`path` loop and FALSE of the steal-token loops, which
+ * is how three reachable, permanent hangs survived two review rounds.
+ * Structural arguments are used below only to explain why a loop normally
+ * finishes in ONE iteration - never as the reason it terminates.
+ *
+ * Taking over a `stale` file is ALSO a race, and NEITHER an unconditional
+ * `remove` NOR a bare `rename` can arbitrate it on their own (fix round 1,
+ * review IMPORTANT 1; the rename-only version of round 1 was ALSO wrong -
+ * ruling R13). `rename(from, to)` moves whatever currently sits at `from`,
+ * unconditionally - it has exactly one winner for "did a rename land", but it
+ * proves nothing about WHAT got moved. Two racers A and B can both read the
+ * same stale payload and both decide "stale"; if A wins first (rename, clean
+ * up, `"wx"`-create its own live lock) and B was merely descheduled, B's
+ * rename now moves A's freshly-written LIVE lock - rename does not check
+ * identity, so it succeeds anyway, and B goes on to also "win" its own
+ * `"wx"`-create. Two live handles, exactly the bug this module exists to
+ * prevent.
+ *
+ * The actual fix is a STEAL TOKEN plus a confirm-then-act re-read
+ * (`stealStale`/`confirmAndTakeOver` below):
+ *   1. `"wx"`-create `<path>.steal`. Atomic - exactly one stealer proceeds.
+ *      What the loser (`AlreadyExists`) does is NOT an unconditional
+ *      loop-back; see "TOKEN LIVENESS" below, which is where rounds 2-3 hung.
+ *   2. Under the token, RE-READ `path` and confirm its payload is still
+ *      BYTE-IDENTICAL to the one just classified `stale`. If it changed,
+ *      someone else already installed a fresh lock while we held nothing but
+ *      the token - release the token and loop back (that re-decide will
+ *      correctly see it as `held`).
+ *   3. Only after that confirmation does it rename `path` away and
+ *      `"wx"`-create it with our own payload. Only the token holder reaches
+ *      this step for a `stale` takeover - so AS LONG AS exactly one process
+ *      holds the token, no second racer can rename the same confirmed-fresh
+ *      file out from under a live winner. That premise is NOT unconditional:
+ *      residuals (1) and (2) below are the two ways two processes can both
+ *      believe they hold it.
+ *   4. The token is removed under `Effect.ensuring`, on every exit path.
+ * While the token is genuinely held by ONE process, this closes the interleave
+ * the bare rename could not: B cannot reach step 3 while A holds the token,
+ * and when B finally gets the token, its re-read sees A's LIVE payload - which
+ * differs from the stale payload B originally classified - so B loops back
+ * instead of touching anything. Read that together with residuals (1) and (2),
+ * which are the cases where the "ONE process" premise fails.
+ *
+ * TOKEN LIVENESS (fix round 4). `<path>.steal` is ONE machine-wide path, so a
+ * leaked token wedges every later `ax ingest` and the LaunchAgent watcher on
+ * the box. Rounds 2-3 had the token loser loop back to `attempt`
+ * UNCONDITIONALLY, which produced three reachable, PERMANENT hangs, all three
+ * reproduced as an `acquire()` that never returned:
+ *   1. A leaked token whose pid is ALIVE - a crash plus pid reuse, or a
+ *      non-`NotFound` token removal the code swallows. A dead-pid check
+ *      declines forever.
+ *   2. A leaked token that is EMPTY or unparseable - a crash between the
+ *      `"wx"` open and the write. There is no pid to probe at all, so no pid
+ *      check can ever free it. No pid reuse needed.
+ *   3. `createExclusive`'s `AlreadyExists` branch re-deciding while still
+ *      nested UNDER a token we ourselves held: it re-entered `stealStale`,
+ *      lost the `"wx"` on its OWN token, saw its own live pid, and never made
+ *      progress.
+ * The deadline did not save any of them, because it was only consulted on the
+ * `held` branch - `acquire({ wait: true, timeoutMs: 300 })` hung too. Rounds
+ * 2-3 documented these loops as bounded ("the caller's loop-back will just
+ * retry shortly"); round 3 went further and described the fix below as if it
+ * were already written when the file still contained none of it. That is
+ * recorded here because a false safety claim is what removed the reason to
+ * look again.
+ *
+ * The fix has three parts:
+ *  - `reclaimStaleToken`: a token loser reads the existing token and reclaims
+ *    it - NEVER seizes it - when the pid inside is DEAD, or when the token is
+ *    older than `STALE_RECLAIM_AGE_MS` regardless of parseability or pid
+ *    liveness. Age comes from `mtime`, not from the payload, so it still
+ *    applies to an empty token (hang 2) and to a reused pid (hang 1).
+ *  - When reclaim DECLINES (a live, young stealer genuinely holds the token),
+ *    that is real contention and is bounded exactly like a `held` main lock:
+ *    no-wait fails immediately with a typed `IngestLockError` naming the TOKEN
+ *    path; wait mode sleeps `pollMs` and retries until `timeoutMs`.
+ *  - `createExclusive` returns the `"retry"` sentinel instead of looping
+ *    itself (hang 3), so `stealStale`'s `Effect.ensuring` releases the token
+ *    BEFORE any loop-back runs, from every branch without exception.
+ * On top of all three, every surviving loop-back goes through `retryOrGiveUp`
+ * and therefore through `AttemptCtx.deadline`.
+ *
+ * The CONFIRM step has the same empty-file problem as the token, and is closed
+ * the same way. `writeFileString(..., { flag: "wx" })` is create-then-write, so
+ * a LIVE holder is briefly a zero-byte file. `decideLock` calls unparseable
+ * content `stale`, and two racers reading inside that window would both compare
+ * `"" === ""` and both "confirm" a live lock. `confirmAndTakeOver` therefore
+ * treats empty/unparseable content as NOT confirmable until it has aged past
+ * `STALE_RECLAIM_AGE_MS`; below that the token is released and the call is
+ * bounded as CONTENTION (fail fast / poll), not retried - only the holder can
+ * clear that condition, so a retry against it is a busy-wait by construction.
+ *
+ * Residual, stated precisely rather than assumed away:
+ *  1. `reclaimStaleToken` removes the token BY PATH; it never confirms that
+ *     the file it removes is the file it classified. Two losers can observe
+ *     the SAME reclaimable token, and the second one's remove can land AFTER
+ *     a third contender has already `"wx"`-created a FRESH, LIVE token - so it
+ *     deletes a live token rather than a corpse. Two processes then hold "the
+ *     token" concurrently, both reach `confirmAndTakeOver`, and the two-winner
+ *     rename outcome from the pre-token design is reachable again.
+ *     This needs NO 60s suspension. A few milliseconds of deschedule between
+ *     the read at the top of `reclaimStaleToken` and its remove is enough, and
+ *     a GC pause or a loaded machine supplies that.
+ *     An earlier version of this comment called the double reclaim "harmless -
+ *     removing an already-removed file is a no-op". That is FALSE. A fix-round-5
+ *     reviewer verified it false on BOTH reclaim branches (dead-pid and age):
+ *     with a fresh live token installed between classify and remove, the fresh
+ *     live token did not survive. The read-then-remove gap itself pre-dates the
+ *     age branch; what is retracted here is the certification that it was
+ *     harmless. The precondition is still a LEAKED token plus concurrent
+ *     acquirers, so this is not an everyday path - but it is not arbitrated.
+ *     A pre-rename token-ownership re-check does NOT fix it: that moves the
+ *     window from (confirm-read -> rename) to (re-check -> rename). Every step
+ *     in this module is check-then-act on a PATH, and no additional re-check
+ *     closes that. See residual (5).
+ *  2. The age-based reclaim is a TIMEOUT-based liveness heuristic, not a
+ *     proof. A process merely SUSPENDED (not dead) for longer than
+ *     `STALE_RECLAIM_AGE_MS` mid-steal can have its token reclaimed by a new
+ *     contender; if it then resumes and completes its rename without
+ *     re-checking token ownership (this module does not re-check), two winners
+ *     are possible again. That needs a process stalled longer than
+ *     `STALE_RECLAIM_AGE_MS` mid-steal PLUS a contender racing into that
+ *     window. The stall does NOT require slow syscalls: `SIGSTOP`,
+ *     suspend-to-RAM, a VM snapshot restore, and a forward NTP step all
+ *     satisfy an `mtime`-relative 60s with no syscall involved.
+ *  3. Nothing REAPS a `<path>.steal` or `<path>.stale.<pid>.<nonce>` sibling
+ *     proactively; they are only cleaned up by the next acquirer that trips
+ *     over them (deferred, out of scope for this fix).
+ *  4. A non-`NotFound` failure removing the token is swallowed by
+ *     `Effect.ensuring`'s infallible finalizer. That leak is no longer
+ *     permanent - it ages out - but it does cost one threshold.
+ *  5. The only primitives that actually arbitrate residuals (1) and (2) are an
+ *     OS advisory lock (`flock`/`fcntl`) held ACROSS the takeover, or a design
+ *     that never removes a foreign file. Both are out of scope for this chunk
+ *     and are raised to the v2-duckdb epic, gated on wiring this module into
+ *     `ax ingest` - nothing imports it outside its own test today.
+ *  6. `confirmAndTakeOver` folds "the lock file VANISHED between the confirm
+ *     read and the `stat`" (`age === null`) into `"unconfirmable"` rather than
+ *     `"retry"`. The lock is actually FREE at that instant, so a no-wait caller
+ *     gets a spurious failure whose message ("empty or unparseable and too
+ *     recent to be a corpse") is factually wrong for that state. Bounded, and
+ *     it self-corrects in wait mode. Known; deliberately not changed in a
+ *     documentation-only round.
+ * Points 1, 2 and 4 are the limit of what a plain lockfile with no external
+ * coordinator (no fcntl advisory lock, no lease service) can arbitrate; (5) is
+ * what would actually close them.
+ *
+ * `decideLock` cannot classify our own pid from `isAlive` alone (fix round 1,
+ * review IMPORTANT 2): our own pid is by definition always alive, so without
+ * more information a second `acquire()` call in the SAME process (e.g. two
+ * in-process `ax serve` ingest requests) would see the first's still-open,
+ * valid lock and misclassify it as a stale leftover from a pid the OS
+ * reused - then delete and steal it out from under the first caller. The fix
+ * threads a `selfHolds` boolean into `decideLock` so "our pid, and we hold
+ * it" (a genuine second in-process acquirer - reject it) is distinguished
+ * from "our pid, and we do NOT hold it" (a genuine crashed-run leftover -
+ * take it over). That state must be PROCESS-scoped, not per-layer-instance
+ * (fix round 2, review "also fix"): `ax` can build a fresh `AppLayer` (and
+ * hence a fresh `IngestLock` layer) per `run(provide(...))` call, so a Ref
+ * closed over by one layer instance is invisible to a second in-process
+ * acquirer that goes through a DIFFERENT layer instance for the SAME path -
+ * exactly the `ax serve`-forking-`runIngest` shape this module is built for.
+ * `inProcessHolders` below is a module-level `Map<path, boolean>`, the one
+ * piece of truly global state in this file, scoped by the resolved lock path
+ * so it is correct regardless of how many layer instances a consumer builds.
+ *
+ * RULING R6: this is a runtime module under `packages/lib/src/`, so
+ * `node:fs` / `node:path` are banned (`check:no-node-fs`). Filesystem access
+ * goes through `FileSystem.FileSystem`, acquired once in the layer and closed
+ * over by every method - so `IngestLockService`'s signatures keep `R = never`,
+ * exactly as declared. Path joins go through `posixPath`
+ * (`@ax/lib/shared/path`, mirroring `dylib.ts`). `node:os#homedir` is not
+ * banned and stays.
+ */
+import { BunFileSystem } from "@effect/platform-bun";
+import { Context, Effect, FileSystem, Layer, Option, type PlatformError } from "effect";
+import { homedir } from "node:os";
+import { skipNotFound } from "../shared/fs-error.ts";
+import { posixPath } from "../shared/path.ts";
+import { IngestLockError, IngestLockHeldError } from "./errors.ts";
+import { decideLock, decodeLockPayload, encodeLockPayload, type LockPayload } from "./lock-state.ts";
+
+export interface IngestLockHandle {
+    readonly path: string;
+    readonly release: Effect.Effect<void>;
+}
+
+export interface AcquireOptions {
+    /**
+     * `true` polls a held lock until `timeoutMs`. `false` (the default) does
+     * not WAIT on a held lock - a `held` decision fails immediately with
+     * `IngestLockHeldError`.
+     *
+     * `false` bounds WAITING, not wall-clock. Loop-backs that are genuine
+     * progress rather than waiting - a reclaimed leaked token, a racer
+     * changing the file under us - still run in no-wait mode, each backing off
+     * `RETRY_BACKOFF_MS`, against a total budget of `NO_WAIT_RETRY_BUDGET_MS`
+     * (2s). So under pathological churn a no-wait `acquire()` can take up to
+     * ~2s before failing with a typed error naming the file that blocked it.
+     * Ordinary contention against a held lock still returns in ~1ms.
+     */
+    readonly wait?: boolean;
+    /** Deadline for the `held` poll loop in wait mode. Default `DEFAULT_TIMEOUT_MS` (30s). */
+    readonly timeoutMs?: number;
+    /** Poll interval for the `held` loop in wait mode. Default `DEFAULT_POLL_MS` (100ms). */
+    readonly pollMs?: number;
+}
+
+export interface IngestLockService {
+    readonly acquire: (
+        options?: AcquireOptions,
+    ) => Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError>;
+    readonly holder: Effect.Effect<LockPayload | null, IngestLockError>;
+}
+
+export class IngestLock extends Context.Service<IngestLock, IngestLockService>()(
+    "ax/IngestLock",
+) {}
+
+/** `~/.ax/ingest.lock`, overridable for tests/alternate data dirs. */
+export const ingestLockPath = (): string => {
+    const override = process.env.AX_INGEST_LOCK?.trim();
+    return override ? override : posixPath.join(homedir(), ".ax", "ingest.lock");
+};
+
+/** `process.kill(pid, 0)` probes liveness without sending a real signal.
+ *  `EPERM` means the process exists but belongs to another user - still
+ *  alive, just not ours to see into. Any other thrown error (e.g. `ESRCH`)
+ *  means the pid is gone. */
+const isAlive = (pid: number): boolean => {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        return (err as NodeJS.ErrnoException).code === "EPERM";
+    }
+};
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_MS = 100;
+
+/**
+ * How old a steal token (or an empty/unparseable lock file) must be before it
+ * is treated as a corpse and reclaimed regardless of what its pid says.
+ *
+ * Why 60s specifically:
+ * - A LIVE stealer holds the token across four local syscalls (one read of
+ *   `path`, one rename, one remove, one `"wx"` write) - sub-millisecond in
+ *   practice. 60s is ~5 orders of magnitude of headroom, far beyond any
+ *   plausible page-fault, disk, or scheduler blip.
+ * - It is deliberately LONGER than `DEFAULT_TIMEOUT_MS` (30s), so a single
+ *   `acquire({ wait: true })` AT THE DEFAULT TIMEOUT gives up before it could
+ *   age out a token created after that acquire started. `timeoutMs` is a
+ *   caller-supplied public option, so this does NOT hold in general:
+ *   `acquire({ wait: true, timeoutMs: 120_000 })` outlives the threshold and
+ *   can age out such a token.
+ * - The alternative is what this replaces: a leaked token wedging every later
+ *   `ax ingest` on the machine FOREVER. A bounded 60s of self-healing beats
+ *   an unbounded wedge, and 60s is short enough that an operator waiting on a
+ *   crashed ingest does not conclude the tool is broken.
+ * This is a TIMEOUT-based liveness heuristic, not a proof - see the module
+ * doc comment's residual (2) for what it costs.
+ */
+const STALE_RECLAIM_AGE_MS = 60_000;
+
+/**
+ * Absolute budget for the internal loop-backs of a NO-WAIT `acquire()`.
+ * No-wait callers never poll (a `held` lock fails immediately), but some
+ * loop-backs are genuine progress rather than waiting - a reclaimed leaked
+ * token, or a racer changing the file under us - and those must still be able
+ * to run. They get this budget instead of `timeoutMs`, and every one of them
+ * is checked against it, so no retry path can loop without a deadline. In the
+ * ordinary case exactly one retry happens and costs one `RETRY_BACKOFF_MS`
+ * hop; this budget only ever runs out against pathological churn, and when it
+ * does it fails with a typed error naming the file that blocked.
+ */
+const NO_WAIT_RETRY_BUDGET_MS = 2_000;
+
+/**
+ * A loop-back always waits at least this long. Every remaining retry cause is
+ * "another process mutated the file under us", which normally resolves on the
+ * first re-decide, so the cost is one 5ms hop. The point is that a deadline
+ * alone still permits thousands of syscalls per second against it - the round-3
+ * hangs burned ~8,000 iterations/second - and a bounded busy-wait is still a
+ * busy-wait. This caps a pathological retry storm at a few hundred iterations.
+ * The `held` fail-fast path never reaches here and never sleeps.
+ */
+const RETRY_BACKOFF_MS = 5;
+
+/**
+ * The bounds that govern one `acquire()` call, threaded through every loop in
+ * this module so none of them can spin.
+ */
+interface AttemptCtx {
+    /** Absolute `Date.now()` deadline for the `held` POLL loop, or `null` in
+     *  no-wait mode (where a `held` decision fails immediately). */
+    readonly waitUntil: number | null;
+    /** Absolute `Date.now()` backstop for EVERY loop-back in this call,
+     *  including the ones no-wait mode would otherwise retry unbounded. */
+    readonly deadline: number;
+    readonly pollMs: number;
+}
+
+const toLockError = (path: string, err: PlatformError.PlatformError): IngestLockError =>
+    new IngestLockError({ path, message: err.message });
+
+const isAlreadyExists = (err: PlatformError.PlatformError): boolean =>
+    err.reason._tag === "AlreadyExists";
+
+const isNotFoundError = (err: PlatformError.PlatformError): boolean =>
+    err.reason._tag === "NotFound";
+
+/**
+ * Process-wide (deliberately NOT per-layer-instance) in-process holding
+ * state, keyed by the resolved lock path - see the module doc comment for
+ * why a `Ref` closed over by one layer instance is not enough. The only
+ * reader/writer of this map is `selfHoldsFor`/`setSelfHolds` below; nothing
+ * else touches it. Plain synchronous `Map` mutation is safe here: Effect
+ * fibers only interleave at yield points, and every read/write of a single
+ * entry below happens inside one synchronous statement, never straddling a
+ * yield.
+ */
+const inProcessHolders = new Map<string, boolean>();
+
+const selfHoldsFor = (path: string): boolean => inProcessHolders.get(path) ?? false;
+
+const setSelfHolds = (path: string, value: boolean): void => {
+    if (value) inProcessHolders.set(path, true);
+    else inProcessHolders.delete(path);
+};
+
+/** Build the `IngestLockService` over an already-acquired `FileSystem`. */
+const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService => {
+    /** `null` when the file is not there (ENOENT); every other read failure
+     *  becomes `IngestLockError`. */
+    const readTolerant = (target: string) =>
+        fs
+            .readFileString(target)
+            .pipe(
+                skipNotFound(null as string | null),
+                Effect.mapError((err) => toLockError(target, err)),
+            );
+
+    /** Built ONCE, deliberately: `lock.test.ts`'s `readFileString` decorator
+     *  relies on this being a re-runnable Effect value rather than a fresh
+     *  call per read. */
+    const readLockText = readTolerant(path);
+
+    /** Age of `target` in milliseconds, `null` when it no longer exists.
+     *  A file with NO timestamp at all reads as infinitely old: the whole
+     *  point of the age fallback is that nothing wedges forever, and every
+     *  platform this runs on reports `mtime`, so the unreachable branch is
+     *  resolved toward self-healing rather than toward a permanent wedge. */
+    const fileAgeMs = (target: string): Effect.Effect<number | null, IngestLockError> =>
+        fs
+            .stat(target)
+            .pipe(
+                Effect.map((info) => {
+                    const stamp = Option.getOrUndefined(info.mtime) ?? Option.getOrUndefined(info.birthtime);
+                    return stamp === undefined ? Number.POSITIVE_INFINITY : Date.now() - stamp.getTime();
+                }),
+                skipNotFound(null as number | null),
+                Effect.mapError((err) => toLockError(target, err)),
+            );
+
+    /** Remove a file, tolerating "already gone" (a concurrent racer beat us
+     *  to it, or a `release` racing this same removal). */
+    const removeTolerant = (target: string) =>
+        fs
+            .remove(target)
+            .pipe(
+                Effect.catchTag("PlatformError", (err) =>
+                    isNotFoundError(err) ? Effect.void : Effect.fail(toLockError(target, err)),
+                ),
+            );
+
+    const holder: Effect.Effect<LockPayload | null, IngestLockError> = readLockText.pipe(
+        Effect.map((text) =>
+            text === null ? null : (decideLock(text, isAlive, process.pid, selfHoldsFor(path)).holder ?? null),
+        ),
+    );
+
+    /**
+     * One attempt: decide against what's currently on disk, take the lock if
+     * `free`, steal it if `stale`, wait-and-retry or fail-fast if `held`.
+     */
+    const attempt = (
+        ctx: AttemptCtx,
+    ): Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError> =>
+        Effect.gen(function* () {
+            yield* fs
+                .makeDirectory(posixPath.dirname(path), { recursive: true })
+                .pipe(Effect.mapError((err) => toLockError(path, err)));
+
+            const text = yield* readLockText;
+            const decision = decideLock(text, isAlive, process.pid, selfHoldsFor(path));
+
+            if (decision.kind === "held") {
+                // `decideLock` always attaches `holder` on a "held" decision.
+                const heldHolder = decision.holder!;
+                if (ctx.waitUntil !== null && Date.now() < ctx.waitUntil) {
+                    yield* Effect.sleep(ctx.pollMs);
+                    return yield* attempt(ctx);
+                }
+                return yield* new IngestLockHeldError({
+                    path,
+                    pid: heldHolder.pid,
+                    startedAt: heldHolder.started_at,
+                });
+            }
+
+            if (decision.kind === "stale") {
+                // `text` is what we classified `stale` FROM - `stealStale`
+                // re-reads and confirms against this exact string before
+                // touching anything (ruling R13; see the module doc comment
+                // for why a bare rename cannot arbitrate this on its own).
+                // `decideLock` only ever returns "stale" from a non-null
+                // `text` (the `text === null` case is always "free").
+                return yield* stealStale(text!, ctx);
+            }
+
+            const created = yield* createExclusive();
+            if (created === "retry") {
+                return yield* retryOrGiveUp(
+                    ctx,
+                    path,
+                    "kept losing the exclusive lock-file create to racing writers",
+                );
+            }
+            return created;
+        });
+
+    /**
+     * The one place a RETRY loop-back happens - "something changed under us,
+     * go re-decide". All three retry sites funnel through here, so none of
+     * them can loop without a deadline, which is exactly what the three
+     * round-3 hangs had in common.
+     *
+     * This is NOT every loop-back in the module: the three POLL loop-backs
+     * (`held`, declined token contention, `unconfirmable`) are bounded
+     * separately by `ctx.waitUntil` and sleep `ctx.pollMs` - see the module
+     * doc comment. Do not read this as covering them.
+     *
+     * Past the deadline it fails with a typed `IngestLockError` NAMING
+     * `blocker`: the file the operator has to look at (often `<path>.steal`,
+     * which is one machine-wide path, so a leak there wedges every later
+     * `ax ingest` and an unnamed error leaves nothing to act on).
+     */
+    const retryOrGiveUp = (
+        ctx: AttemptCtx,
+        blocker: string,
+        why: string,
+    ): Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError> =>
+        Effect.gen(function* () {
+            if (Date.now() < ctx.deadline) {
+                yield* Effect.sleep(RETRY_BACKOFF_MS);
+                return yield* attempt(ctx);
+            }
+            return yield* new IngestLockError({
+                path: blocker,
+                message: `${why}; gave up on ${path} after the acquire deadline. Inspect ${blocker} and remove it if no ingest is running.`,
+            });
+        });
+
+    /**
+     * `"wx"`-create `path` with our own payload. Losing the create to a
+     * racing writer (`AlreadyExists`) is NOT an error and NOT a recursion:
+     * it returns the `"retry"` sentinel, so the caller decides when to loop
+     * back. That matters because one caller (`confirmAndTakeOver`) reaches
+     * here while HOLDING the steal token, and a loop-back from inside that
+     * scope was hang #3 - it could re-enter `stealStale` and then block on
+     * its own, still-held token forever. Every caller now loops back only
+     * after the token has been released, and only against `ctx.deadline`.
+     */
+    const createExclusive = (): Effect.Effect<IngestLockHandle | "retry", IngestLockError> =>
+        Effect.gen(function* () {
+            const payload = encodeLockPayload({ pid: process.pid, started_at: new Date().toISOString() });
+            const written = yield* Effect.result(fs.writeFileString(path, payload, { flag: "wx" }));
+
+            if (written._tag === "Success") {
+                setSelfHolds(path, true);
+                return { path, release: releaseHandle };
+            }
+
+            if (isAlreadyExists(written.failure)) {
+                return "retry" as const;
+            }
+
+            return yield* toLockError(path, written.failure);
+        });
+
+    /**
+     * Take the steal token (`<path>.steal`, `"wx"`-created - exactly one
+     * stealer proceeds). What happens to the LOSER is the part that used to
+     * hang: it now asks `reclaimStaleToken` whether the token is a corpse.
+     *  - Reclaimed (dead pid, or aged past `STALE_RECLAIM_AGE_MS`, or already
+     *    gone): loop back through `retryOrGiveUp`, so even a pathological
+     *    reclaim-then-lose cycle is bounded by `ctx.deadline`.
+     *  - Declined (a live, YOUNG stealer legitimately holds it): that is real
+     *    contention, and it is bounded exactly like a `held` main lock -
+     *    no-wait fails immediately, wait mode sleeps `pollMs` and retries
+     *    until `waitUntil`. Either way the failure NAMES the token path.
+     * Token contention surfaces as `IngestLockError`, not
+     * `IngestLockHeldError`, because a token is not a lock holder: it carries
+     * no committed pid/started_at claim about who owns the database, and an
+     * empty token carries no pid at all.
+     */
+    const stealStale = (
+        staleText: string,
+        ctx: AttemptCtx,
+    ): Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError> =>
+        Effect.gen(function* () {
+            const tokenPath = `${path}.steal`;
+            const tokenPayload = encodeLockPayload({ pid: process.pid, started_at: new Date().toISOString() });
+            const tokenCreated = yield* Effect.result(fs.writeFileString(tokenPath, tokenPayload, { flag: "wx" }));
+
+            if (tokenCreated._tag === "Failure") {
+                if (!isAlreadyExists(tokenCreated.failure)) {
+                    return yield* toLockError(tokenPath, tokenCreated.failure);
+                }
+                const reclaimed = yield* reclaimStaleToken(tokenPath);
+                if (reclaimed) {
+                    return yield* retryOrGiveUp(
+                        ctx,
+                        tokenPath,
+                        "kept losing the steal token immediately after reclaiming it",
+                    );
+                }
+                if (ctx.waitUntil !== null && Date.now() < ctx.waitUntil) {
+                    yield* Effect.sleep(ctx.pollMs);
+                    return yield* attempt(ctx);
+                }
+                return yield* new IngestLockError({
+                    path: tokenPath,
+                    message: `another process is taking over the stale lock at ${path}. If none is running, this token leaked - remove ${tokenPath} (it is reclaimed automatically once it is ${STALE_RECLAIM_AGE_MS}ms old).`,
+                });
+            }
+
+            // We hold the token. Confirm-then-act, and ALWAYS release the
+            // token on the way out (success, failure, or a mismatch/TOCTOU
+            // that needs a retry). Ruling R13 step 2 is "release the token
+            // AND loop back" - strictly sequential - so `confirmAndTakeOver`
+            // never recurses into `attempt` itself, and neither does
+            // `createExclusive` underneath it: both return the "retry"
+            // sentinel, and the actual loop-back happens HERE, only after
+            // `Effect.ensuring` has finished releasing the token. Looping
+            // back while still nested inside our own still-held token was
+            // hang #3, and it was reachable: a re-decide that landed on
+            // `stale` again would try to `"wx"`-create a token we ourselves
+            // already hold, find our own pid alive, and never make progress.
+            // `Effect.ensuring` requires an infallible finalizer, so a
+            // genuine (non-`NotFound`) failure removing the token is
+            // deliberately swallowed (`Effect.ignore`) rather than masking
+            // the primary result. That leak is no longer permanent: the
+            // token now ages out after `STALE_RECLAIM_AGE_MS`.
+            const outcome = yield* confirmAndTakeOver(staleText).pipe(
+                Effect.ensuring(removeTolerant(tokenPath).pipe(Effect.ignore)),
+            );
+            if (outcome === "unconfirmable") {
+                // The file is empty/unparseable and YOUNG: overwhelmingly a
+                // live holder caught mid-`"wx"`-write, not a corpse. That is
+                // the same situation as `held`, so it gets the same bounds -
+                // no-wait fails immediately, wait mode polls - rather than a
+                // retry storm against a condition only the holder can clear.
+                if (ctx.waitUntil !== null && Date.now() < ctx.waitUntil) {
+                    yield* Effect.sleep(ctx.pollMs);
+                    return yield* attempt(ctx);
+                }
+                return yield* new IngestLockError({
+                    path,
+                    message: `the lock file at ${path} is empty or unparseable and too recent to be a corpse - another process is most likely writing it right now. It becomes reclaimable once it is ${STALE_RECLAIM_AGE_MS}ms old.`,
+                });
+            }
+            if (outcome === "retry") {
+                return yield* retryOrGiveUp(
+                    ctx,
+                    path,
+                    `could not confirm the stale lock at ${path} long enough to take it over`,
+                );
+            }
+            return outcome;
+        });
+
+    /**
+     * A `"wx"`-create of the steal token lost to `AlreadyExists`. Decide
+     * whether that token is a corpse. Returns `true` when the token is gone
+     * (we removed it, or it had already vanished) so the caller may loop
+     * back; `false` when a live, young stealer legitimately holds it.
+     *
+     * It never SEIZES the token - seizing would move the same two-winner race
+     * up one level. Two conditions make a token reclaimable:
+     *  1. Its pid is DEAD. Unambiguous.
+     *  2. It is older than `STALE_RECLAIM_AGE_MS`, whatever its content says.
+     *     This is the case a pid check cannot reach, and it covers both
+     *     round-3 hangs: an EMPTY/unparseable token (a crash between the
+     *     `"wx"` open and the write - no pid to probe at all) and a token
+     *     whose pid the OS has since REUSED (reads alive forever).
+     * Age comes from the filesystem (`mtime`), not from the payload's
+     * `started_at`, precisely so an unparseable token still has an age.
+     */
+    const reclaimStaleToken = (tokenPath: string): Effect.Effect<boolean, IngestLockError> =>
+        Effect.gen(function* () {
+            const tokenText = yield* readTolerant(tokenPath);
+            if (tokenText === null) return true; // already gone
+            const tokenHolder = decodeLockPayload(tokenText);
+            if (tokenHolder !== null && !isAlive(tokenHolder.pid)) {
+                yield* removeTolerant(tokenPath);
+                return true;
+            }
+            const age = yield* fileAgeMs(tokenPath);
+            if (age === null) return true; // vanished under us
+            if (age < STALE_RECLAIM_AGE_MS) return false; // live and young: real contention
+            yield* removeTolerant(tokenPath);
+            return true;
+        });
+
+    /**
+     * Holding the steal token, re-read `path` and confirm it is still
+     * BYTE-IDENTICAL to `staleText` - the exact payload just classified
+     * `stale`. A mismatch means someone else installed a fresh lock (or
+     * otherwise changed `path`) while we held nothing but the token: return
+     * the `"retry"` sentinel rather than recursing into `attempt` directly -
+     * `stealStale` (the caller) releases the token FIRST and only then loops
+     * back, so no re-decide runs while we still nominally hold the token.
+     * The same sentinel covers the narrower TOCTOU where the confirmed
+     * payload vanishes between this re-read and the rename below, and the
+     * `AlreadyExists` a third acquirer can hand `createExclusive` after the
+     * rename.
+     *
+     * Byte identity is NOT sufficient on its own when the bytes are empty or
+     * unparseable. `writeFileString(..., { flag: "wx" })` is create-then-
+     * write, so a LIVE holder is briefly a zero-byte file; two racers reading
+     * inside that window both classify `stale` and both compare `"" === ""`,
+     * which "confirms" a lock that is very much alive. So unparseable content
+     * is only confirmable once it has aged past `STALE_RECLAIM_AGE_MS` - far
+     * longer than any create-then-write window. Below that it returns the
+     * DISTINCT `"unconfirmable"` sentinel, which the caller releases the token
+     * for and then treats as contention (fail fast / poll), not as a retry:
+     * only the holder can clear this condition, so retrying against it is a
+     * busy-wait by construction. Above the threshold the file is a genuine
+     * corpse and must not wedge the path forever.
+     */
+    const confirmAndTakeOver = (
+        staleText: string,
+    ): Effect.Effect<IngestLockHandle | "retry" | "unconfirmable", IngestLockError> =>
+        Effect.gen(function* () {
+            const reread = yield* readLockText;
+            if (reread !== staleText) {
+                return "retry" as const;
+            }
+
+            if (decodeLockPayload(reread) === null) {
+                const age = yield* fileAgeMs(path);
+                if (age === null || age < STALE_RECLAIM_AGE_MS) {
+                    return "unconfirmable" as const;
+                }
+            }
+
+            const stagingPath = `${path}.stale.${process.pid}.${crypto.randomUUID()}`;
+            const renamed = yield* Effect.result(fs.rename(path, stagingPath));
+            if (renamed._tag === "Failure") {
+                if (isNotFoundError(renamed.failure)) {
+                    // The confirmed payload vanished between our re-read and
+                    // this rename - a narrower TOCTOU window the confirm-read
+                    // alone cannot close. Same sentinel, same reasoning.
+                    return "retry" as const;
+                }
+                return yield* toLockError(path, renamed.failure);
+            }
+            // Clean up the renamed-away evidence (best-effort; the staging
+            // name is nonce'd, so nothing else should be racing it).
+            yield* removeTolerant(stagingPath);
+
+            return yield* createExclusive();
+        });
+
+    /**
+     * Re-read the file and unlink only when the payload's pid is ours - a
+     * late/idempotent release must never delete a successor's lock. Uses
+     * `decodeLockPayload` directly (not `decideLock`) because release only
+     * cares "does the file currently name our pid", not the held/stale
+     * classification. Always clears the in-process holding state for `path`,
+     * whether or not the on-disk file was ours to remove - once `release` is
+     * called, THIS process no longer considers itself the holder, full stop.
+     * The `IngestLockHandle` contract (matching `close` in `client.ts`) gives
+     * `release` no error channel, so any failure here (e.g. permission denied
+     * on the unlink) is swallowed rather than propagated - release is always
+     * best-effort.
+     */
+    const releaseHandle: Effect.Effect<void> = readLockText.pipe(
+        Effect.flatMap((text) => {
+            if (text === null) return Effect.void;
+            const current = decodeLockPayload(text);
+            if (current?.pid !== process.pid) return Effect.void;
+            return removeTolerant(path);
+        }),
+        Effect.ensuring(Effect.sync(() => setSelfHolds(path, false))),
+        Effect.ignore,
+    );
+
+    const acquire: IngestLockService["acquire"] = (options) => {
+        const wait = options?.wait ?? false;
+        const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
+        const now = Date.now();
+        // Wait mode: one deadline governs both the `held` poll loop and the
+        // internal loop-backs. No-wait mode: `held` fails immediately
+        // (`waitUntil === null`), but the internal loop-backs - which are
+        // progress, not waiting - still get a bounded budget so nothing can
+        // spin. The fast paths reach neither.
+        const waitUntil = wait ? now + timeoutMs : null;
+        const deadline = now + (wait ? timeoutMs : NO_WAIT_RETRY_BUDGET_MS);
+        return attempt({ waitUntil, deadline, pollMs });
+    };
+
+    return { acquire, holder };
+};
+
+/** Exported (not just internal) so tests can inject a decorated `FileSystem`
+ *  that overrides one operation - the seam that makes the steal-token race
+ *  deterministically testable without a real multi-process harness. */
+export const base = (path: string): Layer.Layer<IngestLock, never, FileSystem.FileSystem> =>
+    Layer.effect(IngestLock)(
+        Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            return makeService(fs, path);
+        }),
+    );
+
+/** Layer over an explicit lock file path - the injection point for tests. */
+export const IngestLockLayer = (path: string): Layer.Layer<IngestLock> =>
+    base(path).pipe(Layer.provide(BunFileSystem.layer));
+
+/** Default layer: `~/.ax/ingest.lock` (or `AX_INGEST_LOCK`). */
+export const IngestLockLive: Layer.Layer<IngestLock> = IngestLockLayer(ingestLockPath());

--- a/packages/lib/src/duckdb/lock.ts
+++ b/packages/lib/src/duckdb/lock.ts
@@ -5,9 +5,12 @@
  * ingest, under this lock.
  *
  * The lock is a small JSON file (`lock-state.ts`'s `LockPayload`) holding the
- * writer's pid and start time. `decideLock` (pure, tested in isolation)
- * classifies what's on disk into `free` / `held` / `stale` given a liveness
- * probe; this module supplies that probe (`process.kill(pid, 0)`), the real
+ * writer's pid, when it took the lock, a per-acquire random token (so a stale
+ * handle can tell its own lock from a successor's) and the holder process's
+ * start time (so a REUSED pid is not mistaken for a live holder).
+ * `decideLock` (pure, tested in isolation) classifies what's on disk into
+ * `free` / `held` / `stale` given a liveness probe; this module supplies that
+ * probe (`process.kill(pid, 0)`, plus the start-time fingerprint), the real
  * filesystem operations, and the acquire/release lifecycle around them.
  *
  * The exclusive create (`"wx"`) is what actually breaks a race between two
@@ -128,7 +131,10 @@
  * bounded as CONTENTION (fail fast / poll), not retried - only the holder can
  * clear that condition, so a retry against it is a busy-wait by construction.
  *
- * Residual, stated precisely rather than assumed away:
+ * Residual, stated precisely rather than assumed away. Read (1) and (2) with
+ * the cross-review note below: BOTH now require two distinct PROCESSES. Two
+ * fibers of THIS process can no longer both be inside `acquire` for the same
+ * canonical path at all, because the per-path acquire mutex serializes them.
  *  1. `reclaimStaleToken` removes the token BY PATH; it never confirms that
  *     the file it removes is the file it classified. Two losers can observe
  *     the SAME reclaimable token, and the second one's remove can land AFTER
@@ -170,8 +176,11 @@
  *  5. The only primitives that actually arbitrate residuals (1) and (2) are an
  *     OS advisory lock (`flock`/`fcntl`) held ACROSS the takeover, or a design
  *     that never removes a foreign file. Both are out of scope for this chunk
- *     and are raised to the v2-duckdb epic, gated on wiring this module into
- *     `ax ingest` - nothing imports it outside its own test today.
+ *     and are tracked as issue #789 on the v2-duckdb epic, gated on wiring
+ *     this module into `ax ingest` - nothing imports it outside its own test
+ *     today. The cross-review fixes below deliberately did NOT attempt that
+ *     redesign; they close the in-process and same-handle holes, which are a
+ *     different (and reachable without any leaked token) class of bug.
  *  6. `confirmAndTakeOver` folds "the lock file VANISHED between the confirm
  *     read and the `stat`" (`age === null`) into `"unconfirmable"` rather than
  *     `"retry"`. The lock is actually FREE at that instant, so a no-wait caller
@@ -198,9 +207,50 @@
  * closed over by one layer instance is invisible to a second in-process
  * acquirer that goes through a DIFFERENT layer instance for the SAME path -
  * exactly the `ax serve`-forking-`runIngest` shape this module is built for.
- * `inProcessHolders` below is a module-level `Map<path, boolean>`, the one
- * piece of truly global state in this file, scoped by the resolved lock path
- * so it is correct regardless of how many layer instances a consumer builds.
+ * `inProcessHolders` below is a module-level `Map`, scoped by the CANONICAL
+ * lock path, so it is correct regardless of how many layer instances a
+ * consumer builds.
+ *
+ * CROSS-REVIEW FIXES (what this module no longer gets wrong). Four holes that
+ * an earlier version of this comment did not list, each closed and each
+ * covered by a test that is RED against the previous implementation:
+ *  - P1-3, the create/register race. `createExclusive` wrote the lock file
+ *    and only THEN called `setSelfHolds`. A second fiber scheduled in that
+ *    gap read a file naming OUR pid with `selfHolds` still false - which
+ *    `decideLock` calls `stale` - and took over a lock the first fiber had
+ *    just won, so BOTH held a handle. Every acquire for a given canonical
+ *    path now runs under a per-path `Semaphore` (1 permit), which removes the
+ *    interleave rather than reordering two statements inside it, and the
+ *    create+register pair is `Effect.uninterruptible` so interruption cannot
+ *    split it either. `acquire` pairs that with an `onInterrupt` that
+ *    releases a lock created but never handed to a caller: the outcome is
+ *    always owned or removed, never orphaned. This says NOTHING about other
+ *    processes - see residuals (1) and (2).
+ *  - P1-4, a stale handle deleting its successor. `release` asked only "does
+ *    the file name our pid", which every handle from this process satisfies,
+ *    so acquire A -> release A -> acquire B -> release A (a duplicated or
+ *    late release) deleted B's live lock. Each acquire now stamps a random
+ *    `token` into the payload, and `release` removes the file only when the
+ *    bytes on disk are still EXACTLY the ones it wrote. A superseded handle's
+ *    release is a no-op success, and it does not clear the current holder's
+ *    in-process registration either.
+ *  - P1-5, path aliasing. Process-local state was keyed by the caller's
+ *    STRING, so `ingest.lock`, `/abs/ingest.lock` and a symlinked alias of
+ *    the directory looked like three separate locks and the second spelling
+ *    stole the first one's live lock. All process-local state is now keyed by
+ *    the canonical path (`canonicalKey`, resolved once per service).
+ *  - P2-3, pid reuse. A crashed holder's pid gets handed to some unrelated
+ *    process, which then reads as a live holder forever (`ax ingest` blocked
+ *    with nothing running). The payload carries the holder's process start
+ *    time (`ps -o lstart=`, best effort) and a live pid whose fingerprint no
+ *    longer matches is treated as stale. A missing/unreadable fingerprint
+ *    degrades exactly to the old pid-only behavior.
+ *  - P2-5, release reporting success after failing. `release` ended in
+ *    `Effect.ignore`, so a failed unlink (permissions, read-only mount, IO)
+ *    was reported as a successful release while the lock file stayed on disk
+ *    and every other process kept seeing a live holder. Real failures now
+ *    surface as `IngestLockError`; only the benign already-gone case is
+ *    silent.
  *
  * RULING R6: this is a runtime module under `packages/lib/src/`, so
  * `node:fs` / `node:path` are banned (`check:no-node-fs`). Filesystem access
@@ -211,16 +261,36 @@
  * banned and stays.
  */
 import { BunFileSystem } from "@effect/platform-bun";
-import { Context, Effect, FileSystem, Layer, Option, type PlatformError } from "effect";
+import { Context, Effect, FileSystem, Layer, Option, Semaphore, type PlatformError } from "effect";
 import { homedir } from "node:os";
 import { skipNotFound } from "../shared/fs-error.ts";
 import { posixPath } from "../shared/path.ts";
+import { canonicalPath } from "./canonical-path.ts";
 import { IngestLockError, IngestLockHeldError } from "./errors.ts";
-import { decideLock, decodeLockPayload, encodeLockPayload, type LockPayload } from "./lock-state.ts";
+import {
+    decideLock,
+    decodeLockPayload,
+    encodeLockPayload,
+    type LockDecision,
+    type LockPayload,
+} from "./lock-state.ts";
 
 export interface IngestLockHandle {
     readonly path: string;
-    readonly release: Effect.Effect<void>;
+    /**
+     * Give the lock back. Releasing a handle that no longer owns the file on
+     * disk (someone else took over, or this handle was already released) is a
+     * SUCCESS - the postcondition "this handle holds nothing" is met either
+     * way, and a late release never touches a successor's lock (cross-review
+     * P1-4).
+     *
+     * It DOES have an error channel (cross-review P2-5): when the unlink or
+     * the read genuinely fails - permissions, a read-only mount, IO - the
+     * lock file is still there and every other process will keep seeing a
+     * live holder, so reporting success would be a lie the operator can only
+     * discover by hand. `NotFound` is the one silent case.
+     */
+    readonly release: Effect.Effect<void, IngestLockError>;
 }
 
 export interface AcquireOptions {
@@ -236,6 +306,13 @@ export interface AcquireOptions {
      * (2s). So under pathological churn a no-wait `acquire()` can take up to
      * ~2s before failing with a typed error naming the file that blocked it.
      * Ordinary contention against a held lock still returns in ~1ms.
+     *
+     * One more same-process caveat (cross-review P1-3): acquires for the same
+     * canonical path are SERIALIZED in this process, so a no-wait acquire
+     * issued while another fiber's `wait: true` acquire is polling queues
+     * behind that fiber instead of failing immediately. It is bounded by the
+     * waiting fiber's own `timeoutMs`, and the outcome is the same one it
+     * would have reached anyway.
      */
     readonly wait?: boolean;
     /** Deadline for the `held` poll loop in wait mode. Default `DEFAULT_TIMEOUT_MS` (30s). */
@@ -337,6 +414,15 @@ interface AttemptCtx {
      *  including the ones no-wait mode would otherwise retry unbounded. */
     readonly deadline: number;
     readonly pollMs: number;
+    /** The CANONICAL lock path - the key for every piece of process-local
+     *  state (`inProcessHolders`, the acquire mutex). Never the raw string
+     *  the caller passed; see `canonicalKey` and cross-review P1-5. */
+    readonly key: string;
+    /** Set the moment this attempt actually creates the lock file, so
+     *  `acquire`'s interrupt finalizer can remove a lock that never reached
+     *  its caller. Mutable by design - it is per-acquire scratch state, not
+     *  configuration. */
+    readonly owned: { release: Effect.Effect<void, IngestLockError> | null };
 }
 
 const toLockError = (path: string, err: PlatformError.PlatformError): IngestLockError =>
@@ -350,22 +436,110 @@ const isNotFoundError = (err: PlatformError.PlatformError): boolean =>
 
 /**
  * Process-wide (deliberately NOT per-layer-instance) in-process holding
- * state, keyed by the resolved lock path - see the module doc comment for
- * why a `Ref` closed over by one layer instance is not enough. The only
- * reader/writer of this map is `selfHoldsFor`/`setSelfHolds` below; nothing
- * else touches it. Plain synchronous `Map` mutation is safe here: Effect
- * fibers only interleave at yield points, and every read/write of a single
- * entry below happens inside one synchronous statement, never straddling a
- * yield.
+ * state, keyed by the CANONICAL lock path - see the module doc comment for
+ * why a `Ref` closed over by one layer instance is not enough, and P1-5 for
+ * why the key must be canonical rather than whatever string the caller
+ * happened to pass.
+ *
+ * The value is the current holder's ACQUIRE TOKEN, not a boolean (P1-4): a
+ * boolean cannot tell "the handle clearing this is the one that set it" from
+ * "a stale handle from two acquires ago is clearing a successor's ownership",
+ * and the latter silently un-registers a live holder. Presence in the map IS
+ * `selfHolds`.
+ *
+ * Plain synchronous `Map` mutation is safe here: Effect fibers only interleave
+ * at yield points, and every read/write of a single entry below happens inside
+ * one synchronous statement, never straddling a yield.
  */
-const inProcessHolders = new Map<string, boolean>();
+const inProcessHolders = new Map<string, string>();
 
-const selfHoldsFor = (path: string): boolean => inProcessHolders.get(path) ?? false;
+const selfHoldsFor = (key: string): boolean => inProcessHolders.has(key);
 
-const setSelfHolds = (path: string, value: boolean): void => {
-    if (value) inProcessHolders.set(path, true);
-    else inProcessHolders.delete(path);
+const registerSelfHold = (key: string, token: string): void => {
+    inProcessHolders.set(key, token);
 };
+
+/** Clear ONLY if `token` is still the registered holder - a late release from
+ *  a superseded handle must not un-register the current one. */
+const clearSelfHold = (key: string, token: string): void => {
+    if (inProcessHolders.get(key) === token) inProcessHolders.delete(key);
+};
+
+/**
+ * One acquire-critical-section mutex per canonical lock path (cross-review
+ * P1-3). Module-level for the same reason `inProcessHolders` is: a `Ref` or
+ * a semaphore closed over by one layer instance is invisible to a second
+ * acquirer that goes through a different layer instance for the same file.
+ *
+ * What it buys: `createExclusive` writes the lock file and only THEN
+ * registers the holder in `inProcessHolders`. Between those two steps the
+ * file on disk names OUR pid while `selfHolds` is still false - which
+ * `decideLock` classifies as `stale` - so a second fiber scheduled in that
+ * gap would take over a lock the first fiber had just legitimately won, and
+ * both would hold a handle. Serializing the whole acquire per path removes
+ * the interleave entirely, which also subsumes any ordering fix inside
+ * `createExclusive`.
+ *
+ * What it does NOT buy: anything against another PROCESS. Cross-process
+ * arbitration is still the `"wx"`-create plus steal-token protocol below,
+ * with the residuals the module doc comment lists.
+ *
+ * Cost: a same-process acquire that is WAITING (`wait: true`) holds the
+ * permit while it polls, so a concurrent same-process acquire queues behind
+ * it rather than failing fast. That is bounded by the waiter's own
+ * `timeoutMs`, and queueing behind a same-process waiter is the same outcome
+ * it would have reached anyway (the lock is taken).
+ */
+const acquireMutexes = new Map<string, Semaphore.Semaphore>();
+
+const acquireMutexFor = (key: string): Semaphore.Semaphore => {
+    const existing = acquireMutexes.get(key);
+    if (existing !== undefined) return existing;
+    const created = Semaphore.makeUnsafe(1);
+    acquireMutexes.set(key, created);
+    return created;
+};
+
+/**
+ * The holder process's start time, as `ps` reports it - the fingerprint that
+ * distinguishes "the holder is still running" from "the OS handed that pid to
+ * something else" (cross-review P2-3).
+ *
+ * Best effort ON PURPOSE: `ps` can be missing, sandboxed, or formatted
+ * differently, and none of that is a reason to fail an ingest. A `null` here
+ * degrades exactly to the previous behavior (pid liveness alone).
+ */
+const processStartedAt = (pid: number): Effect.Effect<string | null> =>
+    Effect.sync(() => {
+        try {
+            const probe = Bun.spawnSync(["ps", "-o", "lstart=", "-p", String(pid)]);
+            if (probe.exitCode !== 0) return null;
+            const text = probe.stdout.toString().trim();
+            return text.length === 0 ? null : text;
+        } catch {
+            return null;
+        }
+    });
+
+/**
+ * Is the process named by `holder` STILL the process that took the lock?
+ * `process.kill(pid, 0)` alone answers the weaker question "does this pid
+ * exist", and a crashed holder's pid is reused freely - on Linux the counter
+ * wraps at a few tens of thousands - so an unrelated long-lived process could
+ * hold the ingest lock hostage until it exited. When the payload carries a
+ * start-time fingerprint, a MISMATCH means the pid was reused: the recorded
+ * holder is dead and the lock is stale.
+ */
+const holderIsLive = (holder: LockPayload): Effect.Effect<boolean> =>
+    Effect.suspend(() => {
+        if (!isAlive(holder.pid)) return Effect.succeed(false);
+        if (holder.proc_started_at === undefined) return Effect.succeed(true);
+        return processStartedAt(holder.pid).pipe(
+            // A failed probe must not turn a live holder into a corpse, so an
+            // unreadable start time keeps the old answer (alive).
+            Effect.map((current) => current === null || current === holder.proc_started_at),
+        );
+    });
 
 /** Build the `IngestLockService` over an already-acquired `FileSystem`. */
 const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService => {
@@ -412,11 +586,63 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
                 ),
             );
 
-    const holder: Effect.Effect<LockPayload | null, IngestLockError> = readLockText.pipe(
-        Effect.map((text) =>
-            text === null ? null : (decideLock(text, isAlive, process.pid, selfHoldsFor(path)).holder ?? null),
-        ),
+    /**
+     * The canonical spelling of `path`, resolved once and cached (cross-review
+     * P1-5). EVERY piece of process-local state - `inProcessHolders`, the
+     * per-path acquire mutex - is keyed by this, never by the string the
+     * caller passed: `ingest.lock`, `/abs/ingest.lock` and a symlinked alias
+     * of the directory all name ONE file, and keying by the raw string made
+     * the second name look like a different lock, so it stole the first one's
+     * live lock instead of reporting it held.
+     *
+     * File OPERATIONS still use `path` as given - it addresses the same file,
+     * and error messages should echo what the caller wrote. Only IDENTITY is
+     * canonical. Resolution never fails (see canonical-path.ts); a relative
+     * path is resolved against the cwd at FIRST use, which is also when the
+     * lock directory is guaranteed to exist.
+     */
+    let cachedKey: string | null = null;
+    const canonicalKey: Effect.Effect<string> = Effect.suspend(() =>
+        cachedKey !== null
+            ? Effect.succeed(cachedKey)
+            : canonicalPath(fs, path).pipe(
+                  Effect.tap((resolved) =>
+                      Effect.sync(() => {
+                          cachedKey = resolved;
+                      }),
+                  ),
+              ),
     );
+
+    const ensureDir = fs
+        .makeDirectory(posixPath.dirname(path), { recursive: true })
+        .pipe(Effect.mapError((err) => toLockError(path, err)));
+
+    /**
+     * `decideLock` against what is currently on disk, with the liveness probe
+     * upgraded to the pid-reuse-aware one (P2-3). The probe is effectful (it
+     * may spawn `ps`), so it is resolved HERE and handed to the pure decision
+     * function as a plain boolean for the holder's own pid.
+     */
+    const decideNow = (key: string, text: string | null): Effect.Effect<LockDecision> =>
+        Effect.gen(function* () {
+            if (text === null) return decideLock(null, isAlive, process.pid, selfHoldsFor(key));
+            const parsed = decodeLockPayload(text);
+            const live = parsed === null ? false : yield* holderIsLive(parsed);
+            return decideLock(
+                text,
+                (pid) => (parsed !== null && pid === parsed.pid ? live : isAlive(pid)),
+                process.pid,
+                selfHoldsFor(key),
+            );
+        });
+
+    const holder: Effect.Effect<LockPayload | null, IngestLockError> = Effect.gen(function* () {
+        const text = yield* readLockText;
+        if (text === null) return null;
+        const key = yield* canonicalKey;
+        return (yield* decideNow(key, text)).holder ?? null;
+    });
 
     /**
      * One attempt: decide against what's currently on disk, take the lock if
@@ -426,12 +652,8 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
         ctx: AttemptCtx,
     ): Effect.Effect<IngestLockHandle, IngestLockHeldError | IngestLockError> =>
         Effect.gen(function* () {
-            yield* fs
-                .makeDirectory(posixPath.dirname(path), { recursive: true })
-                .pipe(Effect.mapError((err) => toLockError(path, err)));
-
             const text = yield* readLockText;
-            const decision = decideLock(text, isAlive, process.pid, selfHoldsFor(path));
+            const decision = yield* decideNow(ctx.key, text);
 
             if (decision.kind === "held") {
                 // `decideLock` always attaches `holder` on a "held" decision.
@@ -457,7 +679,7 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
                 return yield* stealStale(text!, ctx);
             }
 
-            const created = yield* createExclusive();
+            const created = yield* createExclusive(ctx);
             if (created === "retry") {
                 return yield* retryOrGiveUp(
                     ctx,
@@ -510,14 +732,33 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
      * its own, still-held token forever. Every caller now loops back only
      * after the token has been released, and only against `ctx.deadline`.
      */
-    const createExclusive = (): Effect.Effect<IngestLockHandle | "retry", IngestLockError> =>
+    const createExclusive = (
+        ctx: AttemptCtx,
+    ): Effect.Effect<IngestLockHandle | "retry", IngestLockError> =>
         Effect.gen(function* () {
-            const payload = encodeLockPayload({ pid: process.pid, started_at: new Date().toISOString() });
+            // Cross-review P1-4: a per-acquire random token, so `release` can
+            // tell ITS OWN lock from a successor's byte-for-byte. Without it
+            // a late release of a superseded handle deleted whatever this
+            // process had acquired since - unlocking a live ingest run.
+            const token = crypto.randomUUID();
+            // Cross-review P2-3: the holder's own process start time, so a
+            // reused pid does not read as a live holder later.
+            const procStartedAt = yield* processStartedAt(process.pid);
+            const payload = encodeLockPayload({
+                pid: process.pid,
+                started_at: new Date().toISOString(),
+                token,
+                ...(procStartedAt === null ? {} : { proc_started_at: procStartedAt }),
+            });
             const written = yield* Effect.result(fs.writeFileString(path, payload, { flag: "wx" }));
 
             if (written._tag === "Success") {
-                setSelfHolds(path, true);
-                return { path, release: releaseHandle };
+                registerSelfHold(ctx.key, token);
+                const release = releaseFor(ctx.key, payload, token);
+                // Recorded so `acquire`'s interrupt finalizer can undo a lock
+                // that was created but never reached its caller.
+                ctx.owned.release = release;
+                return { path, release };
             }
 
             if (isAlreadyExists(written.failure)) {
@@ -525,7 +766,18 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
             }
 
             return yield* toLockError(path, written.failure);
-        });
+        }).pipe(
+            // Cross-review P1-3, interruption half: the create and the
+            // ownership registration must be ONE step. Interruption landing
+            // between them would leave a lock file on disk that this process
+            // owns but does not know it owns - and `decideLock` calls exactly
+            // that shape `stale`, so the next acquirer would steal it while
+            // the (interrupted) creator's caller may still believe it holds
+            // the lock. `acquire` pairs this with an `onInterrupt` that
+            // releases a lock created but never handed back, so the outcome
+            // is always "owned" or "removed", never "orphaned".
+            Effect.uninterruptible,
+        );
 
     /**
      * Take the steal token (`<path>.steal`, `"wx"`-created - exactly one
@@ -591,7 +843,7 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
             // deliberately swallowed (`Effect.ignore`) rather than masking
             // the primary result. That leak is no longer permanent: the
             // token now ages out after `STALE_RECLAIM_AGE_MS`.
-            const outcome = yield* confirmAndTakeOver(staleText).pipe(
+            const outcome = yield* confirmAndTakeOver(staleText, ctx).pipe(
                 Effect.ensuring(removeTolerant(tokenPath).pipe(Effect.ignore)),
             );
             if (outcome === "unconfirmable") {
@@ -641,7 +893,7 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
             const tokenText = yield* readTolerant(tokenPath);
             if (tokenText === null) return true; // already gone
             const tokenHolder = decodeLockPayload(tokenText);
-            if (tokenHolder !== null && !isAlive(tokenHolder.pid)) {
+            if (tokenHolder !== null && !(yield* holderIsLive(tokenHolder))) {
                 yield* removeTolerant(tokenPath);
                 return true;
             }
@@ -680,6 +932,7 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
      */
     const confirmAndTakeOver = (
         staleText: string,
+        ctx: AttemptCtx,
     ): Effect.Effect<IngestLockHandle | "retry" | "unconfirmable", IngestLockError> =>
         Effect.gen(function* () {
             const reread = yield* readLockText;
@@ -709,47 +962,82 @@ const makeService = (fs: FileSystem.FileSystem, path: string): IngestLockService
             // name is nonce'd, so nothing else should be racing it).
             yield* removeTolerant(stagingPath);
 
-            return yield* createExclusive();
+            return yield* createExclusive(ctx);
         });
 
     /**
-     * Re-read the file and unlink only when the payload's pid is ours - a
-     * late/idempotent release must never delete a successor's lock. Uses
-     * `decodeLockPayload` directly (not `decideLock`) because release only
-     * cares "does the file currently name our pid", not the held/stale
-     * classification. Always clears the in-process holding state for `path`,
-     * whether or not the on-disk file was ours to remove - once `release` is
-     * called, THIS process no longer considers itself the holder, full stop.
-     * The `IngestLockHandle` contract (matching `close` in `client.ts`) gives
-     * `release` no error channel, so any failure here (e.g. permission denied
-     * on the unlink) is swallowed rather than propagated - release is always
-     * best-effort.
+     * Re-read the file and unlink it ONLY when its bytes are still exactly
+     * the payload this handle wrote.
+     *
+     * Cross-review P1-4: the old check was "does the file name our pid",
+     * which EVERY handle from this process passes. So the sequence acquire A
+     * -> release A -> acquire B -> release A (a late or duplicated release,
+     * e.g. a scope finalizer running after an explicit release) deleted B's
+     * lock: a live ingest run silently unlocked, with the next acquirer free
+     * to write the same database concurrently. The per-acquire token in the
+     * payload makes the comparison identity-checking rather than
+     * pid-checking, and a byte compare needs no parsing at all.
+     *
+     * A stale handle's release is a SUCCESS, not an error - "the lock I held
+     * is no longer mine" is precisely what a late release should conclude,
+     * and it must not clear the CURRENT holder's registration either (hence
+     * the token-matched `clearSelfHold`).
+     *
+     * Cross-review P2-5: this used to end in `Effect.ignore`, so a read or
+     * unlink failure - a permission change, a read-only mount, an IO error -
+     * reported SUCCESS while the lock file stayed on disk, and every other
+     * process went on seeing a live holder. Real failures now surface as
+     * `IngestLockError`; the benign already-gone case (`NotFound`, someone
+     * else cleaned up) stays silent, via `removeTolerant`/`readLockText`.
      */
-    const releaseHandle: Effect.Effect<void> = readLockText.pipe(
-        Effect.flatMap((text) => {
-            if (text === null) return Effect.void;
-            const current = decodeLockPayload(text);
-            if (current?.pid !== process.pid) return Effect.void;
-            return removeTolerant(path);
-        }),
-        Effect.ensuring(Effect.sync(() => setSelfHolds(path, false))),
-        Effect.ignore,
-    );
+    const releaseFor = (
+        key: string,
+        payloadText: string,
+        token: string,
+    ): Effect.Effect<void, IngestLockError> =>
+        readLockText.pipe(
+            Effect.flatMap((text) =>
+                text !== null && text === payloadText ? removeTolerant(path) : Effect.void,
+            ),
+            Effect.ensuring(Effect.sync(() => clearSelfHold(key, token))),
+        );
 
-    const acquire: IngestLockService["acquire"] = (options) => {
-        const wait = options?.wait ?? false;
-        const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-        const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
-        const now = Date.now();
-        // Wait mode: one deadline governs both the `held` poll loop and the
-        // internal loop-backs. No-wait mode: `held` fails immediately
-        // (`waitUntil === null`), but the internal loop-backs - which are
-        // progress, not waiting - still get a bounded budget so nothing can
-        // spin. The fast paths reach neither.
-        const waitUntil = wait ? now + timeoutMs : null;
-        const deadline = now + (wait ? timeoutMs : NO_WAIT_RETRY_BUDGET_MS);
-        return attempt({ waitUntil, deadline, pollMs });
-    };
+    const acquire: IngestLockService["acquire"] = (options) =>
+        Effect.gen(function* () {
+            const wait = options?.wait ?? false;
+            const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+            const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
+
+            // Hoisted out of `attempt` (it used to run on every recursion):
+            // the directory has to exist before the path can be canonicalized
+            // OR written, and once per acquire is enough.
+            yield* ensureDir;
+            const key = yield* canonicalKey;
+
+            const now = Date.now();
+            // Wait mode: one deadline governs both the `held` poll loop and
+            // the internal loop-backs. No-wait mode: `held` fails immediately
+            // (`waitUntil === null`), but the internal loop-backs - which are
+            // progress, not waiting - still get a bounded budget so nothing
+            // can spin. The fast paths reach neither.
+            const waitUntil = wait ? now + timeoutMs : null;
+            const deadline = now + (wait ? timeoutMs : NO_WAIT_RETRY_BUDGET_MS);
+            const ctx: AttemptCtx = { waitUntil, deadline, pollMs, key, owned: { release: null } };
+
+            // Cross-review P1-3: one acquire per canonical path at a time, so
+            // no fiber can observe the window between "the lock file exists"
+            // and "this process is registered as its holder". `onInterrupt`
+            // sits INSIDE the permit so a lock created but never handed back
+            // to a caller is removed while no other acquirer can be running -
+            // the half-created lock is always either owned or gone.
+            return yield* acquireMutexFor(key).withPermits(1)(
+                attempt(ctx).pipe(
+                    Effect.onInterrupt(() =>
+                        ctx.owned.release === null ? Effect.void : Effect.ignore(ctx.owned.release),
+                    ),
+                ),
+            );
+        });
 
     return { acquire, holder };
 };

--- a/packages/lib/src/duckdb/row-decode.test.ts
+++ b/packages/lib/src/duckdb/row-decode.test.ts
@@ -143,6 +143,20 @@ describe("coerceValue", () => {
         );
     });
 
+    // Cross-review P2-2: DuckDB keeps TIMESTAMP at MICROSECOND grain and a JS
+    // `Date` is millisecond-grain, so the last three digits are dropped -
+    // `.999999` becomes `.999`, and the same truncation applies to negative
+    // (pre-epoch) instants. ax data is millisecond-grain, so this is the
+    // accepted trade rather than a bug to fix; it is PINNED here (and stated
+    // in the decoder docstring + the `DuckDbValue` docs) so it stays a
+    // contract instead of an accident.
+    test("truncates sub-millisecond precision, documented and pinned", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP, "2026-08-14 10:11:12.999999");
+        expect((ts as Date).toISOString()).toBe("2026-08-14T10:11:12.999Z");
+        const before = coerceValue(DuckDbTypeId.TIMESTAMP, "1969-07-20 20:17:40.123456");
+        expect((before as Date).toISOString()).toBe("1969-07-20T20:17:40.123Z");
+    });
+
     test("leaves an unparseable timestamp as its original text rather than an Invalid Date", () => {
         expect(coerceValue(DuckDbTypeId.TIMESTAMP, "infinity")).toBe("infinity");
     });

--- a/packages/lib/src/duckdb/row-decode.test.ts
+++ b/packages/lib/src/duckdb/row-decode.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { accessorFor, coerceValue, unsupportedColumns } from "./row-decode.ts";
+import { DuckDbTypeId } from "./types.ts";
+
+describe("accessorFor", () => {
+    test("maps each integer width to the widest safe row-major accessor", () => {
+        for (const id of [
+            DuckDbTypeId.TINYINT,
+            DuckDbTypeId.SMALLINT,
+            DuckDbTypeId.INTEGER,
+            DuckDbTypeId.BIGINT,
+        ]) {
+            expect(accessorFor(id)).toBe("int64");
+        }
+        for (const id of [
+            DuckDbTypeId.UTINYINT,
+            DuckDbTypeId.USMALLINT,
+            DuckDbTypeId.UINTEGER,
+            DuckDbTypeId.UBIGINT,
+        ]) {
+            expect(accessorFor(id)).toBe("uint64");
+        }
+    });
+
+    test("maps booleans, floats and text", () => {
+        expect(accessorFor(DuckDbTypeId.BOOLEAN)).toBe("boolean");
+        expect(accessorFor(DuckDbTypeId.FLOAT)).toBe("double");
+        expect(accessorFor(DuckDbTypeId.DOUBLE)).toBe("double");
+        expect(accessorFor(DuckDbTypeId.VARCHAR)).toBe("varchar");
+    });
+
+    // Positive control (fix round 1, ruling R10): every one of these was
+    // re-verified against libduckdb v1.5.5 during the fix-round-1 sweep to
+    // actually render through duckdb_value_varchar - this guards against a
+    // future over-eager pruning of VARCHAR_TYPES lumping the proven-good
+    // types in with the eight broken ones below.
+    test("reads date/time/plain-timestamp, decimal, interval and (u)hugeint columns as text", () => {
+        for (const id of [
+            DuckDbTypeId.DATE,
+            DuckDbTypeId.TIME,
+            DuckDbTypeId.TIMESTAMP,
+            DuckDbTypeId.DECIMAL,
+            DuckDbTypeId.HUGEINT,
+            DuckDbTypeId.UHUGEINT,
+            DuckDbTypeId.INTERVAL,
+        ]) {
+            expect(accessorFor(id)).toBe("varchar");
+        }
+    });
+
+    test("refuses BLOB and the nested types (no row-major accessor exists at all)", () => {
+        for (const id of [
+            DuckDbTypeId.BLOB,
+            DuckDbTypeId.LIST,
+            DuckDbTypeId.STRUCT,
+            DuckDbTypeId.MAP,
+            DuckDbTypeId.UNION,
+            DuckDbTypeId.ARRAY,
+        ]) {
+            expect(accessorFor(id)).toBeNull();
+        }
+    });
+
+    // Fix round 1 (ruling R10): empirically swept against libduckdb v1.5.5 -
+    // for every one of these eight, duckdb_value_is_null correctly reports
+    // false for a real (non-SQL-NULL) value, for both a bare literal and a
+    // real table column, but duckdb_value_varchar STILL returns a NULL
+    // char* - a different failure mode than BLOB/nested above (which have
+    // no accessor at all; these DO have one, it just doesn't work). The
+    // value is displayable via CAST(col AS VARCHAR) in SQL; the fixed-width
+    // accessors don't rescue it either (duckdb_value_int64 returns a
+    // plausible-looking 0 for all eight, with no failure signal). Before
+    // this fix these all mapped to "varchar" and silently decoded to "".
+    // Some of these assertions used to live in the "reads ... as text" test
+    // above (TIMESTAMP_S/_MS/_NS, UUID, ENUM all asserted "varchar"); they
+    // move here now that that mapping is wrong, rather than being deleted.
+    test("refuses TIME_TZ, TIMESTAMP_TZ, TIMESTAMP_S/MS/NS, UUID, ENUM, BIT - duckdb_value_varchar cannot render them", () => {
+        for (const id of [
+            DuckDbTypeId.TIME_TZ,
+            DuckDbTypeId.TIMESTAMP_TZ,
+            DuckDbTypeId.TIMESTAMP_S,
+            DuckDbTypeId.TIMESTAMP_MS,
+            DuckDbTypeId.TIMESTAMP_NS,
+            DuckDbTypeId.UUID,
+            DuckDbTypeId.ENUM,
+            DuckDbTypeId.BIT,
+        ]) {
+            expect(accessorFor(id)).toBeNull();
+        }
+    });
+});
+
+describe("coerceValue", () => {
+    test("narrows small integers to number and keeps BIGINT as bigint", () => {
+        expect(coerceValue(DuckDbTypeId.INTEGER, 7n)).toBe(7);
+        expect(coerceValue(DuckDbTypeId.SMALLINT, -3n)).toBe(-3);
+        expect(coerceValue(DuckDbTypeId.BIGINT, 9007199254740993n)).toBe(9007199254740993n);
+    });
+
+    test("keeps BIGINT values inside the safe range as bigint for a stable row type", () => {
+        expect(coerceValue(DuckDbTypeId.BIGINT, 5n)).toBe(5n);
+        expect(coerceValue(DuckDbTypeId.UBIGINT, 5n)).toBe(5n);
+    });
+
+    test("passes booleans, doubles and strings through", () => {
+        expect(coerceValue(DuckDbTypeId.BOOLEAN, true)).toBe(true);
+        expect(coerceValue(DuckDbTypeId.DOUBLE, 1.5)).toBe(1.5);
+        expect(coerceValue(DuckDbTypeId.VARCHAR, "hi")).toBe("hi");
+    });
+
+    test("turns timestamp text into a Date and leaves DATE/TIME as text", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP, "2026-08-14 10:11:12.5");
+        expect(ts).toBeInstanceOf(Date);
+        expect((ts as Date).toISOString()).toBe("2026-08-14T10:11:12.500Z");
+        expect(coerceValue(DuckDbTypeId.DATE, "2026-08-14")).toBe("2026-08-14");
+        expect(coerceValue(DuckDbTypeId.TIME, "10:11:12")).toBe("10:11:12");
+    });
+
+    // Fix round 1 (ruling R10): TIMESTAMP_TZ is no longer in TIMESTAMP_TYPES
+    // (accessorFor now excludes it entirely, see row-decode.ts's
+    // VARCHAR_TYPES comment - duckdb_value_varchar can't render it, so it
+    // never reaches coerceValue from the real read path). These two tests
+    // used to call coerceValue with DuckDbTypeId.TIMESTAMP_TZ to exercise
+    // parseTimestamp's offset/Z-suffix branches; they now do so through
+    // DuckDbTypeId.TIMESTAMP instead, which stays in TIMESTAMP_TYPES - this
+    // is honest about the branches being defensive/unreached-in-production
+    // today (real TIMESTAMP text from DuckDB is always offset-free), kept as
+    // pure-function robustness coverage rather than deleted.
+    test("parseTimestamp normalizes an explicit offset without double-applying it (defensive branch)", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP, "2026-08-14 10:11:12+02");
+        expect((ts as Date).toISOString()).toBe("2026-08-14T08:11:12.000Z");
+    });
+
+    test("parseTimestamp doesn't double a Z suffix that's already present (defensive branch)", () => {
+        const ts = coerceValue(DuckDbTypeId.TIMESTAMP, "2026-08-14 10:11:12Z");
+        expect(ts).toBeInstanceOf(Date);
+        expect((ts as Date).toISOString()).toBe("2026-08-14T10:11:12.000Z");
+    });
+
+    test("TIMESTAMP_TZ is no longer special-cased - accessorFor excludes it upstream, so coerceValue now treats it as opaque text like DATE/TIME", () => {
+        expect(coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "2026-08-14 10:11:12+02")).toBe(
+            "2026-08-14 10:11:12+02",
+        );
+    });
+
+    test("leaves an unparseable timestamp as its original text rather than an Invalid Date", () => {
+        expect(coerceValue(DuckDbTypeId.TIMESTAMP, "infinity")).toBe("infinity");
+    });
+});
+
+describe("unsupportedColumns", () => {
+    test("returns only the columns with no row-major accessor", () => {
+        const columns = [
+            { name: "id", typeId: DuckDbTypeId.BIGINT },
+            { name: "payload", typeId: DuckDbTypeId.BLOB },
+            { name: "tags", typeId: DuckDbTypeId.LIST },
+        ];
+        expect(unsupportedColumns(columns).map((c) => c.name)).toEqual(["payload", "tags"]);
+    });
+});

--- a/packages/lib/src/duckdb/row-decode.ts
+++ b/packages/lib/src/duckdb/row-decode.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure decode rules for the row-major `duckdb_value_*` accessors.
+ *
+ * `bun:ffi` cannot pass structs by value, which rules out `duckdb_fetch_chunk`
+ * (it takes the 48-byte `duckdb_result` by value), so every cell is read
+ * through a pointer-based `duckdb_value_*` accessor. This module holds the two
+ * decisions that follow from that - WHICH accessor a column type needs, and how
+ * the raw accessor result becomes a JS value - so both are testable without a
+ * database.
+ */
+import { DuckDbTypeId, type DuckDbColumn, type DuckDbValue } from "./types.ts";
+
+export type AccessorKind = "boolean" | "int64" | "uint64" | "double" | "varchar";
+
+const INT64_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.TINYINT,
+    DuckDbTypeId.SMALLINT,
+    DuckDbTypeId.INTEGER,
+    DuckDbTypeId.BIGINT,
+]);
+
+const UINT64_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.UTINYINT,
+    DuckDbTypeId.USMALLINT,
+    DuckDbTypeId.UINTEGER,
+    DuckDbTypeId.UBIGINT,
+]);
+
+const DOUBLE_TYPES: ReadonlySet<number> = new Set([DuckDbTypeId.FLOAT, DuckDbTypeId.DOUBLE]);
+
+/**
+ * Types with no fixed-width row-major accessor that DuckDB WILL render
+ * faithfully as text via `duckdb_value_varchar`: strings, date/time/plain
+ * timestamp, intervals, 128-bit ints, decimal. `SQLNULL` is here too, but
+ * never actually reaches the accessor - a literal SQL `NULL`'s cell always
+ * reports `duckdb_value_is_null() == true`, so `readResult` takes the
+ * null-cell branch before any accessor is called for it.
+ *
+ * EIGHT other types were empirically swept against libduckdb v1.5.5 (fix
+ * round 1, ruling R10) and are DELIBERATELY EXCLUDED, for a DIFFERENT reason
+ * than BLOB/nested types below (which have no row-major accessor at all):
+ * for these eight, `duckdb_value_is_null` correctly reports `false` for a
+ * real value, but `duckdb_value_varchar` still returns a NULL `char *` - on
+ * both a bare literal and a real table column, and even though a SQL
+ * `CAST(col AS VARCHAR)` on the same value renders it fine. (One caveat:
+ * UUID's `duckdb_value_is_null` was also observed reporting `false` for a
+ * GENUINELY NULL value under a `WHERE u IS NULL` filter - the other seven
+ * were not re-swept for the same anomaly. This does not change shipped
+ * behavior: UUID is rejected earlier, structurally, at `unsupportedColumns`
+ * below, so `readResult`'s per-cell `is_null` check is never reached for it
+ * at all.) The fixed-width
+ * accessors don't rescue them either: `duckdb_value_int64` was checked and
+ * returns a plausible-looking `0` for every one of them, with no failure
+ * signal at all - so none of these should ever be routed to
+ * `int64`/`uint64`/`double` as a workaround. Before this fix, the NULL
+ * varchar pointer silently decoded to `""` for all eight. A future reader:
+ * do not try to "fix" this by giving these an accessor again without first
+ * re-verifying against whatever libduckdb build is in use.
+ *
+ *   TIME_TZ (30), TIMESTAMP_TZ (31), TIMESTAMP_S (20), TIMESTAMP_MS (21),
+ *   TIMESTAMP_NS (22), UUID (27), ENUM (23), BIT (29)
+ *
+ * `client.ts`'s `readResult` also carries a general guard for this exact
+ * failure shape (not-null cell, NULL varchar pointer) on any type still
+ * listed here as "varchar" - it is what would have caught these eight
+ * before they shipped, and is what will catch whatever DuckDB adds next.
+ */
+const VARCHAR_TYPES: ReadonlySet<number> = new Set([
+    DuckDbTypeId.VARCHAR,
+    DuckDbTypeId.DATE,
+    DuckDbTypeId.TIME,
+    DuckDbTypeId.TIMESTAMP,
+    DuckDbTypeId.INTERVAL,
+    DuckDbTypeId.HUGEINT,
+    DuckDbTypeId.UHUGEINT,
+    DuckDbTypeId.DECIMAL,
+    DuckDbTypeId.SQLNULL,
+]);
+
+/** Which `duckdb_value_*` accessor reads this column, or null when none can. */
+export const accessorFor = (typeId: number): AccessorKind | null => {
+    if (typeId === DuckDbTypeId.BOOLEAN) return "boolean";
+    if (INT64_TYPES.has(typeId)) return "int64";
+    if (UINT64_TYPES.has(typeId)) return "uint64";
+    if (DOUBLE_TYPES.has(typeId)) return "double";
+    if (VARCHAR_TYPES.has(typeId)) return "varchar";
+    return null;
+};
+
+/**
+ * Types read as text but handed back as a Date. As of fix round 1, this is
+ * exactly ONE type - `TIMESTAMP_S`/`_MS`/`_NS`/`_TZ` and `TIME_TZ` were all
+ * removed from `VARCHAR_TYPES` above (they never reach `coerceValue` from
+ * the real read path any more), so keeping them here too would just be dead
+ * entries. Left as a `Set` rather than inlining `typeId === TIMESTAMP`
+ * below so a future temporal type can be added back in one place if a later
+ * libduckdb build ever fixes the accessor for it.
+ */
+const TIMESTAMP_TYPES: ReadonlySet<number> = new Set([DuckDbTypeId.TIMESTAMP]);
+
+/**
+ * DuckDB prints a `TIMESTAMP` (offset-free, means UTC here) as
+ * `YYYY-MM-DD HH:MM:SS[.ffffff]`, so the common case just needs a `Z`
+ * appended. The `Z`-suffix and explicit-offset branches below exist for
+ * defensive robustness against text that already carries either - `TIMESTAMP`
+ * never actually renders one, and `TIMESTAMP_TZ` (which would have) is no
+ * longer routed here at all (fix round 1; see the comment on
+ * `VARCHAR_TYPES`), so neither branch is exercised by any type today. Kept,
+ * not deleted, as pure and independently-testable behavior of this
+ * function, in case a future offset-bearing temporal type is ever routed
+ * here.
+ */
+const parseTimestamp = (text: string): Date | string => {
+    if (/Z$/.test(text)) {
+        return finishTimestamp(text.replace(" ", "T"), text);
+    }
+    const offsetMatch = /([+-])(\d{2}(?::?\d{2})?)$/.exec(text);
+    if (offsetMatch) {
+        const [, sign, digits] = offsetMatch;
+        const clean = digits.replace(":", "");
+        const offset = `${sign}${clean.slice(0, 2)}:${clean.slice(2, 4) || "00"}`;
+        const body = text.slice(0, offsetMatch.index).replace(" ", "T");
+        return finishTimestamp(`${body}${offset}`, text);
+    }
+    return finishTimestamp(`${text.replace(" ", "T")}Z`, text);
+};
+
+/** Parse `iso`; fall back to `original` text rather than an Invalid Date. */
+const finishTimestamp = (iso: string, original: string): Date | string => {
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? original : date;
+};
+
+/** Raw accessor output -> the JS value callers see. */
+export const coerceValue = (
+    typeId: number,
+    raw: boolean | bigint | number | string,
+): DuckDbValue => {
+    if (typeof raw === "string") {
+        return TIMESTAMP_TYPES.has(typeId) ? parseTimestamp(raw) : raw;
+    }
+    if (typeof raw === "bigint") {
+        // 64-bit columns stay bigint so a row's TS type never depends on the
+        // magnitude of the value it happens to hold. Narrower widths cannot
+        // overflow a JS number, so they come back as number.
+        if (typeId === DuckDbTypeId.BIGINT || typeId === DuckDbTypeId.UBIGINT) return raw;
+        return Number(raw);
+    }
+    return raw;
+};
+
+/** Result columns this client cannot decode. */
+export const unsupportedColumns = (
+    columns: ReadonlyArray<DuckDbColumn>,
+): ReadonlyArray<DuckDbColumn> => columns.filter((c) => accessorFor(c.typeId) === null);

--- a/packages/lib/src/duckdb/row-decode.ts
+++ b/packages/lib/src/duckdb/row-decode.ts
@@ -125,7 +125,26 @@ const parseTimestamp = (text: string): Date | string => {
     return finishTimestamp(`${text.replace(" ", "T")}Z`, text);
 };
 
-/** Parse `iso`; fall back to `original` text rather than an Invalid Date. */
+/**
+ * Parse `iso`; fall back to `original` text rather than an Invalid Date.
+ *
+ * PRECISION IS LOST HERE, DELIBERATELY (cross-review P2-2). DuckDB stores
+ * `TIMESTAMP` at MICROSECOND grain and renders all six digits; a JS `Date`
+ * holds whole MILLISECONDS, so `new Date(...)` TRUNCATES the last three:
+ * `2026-08-14 10:11:12.999999` comes back as `...12.999Z`, and the same
+ * applies to pre-epoch instants (truncation toward the millisecond boundary
+ * `Date` can represent, never a rounding). Nothing warns; the value simply
+ * loses its tail.
+ *
+ * This is accepted, not overlooked: every ax timestamp is millisecond-grain
+ * (JS `Date.now()`, transcript timestamps, OTLP millis), so the truncated
+ * digits carry no information ax ever wrote, and a `Date` is what every
+ * caller and every `Schema` in this repo expects. A caller that genuinely
+ * needs microsecond fidelity must NOT read the column as `TIMESTAMP` - it
+ * should project it in SQL (`CAST(ts AS VARCHAR)`, or `epoch_us(ts)` for an
+ * exact integer) and keep the text/bigint. The behavior is pinned by a test
+ * in row-decode.test.ts so it stays a contract rather than an accident.
+ */
 const finishTimestamp = (iso: string, original: string): Date | string => {
     const date = new Date(iso);
     return Number.isNaN(date.getTime()) ? original : date;

--- a/packages/lib/src/duckdb/snapshot.test.ts
+++ b/packages/lib/src/duckdb/snapshot.test.ts
@@ -1,0 +1,366 @@
+/**
+ * `publishSnapshot` / `openSnapshot` - the atomic hand-off between the live,
+ * ingest-locked database and the read-only snapshot every reader opens.
+ *
+ * Ruling R9: `Effect.either` does not exist in `effect@4.0.0-beta.78` - the
+ * v4 equivalent is `Effect.result`, returning `Result.Result<A, E>` with
+ * `_tag: "Success" | "Failure"` and the failure value on `.failure` (verified
+ * against `node_modules/effect/src/Effect.ts:3454` and
+ * `node_modules/effect/src/Result.ts:159`).
+ *
+ * Ruling R3 / task-7 brief note: `count(*)` decodes as `BIGINT`, which this
+ * client keeps as `bigint` (see row-decode.ts) - so the expected values below
+ * are `1n`/`2n`, not `1`/`2`.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { noteSkippedDylib, resolveTestDylib } from "../testing/duckdb-dylib.ts";
+import { DuckDb, DuckDbLayer } from "./client.ts";
+import type { DuckDbService } from "./client.ts";
+
+// Resolved at module load (top-level await), not in `beforeAll`, so
+// `test.skipIf` below sees a real boolean at test-registration time and bun
+// reports a SKIP status - distinct from a PASS - when no dylib is available.
+// Finding 3 (final fix round): the previous `beforeAll` + runtime
+// `expect(skipReason.length).toBeGreaterThan(0)` guard reported PASS for
+// every one of these tests on a dylib-less box, with only a console.warn as
+// the signal - mirrors ffi.test.ts's convention exactly.
+const found = await resolveTestDylib();
+const dylibPath = found.ok ? found.path : null;
+if (!found.ok) noteSkippedDylib("duckdb snapshot", found.reason);
+const layer = dylibPath !== null ? DuckDbLayer(dylibPath) : null;
+
+/** `test`, bound to skip (not pass) every dylib-dependent case below when no
+ *  dylib is available. */
+const dtest = test.skipIf(dylibPath === null);
+
+// Finding 4 (final fix round): every dir this suite creates is collected
+// here and removed in one afterAll - see dylib.test.ts for the measured
+// leak this closes.
+const createdTempDirs: string[] = [];
+const workDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-duckdb-snapshot-"));
+    createdTempDirs.push(dir);
+    return dir;
+};
+
+afterAll(() => {
+    for (const dir of createdTempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Runs `body` with the DuckDb service. Only ever invoked via `dtest`, which
+ *  skips registration entirely when `layer` is null - the non-null assertion
+ *  is safe by construction. */
+const withDuckDb = <A>(body: (db: DuckDbService) => Effect.Effect<A, unknown>) => async () => {
+    await Effect.runPromise(
+        Effect.gen(function* () {
+            const db = yield* DuckDb;
+            yield* body(db);
+        }).pipe(Effect.provide(layer as NonNullable<typeof layer>)) as Effect.Effect<void>,
+    );
+};
+
+describe("publishSnapshot", () => {
+    dtest(
+        "copies the live database to the snapshot path and leaves no temp files",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'first')");
+                yield* rw.close;
+
+                yield* db.publishSnapshot(live, snap);
+                expect(existsSync(snap)).toBe(true);
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+
+                const reader = yield* db.openSnapshot(snap);
+                expect(reader.readOnly).toBe(true);
+                expect((yield* reader.query("SELECT note FROM t")).rows).toEqual([
+                    { note: "first" },
+                ]);
+                yield* reader.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "a reader holding the OLD snapshot keeps reading while a new one is renamed into place",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'v1')");
+                yield* rw.close;
+                yield* db.publishSnapshot(live, snap);
+
+                // A reader opens v1 and HOLDS it open across the republish.
+                const reader = yield* db.openSnapshot(snap);
+                const inodeBefore = statSync(snap).ino;
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+
+                const rw2 = yield* db.open(live);
+                yield* rw2.exec("INSERT INTO t VALUES (2, 'v2')");
+                yield* rw2.close;
+                yield* db.publishSnapshot(live, snap);
+
+                // the path now points at a NEW inode ...
+                expect(statSync(snap).ino).not.toBe(inodeBefore);
+                // ... while the held reader still sees the OLD contents.
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+                yield* reader.close;
+
+                // a fresh reader sees the new snapshot
+                const fresh = yield* db.openSnapshot(snap);
+                expect((yield* fresh.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(2n);
+                yield* fresh.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "a failed publish leaves the previous snapshot intact",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+                yield* rw.close;
+                yield* db.publishSnapshot(live, snap);
+
+                const result = yield* Effect.result(
+                    db.publishSnapshot(join(dir, "does-not-exist.duckdb"), snap),
+                );
+                expect(result._tag).toBe("Failure");
+
+                const reader = yield* db.openSnapshot(snap);
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+                yield* reader.close;
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+            }),
+        ),
+    );
+
+    // Fix round 1 evidence gap: the "missing livePath" case above returns at
+    // the very first guard, before any temp file is ever created - so its
+    // "no litter" assertion (and, less obviously, "previous snapshot
+    // intact") holds vacuously and would pass against an implementation with
+    // NO cleanup logic at all. This test forces the failure at the LAST
+    // possible step instead - the final rename - by pre-seeding the
+    // destination as a non-empty directory. Standard POSIX `rename(2)`
+    // refuses to replace a non-empty directory with a file (no special
+    // privilege needed, portable to Linux CI - unlike an immutable-file
+    // trick, which is macOS-only), so CHECKPOINT/ATTACH/COPY/DETACH all run
+    // to completion FIRST, producing a real, fully-populated temp snapshot
+    // file on disk, and ONLY THEN does the rename fail. An implementation
+    // with no cleanup logic would leave that real file sitting in `dir`,
+    // which this test's `readdirSync` assertion would catch.
+    dtest(
+        "a failure at the final rename still removes the fully-copied temp file and leaves the destination untouched",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+                yield* rw.close;
+
+                // Sabotage: `snap` is a non-empty directory, not a file -
+                // the eventual `fs.rename(tmp, snap)` cannot succeed.
+                mkdirSync(snap);
+                mkdirSync(join(snap, "nested"));
+
+                const result = yield* Effect.result(db.publishSnapshot(live, snap));
+                expect(result._tag).toBe("Failure");
+
+                // the destination is exactly as it was - still the pre-seeded
+                // directory, never swapped for the temp file.
+                expect(existsSync(join(snap, "nested"))).toBe(true);
+                // and the fully-copied temp file (a real duckdb database, not
+                // a stub) was removed - no litter, this time non-vacuously.
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+            }),
+        ),
+    );
+});
+
+describe("publishSnapshot options.from (RULING R14)", () => {
+    dtest(
+        "publishing through the caller's own connection sees commits made through that same connection",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+                yield* rw.exec("INSERT INTO t VALUES (2)");
+                yield* rw.exec("INSERT INTO t VALUES (3)");
+
+                // Publish WHILE rw stays open, running the copy THROUGH rw.
+                yield* db.publishSnapshot(live, snap, { from: rw });
+                const reader1 = yield* db.openSnapshot(snap);
+                expect((yield* reader1.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3n);
+                yield* reader1.close;
+
+                // Commit MORE through the still-open writer and republish
+                // through it again - the snapshot must reflect the new rows.
+                yield* rw.exec("INSERT INTO t VALUES (4)");
+                yield* rw.exec("INSERT INTO t VALUES (5)");
+                yield* db.publishSnapshot(live, snap, { from: rw });
+                const reader2 = yield* db.openSnapshot(snap);
+                expect((yield* reader2.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(5n);
+                yield* reader2.close;
+
+                // `publishSnapshot` never closes a connection handed in via
+                // `from` - it must still be usable here.
+                expect((yield* rw.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(5n);
+                yield* rw.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "documented hazard: WITHOUT `from`, publishing while the same-process writer stays open can freeze the snapshot at a stale row count",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+                yield* rw.exec("INSERT INTO t VALUES (2)");
+                yield* rw.exec("INSERT INTO t VALUES (3)");
+
+                // No `from` - publishSnapshot opens its OWN handle on `live`
+                // while `rw` is still open in this same process (RULING R14).
+                yield* db.publishSnapshot(live, snap);
+                const reader1 = yield* db.openSnapshot(snap);
+                expect((yield* reader1.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3n);
+                yield* reader1.close;
+
+                // The writer commits two MORE rows while still open ...
+                yield* rw.exec("INSERT INTO t VALUES (4)");
+                yield* rw.exec("INSERT INTO t VALUES (5)");
+                expect((yield* rw.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(5n);
+
+                // ... but a second no-`from` publish, still with the writer
+                // open, does NOT see them: this is the documented hazard -
+                // a stale snapshot, silently, with no error raised.
+                yield* db.publishSnapshot(live, snap);
+                const reader2 = yield* db.openSnapshot(snap);
+                expect((yield* reader2.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3n);
+                yield* reader2.close;
+
+                yield* rw.close;
+
+                // Once the writer is closed, a fresh no-`from` publish sees
+                // everything - confirming the 5 rows really were committed to
+                // disk all along, and the earlier staleness was purely a
+                // same-process, writer-still-open artifact of opening a
+                // second handle on `live`, not data loss.
+                yield* db.publishSnapshot(live, snap);
+                const reader3 = yield* db.openSnapshot(snap);
+                expect((yield* reader3.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(5n);
+                yield* reader3.close;
+            }),
+        ),
+    );
+
+    // Fix round 2: before this round, the ATTACH...DETACH span ran as a flat
+    // sequence with no `Effect.ensuring`. That was harmless for the no-`from`
+    // path (its connection is always closed unconditionally right after, and
+    // closing a DuckDB handle tears down its attachments anyway) - but the
+    // WHOLE POINT of `from` is a long-lived, caller-owned connection reused
+    // across repeated publishes. A mid-copy failure left `ax_snapshot`
+    // permanently attached on that connection, so every LATER publish
+    // through it failed forever with "database ax_snapshot already exists" -
+    // silently, since the connection stayed otherwise perfectly usable.
+    dtest(
+        "a mid-copy failure on the `from` path still leaves the connection usable for a later publish",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                for (let i = 0; i < 3000; i++) {
+                    yield* rw.exec(`INSERT INTO t VALUES (${i}, '${"x".repeat(2000)}')`);
+                }
+                // Flush normally at full memory, THEN clamp memory_limit so
+                // the COPY step itself (not CHECKPOINT, which has nothing
+                // left to flush) runs out of memory - a real, non-fatal
+                // DuckDB error ("Out of Memory Error: failed to pin block"),
+                // not the FATAL "database has been invalidated" error a low
+                // memory_limit produces during an actual checkpoint. This
+                // leaves `rw` perfectly usable afterward, matching the
+                // documented hazard exactly: the connection looks fine, only
+                // `publishSnapshot` through it is broken.
+                yield* rw.exec("CHECKPOINT");
+                yield* rw.exec("PRAGMA memory_limit='2MB'");
+
+                // THE ASSERTION THAT MATTERS: `publishSnapshot` ATTACHes a
+                // randomly-aliased database on `rw` and must DETACH it again
+                // on every path, including a mid-copy failure - a leaked
+                // attachment does NOT collide with any later publish (the
+                // alias is a fresh `crypto.randomUUID()` per call, so "a
+                // later publish through the same connection still succeeds"
+                // proves nothing: it passes even with
+                // `Effect.ensuring(detach)` deleted entirely). The direct
+                // check is the attachment count on `rw` itself, via
+                // `duckdb_databases()`, taken immediately before and after
+                // the failed publish.
+                const attachmentCount = () =>
+                    Effect.gen(function* () {
+                        const result = yield* rw.query("SELECT count(*) AS n FROM duckdb_databases()");
+                        return result.rows[0]!.n as bigint;
+                    });
+
+                const attachmentsBefore = yield* attachmentCount();
+
+                const first = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
+                expect(first._tag).toBe("Failure");
+
+                const attachmentsAfter = yield* attachmentCount();
+                expect(attachmentsAfter).toBe(attachmentsBefore);
+
+                // restore normal memory and confirm the connection is
+                // otherwise completely healthy - the failure was ordinary,
+                // not fatal.
+                yield* rw.exec("PRAGMA memory_limit='4GB'");
+                expect((yield* rw.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3000n);
+
+                // A subsequent publish through the same connection still
+                // succeeds too, kept as a secondary end-to-end check.
+                const second = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
+                expect(second._tag).toBe("Success");
+
+                yield* rw.close;
+            }),
+        ),
+    );
+});

--- a/packages/lib/src/duckdb/snapshot.test.ts
+++ b/packages/lib/src/duckdb/snapshot.test.ts
@@ -202,6 +202,94 @@ describe("publishSnapshot", () => {
     );
 });
 
+// Cross-review P1-6 / P2-4: `publishSnapshot` trusted its arguments. With a
+// `from` connection open on a DIFFERENT database it published that unrelated
+// database under the caller's snapshot name; with live === snapshot it
+// renamed the live pathname onto itself, leaving any later writer working on
+// an unlinked inode. Both are now typed refusals, compared on the CANONICAL
+// (realpath'd) form so `./x` and a symlinked alias cannot slip past.
+describe("publishSnapshot argument checks", () => {
+    dtest(
+        "refuses to publish when options.from is open on a different database",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const other = join(dir, "other.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.close;
+
+                const foreign = yield* db.open(other);
+                yield* foreign.exec("CREATE TABLE other_table (id INTEGER)");
+
+                const result = yield* Effect.result(db.publishSnapshot(live, snap, { from: foreign }));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("SnapshotPublishError");
+                    const message = (result.failure as { message: string }).message;
+                    expect(message).toContain("other.duckdb");
+                    expect(message).toContain("live.duckdb");
+                }
+                // nothing was published from the wrong database
+                expect(existsSync(snap)).toBe(false);
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+
+                yield* foreign.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "accepts options.from opened through a path alias of the same database",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.exec("INSERT INTO t VALUES (1)");
+
+                // Same file, spelled differently - canonicalization must see
+                // through it rather than rejecting a legitimate publish.
+                yield* db.publishSnapshot(join(dir, ".", "live.duckdb"), snap, { from: rw });
+                const reader = yield* db.openSnapshot(snap);
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+                yield* reader.close;
+                yield* rw.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "refuses to publish a database onto itself",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER)");
+                yield* rw.close;
+
+                for (const target of [live, join(dir, ".", "live.duckdb")]) {
+                    const result = yield* Effect.result(db.publishSnapshot(live, target));
+                    expect(result._tag).toBe("Failure");
+                    if (result._tag === "Failure") {
+                        expect(result.failure._tag).toBe("SnapshotPublishError");
+                        expect((result.failure as { message: string }).message).toContain("same");
+                    }
+                }
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+            }),
+        ),
+    );
+});
+
 describe("publishSnapshot options.from (RULING R14)", () => {
     dtest(
         "publishing through the caller's own connection sees commits made through that same connection",

--- a/packages/lib/src/duckdb/types.ts
+++ b/packages/lib/src/duckdb/types.ts
@@ -47,9 +47,29 @@ export type DuckDbTypeId = (typeof DuckDbTypeId)[keyof typeof DuckDbTypeId];
 export const duckDbTypeName = (id: number): string =>
     Object.entries(DuckDbTypeId).find(([, v]) => v === id)?.[0] ?? `TYPE_${id}`;
 
-/** Every JS value a decoded cell can take. */
+/**
+ * Every JS value a decoded cell can take.
+ *
+ * `Date` (a `TIMESTAMP` column) is MILLISECOND-grain while DuckDB stores
+ * microseconds, so the last three digits of a sub-second value are TRUNCATED
+ * on the way out - `10:11:12.999999` reads back as `10:11:12.999`
+ * (cross-review P2-2; see `finishTimestamp` in row-decode.ts for why this is
+ * the accepted trade for ax data, and what to do when it is not acceptable:
+ * project the column as text or `epoch_us(...)`).
+ *
+ * `bigint` is reserved for 64-bit integer columns (`BIGINT`/`UBIGINT`), so a
+ * row's TS type never depends on the magnitude of the value it happens to
+ * hold; narrower integer widths come back as `number`.
+ */
 export type DuckDbValue = string | number | bigint | boolean | Date | null;
 
+/**
+ * One decoded row, keyed by column name. Built on a NULL-PROTOTYPE object
+ * (cross-review P2-1), so `__proto__`, `constructor` and `toString` are plain
+ * data keys like any other and a lookup can never reach `Object.prototype`.
+ * Column names are unique by construction - a result with two columns of the
+ * same name is refused at decode time rather than silently collapsing them.
+ */
 export type DuckDbRow = Readonly<Record<string, DuckDbValue>>;
 
 export interface DuckDbColumn {

--- a/packages/lib/src/duckdb/types.ts
+++ b/packages/lib/src/duckdb/types.ts
@@ -1,0 +1,68 @@
+/**
+ * `duckdb_type` enum values from duckdb.h (v1.5.5). Only the ids this client
+ * can decode are named; anything else surfaces as a raw number in
+ * `DuckDbUnsupportedTypeError`.
+ */
+export const DuckDbTypeId = {
+    INVALID: 0,
+    BOOLEAN: 1,
+    TINYINT: 2,
+    SMALLINT: 3,
+    INTEGER: 4,
+    BIGINT: 5,
+    UTINYINT: 6,
+    USMALLINT: 7,
+    UINTEGER: 8,
+    UBIGINT: 9,
+    FLOAT: 10,
+    DOUBLE: 11,
+    TIMESTAMP: 12,
+    DATE: 13,
+    TIME: 14,
+    INTERVAL: 15,
+    HUGEINT: 16,
+    VARCHAR: 17,
+    BLOB: 18,
+    DECIMAL: 19,
+    TIMESTAMP_S: 20,
+    TIMESTAMP_MS: 21,
+    TIMESTAMP_NS: 22,
+    ENUM: 23,
+    LIST: 24,
+    STRUCT: 25,
+    MAP: 26,
+    UUID: 27,
+    UNION: 28,
+    BIT: 29,
+    TIME_TZ: 30,
+    TIMESTAMP_TZ: 31,
+    UHUGEINT: 32,
+    ARRAY: 33,
+    SQLNULL: 36,
+} as const;
+
+export type DuckDbTypeId = (typeof DuckDbTypeId)[keyof typeof DuckDbTypeId];
+
+/** Human name for a duckdb type id, for error messages. */
+export const duckDbTypeName = (id: number): string =>
+    Object.entries(DuckDbTypeId).find(([, v]) => v === id)?.[0] ?? `TYPE_${id}`;
+
+/** Every JS value a decoded cell can take. */
+export type DuckDbValue = string | number | bigint | boolean | Date | null;
+
+export type DuckDbRow = Readonly<Record<string, DuckDbValue>>;
+
+export interface DuckDbColumn {
+    readonly name: string;
+    readonly typeId: number;
+}
+
+export interface QueryResult {
+    readonly columns: ReadonlyArray<DuckDbColumn>;
+    readonly rows: ReadonlyArray<DuckDbRow>;
+    /** Rows changed by a DML statement; 0 for SELECTs. */
+    readonly rowsChanged: number;
+}
+
+/** Values accepted as prepared-statement parameters. */
+export type DuckDbParam = string | number | bigint | boolean | Date | null | undefined;

--- a/packages/lib/src/testing/duckdb-dylib.test.ts
+++ b/packages/lib/src/testing/duckdb-dylib.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
-import { repoRootFrom, resolveTestDylib } from "./duckdb-dylib.ts";
+import { existsSync, mkdtempSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    claimDownloadSentinel,
+    releaseDownloadSentinel,
+    repoRootFrom,
+    resolveTestDylib,
+} from "./duckdb-dylib.ts";
 
 describe("resolveTestDylib", () => {
     test("either resolves to a real file on disk or explains why it cannot", async () => {
@@ -23,6 +30,40 @@ describe("resolveTestDylib", () => {
         } finally {
             if (prev === undefined) delete process.env.AX_DUCKDB_DYLIB;
             else process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+});
+
+// Cross-review P3-4: parallel test processes shared ONE zip path and ONE
+// extraction directory, so a second process could read a half-written
+// archive or a half-extracted library. Downloads now run single-file behind
+// an exclusive-create sentinel; everyone else waits for the result.
+describe("download single-flight", () => {
+    test("only the first caller claims the sentinel; a second call is told to wait", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dylib-sentinel-"));
+        try {
+            const sentinel = join(dir, "download.lock");
+            expect(claimDownloadSentinel(sentinel)).toBe("claimed");
+            expect(claimDownloadSentinel(sentinel)).toBe("busy");
+            releaseDownloadSentinel(sentinel);
+            expect(claimDownloadSentinel(sentinel)).toBe("claimed");
+            releaseDownloadSentinel(sentinel);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("a sentinel left behind by a crashed process ages out instead of wedging every later run", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dylib-sentinel-"));
+        try {
+            const sentinel = join(dir, "download.lock");
+            expect(claimDownloadSentinel(sentinel)).toBe("claimed");
+            const longAgo = new Date(Date.now() - 60 * 60_000);
+            utimesSync(sentinel, longAgo, longAgo);
+            expect(claimDownloadSentinel(sentinel)).toBe("claimed");
+            releaseDownloadSentinel(sentinel);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
         }
     });
 });

--- a/packages/lib/src/testing/duckdb-dylib.test.ts
+++ b/packages/lib/src/testing/duckdb-dylib.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { repoRootFrom, resolveTestDylib } from "./duckdb-dylib.ts";
+
+describe("resolveTestDylib", () => {
+    test("either resolves to a real file on disk or explains why it cannot", async () => {
+        const found = await resolveTestDylib();
+        if (found.ok) {
+            expect(existsSync(found.path)).toBe(true);
+        } else {
+            expect(found.reason.length).toBeGreaterThan(0);
+        }
+    });
+
+    test("honours AX_DUCKDB_DYLIB when it points at an existing file", async () => {
+        const first = await resolveTestDylib();
+        if (!first.ok) return; // nothing on disk to point at; covered by the test above
+        const prev = process.env.AX_DUCKDB_DYLIB;
+        process.env.AX_DUCKDB_DYLIB = first.path;
+        try {
+            const second = await resolveTestDylib();
+            expect(second).toEqual({ ok: true, path: first.path });
+        } finally {
+            if (prev === undefined) delete process.env.AX_DUCKDB_DYLIB;
+            else process.env.AX_DUCKDB_DYLIB = prev;
+        }
+    });
+});
+
+describe("repoRootFrom", () => {
+    test("reports failure instead of silently falling back when no turbo.json is found while walking up", () => {
+        // /private/tmp -> /private -> / ; none of these hold a turbo.json,
+        // so the walk exhausts and the failure must be observable, not a
+        // silent process.cwd() fallback.
+        const result = repoRootFrom("/private/tmp");
+        expect(result.ok).toBe(false);
+    });
+
+    test("finds the repo root when turbo.json is present on the walk", () => {
+        const result = repoRootFrom(import.meta.dir);
+        expect(result).toEqual({ ok: true, dir: expect.any(String) });
+        if (result.ok) {
+            expect(existsSync(`${result.dir}/turbo.json`)).toBe(true);
+        }
+    });
+});

--- a/packages/lib/src/testing/duckdb-dylib.ts
+++ b/packages/lib/src/testing/duckdb-dylib.ts
@@ -1,0 +1,117 @@
+/**
+ * Test-only resolution of a libduckdb shared library.
+ *
+ * Order: `AX_DUCKDB_DYLIB` (the injection point the custom static dylib from
+ * chunk w0-dylib-ci will use) -> the gitignored `vendor/duckdb/<version>/`
+ * cache -> a one-time download of the official prebuilt release. When the
+ * download is impossible (offline CI, unsupported platform) this returns a
+ * REASON rather than throwing, so suites can skip with a notice instead of
+ * failing red for an environment problem.
+ */
+import { existsSync, mkdirSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DUCKDB_VERSION = "v1.5.5";
+
+export type TestDylib =
+    | { readonly ok: true; readonly path: string }
+    | { readonly ok: false; readonly reason: string };
+
+export type RepoRootResult = { readonly ok: true; readonly dir: string } | { readonly ok: false };
+
+/**
+ * Walk up from `startDir` looking for the directory holding `turbo.json`.
+ * Exported separately from `repoRoot()` below so the failure path (no
+ * `turbo.json` found within 10 levels) is unit-testable without having to
+ * fake `import.meta.url`.
+ */
+export const repoRootFrom = (startDir: string): RepoRootResult => {
+    let dir = startDir;
+    for (let i = 0; i < 10; i += 1) {
+        if (existsSync(join(dir, "turbo.json"))) return { ok: true, dir };
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    return { ok: false };
+};
+
+/**
+ * Repo root, found by walking up from this file. Uses `Bun.fileURLToPath`
+ * (not `new URL(...).pathname`) because the pathname is percent-encoded -
+ * a checkout under a path with a space or non-ASCII character (e.g.
+ * `/Users/x/My Projects/...`) would make every `existsSync` probe below miss
+ * and the walk would exhaust silently.
+ */
+const repoRoot = (): RepoRootResult => repoRootFrom(dirname(Bun.fileURLToPath(import.meta.url)));
+
+const libFileName = (): string => (platform() === "darwin" ? "libduckdb.dylib" : "libduckdb.so");
+
+/** Official release asset for this platform, or null when unsupported. */
+const releaseAsset = (): string | null => {
+    if (platform() === "darwin") return "libduckdb-osx-universal.zip";
+    if (platform() === "linux") {
+        return arch() === "arm64" ? "libduckdb-linux-arm64.zip" : "libduckdb-linux-amd64.zip";
+    }
+    return null;
+};
+
+export const vendorDir = (root: string): string => join(root, "vendor", "duckdb", DUCKDB_VERSION);
+
+export const resolveTestDylib = async (): Promise<TestDylib> => {
+    const injected = process.env.AX_DUCKDB_DYLIB?.trim();
+    if (injected) {
+        return existsSync(injected)
+            ? { ok: true, path: injected }
+            : { ok: false, reason: `AX_DUCKDB_DYLIB points at a missing file: ${injected}` };
+    }
+
+    const root = repoRoot();
+    if (!root.ok) {
+        return {
+            ok: false,
+            reason:
+                "could not locate the repo root (walked up 10 levels from duckdb-dylib.ts without finding turbo.json)",
+        };
+    }
+    const dir = vendorDir(root.dir);
+
+    const cached = join(dir, libFileName());
+    if (existsSync(cached)) return { ok: true, path: cached };
+
+    const asset = releaseAsset();
+    if (asset === null) {
+        return { ok: false, reason: `no official libduckdb build for ${platform()}/${arch()}` };
+    }
+
+    const url = `https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/${asset}`;
+    try {
+        mkdirSync(dir, { recursive: true });
+        const zipPath = join(dir, asset);
+        const response = await fetch(url);
+        if (!response.ok) {
+            return { ok: false, reason: `download failed: ${url} -> HTTP ${response.status}` };
+        }
+        await Bun.write(zipPath, await response.arrayBuffer());
+        const unzip = Bun.spawnSync(["unzip", "-o", "-q", zipPath, "-d", dir], {
+            stdout: "ignore",
+            stderr: "pipe",
+        });
+        if (unzip.exitCode !== 0) {
+            return { ok: false, reason: `unzip failed: ${unzip.stderr.toString().trim()}` };
+        }
+        if (!existsSync(cached)) {
+            return { ok: false, reason: `archive ${asset} did not contain ${libFileName()}` };
+        }
+        return { ok: true, path: cached };
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, reason: `download failed: ${url} -> ${message}` };
+    }
+};
+
+/** Prints a uniform notice so a skipped suite is visible in test output. */
+export const noteSkippedDylib = (suite: string, reason: string): void => {
+    console.warn(`[skip] ${suite}: no libduckdb available (${reason})`);
+};

--- a/packages/lib/src/testing/duckdb-dylib.ts
+++ b/packages/lib/src/testing/duckdb-dylib.ts
@@ -7,8 +7,17 @@
  * download is impossible (offline CI, unsupported platform) this returns a
  * REASON rather than throwing, so suites can skip with a notice instead of
  * failing red for an environment problem.
+ *
+ * The download is SINGLE-FLIGHT across processes (cross-review P3-4): one
+ * caller claims an exclusive-create sentinel and downloads, everyone else
+ * waits for the published library rather than racing it into the same files.
+ *
+ * `node:fs` is used deliberately here and only here in this module family:
+ * this is a TEST FIXTURE, not runtime code, so the `check:no-node-fs` gate
+ * (which scans runtime sources) does not apply and an Effect `FileSystem`
+ * would only add ceremony to something that runs before any layer exists.
  */
-import { existsSync, mkdirSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, rmSync, statSync } from "node:fs";
 import { arch, platform } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -59,6 +68,66 @@ const releaseAsset = (): string | null => {
 
 export const vendorDir = (root: string): string => join(root, "vendor", "duckdb", DUCKDB_VERSION);
 
+/**
+ * How long a download sentinel may sit before it is treated as a corpse from
+ * a crashed or killed test process. Generous next to a ~40MB download, short
+ * enough that a killed CI job does not wedge the next one.
+ */
+const SENTINEL_STALE_MS = 10 * 60_000;
+
+/** How long a waiting process gives the downloader before giving up. */
+const SENTINEL_WAIT_MS = 5 * 60_000;
+const SENTINEL_POLL_MS = 100;
+
+/**
+ * Claim the exclusive right to run the download (cross-review P3-4).
+ *
+ * `bun test` can run several files - and CI several jobs - against ONE vendor
+ * directory, and the download wrote a fixed zip path and unzipped into a
+ * fixed directory. A second process arriving mid-download could read a
+ * partial archive, or a partially-extracted `libduckdb.dylib`, and fail with
+ * something that looks like a real dylib bug. Exactly one caller downloads;
+ * everyone else waits for the result (see `waitForFile`).
+ *
+ * `openSync(..., "wx")` is the atomic primitive - the same one the ingest
+ * lock uses - and a sentinel older than `SENTINEL_STALE_MS` is reclaimed so a
+ * crashed process cannot wedge every later run.
+ */
+export const claimDownloadSentinel = (sentinelPath: string): "claimed" | "busy" => {
+    try {
+        closeSync(openSync(sentinelPath, "wx"));
+        return "claimed";
+    } catch {
+        try {
+            const age = Date.now() - statSync(sentinelPath).mtimeMs;
+            if (age < SENTINEL_STALE_MS) return "busy";
+            rmSync(sentinelPath, { force: true });
+            closeSync(openSync(sentinelPath, "wx"));
+            return "claimed";
+        } catch {
+            // Either it vanished under us or another process reclaimed it
+            // first - both mean "somebody else is on it".
+            return "busy";
+        }
+    }
+};
+
+export const releaseDownloadSentinel = (sentinelPath: string): void => {
+    rmSync(sentinelPath, { force: true });
+};
+
+/** Wait for the download holder to publish `target`. */
+const waitForFile = async (target: string, sentinelPath: string): Promise<boolean> => {
+    const deadline = Date.now() + SENTINEL_WAIT_MS;
+    while (Date.now() < deadline) {
+        if (existsSync(target)) return true;
+        // The holder died without publishing: stop waiting on a ghost.
+        if (!existsSync(sentinelPath)) return existsSync(target);
+        await Bun.sleep(SENTINEL_POLL_MS);
+    }
+    return existsSync(target);
+};
+
 export const resolveTestDylib = async (): Promise<TestDylib> => {
     const injected = process.env.AX_DUCKDB_DYLIB?.trim();
     if (injected) {
@@ -86,28 +155,52 @@ export const resolveTestDylib = async (): Promise<TestDylib> => {
     }
 
     const url = `https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/${asset}`;
+    mkdirSync(dir, { recursive: true });
+
+    // Cross-review P3-4: single-flight. Parallel test processes shared one
+    // zip path and one extraction directory, so a late arrival could read a
+    // half-written archive or a half-extracted library.
+    const sentinelPath = join(dir, `${asset}.download.lock`);
+    if (claimDownloadSentinel(sentinelPath) === "busy") {
+        const published = await waitForFile(cached, sentinelPath);
+        return published
+            ? { ok: true, path: cached }
+            : {
+                  ok: false,
+                  reason: `another process is downloading ${asset} and did not publish ${cached} in time; re-run, or remove ${sentinelPath} if nothing is downloading`,
+              };
+    }
+
     try {
-        mkdirSync(dir, { recursive: true });
-        const zipPath = join(dir, asset);
-        const response = await fetch(url);
-        if (!response.ok) {
-            return { ok: false, reason: `download failed: ${url} -> HTTP ${response.status}` };
+        // Own the staged archive too: the sentinel already serializes
+        // downloaders, but a pid-scoped name keeps a leftover zip from a
+        // killed run out of this one's way.
+        const zipPath = join(dir, `${asset}.${process.pid}.part`);
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                return { ok: false, reason: `download failed: ${url} -> HTTP ${response.status}` };
+            }
+            await Bun.write(zipPath, await response.arrayBuffer());
+            const unzip = Bun.spawnSync(["unzip", "-o", "-q", zipPath, "-d", dir], {
+                stdout: "ignore",
+                stderr: "pipe",
+            });
+            if (unzip.exitCode !== 0) {
+                return { ok: false, reason: `unzip failed: ${unzip.stderr.toString().trim()}` };
+            }
+            if (!existsSync(cached)) {
+                return { ok: false, reason: `archive ${asset} did not contain ${libFileName()}` };
+            }
+            return { ok: true, path: cached };
+        } finally {
+            rmSync(zipPath, { force: true });
         }
-        await Bun.write(zipPath, await response.arrayBuffer());
-        const unzip = Bun.spawnSync(["unzip", "-o", "-q", zipPath, "-d", dir], {
-            stdout: "ignore",
-            stderr: "pipe",
-        });
-        if (unzip.exitCode !== 0) {
-            return { ok: false, reason: `unzip failed: ${unzip.stderr.toString().trim()}` };
-        }
-        if (!existsSync(cached)) {
-            return { ok: false, reason: `archive ${asset} did not contain ${libFileName()}` };
-        }
-        return { ok: true, path: cached };
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { ok: false, reason: `download failed: ${url} -> ${message}` };
+    } finally {
+        releaseDownloadSentinel(sentinelPath);
     }
 };
 

--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -51,6 +51,11 @@ const EXCLUDED_FILES: readonly string[] = [
     // fires as `bun <file>.ts` outside the axctl Effect runtime, so node fs/os/
     // path are the correct deps. Committed here for reproducibility, not bundled.
     "apps/axctl/src/advice/advise-tap.ts",
+    // Test-only fixture: resolves a libduckdb dylib from a plain `beforeAll`,
+    // returning a plain Promise deliberately outside the Effect runtime.
+    // Porting it to FileSystem would force every downstream test file that
+    // needs a dylib path to build a platform layer just to call it.
+    "packages/lib/src/testing/duckdb-dylib.ts",
 ];
 
 const BANNED_SPECIFIERS = [


### PR DESCRIPTION
Wave-0 chunk of the v2 DuckDB refactor (fleet map #768; backlog in docs/superpowers/plans/2026-08-14-v2-duckdb-backlog.md). The last wave-0 chunk.

## What

`@ax/lib/duckdb` - the typed, Effect-native DuckDB client over bun:ffi, from the proven spike (#756):

- `client.ts` - DuckDb service: open (rw/read-only), typed query/queryAs/exec, close (idempotent, guarded), scoped; snapshot publisher (`COPY FROM DATABASE` → tmp → atomic rename; readers on the old inode survive) + snapshot opener.
- `lock.ts` / `lock-state.ts` - the ingest lockfile (`~/.ax/ingest.lock`): fail-fast + `--wait`, atomic wx create, steal token, pid+start-time liveness fingerprint, per-acquire ownership token, canonical-path keying, per-process acquire semaphore.
- `dylib.ts` - source-mode real path / compiled-mode `$bunfs` extract to content-hash path with reuse.
- `row-decode.ts` - pure column-accessor mapping; 8 undecodable types raise typed `DuckDbUnsupportedTypeError` (the constraint behind #792's DDL banned-type guard).
- Test fixture that resolves/downloads the v1.5.5 dylib and skips loudly when impossible.

## Review

Deepest gate of the wave: 8 per-task internal reviews + a whole-branch review (16 recorded rulings incl. one self-reversal on a rename race), an orchestrator probe that exposed the TIMESTAMPTZ/LIST cross-chunk conflict (fixed separately in #792), then a codex cross-engine review that found 18 findings - 6 P1, several REPRODUCED live: query-after-close segfault, 2^63 → -2^63 through the signed i64 bind, a same-process lock create/register fiber race, stale-handle release deleting its successor's lock, path aliases stealing live locks, and publishSnapshot never validating `options.from`. All 18 fixed in the follow-up commit (close guard on every op, bigint range errors, per-acquire token + canonical-path keying + acquire semaphore, from/live path validation, null-prototype rows with duplicate-column errors, ps-lstart pid-reuse fingerprint, scoped layers that release the dlopen handle).

Codex also verified: every bound FFI signature matches the official v1.5.5 header; NULL vs empty text distinct; HUGEINT/DECIMAL exact.

Known limits carried as issues: pointer-based read path #788 (unlocks TIMESTAMPTZ/LIST/NUL text), kernel flock before ax-ingest wiring #789, NUL-byte writer guard #790, embedded-asset layer wiring #791.

Gates post-rebase on v2/duckdb: `bun test packages/lib/src` → 704 pass / 0 fail (e2e against the real dylib, no skips) · `bun run typecheck` 0 · `bunx tsc --noEmit` 0 · `check:no-node-fs` clean.
