### PR TITLE
fix(v2): wave-0 milestone integration + adversarial fixes (4 P1 data-loss/security)

### DIFF
--- a/apps/axctl/src/cli/commands/ingest-scope.test.ts
+++ b/apps/axctl/src/cli/commands/ingest-scope.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { isGlobalIngest } from "./ingest.ts";
+
+// The blob-GC gate (#F2, wave-0 integration finding P1-1): GC deletes any
+// bucket blob no session references, so it may run ONLY on a truly global
+// ingest whose `session` table is a complete reference set. Any scope
+// narrowing - a --since window, repo/project scope, or a --stages subset -
+// leaves that table partial and must SKIP GC (else it deletes blobs referenced
+// only by out-of-scope repos/sessions).
+describe("isGlobalIngest (blob-GC gate)", () => {
+    test("a bare global ingest is global -> GC runs", () => {
+        expect(isGlobalIngest([])).toBe(true);
+        expect(isGlobalIngest(["--verbose"])).toBe(true);
+        expect(isGlobalIngest(["--debug", "--progress=plain"])).toBe(true);
+    });
+
+    test("a --since= window is NOT global -> GC skips", () => {
+        expect(isGlobalIngest(["--since=1"])).toBe(false);
+        expect(isGlobalIngest(["--since=7d", "--verbose"])).toBe(false);
+    });
+
+    test("a --stages= subset is NOT global -> GC skips", () => {
+        expect(isGlobalIngest(["--stages=git"])).toBe(false);
+        expect(isGlobalIngest(["--stages=claude,codex"])).toBe(false);
+    });
+
+    test("`ax ingest here` (repo/project scope) is NOT global -> GC skips", () => {
+        // cmdIngestHere passes repoPaths + claudeProject (and injects --stages=).
+        expect(
+            isGlobalIngest(["--stages=git,claude"], {
+                command: "ingest-here",
+                repoPaths: ["/repo"],
+                claudeProject: "-repo",
+            }),
+        ).toBe(false);
+        // repoPaths alone (no injected --stages) still narrows scope.
+        expect(isGlobalIngest([], { repoPaths: ["/repo"] })).toBe(false);
+        expect(isGlobalIngest([], { claudeProject: "-repo" })).toBe(false);
+    });
+});

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -209,6 +209,26 @@ interface IngestCommandOpts {
     readonly claudeProject?: string;
 }
 
+/**
+ * Blob GC deletes any bucket blob no `session` row references. That is only
+ * safe when the run built a COMPLETE reference set - i.e. a truly GLOBAL
+ * ingest. `--since` was the only scope the old `fullIngest` gate checked (#F2),
+ * but repo/project scope (`ax ingest here`, an explicit project) and a
+ * `--stages=` subset each leave the `session` table a PARTIAL view too, so a
+ * scoped run would GC blobs referenced only by out-of-scope repos/sessions.
+ *
+ * This is the single predicate the GC gate reads: true ONLY when NONE of the
+ * scope narrowings are present - no `--since=`, no `--stages=`/stage subset,
+ * and no repo/project scope (repoPaths / claudeProject, set by
+ * `ax ingest here` and project-scoped callers). Retention (otel, rebuildable)
+ * is unaffected and still runs on every ingest.
+ */
+export const isGlobalIngest = (args: readonly string[], opts: IngestCommandOpts = {}): boolean =>
+    !args.some((a) => a.startsWith("--since=")) &&
+    !args.some((a) => a.startsWith("--stages=")) &&
+    opts.repoPaths === undefined &&
+    opts.claudeProject === undefined;
+
 /** `ax ingest-here` resumes as `ax ingest here`; everything else as-is. */
 const resumeCommand = (command: string): string =>
     command === "ingest-here" ? "ax ingest here" : `ax ${command}`;
@@ -365,10 +385,11 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         );
 
         // GC's reference set is built from the CURRENT `session` table (#F2):
-        // a `--since`-windowed run only touches sessions inside that window,
-        // so the table is a PARTIAL view of what's referenced. Only a full
-        // (unwindowed) ingest run is trustworthy enough to GC against.
-        const fullIngest = !args.some((a) => a.startsWith("--since="));
+        // any scoped run (--since window, repo/project scope, or a --stages
+        // subset) leaves that table a PARTIAL view of what's referenced. Only a
+        // truly GLOBAL ingest run is trustworthy enough to GC against, so the
+        // gate reads the single `isGlobalIngest` predicate over args + scope.
+        const globalIngest = isGlobalIngest(args, opts);
 
         const work = runIngest({
             command: commandName,
@@ -402,7 +423,7 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
                 }
 
                 const blobGc = yield* runMaintenanceHalf(
-                    gcFileBuckets(path.join(cfg.paths.dataDir, "buckets"), { fullIngest }),
+                    gcFileBuckets(path.join(cfg.paths.dataDir, "buckets"), { isGlobalIngest: globalIngest }),
                 );
                 if (blobGc.error) {
                     process.stderr.write(`axctl ${commandName}: blob gc failed - ${blobGc.error}\n`);

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -826,6 +826,19 @@ function loadedDbPid(): number | null {
     return Number.isFinite(pid) ? pid : null;
 }
 
+/** launchctl PID of our otlpd LaunchAgent, or null. Mirrors {@link loadedDbPid}
+ *  so a 1738 owner-check can tell "our otlpd" from a foreign listener. */
+function loadedOtlpdPid(): number | null {
+    if (!isMacos()) return null;
+    const r = spawnSync("launchctl", ["list", OTLPD_LABEL], { encoding: "utf8" });
+    if (r.status !== 0) return null;
+    const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+    const m = output.match(/"PID"\s*=\s*(\d+);/);
+    if (!m) return null;
+    const pid = Number.parseInt(m[1] ?? "", 10);
+    return Number.isFinite(pid) ? pid : null;
+}
+
 function launchdStatus(
     label: string,
     plist: string,
@@ -966,6 +979,9 @@ function collectDaemonStatus(): Effect.Effect<DaemonStatus, never, FileSystem.Fi
                 yield* launchdStatus(DERIVE_LABEL, DERIVE_PLIST),
                 yield* launchdStatus(QUOTA_REFRESH_LABEL, QUOTA_REFRESH_PLIST),
                 yield* launchdStatus(SERVE_LABEL, SERVE_PLIST),
+                // otlpd is consent-gated + write-only while serve owns 1738, so a
+                // "not loaded; plist=present" line here is normal, not a fault.
+                yield* launchdStatus(OTLPD_LABEL, OTLPD_PLIST),
             ],
         };
     });
@@ -1633,6 +1649,28 @@ export function cmdDaemon(
                 return db && watch && derive && quotaRefresh && serve;
             });
 
+        // otlpd binds the SAME port (1738) serve does, so it must never start
+        // while another process already owns it. Load it only when its plist
+        // exists, no serve LaunchAgent is managing that port (mirrors
+        // resolveOtlpdPlistDecision's serveAgentManaged gate), and nothing
+        // foreign is currently LISTENing on 1738.
+        const otlpdShouldLoad = (): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+            Effect.gen(function* () {
+                const plistExists = yield* fs.exists(OTLPD_PLIST).pipe(orAbsent(false));
+                if (!plistExists) return false;
+                const serveManaged = yield* fs.exists(SERVE_PLIST).pipe(orAbsent(false));
+                if (serveManaged) return false;
+                const probe = probePort(DEFAULT_DASHBOARD_PORT);
+                if (probe.listening && (probe.holder === null || probe.holder.pid !== loadedOtlpdPid())) {
+                    return false;
+                }
+                return true;
+            });
+        const maybeLoadOtlpd = (): Effect.Effect<void, never, FileSystem.FileSystem> =>
+            Effect.gen(function* () {
+                if (yield* otlpdShouldLoad()) yield* Effect.promise(() => loadAgent(OTLPD_PLIST));
+            });
+
         if (!isMacos()) {
             console.log(formatDaemonStatus(yield* collectDaemonStatus(), parsed.json));
             if (parsed.command !== "status") {
@@ -1650,14 +1688,19 @@ export function cmdDaemon(
                 yield* Effect.promise(() => loadAgent(DERIVE_PLIST));
                 yield* Effect.promise(() => loadAgent(QUOTA_REFRESH_PLIST));
                 yield* Effect.promise(() => loadAgent(SERVE_PLIST));
+                // Last, and only when 1738 is free (serve otherwise owns it).
+                yield* maybeLoadOtlpd();
             }
         } else if (parsed.command === "stop") {
+            // otlpd first - it shares serve's port, so drop it before the rest.
+            yield* Effect.promise(() => unloadAgentKeepPlist(OTLPD_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(SERVE_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(QUOTA_REFRESH_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(DERIVE_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(WATCH_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(DB_PLIST));
         } else if (parsed.command === "restart") {
+            yield* Effect.promise(() => unloadAgentKeepPlist(OTLPD_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(SERVE_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(QUOTA_REFRESH_PLIST));
             yield* Effect.promise(() => unloadAgentKeepPlist(DERIVE_PLIST));
@@ -1671,6 +1714,7 @@ export function cmdDaemon(
                 yield* Effect.promise(() => loadAgent(DERIVE_PLIST));
                 yield* Effect.promise(() => loadAgent(QUOTA_REFRESH_PLIST));
                 yield* Effect.promise(() => loadAgent(SERVE_PLIST));
+                yield* maybeLoadOtlpd();
             }
         }
 

--- a/apps/axctl/src/dashboard/host-guard.ts
+++ b/apps/axctl/src/dashboard/host-guard.ts
@@ -1,0 +1,21 @@
+// Shared loopback Host-header guard. Both the dashboard server and the DB-free
+// OTLP spool server bind a loopback port; a DNS-rebinding page re-points its own
+// domain at 127.0.0.1 and issues "same-origin" requests that sail past CORS, but
+// it cannot forge the Host header (the browser always sends its own domain). So
+// a PRESENT, non-loopback Host is rejected; a MISSING Host (curl, unit tests,
+// non-browser exporters) is allowed - a browser can never produce that.
+//
+// Kept in its own dep-free module so the lean spool server can import it without
+// pulling in the whole serve runtime (router, durable streams, Effect runtime).
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+
+/** True when the Host header names the loopback interface (optional :port), or
+ *  is absent/empty. */
+export function isAllowedHost(host: string | null): boolean {
+    if (host === null || host === "") return true;
+    const hostname = host.startsWith("[")
+        ? host.slice(0, host.indexOf("]") + 1) // strip :port after ]
+        : host.split(":")[0]!;
+    return LOOPBACK_HOSTS.has(hostname);
+}

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -142,23 +142,11 @@ function isLocalDevOrigin(origin: string): boolean {
     return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
 }
 
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
-
-/**
- * True when the Host header names the loopback interface (optional :port), or
- * is absent. A DNS-rebinding page re-points its own domain at 127.0.0.1 and
- * issues same-origin requests, sailing past CORS; the only value it cannot
- * forge is the Host header (the browser always sends its own domain). So a
- * PRESENT, non-loopback Host is rejected; a MISSING Host (curl, unit tests,
- * non-browser callers) is allowed - a browser can never produce that.
- */
-export function isAllowedHost(host: string | null): boolean {
-    if (host === null || host === "") return true;
-    const hostname = host.startsWith("[")
-        ? host.slice(0, host.indexOf("]") + 1) // strip :port after ]
-        : host.split(":")[0]!;
-    return LOOPBACK_HOSTS.has(hostname);
-}
+// The loopback Host-header guard now lives in a dep-free module shared with the
+// OTLP spool server (host-guard.ts). Imported for use below and re-exported so
+// existing importers and tests keep resolving it from server.ts.
+import { isAllowedHost } from "./host-guard.ts";
+export { isAllowedHost };
 
 function corsHeadersFor(origin: string | null, requestedHeaders?: string | null): Record<string, string> {
     if (!origin) return {};

--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Effect, Layer } from "effect";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { ingestOtelSpool, otelSpoolStage } from "./otel-spool.ts";
+import { ingestOtelSpool, otelSpoolStage, stampReceivedAt } from "./otel-spool.ts";
 
 const roots: string[] = [];
 
@@ -74,5 +74,35 @@ describe("otel-spool ingest stage", () => {
     it("declares the ingest stage contract", () => {
         expect(otelSpoolStage.meta.key).toBe("otel-spool");
         expect(otelSpoolStage.meta.tags).toEqual(["ingest"]);
+    });
+});
+
+describe("stampReceivedAt (timeless-event epoch collision guard)", () => {
+    const received = new Date("2026-08-14T12:00:00.000Z");
+
+    it("stamps an epoch-dated (timeless) row with received_at", () => {
+        const rows = [{ event_name: "e", observed_at: new Date(0) }];
+        const out = stampReceivedAt(rows, received);
+        expect(out[0]!.observed_at.toISOString()).toBe(received.toISOString());
+    });
+
+    it("leaves a row that already has a real event-time untouched", () => {
+        const real = new Date("2026-06-15T00:00:00.000Z");
+        const rows = [{ event_name: "e", observed_at: real }];
+        const out = stampReceivedAt(rows, received);
+        expect(out[0]!.observed_at).toBe(real);
+    });
+
+    it("two timeless events at the same received_at get the same fallback, but distinct-time events do not alias at the epoch", () => {
+        const a = stampReceivedAt([{ observed_at: new Date(0) }], new Date("2026-08-14T12:00:00.000Z"));
+        const b = stampReceivedAt([{ observed_at: new Date(0) }], new Date("2026-08-14T12:05:00.000Z"));
+        // Different POSTs (different received_at) no longer collide at 1970.
+        expect(a[0]!.observed_at.toISOString()).not.toBe(b[0]!.observed_at.toISOString());
+    });
+
+    it("is a no-op when received_at is null or invalid", () => {
+        const rows = [{ observed_at: new Date(0) }];
+        expect(stampReceivedAt(rows, null)[0]!.observed_at.getTime()).toBe(0);
+        expect(stampReceivedAt(rows, new Date("nope"))[0]!.observed_at.getTime()).toBe(0);
     });
 });

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -13,6 +13,10 @@ import type { StageDef } from "./stage/registry.ts";
 interface SpoolEnvelope {
     readonly path: string;
     readonly body: string;
+    /** Server receive time (spool-server stamps every record). Used as the
+     *  observed_at FALLBACK for OTLP events that carry no event-time, so two
+     *  timeless events do not collide on the unix-epoch row key. */
+    readonly received_at: string | null;
 }
 
 const decodeEnvelope = (line: string): SpoolEnvelope | null => {
@@ -21,11 +25,36 @@ const decodeEnvelope = (line: string): SpoolEnvelope | null => {
         if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
         const record = value as Record<string, unknown>;
         return typeof record.path === "string" && typeof record.body === "string"
-            ? { path: record.path, body: record.body }
+            ? {
+                path: record.path,
+                body: record.body,
+                received_at: typeof record.received_at === "string" ? record.received_at : null,
+            }
             : null;
     } catch {
         return null;
     }
+};
+
+/**
+ * OTLP events that carry no event-time normalize to `observed_at = new Date(0)`
+ * (the unix epoch - see nanoToDate). The metric/log row keys embed observed_at,
+ * so two such timeless events in one session would collide on the epoch key and
+ * silently overwrite (stable-id bans time keys; missing times must not alias).
+ * Stamp any epoch-dated row with the spool record's `received_at` instead, so
+ * events received at different times get distinct identities/ordering.
+ */
+const EPOCH_MS = 0;
+export const stampReceivedAt = <R extends { readonly observed_at: Date }>(
+    rows: readonly R[],
+    receivedAt: Date | null,
+): readonly R[] => {
+    if (receivedAt === null || Number.isNaN(receivedAt.getTime())) return rows;
+    return rows.map((r) =>
+        r.observed_at instanceof Date && r.observed_at.getTime() === EPOCH_MS
+            ? { ...r, observed_at: receivedAt }
+            : r,
+    );
 };
 
 const parseBody = (body: string): unknown | undefined => {
@@ -78,6 +107,12 @@ export const ingestOtelSpool = (
             ...(opts.runId === undefined ? {} : { runId: opts.runId }),
             processFile: (candidate) =>
                 Effect.gen(function* () {
+                    // Whole-file read (not a true tail): the daily spool file is
+                    // re-read in full whenever it changes. The work-unit
+                    // watermark (jsonl-work-unit.ts) skips UNCHANGED files, so a
+                    // quiescent day is not re-read; only a file that grew is read
+                    // whole. A real offset tail is a larger change tracked in
+                    // REPORT.md (wave-1 seam).
                     const text = yield* fs.readFileString(candidate.path);
                     const writer = yield* OtelWriter;
                     for (const line of text.split("\n")) {
@@ -101,7 +136,10 @@ export const ingestOtelSpool = (
                             malformed += 1;
                             continue;
                         }
-                        const normalized = spec.normalize(decoded.value);
+                        const receivedAt = envelope.received_at === null
+                            ? null
+                            : new Date(envelope.received_at);
+                        const normalized = stampReceivedAt(spec.normalize(decoded.value), receivedAt);
                         yield* spec.write(writer)(normalized);
                         payloads += 1;
                         rows += normalized.length;

--- a/apps/axctl/src/otel/correlate.test.ts
+++ b/apps/axctl/src/otel/correlate.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
-import { correlateOrphanOtel } from "./correlate.ts";
+import { sessionRowId } from "@ax/lib/stable-id";
+import { bareUuid, correlateOrphanOtel } from "./correlate.ts";
 
 const UUID = "019fbf3f-9241-40c3-b699-e1f62e7c5341";
+
+// Wave-0 finding P1-3: OTLP correlation matches sessions by extracting the uuid
+// straight out of `session.id`. If sessionRowId HASHED the uuid (the earlier
+// bug), bareUuid(session.id) would return null and every telemetry_of edge
+// would silently vanish. This pins the contract: a session row id round-trips
+// back to the exact uuid this matcher looks for.
+describe("session row id <-> OTLP correlation round-trip (P1-3)", () => {
+    test("bareUuid(sessionRowId(uuid)) recovers the uuid", () => {
+        expect(bareUuid(sessionRowId("claude", UUID))).toBe(UUID);
+        expect(bareUuid(sessionRowId("codex", UUID))).toBe(UUID);
+    });
+
+    test("a subagent session id (non-uuid) yields no uuid, so it is not correlated", () => {
+        expect(bareUuid(sessionRowId("claude", "claude-subagent-af3f3b45c70ccf85c"))).toBeNull();
+    });
+});
 
 /**
  * Stub the four query shapes the pass issues, in order:

--- a/apps/axctl/src/otel/correlate.ts
+++ b/apps/axctl/src/otel/correlate.ts
@@ -41,8 +41,10 @@ const recordKey = (id: unknown): string | null => {
 };
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
-/** Bare uuid from an otel `session_id` (already bare) or a `session:⟨uuid⟩` record. */
-const bareUuid = (v: unknown): string | null => {
+/** Bare uuid from an otel `session_id` (already bare) or a `session:⟨uuid⟩` record.
+ *  Exported so a test can prove `sessionRowId` (@ax/lib/stable-id) output still
+ *  round-trips back to the same uuid this matcher extracts (wave-0 P1-3). */
+export const bareUuid = (v: unknown): string | null => {
     if (v == null) return null;
     const s = typeof v === "string" ? v : String((v as { id?: unknown }).id ?? v);
     const m = UUID_RE.exec(s);

--- a/apps/axctl/src/otel/spool-server.test.ts
+++ b/apps/axctl/src/otel/spool-server.test.ts
@@ -6,6 +6,7 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Effect, Layer } from "effect";
 import {
     OTLP_ACK,
+    OTLP_MAX_BODY_BYTES,
     defaultOtlpSpoolDir,
     startOtlpSpoolServer,
     type OtlpSpoolServer,
@@ -50,6 +51,37 @@ describe("OTLP spool receiver", () => {
             path: "/v1/metrics",
             body: raw,
         }]);
+    });
+
+    it("rejects a present, non-loopback Host header with 403 (DNS-rebinding defense)", async () => {
+        const now = new Date("2026-08-14T12:34:56.000Z");
+        const { spoolDir, server } = await start(() => now);
+
+        const response = await fetch(`${server.url}/v1/metrics`, {
+            method: "POST",
+            headers: { "content-type": "application/json", host: "attacker.com" },
+            body: '{"resourceMetrics":[]}',
+        });
+
+        expect(response.status).toBe(403);
+        // A rejected request must never reach the spool file.
+        expect(await Bun.file(join(spoolDir, "2026-08-14.jsonl")).exists()).toBe(false);
+    });
+
+    it("rejects an oversized body (disk-exhaustion / ingest-OOM defense)", async () => {
+        const now = new Date("2026-08-14T12:34:56.000Z");
+        const { spoolDir, server } = await start(() => now);
+        // One byte past the cap; Bun refuses it before fetch() runs.
+        const huge = "x".repeat(OTLP_MAX_BODY_BYTES + 1);
+
+        const response = await fetch(`${server.url}/v1/logs`, {
+            method: "POST",
+            body: huge,
+        }).catch(() => ({ status: 413 }) as Response);
+
+        expect(response.status).toBe(413);
+        // Nothing oversized was spooled.
+        expect(await Bun.file(join(spoolDir, "2026-08-14.jsonl")).exists()).toBe(false);
     });
 
     it("returns 2xx and preserves a malformed body", async () => {

--- a/apps/axctl/src/otel/spool-server.ts
+++ b/apps/axctl/src/otel/spool-server.ts
@@ -2,10 +2,19 @@ import { homedir } from "node:os";
 import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
 import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
+import { isAllowedHost } from "../dashboard/host-guard.ts";
 import { OTLP_SIGNAL_PATHS } from "./signal.ts";
 
 export const OTLP_ACK = { partialSuccess: {} } as const;
 export const OTLP_SPOOL_RETENTION_DAYS = 90;
+
+/**
+ * Cap on a single OTLP request body. OTLP batches are small (a few KB of JSON
+ * per export); this bound (disk-exhaustion / ingest-OOM defense) is generous
+ * for a real exporter but refuses a multi-GB body that would balloon the daily
+ * spool file and OOM the whole-file read on the ingest side.
+ */
+export const OTLP_MAX_BODY_BYTES = 8 * 1024 * 1024;
 
 export class OtlpSpoolServerError extends Schema.TaggedErrorClass<OtlpSpoolServerError>(
     "OtlpSpoolServerError",
@@ -148,8 +157,19 @@ export const startOtlpSpoolServer = (
         const server = yield* Effect.try({
             try: () => Bun.serve({
                 hostname,
+                // Disk-exhaustion / ingest-OOM defense: Bun rejects a body larger
+                // than this before fetch() runs (413), so a giant POST can never
+                // reach the spool file.
+                maxRequestBodySize: OTLP_MAX_BODY_BYTES,
                 port: opts.port ?? DEFAULT_DASHBOARD_PORT,
                 async fetch(request) {
+                    // DNS-rebinding / browser telemetry-injection defense: a
+                    // PRESENT, non-loopback Host header can only come from a
+                    // browser page pointed at this loopback receiver. Reject it
+                    // (a real exporter sends loopback or no Host at all).
+                    if (!isAllowedHost(request.headers.get("host"))) {
+                        return new Response("forbidden", { status: 403 });
+                    }
                     const pathname = new URL(request.url).pathname;
                     if (request.method !== "POST" || !OTLP_PATHS.has(pathname)) {
                         return new Response("Not Found", { status: 404 });

--- a/packages/lib/src/blob-gc.test.ts
+++ b/packages/lib/src/blob-gc.test.ts
@@ -59,7 +59,7 @@ describe("gcFileBuckets", () => {
 
             // Orphans are freshly written (age ~0), so disable the young-blob
             // guard here - it's covered by its own test below.
-            const result = yield* gcFileBuckets(root, { fullIngest: true, minAgeMs: 0 });
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: true, minAgeMs: 0 });
 
             expect(result).toEqual({ scanned: 4, removed: 2, failed: 0, skipped: false });
             expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
@@ -69,7 +69,7 @@ describe("gcFileBuckets", () => {
         }).pipe(Effect.provide(layer))));
     });
 
-    test("skips entirely for a since-windowed (partial) ingest run", async () => {
+    test("skips entirely for a scoped (partial) ingest run", async () => {
         const db = makeTestSurrealClient({
             routes: {
                 "SELECT raw_file FROM session": [[
@@ -87,13 +87,13 @@ describe("gcFileBuckets", () => {
             yield* fs.makeDirectory(transcripts);
             yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
 
-            const result = yield* gcFileBuckets(root, { fullIngest: false });
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: false });
 
             expect(result.skipped).toBe(true);
-            expect(result.skipReason).toMatch(/since-windowed/);
+            expect(result.skipReason).toMatch(/scoped/);
             expect(result.scanned).toBe(0);
             expect(result.removed).toBe(0);
-            // A since-windowed run must never touch disk - the orphan survives.
+            // A scoped run must never touch disk - the orphan survives.
             expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(true);
         }).pipe(Effect.provide(layer))));
     });
@@ -112,7 +112,7 @@ describe("gcFileBuckets", () => {
             yield* fs.makeDirectory(transcripts);
             yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
 
-            const result = yield* gcFileBuckets(root, { fullIngest: true });
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: true });
 
             expect(result.skipped).toBe(true);
             expect(result.skipReason).toMatch(/empty/);
@@ -141,7 +141,7 @@ describe("gcFileBuckets", () => {
             yield* fs.writeFileString(path.join(transcripts, "young-orphan.jsonl"), "remove");
 
             // Default 24h age guard, real "now" - the orphan was just written.
-            const result = yield* gcFileBuckets(root, { fullIngest: true });
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: true });
 
             expect(result.skipped).toBe(false);
             expect(result.removed).toBe(0);
@@ -172,7 +172,7 @@ describe("gcFileBuckets", () => {
             // Simulate the clock 2 days ahead so the just-written orphan reads
             // as 2 days old against the 24h default guard.
             const twoDaysLater = () => Date.now() + 2 * 24 * 60 * 60 * 1000;
-            const result = yield* gcFileBuckets(root, { fullIngest: true, now: twoDaysLater });
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: true, now: twoDaysLater });
 
             expect(result).toEqual({ scanned: 2, removed: 1, failed: 0, skipped: false });
             expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
@@ -206,7 +206,7 @@ describe("gcFileBuckets", () => {
                 db.layer,
                 Layer.mergeAll(withFailingRemove(failingOrphan), BunPath.layer),
             );
-            const result = yield* gcFileBuckets(root, { fullIngest: true, minAgeMs: 0 }).pipe(
+            const result = yield* gcFileBuckets(root, { isGlobalIngest: true, minAgeMs: 0 }).pipe(
                 Effect.provide(layer),
             );
 

--- a/packages/lib/src/blob-gc.ts
+++ b/packages/lib/src/blob-gc.ts
@@ -23,15 +23,23 @@ export interface BlobGcResult {
 
 export interface BlobGcOptions {
     /**
-     * Only actually delete when the triggering ingest run was NOT
-     * since-windowed (i.e. it scanned every session). The reference set below
-     * is built from the CURRENT `session` table; after a DB wipe + a
-     * `--since`-windowed re-ingest, that table only holds the sessions the
-     * windowed run touched - every session outside the window looks
-     * unreferenced even though its blob is still live. Running GC against
-     * that partial view would permanently delete cold-but-referenced blobs.
+     * Only actually delete when the triggering ingest run scanned EVERY
+     * session - a truly GLOBAL ingest with no scope narrowing of any kind. The
+     * reference set below is built from the CURRENT `session` table, so it is a
+     * trustworthy "everything referenced" set ONLY when the run that populated
+     * it was unscoped. Any narrowing makes the table a PARTIAL view and turns
+     * every out-of-scope session's still-live blob into a false GC candidate:
+     *   - `--since=` windowing (after a DB wipe + windowed re-ingest, the table
+     *     holds only the windowed sessions);
+     *   - repo/project scope (`ax ingest here`, an explicit project/claude
+     *     project) - only that repo's sessions are touched, so another repo's
+     *     blobs look unreferenced;
+     *   - a `--stages=` subset that skips the session-writing stages entirely.
+     * Running GC against any such partial view would permanently delete
+     * cold-but-referenced blobs, so the caller must pass the single
+     * `isGlobalIngest` predicate (see cli/commands/ingest.ts) here.
      */
-    readonly fullIngest: boolean;
+    readonly isGlobalIngest: boolean;
     /** Override the young-blob guard window (ms). Defaults to 24h. */
     readonly minAgeMs?: number;
     readonly now?: () => number;
@@ -50,10 +58,10 @@ export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
     bucketsDir: string,
     opts: BlobGcOptions,
 ) {
-    if (!opts.fullIngest) {
+    if (!opts.isGlobalIngest) {
         return skip(
-            "ingest run was --since-windowed (partial); the session table is not a complete " +
-                "reference set, so blob GC was skipped to avoid deleting live blobs",
+            "ingest run was scoped (--since / repo / --stages subset); the session table is not a " +
+                "complete reference set, so blob GC was skipped to avoid deleting live blobs",
         );
     }
 

--- a/packages/lib/src/duckdb/bigint-column.test.ts
+++ b/packages/lib/src/duckdb/bigint-column.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { NumberFromBigIntColumn } from "./bigint-column.ts";
+
+// Pure coverage of the BIGINT-column coercion (no dylib needed): the DB-backed
+// round-trip lives in client.test.ts (a real BIGINT column), this pins the
+// Schema behavior itself.
+describe("NumberFromBigIntColumn", () => {
+    const decode = (v: unknown) =>
+        Effect.runSync(Effect.result(Schema.decodeUnknownEffect(NumberFromBigIntColumn)(v)));
+
+    test("coerces a bigint to a number", () => {
+        const r = decode(42n);
+        expect(r._tag).toBe("Success");
+        if (r._tag === "Success") expect(r.success).toBe(42);
+    });
+
+    test("passes a plain number through", () => {
+        const r = decode(7);
+        expect(r._tag).toBe("Success");
+        if (r._tag === "Success") expect(r.success).toBe(7);
+    });
+
+    test("FAILS (never truncates) when the bigint exceeds Number's safe range", () => {
+        const over = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+        const r = decode(over);
+        expect(r._tag).toBe("Failure");
+    });
+
+    test("FAILS below the safe range too", () => {
+        const under = BigInt(Number.MIN_SAFE_INTEGER) - 2n;
+        expect(decode(under)._tag).toBe("Failure");
+    });
+
+    test("boundary values are accepted exactly", () => {
+        const max = decode(BigInt(Number.MAX_SAFE_INTEGER));
+        expect(max._tag).toBe("Success");
+        if (max._tag === "Success") expect(max.success).toBe(Number.MAX_SAFE_INTEGER);
+    });
+});

--- a/packages/lib/src/duckdb/bigint-column.ts
+++ b/packages/lib/src/duckdb/bigint-column.ts
@@ -1,0 +1,45 @@
+/**
+ * The BIGINT-column decode contract for `queryAs`.
+ *
+ * A DuckDB `BIGINT`/`UBIGINT` column decodes to a JS `bigint` (see
+ * `coerceValue` in row-decode.ts: 64-bit widths stay `bigint` so a row's TS type
+ * never depends on the magnitude of the value it happens to hold; narrower
+ * integer widths and `DOUBLE` come back as `number`). `queryAs` runs the raw
+ * rows straight through the caller's Schema, so a field typed `Schema.Number`
+ * against a BIGINT column FAILS to decode - a `bigint` is not a `number`. That
+ * surfaces as a typed `DuckDbDecodeError`, never a silent lossy convert, which
+ * is the point: a BIGINT that does not fit a JS number must not be quietly
+ * rounded.
+ *
+ * When a caller genuinely wants a `number` out of a BIGINT column (the value is
+ * known to be small - a count, a token total), use {@link NumberFromBigIntColumn}
+ * for that field. It accepts `bigint | number` and yields `number`, and it
+ * itself FAILS (never truncates) when the bigint is outside the range a JS
+ * number represents exactly. To keep full precision, type the field
+ * `Schema.BigInt` instead.
+ */
+import { Effect, Option, Schema, SchemaGetter, SchemaIssue } from "effect";
+
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+
+/** A numeric column that may arrive as `bigint` (BIGINT/UBIGINT) or `number`,
+ *  coerced to `number` - failing, never truncating, when a bigint is outside
+ *  the JS safe-integer range. */
+export const NumberFromBigIntColumn = Schema.Union([Schema.Number, Schema.BigInt]).pipe(
+    Schema.decodeTo(Schema.Number, {
+        decode: SchemaGetter.transformOrFail((value: number | bigint) => {
+            if (typeof value === "number") return Effect.succeed(value);
+            if (value >= MIN_SAFE && value <= MAX_SAFE) return Effect.succeed(Number(value));
+            return Effect.fail(
+                new SchemaIssue.InvalidValue(Option.some(value), {
+                    message:
+                        `BIGINT value ${value} is outside Number's safe-integer range ` +
+                        `(${Number.MIN_SAFE_INTEGER}..${Number.MAX_SAFE_INTEGER}); type this field ` +
+                        "Schema.BigInt to keep full precision instead of a lossy number",
+                }),
+            );
+        }),
+        encode: SchemaGetter.transform((n: number): number | bigint => n),
+    }),
+);

--- a/packages/lib/src/duckdb/client.test.ts
+++ b/packages/lib/src/duckdb/client.test.ts
@@ -15,6 +15,7 @@ import {
     readResult,
 } from "./client.ts";
 import type { LibDuckDb } from "./ffi.ts";
+import { NumberFromBigIntColumn } from "./bigint-column.ts";
 import { DuckDbTypeId } from "./types.ts";
 
 const { dtest, tempDir, withDuckDb } = await duckdbTestSetup("duckdb client");
@@ -353,6 +354,74 @@ describe("DuckDb", () => {
                 const min = yield* conn.query("SELECT CAST(? AS BIGINT) AS v", [-(2n ** 63n)]);
                 expect(min.rows[0]!.v).toBe(-9223372036854775808n);
 
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Wave-0 finding P1/P2: a VARCHAR bind goes through a NUL-terminated C
+    // string, which silently TRUNCATES at an embedded NUL - and the length-less
+    // read accessor cannot detect it on the way back out. The write side now
+    // makes that a loud typed failure instead of silent data loss.
+    dtest(
+        "refuses a VARCHAR parameter containing a NUL byte instead of silently truncating",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                yield* conn.exec("CREATE TABLE t (note VARCHAR)");
+
+                const result = yield* Effect.result(conn.exec("INSERT INTO t VALUES (?)", ["a\0b"]));
+                expect(result._tag).toBe("Failure");
+                if (result._tag === "Failure") {
+                    expect(result.failure._tag).toBe("DuckDbQueryError");
+                    expect((result.failure as { message: string }).message).toMatch(/NUL byte/i);
+                }
+                // Nothing was written - the guard fired before the bind.
+                const count = yield* conn.query("SELECT count(*) AS n FROM t");
+                expect(count.rows[0]!.n).toBe(0n);
+
+                // A NUL-free string still binds fine.
+                yield* conn.exec("INSERT INTO t VALUES (?)", ["clean"]);
+                const ok = yield* conn.query("SELECT note FROM t");
+                expect(ok.rows).toEqual([{ note: "clean" }]);
+                yield* conn.close;
+            }),
+        ),
+    );
+
+    // Wave-0 finding P2: a BIGINT column decodes to `bigint`, so `queryAs` with
+    // a `Schema.Number` field must FAIL (typed), never silently lossy-convert -
+    // and `NumberFromBigIntColumn` is the sanctioned coercion for a small BIGINT.
+    dtest(
+        "queryAs over a BIGINT column: Schema.Number fails, NumberFromBigIntColumn coerces",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const conn = yield* db.open(tempDb());
+                // A real production BIGINT column, not the INTEGER the old test used.
+                yield* conn.exec("CREATE TABLE t (n BIGINT)");
+                yield* conn.exec("INSERT INTO t VALUES (42)");
+
+                // A number-typed field against a BIGINT column: typed failure.
+                const AsNumber = Schema.Struct({ n: Schema.Number });
+                const failed = yield* Effect.result(conn.queryAs(AsNumber, "SELECT n FROM t"));
+                expect(failed._tag).toBe("Failure");
+                if (failed._tag === "Failure") expect(failed.failure._tag).toBe("DuckDbDecodeError");
+
+                // Schema.BigInt keeps full precision.
+                const AsBigInt = Schema.Struct({ n: Schema.BigInt });
+                expect(yield* conn.queryAs(AsBigInt, "SELECT n FROM t")).toEqual([{ n: 42n }]);
+
+                // The coercion schema yields a number for an in-range value...
+                const AsCoerced = Schema.Struct({ n: NumberFromBigIntColumn });
+                expect(yield* conn.queryAs(AsCoerced, "SELECT n FROM t")).toEqual([{ n: 42 }]);
+
+                // ... and FAILS (not truncates) when the BIGINT exceeds a JS number.
+                yield* conn.exec("INSERT INTO t VALUES (9007199254740993)"); // MAX_SAFE_INTEGER + 2
+                const overflow = yield* Effect.result(
+                    conn.queryAs(AsCoerced, "SELECT n FROM t ORDER BY n"),
+                );
+                expect(overflow._tag).toBe("Failure");
+                if (overflow._tag === "Failure") expect(overflow.failure._tag).toBe("DuckDbDecodeError");
                 yield* conn.close;
             }),
         ),

--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -61,6 +61,17 @@ export interface DuckDbConnection {
         sql: string,
         params?: ReadonlyArray<DuckDbParam>,
     ) => Effect.Effect<QueryResult, DuckDbQueryError | DuckDbUnsupportedTypeError>;
+    /**
+     * Decode each result row through `schema`. BIGINT CONTRACT: a DuckDB
+     * `BIGINT`/`UBIGINT` column decodes to a JS `bigint` (row-decode.ts keeps
+     * 64-bit widths as bigint so a row's TS type never depends on the value's
+     * magnitude), and the raw rows go STRAIGHT through `schema` - so a field
+     * typed `Schema.Number` against a BIGINT column FAILS with a
+     * `DuckDbDecodeError` (a bigint is not a number); it is never silently
+     * rounded. Type such a field `Schema.BigInt` to keep full precision, or
+     * `NumberFromBigIntColumn` (bigint-column.ts) to coerce to number with an
+     * out-of-safe-range failure instead of a lossy convert.
+     */
     readonly queryAs: <S extends Schema.Top>(
         schema: S,
         sql: string,
@@ -225,6 +236,9 @@ export const bindableBigInt = (value: bigint): boolean => value >= I64_MIN && va
 const bigintRangeMessage = (idx: number, value: bigint): string =>
     `parameter ${idx} (${value}) is outside the range this client can bind: DuckDB binds integers as a signed 64-bit int64 (${I64_MIN} to ${I64_MAX}), and a wider value would silently wrap. Pass it as text (and store the column as VARCHAR or HUGEINT) instead.`;
 
+const nulByteMessage = (idx: number): string =>
+    `parameter ${idx} contains a NUL byte (U+0000): this client binds VARCHAR through a NUL-terminated C string, so the value would be SILENTLY TRUNCATED at the first NUL on the way in - and the length-less read accessor cannot detect the truncation on the way back out (see readResult's fix-round-2 note). Strip or escape NUL bytes upstream before binding (writer enforcement lands with wave-2 writers, #790).`;
+
 /** Bind one prepared-statement parameter (1-based `idx`). Returns the
  *  `duckdb_state` from the underlying bind call so the caller can check it. */
 const bindParam = (lib: LibDuckDb, stmtHandle: bigint, idx: bigint, param: DuckDbParam): number => {
@@ -293,6 +307,16 @@ const runStatement = (
                 throw new DuckDbQueryError({
                     sql: sqlExcerpt(sql),
                     message: bigintRangeMessage(i + 1, param),
+                });
+            }
+            // A VARCHAR bind through a NUL-terminated C string would silently
+            // truncate at an embedded NUL. The read side documents "callers must
+            // escape NUL bytes" but nothing enforced it - make the silent
+            // truncation a loud, typed failure at the write boundary instead.
+            if (typeof param === "string" && param.includes("\0")) {
+                throw new DuckDbQueryError({
+                    sql: sqlExcerpt(sql),
+                    message: nulByteMessage(i + 1),
                 });
             }
             const bindState = bindParam(lib, stmtHandle, BigInt(i + 1), params[i]);

--- a/packages/lib/src/duckdb/dylib.test.ts
+++ b/packages/lib/src/duckdb/dylib.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { BunFileSystem } from "@effect/platform-bun";
 import { Effect } from "effect";
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { extractDylib, isEmbeddedPath, resolveDylibPath } from "./dylib.ts";
@@ -74,6 +74,44 @@ describe("extractDylib", () => {
         expect(statSync(second).mtimeMs).toBe(firstMtime);
         // The reuse path must never leave a staging file behind either.
         expect(readdirSync(cache).length).toBe(1);
+    });
+
+    test("creates the cache dir owner-only (0700) and publishes the dylib read-only (0400)", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "duckdb-bytes");
+
+        const out = await runWithFs(extractDylib(source, cache));
+
+        // No group/other permissions on the cache dir; owner-read-only on the file.
+        expect(statSync(cache).mode & 0o077).toBe(0);
+        expect(statSync(out).mode & 0o777).toBe(0o400);
+    });
+
+    test("rejects a tampered cache file and re-extracts the trusted bytes (adversarial P2)", async () => {
+        const dir = tempDir();
+        const cache = join(dir, "cache");
+        const source = join(dir, "src.bin");
+        await Bun.write(source, "trusted-duckdb-bytes");
+
+        const out = await runWithFs(extractDylib(source, cache));
+        expect(await Bun.file(out).text()).toBe("trusted-duckdb-bytes");
+
+        // A same-user attacker plants a malicious library at the predictable
+        // content-hash path (the file is published 0400, so make it writable
+        // first, as an attacker with the same uid could).
+        chmodSync(out, 0o600);
+        await Bun.write(out, "MALICIOUS-PAYLOAD");
+        expect(await Bun.file(out).text()).toBe("MALICIOUS-PAYLOAD");
+
+        // The next resolve must NOT dlopen the tampered bytes: it re-hashes the
+        // on-disk file, sees the mismatch, and re-extracts the trusted bytes.
+        const second = await runWithFs(extractDylib(source, cache));
+        expect(second).toBe(out);
+        expect(await Bun.file(out).text()).toBe("trusted-duckdb-bytes");
+        // Republished read-only again.
+        expect(statSync(out).mode & 0o777).toBe(0o400);
     });
 });
 

--- a/packages/lib/src/duckdb/dylib.ts
+++ b/packages/lib/src/duckdb/dylib.ts
@@ -47,21 +47,40 @@ const toDylibError =
     (err: PlatformError.PlatformError): DuckDbDylibError =>
         new DuckDbDylibError({ message: `${context}: ${err.message}` });
 
+/** First 16 hex chars of the sha256 over `bytes` - the content id that names
+ *  the extraction path. */
+const contentDigest = (bytes: ArrayBuffer): string => {
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(new Uint8Array(bytes));
+    return hasher.digest("hex").slice(0, 16);
+};
+
+/** Cache dir is owner-only (0700); the published dylib is read-only (0400). */
+const CACHE_DIR_MODE = 0o700;
+const DYLIB_FILE_MODE = 0o400;
+
 /**
  * Materialise `embeddedPath`'s bytes at `<cacheDir>/<sha256-16>-libduckdb`,
- * reusing an existing extraction. The hash is over the CONTENT, so a rebuilt
- * binary with a new dylib gets a new path instead of racing the old one.
+ * reusing an existing extraction ONLY when the on-disk bytes still hash to the
+ * same content id.
  *
- * Concurrency: the reuse check (`fs.exists`) runs BEFORE anything is staged,
- * so a process that finds the file already present never touches the
- * filesystem again - no staging file, no leaked temp entry. When extraction
- * IS needed, the bytes are staged at a pid-suffixed sibling and published with
- * `fs.rename` (same directory, so the rename is atomic on every platform this
- * runs on) - two processes racing the same content hash both stage under
- * distinct names and both rename onto the same `out` path; since the bytes
- * are identical (same content hash), whichever rename lands last still
- * produces the correct file, and neither process can observe a partially
- * written dylib.
+ * Integrity (adversarial P2): the path is a CONTENT hash, so a rebuilt binary
+ * with a new dylib gets a new path instead of racing the old one. But the reuse
+ * branch must NOT blindly `dlopen` whatever sits at that predictable path - a
+ * same-user process could plant a malicious library there and turn the next run
+ * into an RCE. So reuse re-hashes the file on disk and accepts it only on a
+ * digest match; a mismatch (tamper / truncated write) falls through and
+ * re-extracts the trusted embedded bytes over it. The cache dir is created
+ * owner-only (0700) and the published file is read-only (0400) to narrow the
+ * window further.
+ *
+ * Concurrency: when extraction IS needed the bytes are staged at a
+ * uniquely-suffixed sibling and published with `fs.rename` (same directory, so
+ * the rename is atomic on every platform this runs on) - two processes racing
+ * the same content hash both stage under distinct names and both rename onto the
+ * same `out` path; since the bytes are identical (same content hash), whichever
+ * rename lands last still produces the correct file, and neither process can
+ * observe a partially written dylib.
  */
 export const extractDylib = (
     embeddedPath: string,
@@ -80,21 +99,32 @@ export const extractDylib = (
                 }),
         });
 
-        const digest = yield* Effect.sync(() => {
-            const hasher = new Bun.CryptoHasher("sha256");
-            hasher.update(new Uint8Array(bytes));
-            return hasher.digest("hex").slice(0, 16);
-        });
+        const digest = yield* Effect.sync(() => contentDigest(bytes));
 
         const out = posixPath.join(cacheDir, `${digest}-libduckdb`);
 
         const alreadyExtracted = yield* fs
             .exists(out)
             .pipe(Effect.mapError(toDylibError(`failed to check for an existing extraction at ${out}`)));
-        if (alreadyExtracted) return out;
+        if (alreadyExtracted) {
+            // Re-hash the on-disk file: accept the cached copy ONLY if its bytes
+            // still match the content id in its name. A mismatch means the file
+            // was tampered with (or a torn write) - re-extract the trusted bytes.
+            const onDisk = yield* Effect.tryPromise({
+                try: () => Bun.file(out).arrayBuffer(),
+                catch: (err) =>
+                    new DuckDbDylibError({
+                        message: `failed to re-hash the cached dylib at ${out}: ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    }),
+            });
+            if (contentDigest(onDisk) === digest) return out;
+            // else: fall through and re-extract over the tampered/torn file.
+        }
 
         yield* fs
-            .makeDirectory(cacheDir, { recursive: true })
+            .makeDirectory(cacheDir, { recursive: true, mode: CACHE_DIR_MODE })
             .pipe(Effect.mapError(toDylibError(`failed to create the dylib cache dir ${cacheDir}`)));
 
         // Stage in a UNIQUELY-suffixed sibling and rename, so a concurrent
@@ -127,6 +157,13 @@ export const extractDylib = (
             yield* fs
                 .rename(staging, out)
                 .pipe(Effect.mapError(toDylibError(`failed to publish the extracted dylib to ${out}`)));
+
+            // Publish read-only so a later same-user process cannot overwrite the
+            // trusted bytes in place (a fresh extraction still renames over it -
+            // rename needs write on the DIR, not the file). Best-effort: a chmod
+            // failure must not fail the whole open - the reuse re-hash above is
+            // the actual integrity gate.
+            yield* fs.chmod(out, DYLIB_FILE_MODE).pipe(Effect.ignore);
         });
 
         yield* stageAndPublish.pipe(Effect.ensuring(fs.remove(staging).pipe(Effect.ignore)));

--- a/packages/lib/src/duckdb/index.test.ts
+++ b/packages/lib/src/duckdb/index.test.ts
@@ -11,7 +11,7 @@ describe("@ax/lib/duckdb public surface", () => {
     // either direction, without this test failing. This subsumes the two
     // former per-group "exports X" tests (services/layers/helpers, tagged
     // errors) - every name they checked is a member of this exact set.
-    test("the runtime surface is exactly this closed set of 29 names", () => {
+    test("the runtime surface is exactly this closed set of 30 names", () => {
         const names = Object.keys(duckdb as Record<string, unknown>).sort();
         expect(names).toEqual(
             [
@@ -30,6 +30,8 @@ describe("@ax/lib/duckdb public surface", () => {
                 "IngestLockHeldError",
                 "IngestLockLayer",
                 "IngestLockLive",
+                // BIGINT-column coercion schema for queryAs (wave-0 P2-10).
+                "NumberFromBigIntColumn",
                 "SnapshotPublishError",
                 "accessorFor",
                 "coerceValue",

--- a/packages/lib/src/duckdb/index.ts
+++ b/packages/lib/src/duckdb/index.ts
@@ -9,6 +9,7 @@
 export * from "./errors.ts";
 export * from "./types.ts";
 export * from "./row-decode.ts";
+export * from "./bigint-column.ts";
 export * from "./dylib.ts";
 export * from "./lock-state.ts";
 

--- a/packages/lib/src/stable-id.test.ts
+++ b/packages/lib/src/stable-id.test.ts
@@ -146,7 +146,9 @@ describe("determinism property", () => {
     // deliberate cache-version bump - doing so invalidates every cached row.
     test("golden row ids are pinned as literals - a regression here breaks every cached row", () => {
         expect(stableId("turn", ["a", 1])).toBe("95e2451f95fb1c6e49bf93c263fa43b6");
-        expect(sessionRowId("claude", "abc")).toBe("3a73bc66bd73afd6c665b1eaa73ec88c");
+        // session is the carve-out: its id is the provider session id VERBATIM,
+        // never a hash (wave-0 finding P1-3) - so this pin is the input string.
+        expect(sessionRowId("claude", "abc")).toBe("abc");
         expect(turnRowId("s1", 7)).toBe("fcfa5ac272f770611d02bbb6c810c19f");
         expect(toolCallRowId("s1", 7, { callId: "toolu_01" })).toBe("772e683e4e9b8bc61b92f1851151a875");
         expect(toolCallRowId("s1", 7, { ordinal: 0 })).toBe("95e7c99eb759ffa4fc9732136b6e11ce");
@@ -157,8 +159,23 @@ describe("determinism property", () => {
     });
 
     test("delegation: helpers compute exactly stableId(table, parts)", () => {
-        expect(sessionRowId("claude", "abc")).toBe(stableId("session", ["claude", "abc"]));
+        // session is the carve-out - its id is the raw provider id, so it does
+        // NOT delegate to stableId. turn (composite key) still does.
         expect(turnRowId("s1", 7)).toBe(stableId("turn", ["s1", 7]));
+    });
+
+    test("sessionRowId is the provider session id verbatim, ignoring provider (P1-3)", () => {
+        // The value OTLP correlation + Studio deeplinks join on must be the bare
+        // provider id, not a hash. A raw uuid round-trips unchanged, so
+        // correlate.ts's bareUuid(session.id) recovers the same uuid it matches
+        // otel session_id against.
+        const uuid = "019fbf3f-1a2b-4c5d-8e9f-0a1b2c3d4e5f";
+        expect(sessionRowId("claude", uuid)).toBe(uuid);
+        // provider does not alter the id (globally-unique ids never collide).
+        expect(sessionRowId("codex", uuid)).toBe(sessionRowId("claude", uuid));
+        // subagent ids (non-uuid) pass through verbatim too.
+        expect(sessionRowId("claude", "claude-subagent-af3f3b45c70ccf85c"))
+            .toBe("claude-subagent-af3f3b45c70ccf85c");
     });
 
     test("500 keys from a genuinely varied 32-bit PRNG collide never and repeat always", () => {

--- a/packages/lib/src/stable-id.ts
+++ b/packages/lib/src/stable-id.ts
@@ -8,6 +8,13 @@
  * rewrites the same ids, which is what makes the cache rebuildable and
  * makes sidecar refs (SQLite) survive a full re-derive.
  *
+ * ONE CARVE-OUT: when a table's natural key IS ALREADY a single provider-native
+ * stable id, the row id is that identifier VERBATIM, not a hash of it. The
+ * canonical case is `session` (see `sessionRowId`): its provider uuid is the
+ * value the rest of the system joins session identity on (OTLP correlation,
+ * Studio deeplinks), so hashing it would break those joins. Composite keys
+ * (turn = session + seq, etc.) have no single provider id and stay hashed.
+ *
  * APPEND-STABILITY (P1-2): a natural key must be append-stable - re-deriving
  * after a source file grows (more lines appended to a transcript) must
  * produce IDENTICAL ids for rows that were already seen before the file
@@ -85,8 +92,31 @@ export function stableId(table: string, parts: readonly NaturalKeyPart[]): strin
     return hasher.digest("hex").slice(0, ID_HEX_LENGTH);
 }
 
-export function sessionRowId(provider: string, providerSessionId: string): string {
-    return stableId("session", [provider, providerSessionId]);
+/**
+ * The `session` row id is the provider-native session identifier VERBATIM - it
+ * is NOT hashed. A provider's session id (a uuid for a main session, a
+ * `<provider>-subagent-<hash>` id for a subagent) is already a stable, globally
+ * unique natural key, and session identity is joined on that BARE value across
+ * the system: OTLP correlation extracts the uuid straight out of `session.id`
+ * (apps/axctl/src/otel/correlate.ts), Studio deeplinks address
+ * `/sessions/<bare-session-id>`, and `ax otel` coverage matches uuid-to-uuid.
+ * The earlier `stableId("session", [provider, id])` replaced the uuid with 32
+ * hex chars that match no uuid, silently zeroing every one of those joins
+ * (wave-0 finding P1-3). This mirrors the old SurrealDB `session:<id>` keying,
+ * where the key was the raw provider session id.
+ *
+ * `provider` stays in the signature for call-site symmetry with the other
+ * row-id helpers, but is NOT folded into the id: provider-native session ids do
+ * not collide across providers (uuids are globally unique; subagent ids embed
+ * the provider name), exactly as the single-namespace Surreal scheme assumed.
+ *
+ * Only tables whose natural key IS itself a provider-native stable id qualify
+ * for verbatim ids. `turn`/`tool_call`/`agent_event` are keyed on a COMPOSITE
+ * (session id + seq + ...), so they have no single provider id to be and stay
+ * hashed via `stableId`.
+ */
+export function sessionRowId(_provider: string, providerSessionId: string): string {
+    return providerSessionId;
 }
 
 export function turnRowId(sessionId: string, seq: number): string {
@@ -155,7 +185,7 @@ export function edgeRowId(
  *  not yet have a concrete recipe below is tracked in RECIPE_TODO instead
  *  of silently having none. */
 export const NATURAL_KEY_RECIPES: Readonly<Record<string, string>> = {
-    session: "provider + provider-native session id",
+    session: "the provider-native session id VERBATIM (NOT hashed) - see sessionRowId; the one carve-out from the hash-the-natural-key rule",
     turn: "session row id + provider-native turn seq",
     tool_call: "session row id + seq + (provider call id OR an explicit ordinal) - see toolCallRowId",
     agent_event: "agent_session row id + seq + provider event id (when present)",

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -9,7 +9,7 @@ import {
     parseDuckdbTables,
     parseSurrealTables,
 } from "./duckdb-ddl.ts";
-import { DUCKDB_SCHEMA_TABLES } from "./duckdb-tables.ts";
+import { DUCKDB_SCHEMA_TABLES, SIDECAR_JUDGMENT_TABLES } from "./duckdb-tables.ts";
 const surrealTables = parseSurrealTables(surql);
 const duckTables = parseDuckdbTables();
 const duckTableSet = new Set(duckTables);
@@ -217,9 +217,42 @@ describe("manifest", () => {
     test("every entry carries a non-empty note and a known stage and kind", () => {
         for (const entry of DUCKDB_SCHEMA_TABLES) {
             expect(entry.note.length).toBeGreaterThan(0);
-            expect(["active", "conditional", "staged"]).toContain(entry.stage);
+            expect(["active", "conditional", "staged", "sidecar"]).toContain(entry.stage);
             expect(["node", "edge"]).toContain(entry.kind);
         }
+    });
+
+    // Wave-0 finding P1-2: the DDL header says durable judgment lives in the
+    // SQLite sidecar and the DuckDB cache is REBUILDABLE, but the manifest had
+    // these tables marked `active` - a cache rebuild would erase user decisions.
+    // Every durable judgment table (proposals, verdicts, role tags + weights,
+    // retros, triage/label-review decisions, dogfood runs) must be `sidecar`.
+    test("every judgment table is marked stage: sidecar (durable, never rebuilt)", () => {
+        const JUDGMENT_TABLES = [
+            "proposal",
+            "skill_proposal",
+            "subagent_proposal",
+            "hook_proposal",
+            "guidance_proposal",
+            "automation_proposal",
+            "experiment",
+            "checkpoint",
+            "role",
+            "plays_role",
+            "retro",
+            "skill_triage_decision",
+            "transcript_label_review",
+            "dogfood_run",
+        ] as const;
+        const stageOf = new Map(DUCKDB_SCHEMA_TABLES.map((t) => [t.table, t.stage] as const));
+        for (const table of JUDGMENT_TABLES) {
+            expect(stageOf.get(table)).toBe("sidecar");
+        }
+        // The exported set and this explicit list must agree, and no OTHER table
+        // may be silently marked sidecar without being enumerated here.
+        expect([...SIDECAR_JUDGMENT_TABLES].sort()).toEqual([...JUDGMENT_TABLES].sort());
+        const sidecarInManifest = DUCKDB_SCHEMA_TABLES.filter((t) => t.stage === "sidecar").map((t) => t.table);
+        expect(sidecarInManifest.sort()).toEqual([...JUDGMENT_TABLES].sort());
     });
 
     test("kind matches the Surreal relation flag", () => {

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -5,9 +5,50 @@
 export interface DuckdbTableSpec {
     readonly table: string;
     readonly kind: "node" | "edge";
-    readonly stage: "active" | "conditional" | "staged";
+    /**
+     * - `active`      - derived from files on disk (transcripts/git/skills/OTLP
+     *                   spool); REBUILDABLE, dropped + re-derived on a cache rebuild.
+     * - `conditional` - active, but only written under a runtime gate (e.g. a
+     *                   GitHub remote + working `gh`).
+     * - `staged`      - reserved/not-yet-wired; also rebuildable.
+     * - `sidecar`     - DURABLE JUDGMENT that a cache rebuild MUST NOT erase
+     *                   (user/agent decisions: proposals, verdicts, role tags +
+     *                   weights, retros, triage/label-review decisions, dogfood
+     *                   runs). The DDL header says durable judgment lives in the
+     *                   SQLite sidecar; this flag is the machine-readable copy of
+     *                   that contract so nothing can treat these tables as
+     *                   rebuildable-from-transcripts. See SIDECAR_JUDGMENT_TABLES.
+     */
+    readonly stage: "active" | "conditional" | "staged" | "sidecar";
     readonly note: string;
 }
+
+/**
+ * Durable judgment tables (wave-3 `c-sidecar-sqlite`): user/agent DECISIONS that
+ * cannot be re-derived from transcripts/git/skills, so a cache rebuild must not
+ * drop them. Enumerated here as the single source of truth; the manifest below
+ * marks each `stage: "sidecar"` and duckdb-schema.test.ts asserts the two agree.
+ *
+ * NOTE: "spar labels" (the wave-3 list) are `session.labels` VALUES stamped by
+ * spar-score, i.e. a COLUMN on the (rebuildable) `session` table, not a table of
+ * their own - there is nothing table-grained to mark here for them.
+ */
+export const SIDECAR_JUDGMENT_TABLES: ReadonlySet<string> = new Set([
+    "proposal",
+    "skill_proposal",
+    "subagent_proposal",
+    "hook_proposal",
+    "guidance_proposal",
+    "automation_proposal",
+    "experiment",
+    "checkpoint",
+    "role",
+    "plays_role",
+    "retro",
+    "skill_triage_decision",
+    "transcript_label_review",
+    "dogfood_run",
+]);
 
 export const DUCKDB_SCHEMA_TABLES: readonly DuckdbTableSpec[] = [
     { table: "skill", kind: "node", stage: "active", note: "Installed skills and slash commands. SEMANTICS (P2-2): ingested_at used Surreal `VALUE time::now()`, not a DEFAULT - the writer must stamp CURRENT_TIMESTAMP on every insert AND update, since DuckDB DEFAULT only fires on an omitted-column insert." },
@@ -53,7 +94,7 @@ export const DUCKDB_SCHEMA_TABLES: readonly DuckdbTableSpec[] = [
     { table: "classifier_graph_node", kind: "node", stage: "active", note: "Generic classifier graph nodes projected from package operations." },
     { table: "classifier_graph_edge", kind: "node", stage: "active", note: "Generic classifier graph edges projected from package operations." },
     { table: "classifier_graph_fact", kind: "node", stage: "active", note: "Generic classifier graph facts projected from package operations." },
-    { table: "transcript_label_review", kind: "node", stage: "active", note: "Human/agent review verdicts for mined transcript label candidates." },
+    { table: "transcript_label_review", kind: "node", stage: "sidecar", note: "Human/agent review verdicts for mined transcript label candidates." },
     { table: "transcript_label_vector", kind: "node", stage: "active", note: "Embedding vectors and nearest-neighbor refs for transcript label candidates." },
     { table: "semantic_signal", kind: "node", stage: "active", note: "Reusable meanings promoted from analyzed turns." },
     { table: "diagnostic_event", kind: "node", stage: "active", note: "Derived diagnostics from failed commands and friction." },
@@ -85,8 +126,8 @@ export const DUCKDB_SCHEMA_TABLES: readonly DuckdbTableSpec[] = [
     { table: "ingest_event", kind: "node", stage: "active", note: "Append-like ingest progress events." },
     { table: "query_sample", kind: "node", stage: "staged", note: "Reserved query execution samples." },
     { table: "graph_health_check", kind: "node", stage: "staged", note: "Persisted graph health check rows." },
-    { table: "role", kind: "node", stage: "active", note: "Skill role labels used for weighting and grouping." },
-    { table: "plays_role", kind: "edge", stage: "active", note: "Skill-to-role classification edges." },
+    { table: "role", kind: "node", stage: "sidecar", note: "Skill role labels used for weighting and grouping." },
+    { table: "plays_role", kind: "edge", stage: "sidecar", note: "Skill-to-role classification edges." },
     { table: "invoked", kind: "edge", stage: "active", note: "Turn-to-skill invocation edges." },
     { table: "loaded", kind: "edge", stage: "active", note: "Session-to-skill auto-load activations (subagent skills: frontmatter); separate from invoked." },
     { table: "proposed", kind: "edge", stage: "active", note: "Skills mentioned but not invoked." },
@@ -117,26 +158,26 @@ export const DUCKDB_SCHEMA_TABLES: readonly DuckdbTableSpec[] = [
     { table: "agent_event_child", kind: "edge", stage: "active", note: "Provider-event parent-child edges." },
     { table: "used_model", kind: "edge", stage: "active", note: "Session-to-agent-model usage edges." },
     { table: "agent_used_model", kind: "edge", stage: "active", note: "Provider-session-to-agent-model usage edges." },
-    { table: "skill_triage_decision", kind: "node", stage: "active", note: "Dashboard keep/archive/review decisions per skill." },
+    { table: "skill_triage_decision", kind: "node", stage: "sidecar", note: "Dashboard keep/archive/review decisions per skill." },
     { table: "harness_hook_event", kind: "node", stage: "active", note: "Native agent harness hook lifecycle events." },
     { table: "hook_command_invocation", kind: "node", stage: "active", note: "Commands invoked by native harness hooks." },
     { table: "ax_invocation", kind: "node", stage: "active", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
     { table: "feedback_case_type", kind: "node", stage: "active", note: "Feedback backtest case definitions." },
     { table: "feedback_case_result", kind: "node", stage: "active", note: "Feedback backtest results." },
     { table: "hook_fire", kind: "node", stage: "active", note: "Runtime file-context hook decisions." },
-    { table: "proposal", kind: "node", stage: "active", note: "Polymorphic shortlist of repeated workflow improvement candidates." },
+    { table: "proposal", kind: "node", stage: "sidecar", note: "Polymorphic shortlist of repeated workflow improvement candidates." },
     { table: "directive_ngram", kind: "node", stage: "active", note: "Per-user n-gram lift table: which user-turn markers predict captured outcomes (directive mining v2, #587)." },
-    { table: "skill_proposal", kind: "node", stage: "active", note: "Typed payload rows for skill-form proposals." },
-    { table: "subagent_proposal", kind: "node", stage: "active", note: "Typed payload rows for subagent-form proposals." },
-    { table: "hook_proposal", kind: "node", stage: "active", note: "Typed payload rows for hook-form proposals." },
-    { table: "guidance_proposal", kind: "node", stage: "active", note: "Typed payload rows for guidance-file proposals." },
-    { table: "automation_proposal", kind: "node", stage: "active", note: "Typed payload rows for automation-form proposals." },
+    { table: "skill_proposal", kind: "node", stage: "sidecar", note: "Typed payload rows for skill-form proposals." },
+    { table: "subagent_proposal", kind: "node", stage: "sidecar", note: "Typed payload rows for subagent-form proposals." },
+    { table: "hook_proposal", kind: "node", stage: "sidecar", note: "Typed payload rows for hook-form proposals." },
+    { table: "guidance_proposal", kind: "node", stage: "sidecar", note: "Typed payload rows for guidance-file proposals." },
+    { table: "automation_proposal", kind: "node", stage: "sidecar", note: "Typed payload rows for automation-form proposals." },
     { table: "cites_evidence", kind: "edge", stage: "active", note: "Proposal-to-evidence edges." },
-    { table: "experiment", kind: "node", stage: "active", note: "Accepted proposals and scaffold/verdict state." },
+    { table: "experiment", kind: "node", stage: "sidecar", note: "Accepted proposals and scaffold/verdict state." },
     { table: "opportunity", kind: "edge", stage: "active", note: "Experiment trigger recurrence evidence edges." },
-    { table: "checkpoint", kind: "node", stage: "active", note: "Experiment measurement snapshots and user verdicts." },
-    { table: "dogfood_run", kind: "node", stage: "active", note: "Terminal dogfood scenario results." },
-    { table: "retro", kind: "node", stage: "active", note: "Structured session retrospectives." },
+    { table: "checkpoint", kind: "node", stage: "sidecar", note: "Experiment measurement snapshots and user verdicts." },
+    { table: "dogfood_run", kind: "node", stage: "sidecar", note: "Terminal dogfood scenario results." },
+    { table: "retro", kind: "node", stage: "sidecar", note: "Structured session retrospectives." },
     { table: "reviewed", kind: "edge", stage: "active", note: "Session-to-retro review edges." },
     { table: "ingest_file_state", kind: "node", stage: "active", note: "Per-source ingest watermark (mtime/size/sha) for skip-unchanged re-ingest." },
     { table: "otel_metric_point", kind: "node", stage: "active", note: "Harness OTLP metric data points (cost/token/usage)." },

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -16,6 +16,11 @@
 -- NATURAL_KEY_RECIPES for what each table hashes. Re-deriving the same input
 -- rewrites byte-identical ids, which is what lets sidecar refs survive a full
 -- re-derive; packages/lib/src/cache-integrity.ts counts the refs that do not.
+-- CARVE-OUT: `session.id` is the provider-native session id VERBATIM, not a hash
+-- of it (see sessionRowId). Its provider uuid is the value OTLP correlation and
+-- Studio deeplinks join session identity on, so hashing it would break those
+-- joins. Only a table whose natural key IS a single provider-native stable id
+-- qualifies; composite-key tables (turn = session + seq, etc.) stay hashed.
 --
 -- EDGES. Every Surreal RELATION table became a plain table with `in_id` / `out_id`
 -- VARCHAR columns holding the endpoint row ids, indexed on both sides. `in` and

--- a/scripts/bench/02_duckdb_load.sql
+++ b/scripts/bench/02_duckdb_load.sql
@@ -49,29 +49,45 @@ CREATE OR REPLACE TABLE skill (
 );
 COPY skill FROM 'jsonl/skill.jsonl' (FORMAT json);
 
+-- Edge tables use the SAME in_id/out_id column names + index shapes as
+-- production (packages/schema/src/schema.duckdb.sql). The bench previously used
+-- invented names (turn_id/skill_id/parent_session/child_session/session_id/
+-- otel_id), so its graph queries never exercised the real edge column names or
+-- indexes - a gate could pass while a production edge join failed (wave-0
+-- finding P1/P2). Keep the bench's mini-fixture row counts; only the shapes
+-- track production now.
 CREATE OR REPLACE TABLE invoked (
-  turn_id VARCHAR,
-  skill_id VARCHAR,
+  in_id VARCHAR,   -- ref -> turn
+  out_id VARCHAR,  -- ref -> skill
   session VARCHAR,
   ts TIMESTAMP
 );
 COPY invoked FROM 'jsonl/invoked.jsonl' (FORMAT json);
+CREATE INDEX invoked_out_ts ON invoked(out_id, ts);
+CREATE INDEX invoked_session_out_ts ON invoked(session, out_id, ts);
+CREATE INDEX invoked_in ON invoked(in_id);
+CREATE INDEX invoked_out ON invoked(out_id);
 
 CREATE OR REPLACE TABLE spawned (
-  parent_session VARCHAR,
-  child_session VARCHAR,
+  in_id VARCHAR,   -- ref -> session (parent)
+  out_id VARCHAR,  -- ref -> session (child)
   ts TIMESTAMP,
   agent_type VARCHAR,
   description VARCHAR
 );
 COPY spawned FROM 'jsonl/spawned.jsonl' (FORMAT json);
+CREATE INDEX spawned_in ON spawned(in_id);
+CREATE INDEX spawned_out ON spawned(out_id);
 
 CREATE OR REPLACE TABLE telemetry_of (
-  session_id VARCHAR,
-  otel_id VARCHAR,
+  in_id VARCHAR,
+  out_id VARCHAR,
+  out_table VARCHAR,
   linked_at TIMESTAMP
 );
 COPY telemetry_of FROM 'jsonl/telemetry_of.jsonl' (FORMAT json);
+CREATE INDEX telemetry_of_in ON telemetry_of(in_id);
+CREATE INDEX telemetry_of_out ON telemetry_of(out_id);
 
 SELECT 'turn' AS tbl, count(*) FROM turn
 UNION ALL SELECT 'tool_call', count(*) FROM tool_call

--- a/scripts/bench/04e_query_graph_traversal.sql
+++ b/scripts/bench/04e_query_graph_traversal.sql
@@ -3,7 +3,7 @@
 .timer on
 SELECT sk.name, count(*) AS n
 FROM invoked i
-JOIN skill sk ON i.skill_id = sk.id
+JOIN skill sk ON i.out_id = sk.id
 GROUP BY sk.name
 ORDER BY n DESC
 LIMIT 20;

--- a/scripts/bench/04f_query_spawn_chain.sql
+++ b/scripts/bench/04f_query_spawn_chain.sql
@@ -1,8 +1,8 @@
 -- Graph traversal shape 2: subagent dispatch table (the "ax dispatches" shape) --
 -- one-hop parent->child session join with a session-attribute lookup.
 .timer on
-SELECT sp.parent_session, sp.child_session, sp.agent_type, s.model
+SELECT sp.in_id AS parent_session, sp.out_id AS child_session, sp.agent_type, s.model
 FROM spawned sp
-JOIN session s ON sp.child_session = s.id
+JOIN session s ON sp.out_id = s.id
 ORDER BY sp.ts DESC
 LIMIT 30;

--- a/scripts/bench/gen-mini-fixture.ts
+++ b/scripts/bench/gen-mini-fixture.ts
@@ -76,24 +76,28 @@ export const writeMiniFixture = (
         scope: i % 2 === 0 ? "user" : "project",
     }));
 
+    // Edge JSONL keys must match the in_id/out_id column names the load DDL
+    // (02_duckdb_load.sql) declares - COPY ... (FORMAT json) matches by name, so
+    // a key mismatch silently loads NULLs. These track production edge shapes.
     const invoked = Array.from({ length: INVOKED_ROWS }, (_, i) => ({
-        turn_id: `turn:t${String(i % TURN_ROWS).padStart(5, "0")}`,
-        skill_id: skillId(i % SKILL_ROWS),
+        in_id: `turn:t${String(i % TURN_ROWS).padStart(5, "0")}`,
+        out_id: skillId(i % SKILL_ROWS),
         session: sessionId(i % SESSION_ROWS),
         ts: iso(i + 3),
     }));
 
     const spawned = Array.from({ length: SPAWNED_ROWS }, (_, i) => ({
-        parent_session: sessionId(i % SESSION_ROWS),
-        child_session: sessionId((i + 1) % SESSION_ROWS),
+        in_id: sessionId(i % SESSION_ROWS),
+        out_id: sessionId((i + 1) % SESSION_ROWS),
         ts: iso(i * 15),
         agent_type: i % 2 === 0 ? "Explore" : "general-purpose",
         description: `dispatch ${i}`,
     }));
 
     const telemetry = Array.from({ length: TELEMETRY_ROWS }, (_, i) => ({
-        session_id: sessionId(i % SESSION_ROWS),
-        otel_id: `otel:o${String(i).padStart(4, "0")}`,
+        in_id: sessionId(i % SESSION_ROWS),
+        out_id: `otel:o${String(i).padStart(4, "0")}`,
+        out_table: "otel_log_event",
         linked_at: iso(i * 9),
     }));
 

--- a/scripts/build-duckdb.sh
+++ b/scripts/build-duckdb.sh
@@ -111,7 +111,26 @@ if [[ "$source_head" != "$duckdb_pinned_sha" ]]; then
     exit 1
 fi
 
-cp "$config_template" "$source_dir/extension/extension_config_local.cmake"
+# HEAD alone proves nothing about the WORKING TREE: a reused checkout could have
+# tracked files patched or extra sources dropped in and still report the pinned
+# HEAD. Reset hard to the pinned commit and wipe every untracked/ignored file
+# (incl. any previous build/) BEFORE applying our config, so the build only ever
+# compiles pinned sources plus the single file we add.
+git -C "$source_dir" reset --hard "$duckdb_pinned_sha"
+git -C "$source_dir" clean -fdx
+
+config_rel="extension/extension_config_local.cmake"
+cp "$config_template" "$source_dir/$config_rel"
+
+# The worktree must now differ from the pinned commit by that ONE file alone.
+# Anything else means tampering survived the reset (or the reset did not take) -
+# fail loudly rather than build it.
+unexpected=$(git -C "$source_dir" status --porcelain | grep -v -F -- "$config_rel" || true)
+if [[ -n "$unexpected" ]]; then
+    echo "reused DuckDB checkout at $source_dir is dirty beyond the config template after reset:" >&2
+    printf '%s\n' "$unexpected" >&2
+    exit 1
+fi
 # STATIC_LIBCPP=1 statically links libstdc++/libc++ into the DuckDB build so
 # the produced binaries don't depend on the runner's system C++ runtime -
 # needed on the Linux matrix legs (glibc/libstdc++ version skew between the


### PR DESCRIPTION
Wave-0 milestone fixes for the v2 DuckDB refactor (fleet map #768). Closes the integration + adversarial findings from the `/review-all` pass over the wave-0 integration diff. The last wave-0 chunk before the seam.

## P1 — data-loss / security

- **Scoped ingest could delete other repos' blobs.** The blob-GC gate checked only `--since`; `ax ingest here` / stage-scoped runs have a partial reference set but passed it, so GC deleted blobs referenced only by out-of-scope repos. Now gated on a pure `isGlobalIngest` predicate (no `--since`, no `--stages`, no repo/project scope). Tested: `here`/`--since`/`--stages` skip GC, bare `ingest` runs it.
- **Judgment tables were marked cache-active.** The cache is rebuildable-from-transcripts, but 14 durable-judgment tables (proposal + typed payloads, role/plays_role, retro, skill_triage_decision, transcript_label_review, dogfood_run, …) were manifest-active — a rebuild would erase user decisions. Added a `sidecar` designation + an explicit enumerated guard test. Metadata only.
- **`sessionRowId` hashed the public session UUID**, breaking OTLP correlation (matches on the bare uuid), session deeplinks, and every session join. Now returns the provider session id verbatim (the one carve-out; composite turn/tool_call/agent_event ids stay hashed). `correlate.test.ts` proves the round-trip match.
- **OTLP spool receiver missing the Host-header guard** the dashboard server has → a web page could POST fabricated telemetry into the spool (CORS simple request). Ported `isAllowedHost` (403 on non-loopback Host) + an 8 MB `maxRequestBodySize` (disk-exhaustion / ingest-OOM defense).
- **NUL-byte VARCHAR binds silently truncated on read** with no write-side enforcement. Now a NUL in a string param is a typed error at the bind boundary — the documented contract is loud, not silent (writer-side stripping lands with wave-2, #790).

## P2 — correctness / hardening

- **Bench measured shadow tables that diverged from the prod DDL** (`skill_id`/`parent_session` vs production `in_id`/`out_id`) — the gate could pass while real queries failed. Aligned the bench load SQL + queries + fixture to the production edge columns and index shapes; verified live against DuckDB v1.5.5 (all 9 metrics pass).
- **Dylib reuse re-`dlopen`ed the content-hash path without re-hashing** the on-disk bytes (same-user plant → RCE). Reuse now re-hashes and accepts only on digest match; cache dir `0700`, published file `0400`.
- **Build script SHA check ignored a dirty worktree** — a tampered reused checkout passed. Now `reset --hard` + `clean -fdx` + a porcelain assertion after the pin check. Full build + air-gap smoke verified.
- **otlpd daemon lifecycle gaps** — `ax daemon status`/start/stop/restart now include otlpd, gated so it never starts while another process owns 1738. `queryAs` BIGINT contract documented + a `NumberFromBigIntColumn` coercion (typed-fail outside safe-int, never lossy). otel-spool threads `received_at` so timeless rows stop colliding at the unix epoch.

Deferred to the wave-1 seam chunk (in its brief): ingest-lock 4→1 unification, `stageAndRename` extraction, deriving the schema mirrors from the DDL. Acknowledged P3s stay open (#789 flock, µs truncation, wall-clock retention, whole-file spool read).

Gates: `bun test packages/lib packages/schema apps/axctl/src/{ingest,otel,cli} scripts/bench` → 2727 pass / 0 fail · `bun run typecheck` 0 · `bunx tsc --noEmit` 0 · `check:no-node-fs` 0 · build air-gap smoke pass.
