### PR TITLE
feat(v2): add typed SQLite judgment sidecar

### DIFF
--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -445,11 +445,10 @@ const cmdSkillsByRole = (input: SkillsByRoleInput) =>
         const json = wantsJsonFlag(input.json);
         const limit = requirePositiveInt("skills by-role", "limit", input.limit);
 
-        const result = yield* fetchSkillsByRole(
-            normalizeSkillsByRoleParams({ role, limit }),
-        ).pipe(
-            catchDbErrorAndExit("axctl skills by-role"),
-        );
+        // No `catchDbErrorAndExit`: this vertical is ported off SurrealDB, so
+        // its failures are `CacheReadError`/`JudgmentError`, not `DbError`. They
+        // bubble to the CLI edge exactly as `ax recall`'s do (the v2 template).
+        const result = yield* fetchSkillsByRole(normalizeSkillsByRoleParams({ role, limit }));
 
         if (json) {
             console.log(renderSkillsByRoleJson(result, role));
@@ -475,9 +474,7 @@ const cmdRolesForSkill = (input: RolesForSkillInput) =>
         const skill = input.skill;
         const json = wantsJsonFlag(input.json);
 
-        const result = yield* fetchRolesForSkill({ skill }).pipe(
-            catchDbErrorAndExit("axctl skills roles"),
-        );
+        const result = yield* fetchRolesForSkill({ skill });
 
         if (!result.skillExists) {
             fail(`axctl skills roles: unknown skill "${skill}"`);
@@ -503,9 +500,7 @@ const cmdRoles = (input: RolesInput) =>
     Effect.gen(function* () {
         const json = wantsJsonFlag(input.json);
 
-        const result = yield* fetchAllRoles().pipe(
-            catchDbErrorAndExit("axctl roles"),
-        );
+        const result = yield* fetchAllRoles();
 
         if (json) {
             console.log(renderAllRolesJson(result));
@@ -901,9 +896,7 @@ const tagCommand = Command.make(
             confidence,
             rationale: optionValue(rationale),
             remove,
-        }).pipe(
-            catchDbErrorAndExit("axctl skills tag"),
-        ),
+        }),
 ).pipe(
     Command.withDescription(
         "Manually assign a role to a skill (writes a plays_role edge with source=user). " +
@@ -1066,5 +1059,17 @@ export const rolesCommand = Command.make(
 
 export const skillsRuntime: RuntimeManifest = {
     skills: "db",
-    roles: "db",
+    // PORTED (c-sidecar-sqlite). `ax roles` is PURE JUDGMENT - the role
+    // vocabulary and the tag counts both live in the SQLite sidecar - so it needs
+    // neither SurrealDB nor a published snapshot, and answers on a machine that
+    // has never run an ingest. The `"cache"` runtime's throwing SurrealClient
+    // proxy is the acceptance signal; roles-no-surreal.test.ts spawns the real
+    // CLI with `AX_DB_URL` on a dead port AND a snapshot path that does not exist,
+    // which an in-process test cannot check.
+    //
+    // The rest of the `skills` family stays on `"db"`: `skills tag`,
+    // `skills roles` and `skills by-role` are ported (they reach only `Judgment`
+    // and `CacheRead`, both of which `withDb` already provides), but their many
+    // siblings under that command are not, and a family flips as ONE step.
+    roles: "cache",
 };

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -7,6 +7,7 @@ import { AxConfigLive } from "@ax/lib/config";
 import { ProcessServiceLive } from "@ax/lib/process";
 import { AppLayer } from "@ax/lib/layers";
 import { CacheRead, CacheReadLive } from "@ax/lib/duckdb/seam";
+import { JudgmentLive } from "../judgment.ts";
 import { maybePrintStarNudge } from "./star-nudge.ts";
 import { insightsCommand, reportCommand, timelineCommand, reportRuntime } from "./commands/report.ts";
 import { signalsCommand, signalsRuntime } from "./commands/signals.ts";
@@ -234,7 +235,7 @@ type CliProgram = Effect.Effect<void, unknown, never>;
  */
 const withDb = (args: ReadonlyArray<string>): CliProgram =>
     withIngestStalenessPreflight(runCli(args)).pipe(
-        Effect.provide(Layer.mergeAll(AppLayer, CacheReadLive)),
+        Effect.provide(Layer.mergeAll(AppLayer, CacheReadLive, JudgmentLive)),
         Effect.scoped,
     );
 
@@ -305,6 +306,7 @@ const withIngest = (args: ReadonlyArray<string>): CliProgram => {
     const layer = Layer.mergeAll(
         transport ? ingestRuntimeLayerWith(transport) : IngestRuntimeLayer,
         CacheReadLive,
+        JudgmentLive,
     );
     return runCli(args).pipe(
         // After ingest completes successfully, link orphan OTLP rows to their
@@ -343,7 +345,7 @@ const withoutDb = (args: ReadonlyArray<string>): CliProgram =>
     // SurrealClient connect path.
     runCli(args).pipe(
         Effect.provideService(SurrealClient, throwingSurrealClient()),
-        Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer, CacheReadLive)),
+        Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer, CacheReadLive, JudgmentLive)),
     );
 
 /**
@@ -366,6 +368,7 @@ const withCache = (args: ReadonlyArray<string>): CliProgram =>
                 AxConfigLive.pipe(Layer.provideMerge(Layer.mergeAll(BunFileSystem.layer, BunPath.layer))),
                 ProcessServiceLive,
                 CacheReadLive,
+                JudgmentLive,
             ),
         ),
         Effect.scoped,

--- a/apps/axctl/src/cli/roles-no-surreal.test.ts
+++ b/apps/axctl/src/cli/roles-no-surreal.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `ax roles`, END TO END, with NO SurrealDB reachable and NO DuckDB snapshot.
+ *
+ * The sibling of recall-no-surreal.test.ts, and the acceptance signal for the
+ * judgment half of the v2 split. An in-process test cannot check this: it is
+ * handed whatever layers it asks for and passes either way. So this spawns the
+ * ACTUAL CLI entrypoint as a child with
+ *
+ *   - `AX_SIDECAR_PATH` pointing at a sidecar this suite wrote,
+ *   - `AX_DB_URL` pointing at a port nothing listens on, so any SurrealDB connect
+ *     FAILS rather than quietly finding the developer's own running daemon and
+ *     passing for the wrong reason, and
+ *   - `AX_DUCKDB_SNAPSHOT` pointing at a file that does not exist.
+ *
+ * The missing snapshot is deliberate and is the extra claim this suite makes over
+ * recall's. `ax roles` is PURE JUDGMENT - the role vocabulary and the tag counts
+ * both live in the sidecar - so it must answer on a machine that has never run an
+ * ingest. If the command touched the cache for any part of its answer, the
+ * missing snapshot would surface as `CacheUnavailableError` and this would fail.
+ *
+ * No dylib gate, for the same reason: nothing here opens DuckDB.
+ */
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+
+/** The CLI entrypoint, run the way `bin/axctl` runs it. */
+const CLI = Bun.fileURLToPath(new URL("./index.ts", import.meta.url));
+
+/** A port nothing listens on, so a SurrealDB connect can only FAIL. */
+const DEAD_DB_URL = "ws://127.0.0.1:1/rpc";
+
+interface CliRun {
+    readonly exitCode: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+const runCli = (args: ReadonlyArray<string>, sidecarPath: string, dir: string): CliRun => {
+    const child = Bun.spawnSync(["bun", CLI, ...args], {
+        env: {
+            ...process.env,
+            AX_SIDECAR_PATH: sidecarPath,
+            // A snapshot that does not exist: any cache read would fail loudly.
+            AX_DUCKDB_SNAPSHOT: join(dir, "there-is-no-snapshot.duckdb"),
+            AX_DB_URL: DEAD_DB_URL,
+            AX_PROGRESS: "off",
+            NO_COLOR: "1",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    return {
+        exitCode: child.exitCode,
+        stdout: child.stdout.toString(),
+        stderr: child.stderr.toString(),
+    };
+};
+
+/** Two roles, one tagged twice and one tagged once, written straight into a
+ *  sidecar file - no ax code involved, so this fixture cannot mask a bug in the
+ *  write path the way an `ax skills tag` call would. */
+const seedSidecar = (sidecarPath: string): void => {
+    const db = new Database(sidecarPath, { create: true });
+    db.exec(SIDECAR_SCHEMA_SQL);
+    db.exec(`
+        INSERT INTO role (id, name, weight) VALUES
+            ('role:verification', 'verification', 2.0),
+            ('role:framing', 'framing', 1.0);
+        INSERT INTO plays_role (id, in_id, out_id, source, confidence) VALUES
+            ('pr1', 'skill:tdd', 'role:verification', 'user', 1.0),
+            ('pr2', 'skill:brainstorming', 'role:verification', 'frontmatter', 0.4),
+            ('pr3', 'skill:brainstorming', 'role:framing', 'user', 1.0);
+    `);
+    db.close();
+};
+
+describe("ax roles on the cache runtime", () => {
+    test("answers from the sidecar with no SurrealDB and no snapshot", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-roles-nodb-"));
+        try {
+            const sidecarPath = join(dir, "judgment.sqlite");
+            seedSidecar(sidecarPath);
+
+            const run = runCli(["roles", "--json"], sidecarPath, dir);
+
+            expect(run.stderr).not.toContain("SurrealClient");
+            expect(run.stderr).not.toContain("CacheUnavailableError");
+            expect(run.exitCode).toBe(0);
+            const body = JSON.parse(run.stdout) as {
+                rows: ReadonlyArray<{ name: string; weight: number; skill_count: number }>;
+            };
+            expect(body.rows.map((r) => [r.name, r.skill_count])).toEqual([
+                ["verification", 2],
+                ["framing", 1],
+            ]);
+            expect(body.rows[0]?.weight).toBe(2);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }, 60_000);
+
+    test("an empty sidecar is a clean exit, not a missing-database error", () => {
+        // The first-run shape: the sidecar file does not exist at all yet. The
+        // seam creates it, the DDL applies, and the answer is honestly empty.
+        const dir = mkdtempSync(join(tmpdir(), "ax-roles-nodb-empty-"));
+        try {
+            const run = runCli(["roles", "--json"], join(dir, "not-created-yet.sqlite"), dir);
+
+            expect(run.exitCode).toBe(0);
+            const body = JSON.parse(run.stdout) as { rows: ReadonlyArray<unknown> };
+            expect(body.rows).toEqual([]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }, 60_000);
+});

--- a/apps/axctl/src/cli/roles-no-surreal.test.ts
+++ b/apps/axctl/src/cli/roles-no-surreal.test.ts
@@ -25,6 +25,7 @@ import { Database } from "bun:sqlite";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { roleRowId } from "@ax/lib/stable-id";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 
 /** The CLI entrypoint, run the way `bin/axctl` runs it. */
@@ -66,14 +67,16 @@ const runCli = (args: ReadonlyArray<string>, sidecarPath: string, dir: string): 
 const seedSidecar = (sidecarPath: string): void => {
     const db = new Database(sidecarPath, { create: true });
     db.exec(SIDECAR_SCHEMA_SQL);
+    const verification = roleRowId("verification");
+    const framing = roleRowId("framing");
     db.exec(`
         INSERT INTO role (id, name, weight) VALUES
-            ('role:verification', 'verification', 2.0),
-            ('role:framing', 'framing', 1.0);
+            ('${verification}', 'verification', 2.0),
+            ('${framing}', 'framing', 1.0);
         INSERT INTO plays_role (id, in_id, out_id, source, confidence) VALUES
-            ('pr1', 'skill:tdd', 'role:verification', 'user', 1.0),
-            ('pr2', 'skill:brainstorming', 'role:verification', 'frontmatter', 0.4),
-            ('pr3', 'skill:brainstorming', 'role:framing', 'user', 1.0);
+            ('pr1', 'skill:tdd', '${verification}', 'user', 1.0),
+            ('pr2', 'skill:brainstorming', '${verification}', 'frontmatter', 0.4),
+            ('pr3', 'skill:brainstorming', '${framing}', 'user', 1.0);
     `);
     db.close();
 };

--- a/apps/axctl/src/cli/skills-tag.test.ts
+++ b/apps/axctl/src/cli/skills-tag.test.ts
@@ -1,274 +1,330 @@
 /**
- * Tests for `ax skills tag <skill> <role>` (P3.4).
+ * `ax skills tag <skill> <role>` across both v2 engines, with nothing stubbed.
  *
- * Mock strategy: stub SurrealClientShape so we can inspect the SQL
- * statements issued without hitting a real DB. Process.exit is captured
- * via a thrown Error so assertions remain synchronous.
+ * The old version of this file asserted the SQL TEXT of the statements the
+ * command issued against a stub. That could tell a working DELETE from a
+ * misspelled one and nothing else - in particular it could not tell whether the
+ * command was IDEMPOTENT, which is the whole contract of `skills tag`, because
+ * "issued a DELETE then a RELATE" is what you observe whether or not the row
+ * ends up singular. Every case here reads the rows back.
  */
-import { describe, test, expect, mock } from "bun:test";
-import { Effect } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import {
-    makeTestSurrealClient,
-    type TestSurrealQueryCall,
-    type TestSurrealUpsertCall,
-} from "@ax/lib/testing/surreal";
+import { describe, expect, mock } from "bun:test";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, FileSystem, Layer, Path, Schema } from "effect";
+import { join } from "node:path";
+import { CacheReadLayer } from "@ax/lib/duckdb/seam";
+import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
+import { publishCacheFixture } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { cmdSkillsTag } from "./skills-tag.ts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("skills tag", { requireFts: true });
 
-function buildMockDb(overrides: {
-    skillExists?: boolean;
-    queryResults?: unknown[][];
-}): { db: SurrealClientShape; calls: TestSurrealQueryCall[]; upserts: TestSurrealUpsertCall[] } {
-    const queryResults = overrides.queryResults ?? [];
+const Platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
-    const tc = makeTestSurrealClient({
-        responses: [
-            // First call is the skill lookup: a skill row with a record id, or empty.
-            overrides.skillExists === false
-                ? []
-                : [[{ id: { tb: "skill", id: "composto" } }]],
-            // For subsequent calls, return from provided queryResults...
-            ...queryResults.map((result) => [result]),
-        ],
-        // ...or empty arrays.
-        fallback: [[]],
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provide(Platform)) as Effect.Effect<A, E>);
+
+const dylibEnv = <A>(body: () => Promise<A>): Promise<A> => {
+    const previous = process.env.AX_DUCKDB_DYLIB;
+    if (dylibPath !== null) process.env.AX_DUCKDB_DYLIB = dylibPath;
+    return body().finally(() => {
+        if (previous === undefined) delete process.env.AX_DUCKDB_DYLIB;
+        else process.env.AX_DUCKDB_DYLIB = previous;
+    });
+};
+
+const TagRow = Schema.Struct({
+    in_id: Schema.String,
+    role_name: Schema.String,
+    source: Schema.String,
+    confidence: Schema.Number,
+    rationale: Schema.NullOr(Schema.String),
+});
+
+/** Every plays_role row in the sidecar, joined to its role's name. */
+const readTags = (j: JudgmentService) =>
+    j.rows(
+        TagRow,
+        `SELECT pr.in_id AS in_id, r.name AS role_name, pr.source AS source,
+                pr.confidence AS confidence, pr.rationale AS rationale
+         FROM plays_role pr JOIN role r ON r.id = pr.out_id
+         ORDER BY r.name`,
+    );
+
+interface Harness {
+    readonly tag: (opts: Parameters<typeof cmdSkillsTag>[0]) => Effect.Effect<void, unknown>;
+    readonly tags: Effect.Effect<ReadonlyArray<typeof TagRow.Type>, unknown>;
+}
+
+/** A cache holding one installed skill, plus an empty sidecar. */
+const harness = (dir: string) =>
+    Effect.gen(function* () {
+        const cache = yield* publishCacheFixture(dir, dylibPath, (write) =>
+            write.put("skill", {
+                id: "skill:content-hashed-id",
+                name: "composto",
+                scope: "user",
+                dir_path: "/tmp/skills/composto",
+                content_hash: "hash",
+            }),
+        );
+        const layers = Layer.mergeAll(
+            JudgmentLayer({ sidecarPath: join(dir, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
+            CacheReadLayer({
+                snapshotPath: cache.snapshotPath,
+                ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+            }),
+        );
+        return {
+            tag: (opts) => cmdSkillsTag(opts).pipe(Effect.scoped, Effect.provide(layers)),
+            tags: Effect.gen(function* () {
+                const j = yield* Judgment;
+                return yield* readTags(j);
+            }).pipe(Effect.scoped, Effect.provide(layers)),
+        } satisfies Harness;
     });
 
-    return { db: tc.client, calls: tc.calls, upserts: tc.upserts };
-}
+/** `fail()` calls `process.exit`, which returns `never` and so must THROW here
+ *  for the effect to stop - otherwise the command would carry on and write. */
+const withExitSpy = () => {
+    const spy = mock(() => {
+        throw new Error("process.exit(2)");
+    });
+    const original = process.exit;
+    (process as { exit: unknown }).exit = spy;
+    return {
+        spy,
+        restore: () => {
+            (process as { exit: unknown }).exit = original;
+        },
+    };
+};
 
-function runTag(
-    opts: Parameters<typeof cmdSkillsTag>[0],
-    db: SurrealClientShape,
-): Promise<void> {
-    return Effect.runPromise(
-        cmdSkillsTag(opts).pipe(
-            Effect.provideService(SurrealClient, db),
-        ),
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const baseOpts = {
+    skillName: "composto",
+    roleName: "verification",
+    confidence: 1,
+    rationale: undefined,
+    remove: false,
+};
 
 describe("cmdSkillsTag", () => {
-    test("1. Tags a new role on a skill: DELETE issued, RELATE issued with source=user", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        await runTag(
-            { skillName: "composto", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-            db,
+    dtest("records the tag against the skill's CACHE id, not its name", async () => {
+        // The name is the user's handle for the skill; the id is what survives a
+        // rename in the catalogue, and what the read side joins on.
+        const dir = tempDir("ax-tag-basic-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    yield* h.tag(baseOpts);
+                    return yield* h.tags;
+                }),
+            ),
         );
-
-        const queryCalls = calls;
-        // call 0: skill lookup
-        expect(queryCalls[0]?.sql).toContain("SELECT id FROM skill WHERE name = $name");
-        // call 1: upsert role (via db.upsert, not query)
-        expect(upserts.length).toBe(1);
-        // call 2: DELETE
-        const deleteSql = queryCalls.find((c) => c.sql.includes("DELETE plays_role"));
-        expect(deleteSql?.sql).toContain(`source = "user"`);
-        expect(deleteSql?.sql).toContain(`role:\`framing\``);
-        // call 3: RELATE
-        const relateSql = queryCalls.find((c) => c.sql.includes("RELATE"));
-        expect(relateSql?.sql).toContain(`->plays_role->`);
-        expect(relateSql?.sql).toContain(`source = "user"`);
-        expect(relateSql?.sql).toContain(`role:\`framing\``);
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.in_id).toBe("skill:content-hashed-id");
+        expect(tags[0]?.role_name).toBe("verification");
+        expect(tags[0]?.source).toBe("user");
     });
 
-    test("2. --remove: DELETE issued, no RELATE", async () => {
-        const { db, calls } = buildMockDb({ skillExists: true });
-        await runTag(
-            { skillName: "composto", roleName: "framing", confidence: 1.0, rationale: undefined, remove: true },
-            db,
+    dtest("is idempotent - tagging the same pair twice leaves ONE row", async () => {
+        const dir = tempDir("ax-tag-idempotent-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    yield* h.tag({ ...baseOpts, confidence: 0.5 });
+                    yield* h.tag({ ...baseOpts, confidence: 0.9, rationale: "second thoughts" });
+                    return yield* h.tags;
+                }),
+            ),
         );
-
-        const queryCalls = calls;
-        const deleteSql = queryCalls.find((c) => c.sql.includes("DELETE plays_role"));
-        expect(deleteSql).toBeDefined();
-
-        const relateSql = queryCalls.find((c) => c.sql.includes("RELATE"));
-        expect(relateSql).toBeUndefined();
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.confidence).toBeCloseTo(0.9);
+        expect(tags[0]?.rationale).toBe("second thoughts");
     });
 
-    test("3. Unknown skill: lookup query issued, error path taken (process.exit(2))", async () => {
-        const { db, calls } = buildMockDb({ skillExists: false });
-        const exitSpy = mock(() => { throw new Error("process.exit(2)"); });
-        const origExit = process.exit;
-        process.exit = exitSpy as unknown as typeof process.exit;
+    dtest("adds a second role without disturbing the first", async () => {
+        const dir = tempDir("ax-tag-two-roles-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    yield* h.tag(baseOpts);
+                    yield* h.tag({ ...baseOpts, roleName: "framing" });
+                    return yield* h.tags;
+                }),
+            ),
+        );
+        expect(tags.map((t) => t.role_name)).toEqual(["framing", "verification"]);
+    });
 
+    dtest("--remove deletes the tag and leaves nothing behind", async () => {
+        const dir = tempDir("ax-tag-remove-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    yield* h.tag(baseOpts);
+                    yield* h.tag({ ...baseOpts, remove: true });
+                    return yield* h.tags;
+                }),
+            ),
+        );
+        expect(tags).toEqual([]);
+    });
+
+    dtest("removes only the USER's tag, never a mined one", async () => {
+        // A user removing their own tag must not silently delete the classifier's
+        // opinion of the same skill; v1 scoped its DELETE with `source = "user"`
+        // and losing that in the port would quietly erase mined classifications.
+        const dir = tempDir("ax-tag-remove-scope-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    const layers = JudgmentLayer({
+                        sidecarPath: join(dir, "judgment.sqlite"),
+                        schemaSql: SIDECAR_SCHEMA_SQL,
+                    });
+                    yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        yield* j.put("role", { id: "role:framing", name: "framing" });
+                        yield* j.put("plays_role", {
+                            id: "mined-1",
+                            in_id: "skill:content-hashed-id",
+                            out_id: "role:framing",
+                            source: "frontmatter",
+                            confidence: 0.7,
+                        });
+                    }).pipe(Effect.scoped, Effect.provide(layers));
+
+                    yield* h.tag({ ...baseOpts, roleName: "framing", remove: true });
+                    return yield* h.tags;
+                }),
+            ),
+        );
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.source).toBe("frontmatter");
+    });
+
+    dtest("adds a user tag without replacing a mined tag for the same skill and role", async () => {
+        const dir = tempDir("ax-tag-source-coexistence-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    const layers = JudgmentLayer({
+                        sidecarPath: join(dir, "judgment.sqlite"),
+                        schemaSql: SIDECAR_SCHEMA_SQL,
+                    });
+                    yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        yield* j.put("role", {
+                            id: "role:verification",
+                            name: "verification",
+                        });
+                        yield* j.put("plays_role", {
+                            id: "mined-verification",
+                            in_id: "skill:content-hashed-id",
+                            out_id: "role:verification",
+                            source: "frontmatter",
+                            confidence: 0.7,
+                        });
+                    }).pipe(Effect.scoped, Effect.provide(layers));
+
+                    yield* h.tag(baseOpts);
+                    return yield* h.tags;
+                }),
+            ),
+        );
+
+        expect(tags.map((tag) => tag.source).sort()).toEqual(["frontmatter", "user"]);
+    });
+
+    dtest("keeps the role's own weight when a second skill is tagged with it", async () => {
+        // A regression pin, not a bug report: the current write already preserves
+        // the weight (the seam's upsert writes only the columns it is given, and
+        // this one gives id + name). What it pins is that tagging a skill is not
+        // a statement about the ROLE - a future write that started naming
+        // `weight` would reset a user's tuning and silently re-rank every
+        // weighted view, and nothing else in the suite would notice.
+        const dir = tempDir("ax-tag-role-weight-");
+        const weight = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    const layers = JudgmentLayer({
+                        sidecarPath: join(dir, "judgment.sqlite"),
+                        schemaSql: SIDECAR_SCHEMA_SQL,
+                    });
+                    yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        yield* j.put("role", { id: "role:verification", name: "verification", weight: 3 });
+                    }).pipe(Effect.scoped, Effect.provide(layers));
+
+                    yield* h.tag(baseOpts);
+
+                    return yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        return yield* j.first(
+                            Schema.Struct({ weight: Schema.Number }),
+                            "SELECT weight FROM role WHERE name = 'verification'",
+                        );
+                    }).pipe(Effect.scoped, Effect.provide(layers));
+                }),
+            ),
+        );
+        expect(weight._tag === "Some" ? weight.value.weight : null).toBe(3);
+    });
+
+    dtest("lowercases and trims the role name", async () => {
+        const dir = tempDir("ax-tag-normalize-");
+        const tags = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const h = yield* harness(dir);
+                    yield* h.tag({ ...baseOpts, roleName: "  VERIFICATION  " });
+                    return yield* h.tags;
+                }),
+            ),
+        );
+        expect(tags[0]?.role_name).toBe("verification");
+    });
+
+    dtest("exits on a skill the cache has never seen, writing nothing", async () => {
+        const dir = tempDir("ax-tag-unknown-");
+        const h = await dylibEnv(() => run(harness(dir)));
+        const exitSpy = withExitSpy();
         try {
-            await runTag(
-                { skillName: "nonexistent-skill", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-                db,
-            );
-            expect(true).toBe(false); // should not reach here
-        } catch (err) {
-            expect((err as Error).message).toBe("process.exit(2)");
+            await expect(run(h.tag({ ...baseOpts, skillName: "nope" }))).rejects.toThrow();
         } finally {
-            process.exit = origExit;
+            exitSpy.restore();
         }
-
-        // The lookup query was issued
-        const queryCalls = calls;
-        expect(queryCalls.length).toBe(1);
-        expect(queryCalls[0]?.sql).toContain("SELECT id FROM skill WHERE name = $name");
-
-        // No RELATE or DELETE issued after failed lookup
-        const relateSql = queryCalls.find((c) => c.sql.includes("RELATE"));
-        expect(relateSql).toBeUndefined();
+        expect(exitSpy.spy).toHaveBeenCalled();
+        expect(await run(h.tags)).toEqual([]);
     });
 
-    test("4. Custom confidence + rationale appear in RELATE SET clause", async () => {
-        const { db, calls } = buildMockDb({ skillExists: true });
-        await runTag(
-            {
-                skillName: "composto",
-                roleName: "execution",
-                confidence: 0.8,
-                rationale: "drives code generation loops",
-                remove: false,
-            },
-            db,
-        );
-
-        const relateSql = calls.find((c) => c.sql.includes("RELATE"));
-        expect(relateSql?.sql).toContain("0.8");
-        expect(relateSql?.sql).toContain("drives code generation loops");
-    });
-
-    test("5. Idempotent: running twice issues DELETE + RELATE both times", async () => {
-        const { db: db1, calls: calls1 } = buildMockDb({ skillExists: true });
-        await runTag(
-            { skillName: "composto", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-            db1,
-        );
-
-        const { db: db2, calls: calls2 } = buildMockDb({ skillExists: true });
-        await runTag(
-            { skillName: "composto", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-            db2,
-        );
-
-        // Both runs: DELETE issued
-        for (const qCalls of [calls1, calls2]) {
-            const deleteSql = qCalls.find((c) => c.sql.includes("DELETE plays_role"));
-            expect(deleteSql).toBeDefined();
-            const relateSql = qCalls.find((c) => c.sql.includes("RELATE"));
-            expect(relateSql).toBeDefined();
-        }
-    });
-
-    test("6. Role name normalized lowercase + trimmed", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        await runTag(
-            { skillName: "composto", roleName: "  FRAMING  ", confidence: 1.0, rationale: undefined, remove: false },
-            db,
-        );
-
-        // The upsert receives the trimmed+lowercased role name
-        const content = upserts[0]?.content;
-        expect(content?.["name"]).toBe("framing");
-
-        // The SQL uses the lowercased role literal
-        const relateSql = calls.find((c) => c.sql.includes("RELATE"));
-        expect(relateSql?.sql).toContain("role:`framing`");
-        expect(relateSql?.sql).not.toContain("FRAMING");
-    });
-
-    test("7. Invalid role name (backtick) → exit 2, no DB calls", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        const exitSpy = mock(() => { throw new Error("process.exit(2)"); });
-        const origExit = process.exit;
-        process.exit = exitSpy as unknown as typeof process.exit;
-
-        try {
-            await runTag(
-                { skillName: "composto", roleName: "bad`role", confidence: 1.0, rationale: undefined, remove: false },
-                db,
-            );
-            expect(true).toBe(false); // unreachable
-        } catch (err) {
-            expect((err as Error).message).toBe("process.exit(2)");
-        } finally {
-            process.exit = origExit;
-        }
-
-        // No DB queries issued (validation fires before lookup)
-        expect(calls.length + upserts.length).toBe(0);
-    });
-
-    test("8. Invalid role name (semicolon injection) → exit 2, no DB calls", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        const exitSpy = mock(() => { throw new Error("process.exit(2)"); });
-        const origExit = process.exit;
-        process.exit = exitSpy as unknown as typeof process.exit;
-
-        try {
-            await runTag(
-                {
-                    skillName: "composto",
-                    roleName: "framing;DROP TABLE role",
-                    confidence: 1.0,
-                    rationale: undefined,
-                    remove: false,
-                },
-                db,
-            );
-            expect(true).toBe(false); // unreachable
-        } catch (err) {
-            expect((err as Error).message).toBe("process.exit(2)");
-        } finally {
-            process.exit = origExit;
-        }
-
-        expect(calls.length + upserts.length).toBe(0);
-    });
-
-    test("9. Invalid skill name (backtick) → exit 2, no DB calls", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        const exitSpy = mock(() => { throw new Error("process.exit(2)"); });
-        const origExit = process.exit;
-        process.exit = exitSpy as unknown as typeof process.exit;
-
-        try {
-            await runTag(
-                { skillName: "bad`skill", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-                db,
-            );
-            expect(true).toBe(false); // unreachable
-        } catch (err) {
-            expect((err as Error).message).toBe("process.exit(2)");
-        } finally {
-            process.exit = origExit;
-        }
-
-        // Validation fires before any DB lookup
-        expect(calls.length + upserts.length).toBe(0);
-    });
-
-    test("10. Invalid skill name (spaces) → exit 2, no DB calls", async () => {
-        const { db, calls, upserts } = buildMockDb({ skillExists: true });
-        const exitSpy = mock(() => { throw new Error("process.exit(2)"); });
-        const origExit = process.exit;
-        process.exit = exitSpy as unknown as typeof process.exit;
-
-        try {
-            await runTag(
-                { skillName: "bad skill name", roleName: "framing", confidence: 1.0, rationale: undefined, remove: false },
-                db,
-            );
-            expect(true).toBe(false); // unreachable
-        } catch (err) {
-            expect((err as Error).message).toBe("process.exit(2)");
-        } finally {
-            process.exit = origExit;
-        }
-
-        expect(calls.length + upserts.length).toBe(0);
-    });
+    for (const [label, opts] of [
+        ["a backticked role name", { ...baseOpts, roleName: "verif`ication" }],
+        ["a semicolon-injected role name", { ...baseOpts, roleName: "verification; DROP TABLE role" }],
+        ["a backticked skill name", { ...baseOpts, skillName: "comp`osto" }],
+        ["a spaced skill name", { ...baseOpts, skillName: "com posto" }],
+    ] as const) {
+        dtest(`refuses ${label} before touching either engine`, async () => {
+            const dir = tempDir("ax-tag-invalid-");
+            const h = await dylibEnv(() => run(harness(dir)));
+            const exitSpy = withExitSpy();
+            try {
+                await expect(run(h.tag(opts))).rejects.toThrow();
+            } finally {
+                exitSpy.restore();
+            }
+            expect(exitSpy.spy).toHaveBeenCalled();
+            expect(await run(h.tags)).toEqual([]);
+        });
+    }
 });

--- a/apps/axctl/src/cli/skills-tag.test.ts
+++ b/apps/axctl/src/cli/skills-tag.test.ts
@@ -14,6 +14,7 @@ import { Effect, FileSystem, Layer, Path, Schema } from "effect";
 import { join } from "node:path";
 import { CacheReadLayer } from "@ax/lib/duckdb/seam";
 import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
+import { roleRowId } from "@ax/lib/stable-id";
 import { publishCacheFixture } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
@@ -37,6 +38,7 @@ const dylibEnv = <A>(body: () => Promise<A>): Promise<A> => {
 
 const TagRow = Schema.Struct({
     in_id: Schema.String,
+    role_id: Schema.String,
     role_name: Schema.String,
     source: Schema.String,
     confidence: Schema.Number,
@@ -47,7 +49,7 @@ const TagRow = Schema.Struct({
 const readTags = (j: JudgmentService) =>
     j.rows(
         TagRow,
-        `SELECT pr.in_id AS in_id, r.name AS role_name, pr.source AS source,
+        `SELECT pr.in_id AS in_id, r.id AS role_id, r.name AS role_name, pr.source AS source,
                 pr.confidence AS confidence, pr.rationale AS rationale
          FROM plays_role pr JOIN role r ON r.id = pr.out_id
          ORDER BY r.name`,
@@ -126,6 +128,7 @@ describe("cmdSkillsTag", () => {
         );
         expect(tags).toHaveLength(1);
         expect(tags[0]?.in_id).toBe("skill:content-hashed-id");
+        expect(tags[0]?.role_id).toBe(roleRowId("verification"));
         expect(tags[0]?.role_name).toBe("verification");
         expect(tags[0]?.source).toBe("user");
     });
@@ -192,11 +195,11 @@ describe("cmdSkillsTag", () => {
                     });
                     yield* Effect.gen(function* () {
                         const j = yield* Judgment;
-                        yield* j.put("role", { id: "role:framing", name: "framing" });
+                        yield* j.put("role", { id: roleRowId("framing"), name: "framing" });
                         yield* j.put("plays_role", {
                             id: "mined-1",
                             in_id: "skill:content-hashed-id",
-                            out_id: "role:framing",
+                            out_id: roleRowId("framing"),
                             source: "frontmatter",
                             confidence: 0.7,
                         });
@@ -224,13 +227,13 @@ describe("cmdSkillsTag", () => {
                     yield* Effect.gen(function* () {
                         const j = yield* Judgment;
                         yield* j.put("role", {
-                            id: "role:verification",
+                            id: roleRowId("verification"),
                             name: "verification",
                         });
                         yield* j.put("plays_role", {
                             id: "mined-verification",
                             in_id: "skill:content-hashed-id",
-                            out_id: "role:verification",
+                            out_id: roleRowId("verification"),
                             source: "frontmatter",
                             confidence: 0.7,
                         });
@@ -263,7 +266,7 @@ describe("cmdSkillsTag", () => {
                     });
                     yield* Effect.gen(function* () {
                         const j = yield* Judgment;
-                        yield* j.put("role", { id: "role:verification", name: "verification", weight: 3 });
+                        yield* j.put("role", { id: roleRowId("verification"), name: "verification", weight: 3 });
                     }).pipe(Effect.scoped, Effect.provide(layers));
 
                     yield* h.tag(baseOpts);

--- a/apps/axctl/src/cli/skills-tag.ts
+++ b/apps/axctl/src/cli/skills-tag.ts
@@ -1,16 +1,32 @@
 /**
- * `ax skills tag <skill> <role>` - write/replace a plays_role edge with source="user".
+ * `ax skills tag <skill> <role>` - record (or remove) a user's role tag on a
+ * skill.
  *
- * Idempotent: deletes any prior user-source edge for the (skill, role) pair
- * before (re-)creating it. Atomic per pair: run the command multiple times
- * with different roles to add multiple roles.
+ * A REQUEST-TIME JUDGMENT WRITE, and the reason the SQLite sidecar exists. There
+ * is no ingest run to attach this to: the user typed a command and expects the
+ * decision recorded now. The DuckDB cache refuses a write outside the ingest
+ * lock by construction, so before the sidecar this command had nowhere to go.
+ *
+ * The two engines split the work exactly as their contracts say:
+ *   - the CACHE answers "does this skill exist, and what is its row id" - a skill
+ *     exists because it is installed on disk, which is a derived fact;
+ *   - the SIDECAR stores the tag, keyed by that row id.
+ *
+ * KEYED BY ID, NOT BY NAME. The tag has to survive a re-derive, and the thing
+ * that makes it survive is the content-hash id contract: re-deriving the same
+ * skill file rewrites a byte-identical id, so the tag still finds it.
+ * `@ax/lib/sqlite/integrity` counts the tags where that fails.
+ *
+ * Idempotent per (skill, role), and ATOMIC: the role upsert, the removal of any
+ * prior user tag, and the new tag are one transaction, so a failure halfway
+ * cannot leave the pair tagless after having deleted the old tag.
  */
 import { Effect } from "effect";
-import { RecordId, SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import type { DbError } from "@ax/lib/errors";
-import { recordLiteral } from "@ax/lib/ids";
+import { edgeRowId } from "@ax/lib/stable-id";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
 import { validateRoleName, validateSkillName } from "@ax/lib/role-name";
-import { surrealString } from "@ax/lib/shared/surql";
+import { Schema } from "effect";
 import { fail } from "./commands/shared.ts";
 
 export interface SkillsTagOptions {
@@ -37,39 +53,35 @@ const safeRoleName = (name: string): string | null => {
     }
 };
 
+const SkillIdRow = Schema.Struct({ id: Schema.String });
+
 /**
- * Resolve a skill record key (id part) by name. Returns null if not found.
- * Uses a binding for the name value (safe), literal interpolation is only
- * needed for record id references in FROM/WHERE clauses per codebase pattern.
+ * The tag's own row id.
+ *
+ * `edgeRowId` - the SAME helper every cache edge uses, not a private hash. A
+ * plays_role row is an edge between a skill and a role, and it gets an edge id
+ * for the same reason a cache edge does: re-running `ax skills tag composto
+ * verification` must land on the SAME user row rather than appending a second
+ * one. The source discriminator lets a mined row for the same pair remain.
  */
-const lookupSkillKey = (
-    db: SurrealClientShape,
-    skillName: string,
-): Effect.Effect<string | null, DbError> =>
-    Effect.gen(function* () {
-        const result = yield* db.query<[Array<{ id: unknown }>]>(
-            "SELECT id FROM skill WHERE name = $name LIMIT 1;",
-            { name: skillName },
-        );
-        const rows = result?.[0] ?? [];
-        if (rows.length === 0) return null;
-        const id = rows[0]!.id;
-        // id comes back as a RecordId object { tb, id } or as a string
-        if (typeof id === "string") {
-            const colon = id.indexOf(":");
-            return colon >= 0 ? id.slice(colon + 1) : id;
-        }
-        if (id !== null && typeof id === "object" && "id" in id) {
-            return String((id as { id: unknown }).id);
-        }
-        return null;
-    });
+const tagId = (skillId: string, role: string): string =>
+    edgeRowId("plays_role", skillId, role, "user");
 
-export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbError, SurrealClient> =>
-    Effect.gen(function* () {
-        const db = yield* SurrealClient;
+/** A role's row id is its name - roles are a small, user-authored vocabulary
+ *  keyed by exactly the thing a user types. */
+const roleId = (roleName: string): string => `role:${roleName}`;
 
-        // 1. Validate inputs
+export const cmdSkillsTag = (
+    opts: SkillsTagOptions,
+): Effect.Effect<void, CacheReadError | JudgmentError, CacheRead | Judgment> =>
+    Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        const read = yield* CacheRead;
+
+        // 1. Validate inputs BEFORE opening anything. These names reach SQL only
+        //    as bound parameters, so this is not injection defence (the seam's
+        //    identifier rule covers that) - it is a refusal to record a decision
+        //    about a name that cannot be a skill or a role.
         const trimmedSkill = safeSkillName(opts.skillName);
         if (trimmedSkill === null) {
             fail(
@@ -87,42 +99,60 @@ export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbErro
             fail(`axctl skills tag: --confidence must be between 0 and 1 (got ${opts.confidence})`);
         }
 
-        // 2. Resolve skill record id by name
-        const skillKey = yield* lookupSkillKey(db, trimmedSkill);
-        if (skillKey === null) {
+        // 2. Resolve the skill's CACHE row id by name.
+        const skill = yield* read.first(SkillIdRow, "SELECT id FROM skill WHERE name = ? LIMIT 1", [
+            trimmedSkill,
+        ]);
+        if (skill._tag === "None") {
             fail(`axctl skills tag: unknown skill "${trimmedSkill}"`);
         }
+        const skillId = skill.value.id;
+        const role = roleId(roleName);
 
-        // Inline record id literal - bypasses SDK RecordId binding which
-        // silently produces empty results against live SurrealDB.
-        // See src/lib/shared/graph-query.ts:132 and skill-role.ts:23.
-        const skillLit = recordLiteral("skill", skillKey);
+        yield* judgment.transaction((transaction) =>
+            Effect.gen(function* () {
+                // 3. The role must exist before a tag can point at it. CREATE
+                //    IF MISSING, never modify: a role's `weight` is judgment of
+                //    its own (`ax roles` shows it, the weighted views multiply by
+                //    it), and tagging a skill is not a statement about it. The
+                //    DDL's DEFAULT seeds 1.0 on the create path.
+                //
+                //    (`put` would ALSO preserve the weight - the seam's upsert
+                //    only writes the columns a caller names, so a two-column put
+                //    leaves `weight` alone. DO NOTHING is here for the intent, not
+                //    to fix a bug in `put`: it says this command never modifies an
+                //    existing role, which is stronger than "happens not to".)
+                yield* transaction.exec(
+                    "INSERT INTO role (id, name) VALUES (?, ?) ON CONFLICT (id) DO NOTHING",
+                    [role, roleName],
+                );
 
-        // 3. Upsert role node by name (lowercase, matches P3.2 behaviour)
-        const roleId = new RecordId("role", roleName);
-        yield* db.upsert(roleId, { name: roleName });
+                // 4. Drop any prior USER tag for this pair. Scoped to
+                //    source='user' because a mined tag (frontmatter, classifier)
+                //    is somebody else's opinion: a user removing their own tag
+                //    must not erase it.
+                yield* transaction.exec(
+                    "DELETE FROM plays_role WHERE in_id = ? AND out_id = ? AND source = 'user'",
+                    [skillId, role],
+                );
 
-        const roleLit = recordLiteral("role", roleName);
+                if (opts.remove) return;
 
-        // 4. Delete any existing user-source edge for this (skill, role) pair
-        yield* db.query(
-            `DELETE plays_role WHERE in = ${skillLit} AND out = ${roleLit} AND source = "user";`,
+                yield* transaction.put("plays_role", {
+                    id: tagId(skillId, role),
+                    in_id: skillId,
+                    out_id: role,
+                    source: "user",
+                    confidence: opts.confidence,
+                    rationale: opts.rationale ?? null,
+                    since: new Date(),
+                });
+            }),
         );
 
-        // 5. If --remove: stop here (edge already deleted in step 4)
-        if (opts.remove) {
-            console.log(`removed plays_role edge: ${trimmedSkill} -> ${roleName} (source=user)`);
-            return;
-        }
-
-        // 6. RELATE skill->plays_role->role with source="user"
-        const setSql = opts.rationale !== undefined
-            ? `source = "user", confidence = ${opts.confidence}, rationale = ${surrealString(opts.rationale)}, since = time::now()`
-            : `source = "user", confidence = ${opts.confidence}, since = time::now()`;
-
-        yield* db.query(
-            `RELATE ${skillLit}->plays_role->${roleLit} SET ${setSql};`,
+        console.log(
+            opts.remove
+                ? `removed plays_role edge: ${trimmedSkill} -> ${roleName} (source=user)`
+                : `tagged ${trimmedSkill} -> ${roleName} (source=user, confidence=${opts.confidence})`,
         );
-
-        console.log(`tagged ${trimmedSkill} -> ${roleName} (source=user, confidence=${opts.confidence})`);
     });

--- a/apps/axctl/src/cli/skills-tag.ts
+++ b/apps/axctl/src/cli/skills-tag.ts
@@ -22,7 +22,7 @@
  * cannot leave the pair tagless after having deleted the old tag.
  */
 import { Effect } from "effect";
-import { edgeRowId } from "@ax/lib/stable-id";
+import { edgeRowId, roleRowId } from "@ax/lib/stable-id";
 import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
 import { validateRoleName, validateSkillName } from "@ax/lib/role-name";
@@ -67,10 +67,6 @@ const SkillIdRow = Schema.Struct({ id: Schema.String });
 const tagId = (skillId: string, role: string): string =>
     edgeRowId("plays_role", skillId, role, "user");
 
-/** A role's row id is its name - roles are a small, user-authored vocabulary
- *  keyed by exactly the thing a user types. */
-const roleId = (roleName: string): string => `role:${roleName}`;
-
 export const cmdSkillsTag = (
     opts: SkillsTagOptions,
 ): Effect.Effect<void, CacheReadError | JudgmentError, CacheRead | Judgment> =>
@@ -107,7 +103,7 @@ export const cmdSkillsTag = (
             fail(`axctl skills tag: unknown skill "${trimmedSkill}"`);
         }
         const skillId = skill.value.id;
-        const role = roleId(roleName);
+        const role = roleRowId(roleName);
 
         yield* judgment.transaction((transaction) =>
             Effect.gen(function* () {

--- a/apps/axctl/src/dashboard/role-queries.test.ts
+++ b/apps/axctl/src/dashboard/role-queries.test.ts
@@ -15,6 +15,7 @@ import { Effect, FileSystem, Layer, Path } from "effect";
 import { join } from "node:path";
 import { CacheReadLayer } from "@ax/lib/duckdb/seam";
 import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
+import { roleRowId } from "@ax/lib/stable-id";
 import { publishCacheFixture } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
@@ -68,14 +69,14 @@ const fixture = (dir: string) =>
         yield* Effect.gen(function* () {
             const j: JudgmentService = yield* Judgment;
             yield* j.putMany("role", [
-                { id: "role:verification", name: "verification", weight: 2 },
-                { id: "role:framing", name: "framing", weight: 1 },
+                { id: roleRowId("verification"), name: "verification", weight: 2 },
+                { id: roleRowId("framing"), name: "framing", weight: 1 },
             ]);
             yield* j.putMany("plays_role", [
                 {
                     id: "pr1",
                     in_id: "skill:tdd",
-                    out_id: "role:verification",
+                    out_id: roleRowId("verification"),
                     source: "user",
                     confidence: 0.9,
                     rationale: "the whole point of it",
@@ -84,7 +85,7 @@ const fixture = (dir: string) =>
                 {
                     id: "pr2",
                     in_id: "skill:brainstorming",
-                    out_id: "role:verification",
+                    out_id: roleRowId("verification"),
                     source: "frontmatter",
                     confidence: 0.4,
                     rationale: null,
@@ -93,7 +94,7 @@ const fixture = (dir: string) =>
                 {
                     id: "pr3",
                     in_id: "skill:brainstorming",
-                    out_id: "role:framing",
+                    out_id: roleRowId("framing"),
                     source: "user",
                     confidence: 1,
                     rationale: null,
@@ -186,11 +187,11 @@ describe("fetchSkillsByRole", () => {
                     const judgmentLayer = JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL });
                     yield* Effect.gen(function* () {
                         const j: JudgmentService = yield* Judgment;
-                        yield* j.put("role", { id: "role:verification", name: "verification" });
+                        yield* j.put("role", { id: roleRowId("verification"), name: "verification" });
                         yield* j.put("plays_role", {
                             id: "pr1",
                             in_id: "skill:gone",
-                            out_id: "role:verification",
+                            out_id: roleRowId("verification"),
                             source: "user",
                         });
                     }).pipe(Effect.scoped, Effect.provide(judgmentLayer));
@@ -287,7 +288,7 @@ describe("fetchAllRoles", () => {
                     const judgmentLayer = JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL });
                     return yield* Effect.gen(function* () {
                         const j: JudgmentService = yield* Judgment;
-                        yield* j.put("role", { id: "role:orphan", name: "orphan", weight: 1.5 });
+                        yield* j.put("role", { id: roleRowId("orphan"), name: "orphan", weight: 1.5 });
                         return yield* fetchAllRoles();
                     }).pipe(Effect.scoped, Effect.provide(judgmentLayer));
                 }),
@@ -307,7 +308,7 @@ describe("fetchAllRoles", () => {
                         yield* judgment.put("plays_role", {
                             id: "pr-user-and-mined",
                             in_id: "skill:tdd",
-                            out_id: "role:verification",
+                            out_id: roleRowId("verification"),
                             source: "frontmatter",
                             confidence: 0.8,
                         });

--- a/apps/axctl/src/dashboard/role-queries.test.ts
+++ b/apps/axctl/src/dashboard/role-queries.test.ts
@@ -1,259 +1,322 @@
 /**
- * P3.7 tests: role-queries data layer.
+ * Role reads across BOTH v2 engines, with nothing stubbed.
  *
- * All tests use a mocked SurrealClient via Layer. The focus is on:
- *   - query shape passed to db.query (correct SQL / params)
- *   - row mapping (raw Record<> → typed output)
- *   - edge cases (empty results, missing fields)
+ * These three fetchers are the first read surface whose answer is a JOIN ACROSS
+ * ENGINES: the tags live in the SQLite sidecar (a user's decision), the skill
+ * names and invocation counts live in the DuckDB cache (derived from disk). A
+ * stub-based test - which is what this file used to be - can assert the SQL text
+ * of either half and still not notice that the two halves no longer meet, which
+ * is the only interesting way this code can now break. So every case here builds
+ * a real published cache and a real sidecar in a temp directory.
  */
+import { describe, expect } from "bun:test";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import { join } from "node:path";
+import { CacheReadLayer } from "@ax/lib/duckdb/seam";
+import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
+import { publishCacheFixture } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { fetchAllRoles, fetchRolesForSkill, fetchSkillsByRole } from "./role-queries.ts";
 
-import { describe, expect, it } from "bun:test";
-import { Effect, type Layer } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import {
-    fetchSkillsByRole,
-    fetchRolesForSkill,
-    fetchAllRoles,
-} from "./role-queries.ts";
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("role queries", { requireFts: true });
 
-// ---------------------------------------------------------------------------
-// Stub helpers
-// ---------------------------------------------------------------------------
+const Platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
-/** Build a Layer from a query stub that always returns the given results. */
-function stubLayer(
-    queryResults: Array<Array<Record<string, unknown>>>,
-): Layer.Layer<SurrealClient> {
-    return makeTestSurrealClient({
-        denyWrites: true,
-        responses: queryResults.map((result) => [result]),
-    }).layer;
-}
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provide(Platform)) as Effect.Effect<A, E>);
 
-// ---------------------------------------------------------------------------
-// fetchSkillsByRole
-// ---------------------------------------------------------------------------
+const dylibEnv = <A>(body: () => Promise<A>): Promise<A> => {
+    const previous = process.env.AX_DUCKDB_DYLIB;
+    if (dylibPath !== null) process.env.AX_DUCKDB_DYLIB = dylibPath;
+    return body().finally(() => {
+        if (previous === undefined) delete process.env.AX_DUCKDB_DYLIB;
+        else process.env.AX_DUCKDB_DYLIB = previous;
+    });
+};
 
-describe("fetchSkillsByRole - row mapping", () => {
-    it("maps raw rows to SkillByRoleRow correctly", async () => {
-        const rawRow = {
-            skill_id: "skill:⟨caveman⟩",
-            skill_name: "caveman",
-            source: "frontmatter",
-            confidence: 0.9,
-            rationale: "debugging tool",
-            invocations: 42,
-        };
+const skillRow = (id: string, name: string) => ({
+    id,
+    name,
+    scope: "user",
+    dir_path: `/tmp/skills/${name}`,
+    content_hash: `hash-${name}`,
+});
 
-        const result = await Effect.runPromise(
-            fetchSkillsByRole({ role: "debugging" }).pipe(
-                Effect.provide(stubLayer([[rawRow]])),
-            ),
+/**
+ * Two skills in the cache, one invoked twice and one never; role tags on both in
+ * the sidecar. Returns the layers a fetcher needs.
+ */
+const fixture = (dir: string) =>
+    Effect.gen(function* () {
+        const cache = yield* publishCacheFixture(dir, dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* write.putMany("skill", [
+                    skillRow("skill:tdd", "tdd"),
+                    skillRow("skill:brainstorming", "brainstorming"),
+                ]);
+                // `invoked` is turn -> skill; only the counts matter here.
+                yield* write.putMany("invoked", [
+                    { id: "inv1", in_id: "turn:1", out_id: "skill:tdd", ts: new Date() },
+                    { id: "inv2", in_id: "turn:2", out_id: "skill:tdd", ts: new Date() },
+                ]);
+            }),
         );
+        const sidecarPath = join(dir, "judgment.sqlite");
+        const judgmentLayer = JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL });
+        yield* Effect.gen(function* () {
+            const j: JudgmentService = yield* Judgment;
+            yield* j.putMany("role", [
+                { id: "role:verification", name: "verification", weight: 2 },
+                { id: "role:framing", name: "framing", weight: 1 },
+            ]);
+            yield* j.putMany("plays_role", [
+                {
+                    id: "pr1",
+                    in_id: "skill:tdd",
+                    out_id: "role:verification",
+                    source: "user",
+                    confidence: 0.9,
+                    rationale: "the whole point of it",
+                    weight: null,
+                },
+                {
+                    id: "pr2",
+                    in_id: "skill:brainstorming",
+                    out_id: "role:verification",
+                    source: "frontmatter",
+                    confidence: 0.4,
+                    rationale: null,
+                    weight: 3,
+                },
+                {
+                    id: "pr3",
+                    in_id: "skill:brainstorming",
+                    out_id: "role:framing",
+                    source: "user",
+                    confidence: 1,
+                    rationale: null,
+                    weight: null,
+                },
+            ]);
+        }).pipe(Effect.scoped, Effect.provide(judgmentLayer));
 
-        expect(result.found).toBe(true);
-        expect(result.rows).toHaveLength(1);
-        const row = result.rows[0]!;
-        expect(row.skill_id).toBe("skill:⟨caveman⟩");
-        expect(row.skill_name).toBe("caveman");
-        expect(row.source).toBe("frontmatter");
-        expect(row.confidence).toBe(0.9);
-        expect(row.rationale).toBe("debugging tool");
-        expect(row.invocations).toBe(42);
+        return Layer.mergeAll(
+            judgmentLayer,
+            CacheReadLayer({
+                snapshotPath: cache.snapshotPath,
+                ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+            }),
+        );
     });
 
-    it("returns found=false when result is empty", async () => {
-        const result = await Effect.runPromise(
-            fetchSkillsByRole({ role: "nonexistent" }).pipe(
-                Effect.provide(stubLayer([[]])),
+describe("fetchSkillsByRole", () => {
+    dtest("names each tagged skill from the CACHE and ranks by its invocations", async () => {
+        const dir = tempDir("ax-roles-by-role-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchSkillsByRole({ role: "verification", limit: 50 }).pipe(
+                        Effect.scoped,
+                        Effect.provide(layers),
+                    );
+                }),
             ),
         );
+        expect(result.found).toBe(true);
+        // The name comes from the cache: the sidecar only stores the skill ID.
+        expect(result.rows.map((r) => r.skill_name)).toEqual(["tdd", "brainstorming"]);
+        expect(result.rows[0]?.invocations).toBe(2);
+        expect(result.rows[1]?.invocations).toBe(0);
+        expect(result.rows[0]?.source).toBe("user");
+        expect(result.rows[0]?.confidence).toBeCloseTo(0.9);
+        expect(result.rows[0]?.rationale).toBe("the whole point of it");
+        expect(result.rows[1]?.rationale).toBeNull();
+    });
 
+    dtest("honours the limit", async () => {
+        const dir = tempDir("ax-roles-limit-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchSkillsByRole({ role: "verification", limit: 1 }).pipe(
+                        Effect.scoped,
+                        Effect.provide(layers),
+                    );
+                }),
+            ),
+        );
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0]?.skill_name).toBe("tdd");
+    });
+
+    dtest("reports not-found for a role nobody tagged", async () => {
+        const dir = tempDir("ax-roles-empty-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchSkillsByRole({ role: "nonesuch", limit: 50 }).pipe(
+                        Effect.scoped,
+                        Effect.provide(layers),
+                    );
+                }),
+            ),
+        );
+        expect(result.rows).toEqual([]);
         expect(result.found).toBe(false);
-        expect(result.rows).toHaveLength(0);
     });
 
-    it("coerces missing fields to defaults", async () => {
-        const rawRow = {
-            skill_id: "skill:test",
-            skill_name: "test",
-            // source, confidence, rationale, invocations all missing
-        };
+    dtest("keeps a tag whose skill the cache no longer has, and says so", async () => {
+        // The dangling case is a REAL state (a re-derive dropped the skill), and
+        // the tag survives it by design. Dropping the row would hide a decision
+        // the user made; inventing a name would be a lie. The id is what is
+        // known, so the id is what is shown.
+        const dir = tempDir("ax-roles-dangling-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const cache = yield* publishCacheFixture(dir, dylibPath, (write) =>
+                        write.put("skill", skillRow("skill:something-else", "something-else")),
+                    );
+                    const sidecarPath = join(dir, "judgment.sqlite");
+                    const judgmentLayer = JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL });
+                    yield* Effect.gen(function* () {
+                        const j: JudgmentService = yield* Judgment;
+                        yield* j.put("role", { id: "role:verification", name: "verification" });
+                        yield* j.put("plays_role", {
+                            id: "pr1",
+                            in_id: "skill:gone",
+                            out_id: "role:verification",
+                            source: "user",
+                        });
+                    }).pipe(Effect.scoped, Effect.provide(judgmentLayer));
 
-        const result = await Effect.runPromise(
-            fetchSkillsByRole({ role: "testing" }).pipe(
-                Effect.provide(stubLayer([[rawRow]])),
+                    return yield* fetchSkillsByRole({ role: "verification", limit: 50 }).pipe(
+                        Effect.scoped,
+                        Effect.provide(
+                            Layer.mergeAll(
+                                judgmentLayer,
+                                CacheReadLayer({
+                                    snapshotPath: cache.snapshotPath,
+                                    ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                                }),
+                            ),
+                        ),
+                    );
+                }),
             ),
         );
-
-        expect(result.found).toBe(true);
-        const row = result.rows[0]!;
-        expect(row.source).toBe("");
-        expect(row.confidence).toBe(0);
-        expect(row.rationale).toBeNull();
-        expect(row.invocations).toBe(0);
-    });
-
-    it("returns multiple rows", async () => {
-        const rows = [
-            { skill_id: "skill:a", skill_name: "a", source: "brief", confidence: 1.0, rationale: null, invocations: 10 },
-            { skill_id: "skill:b", skill_name: "b", source: "user", confidence: 0.8, rationale: "manual", invocations: 5 },
-        ];
-
-        const result = await Effect.runPromise(
-            fetchSkillsByRole({ role: "planning", limit: 10 }).pipe(
-                Effect.provide(stubLayer([rows])),
-            ),
-        );
-
-        expect(result.rows).toHaveLength(2);
-        expect(result.rows[0]!.skill_name).toBe("a");
-        expect(result.rows[1]!.skill_name).toBe("b");
-    });
-});
-
-// ---------------------------------------------------------------------------
-// fetchRolesForSkill
-// ---------------------------------------------------------------------------
-
-describe("fetchRolesForSkill - skill existence check", () => {
-    it("returns skillExists=false when skill not found", async () => {
-        // First call: exists check returns empty; no second call needed.
-        const result = await Effect.runPromise(
-            fetchRolesForSkill({ skill: "unknown-skill" }).pipe(
-                Effect.provide(stubLayer([[]])), // empty rows for exists check
-            ),
-        );
-
-        expect(result.skillExists).toBe(false);
-        expect(result.rows).toHaveLength(0);
-    });
-
-    it("returns rows when skill exists", async () => {
-        const existsRow = { id: "skill:⟨caveman⟩" };
-        const roleRow = {
-            role_name: "debugging",
-            role_weight: 1.5,
-            source: "frontmatter",
-            confidence: 0.9,
-            edge_weight_override: null,
-            rationale: "used for debugging",
-            since: "2026-01-01T00:00:00Z",
-        };
-
-        // Two calls: exists check, then roles query
-        const result = await Effect.runPromise(
-            fetchRolesForSkill({ skill: "caveman" }).pipe(
-                Effect.provide(stubLayer([[existsRow], [roleRow]])),
-            ),
-        );
-
-        expect(result.skillExists).toBe(true);
         expect(result.rows).toHaveLength(1);
-        const row = result.rows[0]!;
-        expect(row.role_name).toBe("debugging");
-        expect(row.role_weight).toBe(1.5);
-        expect(row.source).toBe("frontmatter");
-        expect(row.confidence).toBe(0.9);
-        expect(row.edge_weight_override).toBeNull();
-        expect(row.rationale).toBe("used for debugging");
-        expect(row.since).toBe("2026-01-01T00:00:00Z");
-    });
-
-    it("returns empty rows when skill exists but has no roles", async () => {
-        const existsRow = { id: "skill:⟨caveman⟩" };
-
-        const result = await Effect.runPromise(
-            fetchRolesForSkill({ skill: "caveman" }).pipe(
-                Effect.provide(stubLayer([[existsRow], []])),
-            ),
-        );
-
-        expect(result.skillExists).toBe(true);
-        expect(result.rows).toHaveLength(0);
-    });
-
-    it("coerces missing role fields to defaults", async () => {
-        const existsRow = { id: "skill:x" };
-        const roleRow = { role_name: "planning" }; // minimal row
-
-        const result = await Effect.runPromise(
-            fetchRolesForSkill({ skill: "x" }).pipe(
-                Effect.provide(stubLayer([[existsRow], [roleRow]])),
-            ),
-        );
-
-        const row = result.rows[0]!;
-        expect(row.role_name).toBe("planning");
-        expect(row.role_weight).toBe(1);
-        expect(row.source).toBe("");
-        expect(row.confidence).toBe(0);
-        expect(row.edge_weight_override).toBeNull();
-        expect(row.rationale).toBeNull();
-        expect(row.since).toBeNull();
+        expect(result.rows[0]?.skill_id).toBe("skill:gone");
+        expect(result.rows[0]?.skill_name).toBe("");
     });
 });
 
-// ---------------------------------------------------------------------------
-// fetchAllRoles
-// ---------------------------------------------------------------------------
-
-describe("fetchAllRoles - row mapping", () => {
-    it("returns all roles with skill counts", async () => {
-        const rows = [
-            { name: "debugging", weight: 1.5, skill_count: 12 },
-            { name: "planning", weight: 2.0, skill_count: 8 },
-            { name: "empty-role", weight: 1.0, skill_count: 0 },
-        ];
-
-        const result = await Effect.runPromise(
-            fetchAllRoles().pipe(Effect.provide(stubLayer([rows]))),
+describe("fetchRolesForSkill", () => {
+    dtest("lists a skill's roles with the role's own weight and the edge override", async () => {
+        const dir = tempDir("ax-roles-for-skill-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchRolesForSkill({ skill: "brainstorming" }).pipe(
+                        Effect.scoped,
+                        Effect.provide(layers),
+                    );
+                }),
+            ),
         );
-
-        expect(result.rows).toHaveLength(3);
-        expect(result.rows[0]!.name).toBe("debugging");
-        expect(result.rows[0]!.weight).toBe(1.5);
-        expect(result.rows[0]!.skill_count).toBe(12);
-        // Empty-role included (skill_count=0)
-        expect(result.rows[2]!.name).toBe("empty-role");
-        expect(result.rows[2]!.skill_count).toBe(0);
+        expect(result.skillExists).toBe(true);
+        expect(result.rows.map((r) => r.role_name)).toEqual(["framing", "verification"]);
+        const verification = result.rows.find((r) => r.role_name === "verification");
+        expect(verification?.role_weight).toBe(2);
+        expect(verification?.edge_weight_override).toBe(3);
+        expect(verification?.since).not.toBeNull();
+        expect(result.rows.find((r) => r.role_name === "framing")?.edge_weight_override).toBeNull();
     });
 
-    it("returns empty rows when no roles exist", async () => {
-        const result = await Effect.runPromise(
-            fetchAllRoles().pipe(Effect.provide(stubLayer([[]]))),
+    dtest("reports a skill the CACHE has never heard of as absent", async () => {
+        const dir = tempDir("ax-roles-unknown-skill-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchRolesForSkill({ skill: "never-installed" }).pipe(
+                        Effect.scoped,
+                        Effect.provide(layers),
+                    );
+                }),
+            ),
         );
+        expect(result.skillExists).toBe(false);
+        expect(result.rows).toEqual([]);
+    });
+});
 
-        expect(result.rows).toHaveLength(0);
+describe("fetchAllRoles", () => {
+    dtest("counts tagged skills per role, busiest first, WITHOUT touching the cache", async () => {
+        // Both halves of this answer are judgment, so it needs no cache at all -
+        // which is what lets `ax roles` run on a machine with no snapshot and no
+        // SurrealDB (see roles-no-surreal.test.ts).
+        const dir = tempDir("ax-roles-all-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    return yield* fetchAllRoles().pipe(Effect.scoped, Effect.provide(layers));
+                }),
+            ),
+        );
+        expect(result.rows.map((r) => [r.name, r.skill_count])).toEqual([
+            ["verification", 2],
+            ["framing", 1],
+        ]);
+        expect(result.rows[0]?.weight).toBe(2);
     });
 
-    it("coerces missing fields to defaults", async () => {
-        const rows = [{ name: "test" }]; // weight and skill_count missing
-
-        const result = await Effect.runPromise(
-            fetchAllRoles().pipe(Effect.provide(stubLayer([rows]))),
+    dtest("lists a role nobody has tagged yet with a zero count", async () => {
+        const dir = tempDir("ax-roles-zero-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const sidecarPath = join(dir, "judgment.sqlite");
+                    const judgmentLayer = JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL });
+                    return yield* Effect.gen(function* () {
+                        const j: JudgmentService = yield* Judgment;
+                        yield* j.put("role", { id: "role:orphan", name: "orphan", weight: 1.5 });
+                        return yield* fetchAllRoles();
+                    }).pipe(Effect.scoped, Effect.provide(judgmentLayer));
+                }),
+            ),
         );
-
-        const row = result.rows[0]!;
-        expect(row.name).toBe("test");
-        expect(row.weight).toBe(1);
-        expect(row.skill_count).toBe(0);
+        expect(result.rows).toEqual([{ name: "orphan", weight: 1.5, skill_count: 0 }]);
     });
 
-    it("includes roles with skill_count=0 (empty roles)", async () => {
-        const rows = [
-            { name: "active", weight: 1.0, skill_count: 5 },
-            { name: "orphan", weight: 1.0, skill_count: 0 },
-        ];
-
-        const result = await Effect.runPromise(
-            fetchAllRoles().pipe(Effect.provide(stubLayer([rows]))),
+    dtest("counts one skill once when two sources assign the same role", async () => {
+        const dir = tempDir("ax-roles-distinct-count-");
+        const result = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const layers = yield* fixture(dir);
+                    yield* Effect.gen(function* () {
+                        const judgment = yield* Judgment;
+                        yield* judgment.put("plays_role", {
+                            id: "pr-user-and-mined",
+                            in_id: "skill:tdd",
+                            out_id: "role:verification",
+                            source: "frontmatter",
+                            confidence: 0.8,
+                        });
+                    }).pipe(Effect.scoped, Effect.provide(layers));
+                    return yield* fetchAllRoles().pipe(Effect.scoped, Effect.provide(layers));
+                }),
+            ),
         );
 
-        expect(result.rows).toHaveLength(2);
-        const orphan = result.rows.find((r) => r.name === "orphan");
-        expect(orphan).toBeTruthy();
-        expect(orphan!.skill_count).toBe(0);
+        expect(result.rows.find((r) => r.name === "verification")?.skill_count).toBe(2);
     });
 });

--- a/apps/axctl/src/dashboard/role-queries.ts
+++ b/apps/axctl/src/dashboard/role-queries.ts
@@ -1,15 +1,37 @@
 /**
- * P3.7: Role read queries - pure data layer.
+ * Role read queries - the pure data layer behind `ax skills by-role`,
+ * `ax skills roles`, `ax roles`, their MCP tools, and the dashboard's role views.
  *
- * Exports three Effect fetchers:
- *   fetchSkillsByRole   - skills that play a given role
- *   fetchRolesForSkill  - roles a given skill plays
- *   fetchAllRoles       - full role vocabulary with skill counts
+ * THE FIRST READ SURFACE THAT SPANS BOTH v2 ENGINES, so it is worth saying
+ * plainly where each half of an answer comes from:
+ *
+ *   plays_role, role     -> the SQLite judgment sidecar (`Judgment`). A role tag
+ *                           and a role's weight are DECISIONS; no re-derive can
+ *                           reproduce them, and none may erase them.
+ *   skill.name, invoked  -> the DuckDB cache (`CacheRead`). Both are derived from
+ *                           what is on disk and in the transcripts.
+ *
+ * In v1 both halves were one SurrealQL statement - `WHERE out.name = $role` walked
+ * the edge and dereferenced the skill in a single query. They are now two
+ * databases, so the join happens HERE: read the tags, collect the skill ids they
+ * name, and resolve names and counts in ONE cache query each. Never a query per
+ * row - a tag list is small, but a per-row round trip is the shape that made the
+ * v1 deref-avoidance rules necessary in the first place.
+ *
+ * A TAG WHOSE SKILL IS GONE IS SHOWN, NOT DROPPED. The cache is rebuildable and
+ * the sidecar is not, so "a tag on a skill the cache no longer holds" is a real
+ * state (see `@ax/lib/sqlite/integrity`, which counts them). Dropping the row
+ * would hide a decision the user made; inventing a name would be a lie. The id is
+ * what is known, so the id is what comes back, with an empty name.
  */
 
-import { Effect } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import type { DbError } from "@ax/lib/errors";
+import { Effect, Schema } from "effect";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
+
+/** Everything these fetchers can fail with: one engine's errors or the other's. */
+export type RoleQueryError = CacheReadError | JudgmentError;
 
 // ---------------------------------------------------------------------------
 // Row types
@@ -39,6 +61,57 @@ export interface RoleRow {
     readonly weight: number;
     readonly skill_count: number;
 }
+
+// ---------------------------------------------------------------------------
+// Shared cross-engine helpers
+// ---------------------------------------------------------------------------
+
+/** `?, ?, ?` for `n` bound values. The ids themselves always bind - DuckDB row
+ *  ids are plain strings, so nothing is ever spliced into the SQL text. */
+const placeholders = (n: number): string => Array.from({ length: n }, () => "?").join(", ");
+
+const SkillNameRow = Schema.Struct({ id: Schema.String, name: Schema.String });
+
+/** Cache names for the given skill ids, in ONE query. Ids the cache no longer
+ *  holds are simply absent from the map. */
+const skillNamesById = (
+    read: { readonly rows: typeof CacheRead.Service.rows },
+    ids: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyMap<string, string>, CacheReadError> =>
+    ids.length === 0
+        ? Effect.succeed(new Map<string, string>())
+        : read
+              .rows(SkillNameRow, `SELECT id, name FROM skill WHERE id IN (${placeholders(ids.length)})`, ids)
+              .pipe(Effect.map((rows) => new Map(rows.map((r) => [r.id, r.name] as const))));
+
+const InvocationCountRow = Schema.Struct({
+    out_id: Schema.String,
+    invocations: NumberFromBigIntColumn,
+});
+
+/**
+ * Invocation counts for the given skill ids, in ONE grouped query.
+ *
+ * `count(*)` is a BIGINT, so it decodes through `NumberFromBigIntColumn` rather
+ * than `Schema.Number` - the FFI client keeps 64-bit widths as `bigint`, and a
+ * field typed `Schema.Number` against a BIGINT column is a decode failure, not a
+ * silent round.
+ */
+const invocationCounts = (
+    read: { readonly rows: typeof CacheRead.Service.rows },
+    ids: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyMap<string, number>, CacheReadError> =>
+    ids.length === 0
+        ? Effect.succeed(new Map<string, number>())
+        : read
+              .rows(
+                  InvocationCountRow,
+                  `SELECT out_id, count(*) AS invocations FROM invoked WHERE out_id IN (${placeholders(
+                      ids.length,
+                  )}) GROUP BY out_id`,
+                  ids,
+              )
+              .pipe(Effect.map((rows) => new Map(rows.map((r) => [r.out_id, r.invocations] as const))));
 
 // ---------------------------------------------------------------------------
 // fetchSkillsByRole
@@ -80,40 +153,51 @@ export interface FetchSkillsByRoleResult {
     readonly found: boolean;
 }
 
+const TagByRoleRow = Schema.Struct({
+    in_id: Schema.String,
+    source: Schema.String,
+    confidence: Schema.Number,
+    rationale: Schema.NullOr(Schema.String),
+});
+
 export const fetchSkillsByRole = (
     params: FetchSkillsByRoleParams,
-): Effect.Effect<FetchSkillsByRoleResult, DbError, SurrealClient> =>
+): Effect.Effect<FetchSkillsByRoleResult, RoleQueryError, CacheRead | Judgment> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const judgment = yield* Judgment;
+        const read = yield* CacheRead;
         const limit = params.limit ?? SKILLS_BY_ROLE_DEFAULT_LIMIT;
 
-        const sql = `
-SELECT
-    in AS skill_id,
-    in.name AS skill_name,
-    source,
-    confidence,
-    rationale,
-    (SELECT count() FROM invoked WHERE out = $parent.in)[0].count ?? 0 AS invocations
-FROM plays_role
-WHERE out.name = $role
-ORDER BY invocations DESC
-LIMIT ${limit};`.trim();
+        const tags = yield* judgment.rows(
+            TagByRoleRow,
+            `SELECT pr.in_id AS in_id, pr.source AS source, pr.confidence AS confidence,
+                    pr.rationale AS rationale
+             FROM plays_role pr
+             JOIN role r ON r.id = pr.out_id
+             WHERE r.name = ?`,
+            [params.role],
+        );
 
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql, {
-            role: params.role,
-        });
+        const skillIds = tags.map((t) => t.in_id);
+        const names = yield* skillNamesById(read, skillIds);
+        const counts = yield* invocationCounts(read, skillIds);
 
-        const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
-
-        const mapped: SkillByRoleRow[] = rows.map((r) => ({
-            skill_id: String(r.skill_id ?? ""),
-            skill_name: String(r.skill_name ?? ""),
-            source: String(r.source ?? ""),
-            confidence: Number(r.confidence ?? 0),
-            rationale: r.rationale != null ? String(r.rationale) : null,
-            invocations: Number(r.invocations ?? 0),
-        }));
+        // Ranked HERE rather than in SQL, because the ranking key lives in the
+        // other database. A role's tag list is bounded by the number of installed
+        // skills, so this sorts tens of rows, not a table. The name tie-break
+        // makes the order total - `ORDER BY invocations DESC` alone left ties to
+        // the engine, and two engines would not have agreed.
+        const mapped: SkillByRoleRow[] = tags
+            .map((t) => ({
+                skill_id: t.in_id,
+                skill_name: names.get(t.in_id) ?? "",
+                source: t.source,
+                confidence: t.confidence,
+                rationale: t.rationale,
+                invocations: counts.get(t.in_id) ?? 0,
+            }))
+            .sort((a, b) => b.invocations - a.invocations || a.skill_name.localeCompare(b.skill_name))
+            .slice(0, limit);
 
         return { rows: mapped, found: mapped.length > 0 };
     });
@@ -131,57 +215,49 @@ export interface FetchRolesForSkillResult {
     readonly skillExists: boolean;
 }
 
+const SkillIdRow = Schema.Struct({ id: Schema.String });
+
+const RoleForSkillTagRow = Schema.Struct({
+    role_name: Schema.String,
+    role_weight: Schema.Number,
+    source: Schema.String,
+    confidence: Schema.Number,
+    edge_weight_override: Schema.NullOr(Schema.Number),
+    rationale: Schema.NullOr(Schema.String),
+    since: Schema.NullOr(Schema.String),
+});
+
 export const fetchRolesForSkill = (
     params: FetchRolesForSkillParams,
-): Effect.Effect<FetchRolesForSkillResult, DbError, SurrealClient> =>
+): Effect.Effect<FetchRolesForSkillResult, RoleQueryError, CacheRead | Judgment> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const judgment = yield* Judgment;
+        const read = yield* CacheRead;
 
-        // Check skill existence first (follows P3.4 pattern)
-        const existsResult = yield* db.query<[Array<unknown>]>(
-            "SELECT id FROM skill WHERE name = $name LIMIT 1;",
-            { name: params.skill },
+        // Existence is a CACHE question: a skill exists because it is installed
+        // on disk, not because someone tagged it. Keeping this check means
+        // `ax skills roles never-installed` still says "unknown skill" rather
+        // than "no roles", which are different answers.
+        const skill = yield* read.first(SkillIdRow, "SELECT id FROM skill WHERE name = ? LIMIT 1", [
+            params.skill,
+        ]);
+        if (skill._tag === "None") return { rows: [], skillExists: false };
+
+        // Tags are keyed by the skill's cache ID, not its name - a rename in the
+        // catalogue must not orphan the decision.
+        const rows = yield* judgment.rows(
+            RoleForSkillTagRow,
+            `SELECT r.name AS role_name, r.weight AS role_weight, pr.source AS source,
+                    pr.confidence AS confidence, pr.weight AS edge_weight_override,
+                    pr.rationale AS rationale, pr.since AS since
+             FROM plays_role pr
+             JOIN role r ON r.id = pr.out_id
+             WHERE pr.in_id = ?
+             ORDER BY r.name ASC`,
+            [skill.value.id],
         );
-        const exists =
-            Array.isArray(existsResult?.[0]) && existsResult[0].length > 0;
 
-        if (!exists) {
-            return { rows: [], skillExists: false };
-        }
-
-        const sql = `
-SELECT
-    out.name AS role_name,
-    out.weight AS role_weight,
-    source,
-    confidence,
-    weight AS edge_weight_override,
-    rationale,
-    since
-FROM plays_role
-WHERE in.name = $skill
-ORDER BY role_name ASC;`.trim();
-
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql, {
-            skill: params.skill,
-        });
-
-        const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
-
-        const mapped: RoleForSkillRow[] = rows.map((r) => ({
-            role_name: String(r.role_name ?? ""),
-            role_weight: Number(r.role_weight ?? 1.0),
-            source: String(r.source ?? ""),
-            confidence: Number(r.confidence ?? 0),
-            edge_weight_override:
-                r.edge_weight_override != null
-                    ? Number(r.edge_weight_override)
-                    : null,
-            rationale: r.rationale != null ? String(r.rationale) : null,
-            since: r.since != null ? String(r.since) : null,
-        }));
-
-        return { rows: mapped, skillExists: true };
+        return { rows: [...rows], skillExists: true };
     });
 
 // ---------------------------------------------------------------------------
@@ -192,31 +268,34 @@ export interface FetchAllRolesResult {
     readonly rows: readonly RoleRow[];
 }
 
-export const fetchAllRoles = (): Effect.Effect<
-    FetchAllRolesResult,
-    DbError,
-    SurrealClient
-> =>
+const AllRolesRow = Schema.Struct({
+    name: Schema.String,
+    weight: Schema.Number,
+    skill_count: Schema.Number,
+});
+
+/**
+ * The whole role vocabulary with tag counts.
+ *
+ * PURE JUDGMENT: both halves live in the sidecar, so this needs no cache and no
+ * snapshot at all. That is what lets `ax roles` answer on a machine that has
+ * never run an ingest - see roles-no-surreal.test.ts, which runs it with
+ * SurrealDB pointed at a dead port.
+ *
+ * `LEFT JOIN`, so a role that exists but has been tagged on nothing reports 0
+ * rather than vanishing - the v1 correlated subquery had that property and it is
+ * easy to lose when a subquery becomes a join.
+ */
+export const fetchAllRoles = (): Effect.Effect<FetchAllRolesResult, RoleQueryError, Judgment> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-
-        const sql = `
-SELECT
-    name,
-    weight,
-    (SELECT count() FROM plays_role WHERE out = $parent.id)[0].count ?? 0 AS skill_count
-FROM role
-ORDER BY skill_count DESC;`.trim();
-
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-
-        const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
-
-        const mapped: RoleRow[] = rows.map((r) => ({
-            name: String(r.name ?? ""),
-            weight: Number(r.weight ?? 1.0),
-            skill_count: Number(r.skill_count ?? 0),
-        }));
-
-        return { rows: mapped };
+        const judgment = yield* Judgment;
+        const rows = yield* judgment.rows(
+            AllRolesRow,
+            `SELECT r.name AS name, r.weight AS weight, count(DISTINCT pr.in_id) AS skill_count
+             FROM role r
+             LEFT JOIN plays_role pr ON pr.out_id = r.id
+             GROUP BY r.id, r.name, r.weight
+             ORDER BY skill_count DESC, r.name ASC`,
+        );
+        return { rows: [...rows] };
     });

--- a/apps/axctl/src/judgment.ts
+++ b/apps/axctl/src/judgment.ts
@@ -13,10 +13,19 @@
  * is safe to resolve anywhere. The cache seam has to keep reads and writes apart
  * because a read inside ingest answers from the PREVIOUS run's published snapshot
  * (F1) - the sidecar has no snapshot and no publish step, so a judgment row
- * written by an ingest stage is visible to the next statement in that same stage.
- * `ingest/skill-role.ts` writes mined role tags at ingest; `ax skills tag` writes
- * a user's tag at request time; both go through this one service and see each
- * other's rows.
+ * written by an ingest stage will be visible to the next statement in that same
+ * stage. Ingest is merged now so that the port can land without re-wiring every
+ * runtime.
+ *
+ * WHAT IS PORTED SO FAR - and what is NOT, because the difference is currently
+ * visible to a user. `ax skills tag` writes a user's tag here at request time,
+ * and the role read surface (`ax roles`, `ax skills roles|by-role`) answers from
+ * here. The MINED writer has not moved yet: `ingest/skill-role.ts` still writes
+ * frontmatter-sourced tags to SurrealDB through `RELATE ...->plays_role->...`,
+ * and never touches this service. Until that stage is ported, frontmatter role
+ * tags do not appear in the role read surface. When it lands, both writers will
+ * share this one service and see each other's rows - `plays_role` already carries
+ * `source` in its natural key so the two can coexist on one skill-role pair.
  */
 import { JudgmentLayer, type Judgment } from "@ax/lib/sqlite";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";

--- a/apps/axctl/src/judgment.ts
+++ b/apps/axctl/src/judgment.ts
@@ -1,0 +1,29 @@
+// apps/axctl/src/judgment.ts
+/**
+ * The app's one `Judgment` layer.
+ *
+ * `@ax/lib`'s `JudgmentLayer` takes the DDL as a REQUIRED option rather than
+ * importing it, because `@ax/lib` has no runtime dependency on `@ax/schema` (that
+ * is a package cycle - see the note in `@ax/lib/stable-id`). So the wiring has to
+ * happen somewhere that depends on both, which is here, ONCE. Every runtime that
+ * can reach durable judgment merges this exact layer, so there is never a second
+ * spelling of "which schema does the sidecar have".
+ *
+ * WHY IT IS IN EVERY RUNTIME, INCLUDING INGEST. Unlike `CacheRead`, this service
+ * is safe to resolve anywhere. The cache seam has to keep reads and writes apart
+ * because a read inside ingest answers from the PREVIOUS run's published snapshot
+ * (F1) - the sidecar has no snapshot and no publish step, so a judgment row
+ * written by an ingest stage is visible to the next statement in that same stage.
+ * `ingest/skill-role.ts` writes mined role tags at ingest; `ax skills tag` writes
+ * a user's tag at request time; both go through this one service and see each
+ * other's rows.
+ */
+import { JudgmentLayer, type Judgment } from "@ax/lib/sqlite";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import type { Layer } from "effect";
+
+/** `Judgment` over `~/.ax/judgment.sqlite` (or `AX_SIDECAR_PATH`), with the
+ *  committed sidecar DDL applied on open. */
+export const JudgmentLive: Layer.Layer<Judgment> = JudgmentLayer({
+    schemaSql: SIDECAR_SCHEMA_SQL,
+});

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -10,6 +10,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { AppLayer } from "@ax/lib/layers";
 import { CacheReadLive } from "@ax/lib/duckdb/seam";
+import { JudgmentLive } from "../judgment.ts";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { buildServer, wrapToolError, wrapToolResult } from "./server.ts";
 import { axMcpTools } from "./tools.ts";
@@ -395,7 +396,7 @@ describe("result wrapping", () => {
 
 describe("MCP server over in-memory transport", () => {
     it("lists the recall tool via tools/list", async () => {
-        const runtime = ManagedRuntime.make(Layer.mergeAll(AppLayer, CacheReadLive));
+        const runtime = ManagedRuntime.make(Layer.mergeAll(AppLayer, CacheReadLive, JudgmentLive));
         const server = buildServer(runtime);
         const client = new Client({ name: "smoke-test", version: "0.0.0" });
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/apps/axctl/src/mcp/server.ts
+++ b/apps/axctl/src/mcp/server.ts
@@ -18,6 +18,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { Layer } from "effect";
 import { AppLayer } from "@ax/lib/layers";
 import { CacheReadLive } from "@ax/lib/duckdb/seam";
+import { JudgmentLive } from "../judgment.ts";
 import { AX_VERSION } from "../cli/version.ts";
 import { axMcpTools, type AxRuntime } from "./tools.ts";
 
@@ -53,7 +54,7 @@ export async function serveMcp(_args: ReadonlyArray<string>): Promise<void> {
     // CacheReadLive opens nothing until a query arrives, so a server whose
     // client never calls `recall` pays nothing for it - and one that starts
     // before the first ingest picks the snapshot up when it appears.
-    const runtime = ManagedRuntime.make(Layer.mergeAll(AppLayer, CacheReadLive));
+    const runtime = ManagedRuntime.make(Layer.mergeAll(AppLayer, CacheReadLive, JudgmentLive));
 
     const server = buildServer(runtime);
     const transport = new StdioServerTransport();

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -30,6 +30,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AppLayer } from "@ax/lib/layers";
 import { CacheReadLive } from "@ax/lib/duckdb/seam";
+import { JudgmentLive } from "../judgment.ts";
 import { wrapToolError, wrapToolResult } from "./wrap.ts";
 import {
     fetchRecall,
@@ -94,7 +95,7 @@ import { QuotaEnvLive } from "../quota/quota-env.ts";
  * DuckDB snapshot that `recall` now goes through. The service/error params are
  * derived from the layers so they stay in sync if either changes.
  */
-const McpRuntimeLayer = Layer.mergeAll(AppLayer, CacheReadLive);
+const McpRuntimeLayer = Layer.mergeAll(AppLayer, CacheReadLive, JudgmentLive);
 
 export type AxRuntime = ManagedRuntime.ManagedRuntime<
     Layer.Success<typeof McpRuntimeLayer>,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -13,6 +13,7 @@
     "./shared/team-community": "./src/shared/team-community.ts",
     "./shared/team-fetch": "./src/shared/team-fetch.ts",
     "./duckdb": "./src/duckdb/index.ts",
+    "./sqlite": "./src/sqlite/index.ts",
     "./duckdb/internal": "./src/duckdb/internal.ts",
     "./testing/duckdb-dylib": "./src/testing/duckdb-dylib.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",

--- a/packages/lib/src/sqlite/columns.ts
+++ b/packages/lib/src/sqlite/columns.ts
@@ -1,0 +1,147 @@
+// packages/lib/src/sqlite/columns.ts
+/**
+ * The sidecar's row-decode CONTRACT, stated once as schemas.
+ *
+ * Same job as `@ax/lib/duckdb/columns` and a DIFFERENT set of hazards, because
+ * SQLite has fewer types than DuckDB rather than more. Three column meanings are
+ * not visible in the SQL and are easy to get subtly wrong:
+ *
+ *   TIMESTAMP  -> {@link TimestampColumn}  (TEXT holding an ISO-8601 UTC instant)
+ *   BOOLEAN    -> {@link BooleanColumn}    (INTEGER 0 or 1)
+ *   JSON       -> {@link JsonArrayColumn} / {@link JsonObjectColumn}
+ *
+ * WHY A TIMESTAMP IS TEXT AND NOT A NUMBER. Epoch integers sort and compare
+ * correctly and are unreadable in a `sqlite3` shell; ISO-8601 UTC text sorts and
+ * compares correctly TOO (it is lexicographically ordered for a fixed offset and
+ * fixed precision) and can be read by a human debugging a judgment row at 2am.
+ * The DDL's own defaults use `strftime('%Y-%m-%dT%H:%M:%fZ','now')` for the same
+ * reason - see the TIMESTAMPS block in schema.sidecar.sql.
+ *
+ * WHY THE BOOLEAN CODEC IS STRICT. SQLite will happily store `'true'`, `2` or
+ * `NULL` in a column the DDL calls INTEGER: it has no boolean type and no
+ * constraint here. Decoding "anything truthy" would turn a writer bug into a
+ * plausible-looking `true`, so {@link BooleanColumn} accepts 0 and 1 and refuses
+ * everything else at the column.
+ */
+import { Effect, Option, Schema, SchemaGetter, SchemaIssue } from "effect";
+
+/** A plain text column. Named for symmetry, so a row contract reads as a list of
+ *  column CONTRACTS rather than a mix of contracts and bare primitives. */
+export const TextColumn = Schema.String;
+
+/** An INTEGER or REAL column read as a JS number. */
+export const NumberColumn = Schema.Number;
+
+const EXCERPT_LEN = 120;
+
+const excerptOf = (text: string): string =>
+    text.length > EXCERPT_LEN ? `${text.slice(0, EXCERPT_LEN)}…` : text;
+
+/**
+ * A TEXT column holding an ISO-8601 UTC instant, decoded to a JS `Date`.
+ *
+ * Strict on purpose. SQLite's own `CURRENT_TIMESTAMP` renders
+ * `YYYY-MM-DD HH:MM:SS`, which `new Date()` parses as LOCAL time - so a row
+ * written by a statement that reached for `CURRENT_TIMESTAMP` instead of the
+ * DDL's default would come back hours off, on any non-UTC host, with no error
+ * anywhere. Requiring the `T`/`Z` form makes that a decode failure naming the
+ * column rather than a wrong number in a report.
+ */
+export const TimestampColumn = Schema.String.pipe(
+    Schema.decodeTo(Schema.DateValid, {
+        decode: SchemaGetter.transformOrFail((text: string) => {
+            const ms = Date.parse(text);
+            if (Number.isNaN(ms)) {
+                return Effect.fail(
+                    new SchemaIssue.InvalidValue(Option.some(excerptOf(text)), {
+                        message: `not a parseable timestamp; this column holds an ISO-8601 UTC instant (see @ax/lib/sqlite/columns), and the value was: ${excerptOf(text)}`,
+                    }),
+                );
+            }
+            if (!text.includes("T") || !text.endsWith("Z")) {
+                return Effect.fail(
+                    new SchemaIssue.InvalidValue(Option.some(excerptOf(text)), {
+                        message:
+                            `parseable, but not in the UTC form this schema stores (\`YYYY-MM-DDTHH:MM:SS.sssZ\`), so ` +
+                            `reading it would silently apply the HOST's time zone. Got: ${excerptOf(text)}. A row in ` +
+                            "this shape usually means a writer used SQLite's CURRENT_TIMESTAMP instead of the DDL's " +
+                            "strftime default.",
+                    }),
+                );
+            }
+            return Effect.succeed(new Date(ms));
+        }),
+        encode: SchemaGetter.transform((value: Date) => value.toISOString()),
+    }),
+);
+
+/** An INTEGER column holding 0 or 1, decoded to a JS boolean. */
+export const BooleanColumn = Schema.Number.pipe(
+    Schema.decodeTo(Schema.Boolean, {
+        decode: SchemaGetter.transformOrFail((n: number) =>
+            n === 0 || n === 1
+                ? Effect.succeed(n === 1)
+                : Effect.fail(
+                      new SchemaIssue.InvalidValue(Option.some(n), {
+                          message: `expected 0 or 1; SQLite has no boolean type, so this schema stores one as an INTEGER (see @ax/lib/sqlite/columns) and got ${n}`,
+                      }),
+                  ),
+        ),
+        encode: SchemaGetter.transform((value: boolean) => (value ? 1 : 0)),
+    }),
+);
+
+const jsonIssue = (text: string, why: string) => {
+    const excerpt = excerptOf(text);
+    return new SchemaIssue.InvalidValue(Option.some(excerpt), {
+        message: `${why}; this column holds JSON text (see @ax/lib/sqlite/columns), and the value ${
+            excerpt === text ? "was" : "began"
+        }: ${excerpt}`,
+    });
+};
+
+const parseJson = (text: string): Effect.Effect<unknown, SchemaIssue.InvalidValue> =>
+    Effect.try({
+        try: () => JSON.parse(text) as unknown,
+        catch: (err) =>
+            jsonIssue(text, `not valid JSON (${err instanceof Error ? err.message : String(err)})`),
+    });
+
+/** A TEXT column holding a JSON ARRAY, decoded to `ReadonlyArray<item>`. */
+export const JsonArrayColumn = <S extends Schema.Top>(item: S) =>
+    Schema.String.pipe(
+        Schema.decodeTo(Schema.Array(item), {
+            decode: SchemaGetter.transformOrFail((text: string) =>
+                parseJson(text).pipe(
+                    Effect.flatMap((value) =>
+                        Array.isArray(value)
+                            ? Effect.succeed(value as ReadonlyArray<S["Encoded"]>)
+                            : Effect.fail(jsonIssue(text, `expected a JSON array, got ${typeof value}`)),
+                    ),
+                ),
+            ),
+            encode: SchemaGetter.transform((value: ReadonlyArray<S["Encoded"]>) => JSON.stringify(value)),
+        }),
+    );
+
+/** A TEXT column holding a JSON OBJECT, decoded through `shape`. */
+export const JsonObjectColumn = <S extends Schema.Top>(shape: S) =>
+    Schema.String.pipe(
+        Schema.decodeTo(shape, {
+            decode: SchemaGetter.transformOrFail((text: string) =>
+                parseJson(text).pipe(
+                    Effect.flatMap((value) =>
+                        typeof value === "object" && value !== null && !Array.isArray(value)
+                            ? Effect.succeed(value as S["Encoded"])
+                            : Effect.fail(
+                                  jsonIssue(
+                                      text,
+                                      `expected a JSON object, got ${Array.isArray(value) ? "an array" : typeof value}`,
+                                  ),
+                              ),
+                    ),
+                ),
+            ),
+            encode: SchemaGetter.transform((value: S["Encoded"]) => JSON.stringify(value)),
+        }),
+    );

--- a/packages/lib/src/sqlite/errors.ts
+++ b/packages/lib/src/sqlite/errors.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/sqlite/errors.ts
+/** Typed failures of the judgment sidecar. Deliberately three, split the way a
+ *  caller has to react: "the sidecar would not open" is an environment problem
+ *  a user can fix, "this statement failed" is a bug in the query, and "the rows
+ *  did not match the schema" is a bug in the row contract. */
+import { Schema } from "effect";
+
+/**
+ * The sidecar could not be opened or its schema could not be applied.
+ *
+ * Rarer than its cache counterpart (`CacheUnavailableError`) and for a different
+ * reason: a MISSING sidecar is not an error at all. SQLite creates the file, the
+ * DDL is `IF NOT EXISTS`, and an empty judgment database is a perfectly valid
+ * state - a user who has never filed a proposal has no proposals. This fires
+ * only when the directory cannot be created, the file cannot be opened, or the
+ * schema will not apply.
+ */
+export class SidecarUnavailableError extends Schema.TaggedErrorClass<SidecarUnavailableError>(
+    "SidecarUnavailableError",
+)("SidecarUnavailableError", {
+    path: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** A statement failed to prepare, bind, or execute. `sql` is a short excerpt. */
+export class SidecarQueryError extends Schema.TaggedErrorClass<SidecarQueryError>(
+    "SidecarQueryError",
+)("SidecarQueryError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Rows came back fine but did not match the caller's schema. */
+export class SidecarDecodeError extends Schema.TaggedErrorClass<SidecarDecodeError>(
+    "SidecarDecodeError",
+)("SidecarDecodeError", {
+    sql: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Anything the judgment seam can fail with. Unlike the cache seam there is no
+ *  read/write split: the sidecar is READ-WRITE at request time by design, so a
+ *  reader and a writer carry the same error channel. */
+export type JudgmentError = SidecarUnavailableError | SidecarQueryError | SidecarDecodeError;
+
+/** First 200 chars of a statement - mirrors the cache client's `sqlExcerpt`, so
+ *  one enormous statement never bloats an error message. */
+const SQL_EXCERPT_LEN = 200;
+
+export const sqlExcerpt = (sql: string): string =>
+    sql.length > SQL_EXCERPT_LEN ? `${sql.slice(0, SQL_EXCERPT_LEN)}…` : sql;
+
+export const errorMessage = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);

--- a/packages/lib/src/sqlite/errors.ts
+++ b/packages/lib/src/sqlite/errors.ts
@@ -22,6 +22,30 @@ export class SidecarUnavailableError extends Schema.TaggedErrorClass<SidecarUnav
     message: Schema.String,
 }) {}
 
+/**
+ * The connection this service held was closed under it, so the statement never
+ * ran. Distinct from {@link SidecarUnavailableError} because it says something
+ * stronger and more useful: nothing was attempted, so the caller may simply try
+ * again on a fresh connection.
+ *
+ * WHEN IT HAPPENS. A transaction whose COMMIT failed and whose ROLLBACK then
+ * ALSO failed invalidates the shared connection rather than leaving a poisoned
+ * one behind (see `transaction` in ./sidecar.ts). Any operation that was already
+ * queued on the transaction permit wakes up holding the dead handle. It is
+ * checked BEFORE the first statement, under the permit, which is what makes
+ * "nothing ran" a fact rather than a hope.
+ *
+ * CALLERS SHOULD RARELY SEE THIS. `JudgmentLayer` retries such an operation once
+ * against a freshly opened connection. It reaches a caller only if a SECOND
+ * invalidation lands inside that retry, or if the service was built directly
+ * with no layer around it (which the tests do).
+ */
+export class SidecarConnectionReplacedError extends Schema.TaggedErrorClass<SidecarConnectionReplacedError>(
+    "SidecarConnectionReplacedError",
+)("SidecarConnectionReplacedError", {
+    path: Schema.String,
+}) {}
+
 /** A statement failed to prepare, bind, or execute. `sql` is a short excerpt. */
 export class SidecarQueryError extends Schema.TaggedErrorClass<SidecarQueryError>(
     "SidecarQueryError",
@@ -41,7 +65,11 @@ export class SidecarDecodeError extends Schema.TaggedErrorClass<SidecarDecodeErr
 /** Anything the judgment seam can fail with. Unlike the cache seam there is no
  *  read/write split: the sidecar is READ-WRITE at request time by design, so a
  *  reader and a writer carry the same error channel. */
-export type JudgmentError = SidecarUnavailableError | SidecarQueryError | SidecarDecodeError;
+export type JudgmentError =
+    | SidecarUnavailableError
+    | SidecarConnectionReplacedError
+    | SidecarQueryError
+    | SidecarDecodeError;
 
 /** First 200 chars of a statement - mirrors the cache client's `sqlExcerpt`, so
  *  one enormous statement never bloats an error message. */

--- a/packages/lib/src/sqlite/index.ts
+++ b/packages/lib/src/sqlite/index.ts
@@ -11,11 +11,13 @@ export {
     TimestampColumn,
 } from "./columns.ts";
 export {
+    SidecarConnectionReplacedError,
     SidecarDecodeError,
     SidecarQueryError,
     SidecarUnavailableError,
     type JudgmentError,
 } from "./errors.ts";
+export { findExtraStatement, isSingleStatement, type ExtraStatement } from "./statement.ts";
 export {
     checkSidecarRefs,
     collectSidecarRefs,

--- a/packages/lib/src/sqlite/index.ts
+++ b/packages/lib/src/sqlite/index.ts
@@ -31,6 +31,7 @@ export {
     sidecarPath,
     type JudgmentLayerOptions,
     type JudgmentService,
+    type JudgmentTransaction,
     type SidecarParam,
     type SidecarRow,
     type SidecarValue,

--- a/packages/lib/src/sqlite/index.ts
+++ b/packages/lib/src/sqlite/index.ts
@@ -17,6 +17,15 @@ export {
     type JudgmentError,
 } from "./errors.ts";
 export {
+    checkSidecarRefs,
+    collectSidecarRefs,
+    fetchCacheIds,
+    SIDECAR_CACHE_REFS,
+    SIDECAR_REF_TARGET_TABLES,
+    type CacheIdReader,
+    type SidecarCacheRefSpec,
+} from "./integrity.ts";
+export {
     Judgment,
     JudgmentLayer,
     sidecarPath,

--- a/packages/lib/src/sqlite/index.ts
+++ b/packages/lib/src/sqlite/index.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/sqlite/index.ts
+/** The judgment sidecar's public surface. Import from `@ax/lib/sqlite`; the
+ *  modules behind it are an implementation detail, exactly as `@ax/lib/duckdb`
+ *  fronts the cache seam. */
+export {
+    BooleanColumn,
+    JsonArrayColumn,
+    JsonObjectColumn,
+    NumberColumn,
+    TextColumn,
+    TimestampColumn,
+} from "./columns.ts";
+export {
+    SidecarDecodeError,
+    SidecarQueryError,
+    SidecarUnavailableError,
+    type JudgmentError,
+} from "./errors.ts";
+export {
+    Judgment,
+    JudgmentLayer,
+    sidecarPath,
+    type JudgmentLayerOptions,
+    type JudgmentService,
+    type SidecarParam,
+    type SidecarRow,
+    type SidecarValue,
+} from "./sidecar.ts";

--- a/packages/lib/src/sqlite/integrity-e2e.test.ts
+++ b/packages/lib/src/sqlite/integrity-e2e.test.ts
@@ -16,7 +16,7 @@ import { CacheRead, CacheReadLayer } from "../duckdb/seam.ts";
 import { Judgment, JudgmentLayer, type JudgmentService } from "./index.ts";
 import { checkSidecarRefs, collectSidecarRefs, fetchCacheIds } from "./integrity.ts";
 
-const { dylibPath, dtest, tempDir } = await duckdbTestSetup("judgment integrity e2e");
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("judgment integrity e2e", { requireFts: true });
 
 const Platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 

--- a/packages/lib/src/sqlite/integrity-e2e.test.ts
+++ b/packages/lib/src/sqlite/integrity-e2e.test.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/sqlite/integrity-e2e.test.ts
+//
+// Both engines, wired together, with nothing mocked: a REAL published DuckDB
+// cache and a REAL SQLite sidecar in the same temp directory. integrity.test.ts
+// covers the ref logic against a hand-built id index and needs no dylib; this
+// suite proves the two seams actually meet - that a `SELECT id FROM skill`
+// through `CacheRead` produces ids a judgment row can be checked against.
+import { describe, expect } from "bun:test";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import { join } from "node:path";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { publishCacheFixture } from "../testing/cache-fixture.ts";
+import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
+import { CacheRead, CacheReadLayer } from "../duckdb/seam.ts";
+import { Judgment, JudgmentLayer, type JudgmentService } from "./index.ts";
+import { checkSidecarRefs, collectSidecarRefs, fetchCacheIds } from "./integrity.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("judgment integrity e2e");
+
+const Platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provide(Platform)) as Effect.Effect<A, E>);
+
+/** The dylib the suite resolved, so the seam opens the same build. */
+const dylibEnv = <A>(body: () => Promise<A>): Promise<A> => {
+    const previous = process.env.AX_DUCKDB_DYLIB;
+    if (dylibPath !== null) process.env.AX_DUCKDB_DYLIB = dylibPath;
+    return body().finally(() => {
+        if (previous === undefined) delete process.env.AX_DUCKDB_DYLIB;
+        else process.env.AX_DUCKDB_DYLIB = previous;
+    });
+};
+
+/** A cache `skill` row - every NOT NULL column the real DDL declares. */
+const skillRow = (id: string) => ({
+    id,
+    name: "tdd",
+    scope: "user",
+    dir_path: "/tmp/skills/tdd",
+    content_hash: "hash",
+});
+
+/** A role tag on `skillId`, plus the role it points at. */
+const tagSkill = (j: JudgmentService, skillId: string) =>
+    Effect.gen(function* () {
+        yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+        yield* j.put("plays_role", {
+            id: "pr1",
+            in_id: skillId,
+            out_id: "role:reviewer",
+            source: "user",
+        });
+    });
+
+const checkAgainst = (snapshotPath: string, sidecarPath: string) =>
+    Effect.gen(function* () {
+        const j = yield* Judgment;
+        const read = yield* CacheRead;
+        const refs = yield* collectSidecarRefs(j);
+        const ids = yield* fetchCacheIds(read);
+        return checkSidecarRefs(refs, ids);
+    }).pipe(
+        Effect.scoped,
+        Effect.provide(
+            Layer.mergeAll(
+                JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
+                CacheReadLayer({ snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) }),
+            ),
+        ),
+    );
+
+describe("judgment refs against a real published cache", () => {
+    dtest("reports zero dangling refs when the cache still holds the tagged skill", async () => {
+        const dir = tempDir("ax-integrity-clean-");
+        const report = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const cache = yield* publishCacheFixture(dir, dylibPath, (write) =>
+                        write.put("skill", skillRow("skill:tdd")),
+                    );
+                    const sidecarPath = join(dir, "judgment.sqlite");
+                    yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        yield* tagSkill(j, "skill:tdd");
+                    }).pipe(
+                        Effect.scoped,
+                        Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+                    );
+                    return yield* checkAgainst(cache.snapshotPath, sidecarPath);
+                }),
+            ),
+        );
+        expect(report.checked).toBe(1);
+        expect(report.dangling).toBe(0);
+        expect(report.ok).toBe(true);
+    });
+
+    dtest("names the surviving judgment row when a re-derive dropped the skill it tagged", async () => {
+        // This is the failure the whole content-hash id contract exists to
+        // prevent, so the check has to be able to SEE it: the sidecar keeps the
+        // tag (it must - it is the user's decision), and the skill it named is
+        // no longer in the rebuilt cache.
+        const dir = tempDir("ax-integrity-dangling-");
+        const report = await dylibEnv(() =>
+            run(
+                Effect.gen(function* () {
+                    const cache = yield* publishCacheFixture(dir, dylibPath, (write) =>
+                        write.put("skill", skillRow("skill:renamed-by-a-rederive")),
+                    );
+                    const sidecarPath = join(dir, "judgment.sqlite");
+                    yield* Effect.gen(function* () {
+                        const j = yield* Judgment;
+                        yield* tagSkill(j, "skill:tdd");
+                    }).pipe(
+                        Effect.scoped,
+                        Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+                    );
+                    return yield* checkAgainst(cache.snapshotPath, sidecarPath);
+                }),
+            ),
+        );
+        expect(report.ok).toBe(false);
+        expect(report.dangling).toBe(1);
+        expect(report.byTargetTable).toEqual({ skill: 1 });
+        expect(report.samples[0]?.sidecarTable).toBe("plays_role");
+        expect(report.samples[0]?.sidecarId).toBe("pr1");
+        expect(report.samples[0]?.reason).toBe("missing_id");
+    });
+});

--- a/packages/lib/src/sqlite/integrity-e2e.test.ts
+++ b/packages/lib/src/sqlite/integrity-e2e.test.ts
@@ -13,6 +13,7 @@ import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { publishCacheFixture } from "../testing/cache-fixture.ts";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { CacheRead, CacheReadLayer } from "../duckdb/seam.ts";
+import { roleRowId } from "../stable-id.ts";
 import { Judgment, JudgmentLayer, type JudgmentService } from "./index.ts";
 import { checkSidecarRefs, collectSidecarRefs, fetchCacheIds } from "./integrity.ts";
 
@@ -45,11 +46,11 @@ const skillRow = (id: string) => ({
 /** A role tag on `skillId`, plus the role it points at. */
 const tagSkill = (j: JudgmentService, skillId: string) =>
     Effect.gen(function* () {
-        yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+        yield* j.put("role", { id: roleRowId("reviewer"), name: "reviewer", weight: 2 });
         yield* j.put("plays_role", {
             id: "pr1",
             in_id: skillId,
-            out_id: "role:reviewer",
+            out_id: roleRowId("reviewer"),
             source: "user",
         });
     });

--- a/packages/lib/src/sqlite/integrity.test.ts
+++ b/packages/lib/src/sqlite/integrity.test.ts
@@ -1,0 +1,200 @@
+// packages/lib/src/sqlite/integrity.test.ts
+//
+// The cross-engine half of the integrity check, against a REAL sidecar. The
+// cache side is supplied as a plain id index here, so this suite needs no dylib
+// and runs everywhere; the two engines are wired together end-to-end in
+// integrity-e2e.test.ts.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { buildCacheIdIndex } from "../cache-integrity.ts";
+import { Judgment, JudgmentLayer, type JudgmentService } from "./index.ts";
+import { collectSidecarRefs, SIDECAR_CACHE_REFS, checkSidecarRefs } from "./integrity.ts";
+
+let dir: string;
+let sidecarPath: string;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ax-judgment-refs-"));
+    sidecarPath = join(dir, "judgment.sqlite");
+});
+
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+const run = <A, E>(body: (j: JudgmentService) => Effect.Effect<A, E, never>): Promise<A> =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const j = yield* Judgment;
+            return yield* body(j);
+        }).pipe(
+            Effect.scoped,
+            Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+        ) as Effect.Effect<A, E>,
+    );
+
+/** One row in each table that carries a ref into the cache. */
+const seedJudgment = (j: JudgmentService) =>
+    Effect.gen(function* () {
+        yield* j.put("proposal", {
+            id: "p1",
+            form: "skill",
+            title: "t",
+            hypothesis: "h",
+            dedupe_sig: "sig",
+            confidence: "high",
+        });
+        yield* j.put("experiment", { id: "e1", proposal: "p1", artifact: "skill:tdd" });
+        yield* j.put("role", { id: "role:reviewer", name: "reviewer" });
+        yield* j.put("plays_role", {
+            id: "pr1",
+            in_id: "skill:tdd",
+            out_id: "role:reviewer",
+            source: "user",
+        });
+        yield* j.put("retro", {
+            id: "r1",
+            session: "session:abc",
+            source: "manual",
+            tried: "the port",
+            repository: "repository:ax",
+        });
+        yield* j.put("dogfood_run", {
+            id: "d1",
+            run_id: "run-1",
+            scenario: "install",
+            driver: "wterm",
+            status: "passed",
+            transcript_artifact: "artifact:log",
+            started_at: new Date("2026-08-15T00:00:00.000Z"),
+            ended_at: new Date("2026-08-15T00:01:00.000Z"),
+        });
+        yield* j.put("session_label", { id: "sl1", session_id: "session:abc", label: "spar" });
+    });
+
+describe("SIDECAR_CACHE_REFS", () => {
+    test("declares only refs the v1 schema actually TYPED as record<T>", () => {
+        // `transcript_label_review.candidate_id` and `.graph_fact_id` LOOK like
+        // refs and are plain `string` in schema.surql - a mined candidate id, not
+        // a row id in any cache table. Declaring a target table for them would be
+        // an inference, and every review row would then read as dangling.
+        const declared = SIDECAR_CACHE_REFS.flatMap((r) => `${r.sidecarTable}.${r.column}`);
+        expect(declared.sort()).toEqual(
+            [
+                "dogfood_run.transcript_artifact",
+                "experiment.artifact",
+                "plays_role.in_id",
+                "retro.repository",
+                "retro.session",
+                "session_label.session_id",
+            ].sort(),
+        );
+    });
+
+    test("names no sidecar table as a ref target - these are CROSS-engine refs only", () => {
+        // `experiment.proposal` and `checkpoint.experiment` are refs too, but
+        // both endpoints live in the sidecar, so a cache rebuild cannot break
+        // them and this check would report every one as an unknown table.
+        for (const ref of SIDECAR_CACHE_REFS) {
+            expect(["skill", "session", "repository", "artifact"]).toContain(ref.targetTable);
+        }
+    });
+});
+
+describe("collectSidecarRefs", () => {
+    test("reads one ref per non-null value, across every declared table", async () => {
+        const refs = await run((j) => Effect.andThen(seedJudgment(j), collectSidecarRefs(j)));
+        expect(
+            refs.map((r) => `${r.sidecarTable}.${r.column}->${r.targetTable}:${r.targetId}`).sort(),
+        ).toEqual(
+            [
+                "dogfood_run.transcript_artifact->artifact:artifact:log",
+                "experiment.artifact->skill:skill:tdd",
+                "plays_role.in_id->skill:skill:tdd",
+                "retro.repository->repository:repository:ax",
+                "retro.session->session:session:abc",
+                "session_label.session_id->session:session:abc",
+            ].sort(),
+        );
+    });
+
+    test("skips a NULL optional ref instead of reporting it as dangling", async () => {
+        const refs = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.put("proposal", {
+                    id: "p1",
+                    form: "hook",
+                    title: "t",
+                    hypothesis: "h",
+                    dedupe_sig: "sig",
+                    confidence: "low",
+                });
+                // A hook-form experiment has no skill artifact at all.
+                yield* j.put("experiment", { id: "e1", proposal: "p1", artifact: null });
+                return yield* collectSidecarRefs(j);
+            }),
+        );
+        expect(refs).toEqual([]);
+    });
+
+    test("carries the sidecar row's own id, so a dangling ref names the decision that broke", async () => {
+        const refs = await run((j) => Effect.andThen(seedJudgment(j), collectSidecarRefs(j)));
+        const tag = refs.find((r) => r.sidecarTable === "plays_role");
+        expect(tag?.sidecarId).toBe("pr1");
+    });
+});
+
+describe("checkSidecarRefs", () => {
+    test("reports a clean sidecar when every ref resolves in the cache", async () => {
+        const report = await run((j) =>
+            Effect.andThen(
+                seedJudgment(j),
+                Effect.map(collectSidecarRefs(j), (refs) =>
+                    checkSidecarRefs(
+                        refs,
+                        buildCacheIdIndex([
+                            { table: "skill", id: "skill:tdd" },
+                            { table: "session", id: "session:abc" },
+                            { table: "repository", id: "repository:ax" },
+                            { table: "artifact", id: "artifact:log" },
+                        ]),
+                    ),
+                ),
+            ),
+        );
+        expect(report.ok).toBe(true);
+        expect(report.checked).toBe(6);
+        expect(report.dangling).toBe(0);
+    });
+
+    test("counts a re-derive that dropped a skill as a missing id, not an unknown table", async () => {
+        // The distinction matters: `missing_id` means "the cache no longer holds
+        // that row" (the re-derive dropped it, or the id contract changed);
+        // `unknown_table` means "ax does not have that table at all", which is a
+        // schema bug, not a data one. A cache whose `skill` table happens to be
+        // EMPTY must still report missing_id - which is what knownTables buys.
+        const report = await run((j) =>
+            Effect.andThen(
+                seedJudgment(j),
+                Effect.map(collectSidecarRefs(j), (refs) =>
+                    checkSidecarRefs(
+                        refs,
+                        buildCacheIdIndex([
+                            { table: "session", id: "session:abc" },
+                            { table: "repository", id: "repository:ax" },
+                            { table: "artifact", id: "artifact:log" },
+                        ]),
+                    ),
+                ),
+            ),
+        );
+        expect(report.ok).toBe(false);
+        expect(report.dangling).toBe(2); // experiment.artifact + plays_role.in_id
+        expect(report.byTargetTable).toEqual({ skill: 2 });
+        expect(report.samples.every((s) => s.reason === "missing_id")).toBe(true);
+    });
+});

--- a/packages/lib/src/sqlite/integrity.test.ts
+++ b/packages/lib/src/sqlite/integrity.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { buildCacheIdIndex } from "../cache-integrity.ts";
+import { roleRowId } from "../stable-id.ts";
 import { Judgment, JudgmentLayer, type JudgmentService } from "./index.ts";
 import { collectSidecarRefs, SIDECAR_CACHE_REFS, checkSidecarRefs } from "./integrity.ts";
 
@@ -49,11 +50,11 @@ const seedJudgment = (j: JudgmentService) =>
             confidence: "high",
         });
         yield* j.put("experiment", { id: "e1", proposal: "p1", artifact: "skill:tdd" });
-        yield* j.put("role", { id: "role:reviewer", name: "reviewer" });
+        yield* j.put("role", { id: roleRowId("reviewer"), name: "reviewer" });
         yield* j.put("plays_role", {
             id: "pr1",
             in_id: "skill:tdd",
-            out_id: "role:reviewer",
+            out_id: roleRowId("reviewer"),
             source: "user",
         });
         yield* j.put("retro", {

--- a/packages/lib/src/sqlite/integrity.ts
+++ b/packages/lib/src/sqlite/integrity.ts
@@ -18,9 +18,16 @@
  * SPLIT IN TWO, ON PURPOSE. {@link collectSidecarRefs} needs the sidecar and
  * nothing else; the join against live cache ids is `checkCacheIntegrity` in
  * ../cache-integrity.ts, which takes plain data. So the interesting logic is
- * testable with no DuckDB running, and the same functions serve both callers -
- * ingest (checking against the LIVE database it just wrote, before publish) and
- * `ax doctor` (checking against the published snapshot).
+ * testable with no DuckDB running.
+ *
+ * NO PRODUCTION CALLER YET. This chunk ships the mechanism and its cross-engine
+ * test (integrity-e2e.test.ts publishes a real snapshot and re-derives against
+ * it); the two surfaces that will USE it are separate ports and are not wired
+ * here. The split above is what lets both of them share these functions when
+ * they land: ingest will check against the LIVE database it just wrote, before
+ * publish, and `ax doctor` will check against the published snapshot. Until then
+ * a dangling ref is measurable but not reported anywhere, which is a gap to close
+ * and not a property to rely on.
  *
  * THE CACHE READER IS AN ARGUMENT, NEVER A SERVICE. Same rule wave 2 arrived at
  * for every module called from both sides of ingest (F1/F2 in the backlog): a

--- a/packages/lib/src/sqlite/integrity.ts
+++ b/packages/lib/src/sqlite/integrity.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/sqlite/integrity.ts
+/**
+ * The CROSS-ENGINE integrity check: which judgment rows point at a cache row
+ * that no longer exists?
+ *
+ * WHY THIS CAN HAPPEN AT ALL. The v2 split makes one promise in each direction.
+ * The cache is rebuildable, so nothing in it is precious. The sidecar is durable,
+ * so nothing in it may be lost. But a sidecar row REFERS to the cache - a role
+ * tag names a skill, a retro names a session - and a re-derive rewrites the cache
+ * from scratch. The reason those refs survive at all is the content-hash id
+ * contract (`@ax/lib/stable-id`): re-deriving the same input rewrites a
+ * byte-identical id, so the tag still finds its skill. This module is what
+ * MEASURES that promise instead of assuming it. A dangling count that is anything
+ * but zero on unchanged inputs means the id contract broke, and it is far better
+ * to learn that from `ax doctor` than from a role tag that silently stopped
+ * applying.
+ *
+ * SPLIT IN TWO, ON PURPOSE. {@link collectSidecarRefs} needs the sidecar and
+ * nothing else; the join against live cache ids is `checkCacheIntegrity` in
+ * ../cache-integrity.ts, which takes plain data. So the interesting logic is
+ * testable with no DuckDB running, and the same functions serve both callers -
+ * ingest (checking against the LIVE database it just wrote, before publish) and
+ * `ax doctor` (checking against the published snapshot).
+ *
+ * THE CACHE READER IS AN ARGUMENT, NEVER A SERVICE. Same rule wave 2 arrived at
+ * for every module called from both sides of ingest (F1/F2 in the backlog): a
+ * `CacheRead` resolved inside ingest answers from the PREVIOUS run's snapshot, so
+ * a check running after a re-derive would compare this run's judgment against
+ * last run's ids and invent dangling refs. {@link fetchCacheIds} therefore takes
+ * the reader it should use.
+ */
+import { Effect, Schema } from "effect";
+import {
+    buildCacheIdIndex,
+    checkCacheIntegrity,
+    type CacheIdIndex,
+    type IntegrityReport,
+    type SidecarRef,
+} from "../cache-integrity.ts";
+import type { JudgmentError } from "./errors.ts";
+import type { JudgmentService } from "./sidecar.ts";
+
+/** One column of one sidecar table that holds a CACHE row id. */
+export interface SidecarCacheRefSpec {
+    readonly sidecarTable: string;
+    readonly column: string;
+    readonly targetTable: string;
+}
+
+/**
+ * Every ref that crosses from the sidecar into the cache.
+ *
+ * DERIVED FROM THE v1 TYPES, not from naming. Each entry below was a
+ * `record<T>` field (or a `RELATION FROM T`) in schema.surql, which is what makes
+ * the target table a fact rather than a guess.
+ *
+ * TWO COLUMNS ARE DELIBERATELY ABSENT. `transcript_label_review.candidate_id` and
+ * `.graph_fact_id` read like refs and are plain `string` in schema.surql - a
+ * mined candidate identifier, not a row id in any cache table. Declaring a target
+ * for them would make every label review report as dangling. If those ids are
+ * later given a typed home, they belong here; until then the check says nothing
+ * about them rather than something wrong.
+ *
+ * SIDECAR-TO-SIDECAR REFS ARE ALSO ABSENT (`experiment.proposal`,
+ * `checkpoint.experiment`, `plays_role.out_id -> role`, the five form payloads).
+ * They are real refs, but both endpoints are durable: a cache rebuild cannot
+ * break them, and this check is about what a cache rebuild can break.
+ */
+export const SIDECAR_CACHE_REFS: readonly SidecarCacheRefSpec[] = [
+    // was: DEFINE FIELD artifact ON experiment TYPE option<record<skill>>
+    { sidecarTable: "experiment", column: "artifact", targetTable: "skill" },
+    // was: DEFINE TABLE plays_role TYPE RELATION FROM skill TO role
+    { sidecarTable: "plays_role", column: "in_id", targetTable: "skill" },
+    // was: DEFINE FIELD session ON retro TYPE record<session>
+    { sidecarTable: "retro", column: "session", targetTable: "session" },
+    // was: DEFINE FIELD repository ON retro TYPE option<record<repository>>
+    { sidecarTable: "retro", column: "repository", targetTable: "repository" },
+    // was: DEFINE FIELD transcript_artifact ON dogfood_run TYPE option<record<artifact>>
+    { sidecarTable: "dogfood_run", column: "transcript_artifact", targetTable: "artifact" },
+    // New in v2: the spar stamp that used to be a VALUE in `session.labels`.
+    { sidecarTable: "session_label", column: "session_id", targetTable: "session" },
+];
+
+/** The cache tables this check ever looks in. Passed to `checkCacheIntegrity` as
+ *  `knownTables`, so a ref into a real-but-EMPTY table reports `missing_id` (the
+ *  row is gone) rather than `unknown_table` (ax has no such table) - a different
+ *  diagnosis pointing at a different bug. */
+export const SIDECAR_REF_TARGET_TABLES: ReadonlySet<string> = new Set(
+    SIDECAR_CACHE_REFS.map((r) => r.targetTable),
+);
+
+const RefRow = Schema.Struct({ id: Schema.String, target: Schema.String });
+
+/**
+ * Every non-null cross-engine ref currently in the sidecar.
+ *
+ * One statement per declared column - six statements over tables that hold tens
+ * to thousands of rows, not a join over the cache. A NULL is skipped in SQL
+ * rather than filtered afterwards: an absent optional ref (a hook-form experiment
+ * has no skill artifact) is not a dangling ref, it is no ref.
+ */
+export const collectSidecarRefs = (
+    judgment: JudgmentService,
+): Effect.Effect<ReadonlyArray<SidecarRef>, JudgmentError> =>
+    Effect.gen(function* () {
+        const all: SidecarRef[] = [];
+        for (const spec of SIDECAR_CACHE_REFS) {
+            const rows = yield* judgment.rows(
+                RefRow,
+                // Identifiers are from this module's own constant, never from a
+                // caller - the seam's quoting rule would refuse anything else.
+                `SELECT id, "${spec.column}" AS target FROM "${spec.sidecarTable}" WHERE "${spec.column}" IS NOT NULL`,
+            );
+            for (const row of rows) {
+                all.push({
+                    sidecarTable: spec.sidecarTable,
+                    sidecarId: row.id,
+                    column: spec.column,
+                    targetTable: spec.targetTable,
+                    targetId: row.target,
+                });
+            }
+        }
+        return all;
+    });
+
+/** Join collected refs against live cache ids. Thin by design: the counting
+ *  lives in `checkCacheIntegrity`, and this only supplies the `knownTables` set
+ *  that turns an empty-table ref into the right diagnosis. */
+export const checkSidecarRefs = (
+    refs: Iterable<SidecarRef>,
+    cacheIds: CacheIdIndex,
+    options?: { readonly sampleLimit?: number },
+): IntegrityReport =>
+    checkCacheIntegrity(refs, cacheIds, {
+        knownTables: SIDECAR_REF_TARGET_TABLES,
+        ...(options?.sampleLimit === undefined ? {} : { sampleLimit: options.sampleLimit }),
+    });
+
+/**
+ * What {@link fetchCacheIds} needs of a cache handle: `rows`, and nothing more.
+ *
+ * Structural rather than an import of `CacheReadService`, so this module stays
+ * free of the DuckDB seam and its dylib - and so BOTH a published `CacheRead` and
+ * a live `CacheWriteService` satisfy it without a cast. `E` is left open because
+ * the two differ in their error channel.
+ */
+export interface CacheIdReader<E> {
+    readonly rows: <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+    ) => Effect.Effect<ReadonlyArray<S["Type"]>, E, S["DecodingServices"]>;
+}
+
+const IdRow = Schema.Struct({ id: Schema.String });
+
+/**
+ * Live ids of exactly the cache tables the sidecar refers to.
+ *
+ * One `SELECT id` per target table - four statements, no joins, no `IN` list of
+ * ten thousand ids. The ids come back as a set and the comparison happens in JS,
+ * which is the same shape the wave-2 aggregates settled on for cross-table work:
+ * the alternative (a per-ref `EXISTS` subquery) is one round trip per judgment
+ * row.
+ */
+export const fetchCacheIds = <E>(
+    read: CacheIdReader<E>,
+    tables: Iterable<string> = SIDECAR_REF_TARGET_TABLES,
+): Effect.Effect<CacheIdIndex, E, (typeof IdRow)["DecodingServices"]> =>
+    Effect.gen(function* () {
+        const rows: { table: string; id: string }[] = [];
+        for (const table of tables) {
+            const ids = yield* read.rows(IdRow, `SELECT id FROM "${table}"`);
+            for (const row of ids) rows.push({ table, id: row.id });
+        }
+        return buildCacheIdIndex(rows);
+    });

--- a/packages/lib/src/sqlite/sidecar-path.test.ts
+++ b/packages/lib/src/sqlite/sidecar-path.test.ts
@@ -1,0 +1,33 @@
+// packages/lib/src/sqlite/sidecar-path.test.ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { sidecarPath } from "./sidecar.ts";
+
+const original = process.env.AX_SIDECAR_PATH;
+
+afterEach(() => {
+    if (original === undefined) delete process.env.AX_SIDECAR_PATH;
+    else process.env.AX_SIDECAR_PATH = original;
+});
+
+describe("sidecarPath", () => {
+    test("defaults to ~/.ax/judgment.sqlite - NOT under the cache directory", () => {
+        delete process.env.AX_SIDECAR_PATH;
+        const path = sidecarPath();
+        expect(path).toBe(`${homedir()}/.ax/judgment.sqlite`);
+        // The placement is the contract: `~/.ax/cache/` is the directory a user
+        // (or `ax doctor`) may delete to force a rebuild, and this file is the
+        // one thing in ax that no rebuild can reproduce.
+        expect(path).not.toContain("/.ax/cache/");
+    });
+
+    test("honours AX_SIDECAR_PATH", () => {
+        process.env.AX_SIDECAR_PATH = "/tmp/elsewhere/judgment.sqlite";
+        expect(sidecarPath()).toBe("/tmp/elsewhere/judgment.sqlite");
+    });
+
+    test("ignores a blank override rather than resolving to an empty path", () => {
+        process.env.AX_SIDECAR_PATH = "   ";
+        expect(sidecarPath()).toBe(`${homedir()}/.ax/judgment.sqlite`);
+    });
+});

--- a/packages/lib/src/sqlite/sidecar.test.ts
+++ b/packages/lib/src/sqlite/sidecar.test.ts
@@ -6,7 +6,7 @@
 // an in-memory one would pass every test here while hiding all four.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { Effect, Option, Schema } from "effect";
+import { Deferred, Effect, Fiber, Option, Schema } from "effect";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -233,10 +233,10 @@ describe("the judgment sidecar seam", () => {
     test("rolls the whole transaction back when the body fails", async () => {
         const rows = await run((j) =>
             Effect.gen(function* () {
-                const attempt = j.transaction(
+                const attempt = j.transaction((transaction) =>
                     Effect.gen(function* () {
-                        yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
-                        yield* j.put("plays_role", {
+                        yield* transaction.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                        yield* transaction.put("plays_role", {
                             id: "pr1",
                             in_id: "skill:tdd",
                             out_id: "role:reviewer",
@@ -291,17 +291,17 @@ describe("the judgment sidecar seam", () => {
         // overlap.
         const surviving = await run((j) =>
             Effect.gen(function* () {
-                const doomed = j.transaction(
+                const doomed = j.transaction((transaction) =>
                     Effect.gen(function* () {
-                        yield* j.put("role", { id: "role:doomed", name: "doomed" });
+                        yield* transaction.put("role", { id: "role:doomed", name: "doomed" });
                         yield* Effect.yieldNow;
                         return yield* Effect.fail("no" as const);
                     }),
                 );
-                const kept = j.transaction(
+                const kept = j.transaction((transaction) =>
                     Effect.gen(function* () {
                         yield* Effect.yieldNow;
-                        yield* j.put("role", { id: "role:kept", name: "kept" });
+                        yield* transaction.put("role", { id: "role:kept", name: "kept" });
                     }),
                 );
                 yield* Effect.all([Effect.ignore(doomed), kept], { concurrency: 2 });
@@ -314,12 +314,49 @@ describe("the judgment sidecar seam", () => {
         expect(surviving.map((r) => r.id)).toEqual(["role:kept"]);
     });
 
+    test("keeps ordinary statements outside another fiber's transaction", async () => {
+        const surviving = await run((j) =>
+            Effect.gen(function* () {
+                const started = yield* Deferred.make<void>();
+                const finish = yield* Deferred.make<void>();
+                const doomed = yield* Effect.forkChild(
+                    Effect.ignore(
+                        j.transaction((transaction) =>
+                            Effect.gen(function* () {
+                                yield* transaction.put("role", { id: "role:doomed", name: "doomed" });
+                                yield* Deferred.succeed(started, undefined);
+                                yield* Deferred.await(finish);
+                                return yield* Effect.fail("no" as const);
+                            }),
+                        ),
+                    ),
+                );
+
+                yield* Deferred.await(started);
+                const ordinary = yield* Effect.forkChild(
+                    j.put("role", { id: "role:kept", name: "kept" }),
+                );
+                yield* Effect.yieldNow;
+                yield* Deferred.succeed(finish, undefined);
+                yield* Fiber.join(doomed);
+                yield* Fiber.join(ordinary);
+
+                return yield* j.rows(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM role ORDER BY id",
+                );
+            }),
+        );
+
+        expect(surviving.map((r) => r.id)).toEqual(["role:kept"]);
+    });
+
     test("commits a transaction that succeeds, visible to a SEPARATE connection", async () => {
         await run((j) =>
-            j.transaction(
+            j.transaction((transaction) =>
                 Effect.gen(function* () {
-                    yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
-                    yield* j.put("plays_role", {
+                    yield* transaction.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                    yield* transaction.put("plays_role", {
                         id: "pr1",
                         in_id: "skill:tdd",
                         out_id: "role:reviewer",

--- a/packages/lib/src/sqlite/sidecar.test.ts
+++ b/packages/lib/src/sqlite/sidecar.test.ts
@@ -6,11 +6,12 @@
 // an in-memory one would pass every test here while hiding all four.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { Deferred, Effect, Fiber, Option, Schema } from "effect";
-import { mkdtempSync, rmSync } from "node:fs";
+import { Deferred, Effect, Exit, Fiber, Option, Schema } from "effect";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { roleRowId } from "../stable-id.ts";
 import {
     BooleanColumn,
     Judgment,
@@ -235,11 +236,11 @@ describe("the judgment sidecar seam", () => {
             Effect.gen(function* () {
                 const attempt = j.transaction((transaction) =>
                     Effect.gen(function* () {
-                        yield* transaction.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                        yield* transaction.put("role", { id: roleRowId("reviewer"), name: "reviewer", weight: 2 });
                         yield* transaction.put("plays_role", {
                             id: "pr1",
                             in_id: "skill:tdd",
-                            out_id: "role:reviewer",
+                            out_id: roleRowId("reviewer"),
                             source: "user",
                         });
                         return yield* Effect.fail("the scaffold step failed" as const);
@@ -283,6 +284,26 @@ describe("the judgment sidecar seam", () => {
         expect(Option.getOrNull(n)?.n).toBe(0);
     });
 
+    test("closes each local database handle when setup fails before ownership transfer", async () => {
+        const before = readdirSync("/dev/fd").length;
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const j = yield* Judgment;
+                for (let attempt = 0; attempt < 20; attempt += 1) {
+                    yield* Effect.ignore(j.exec("SELECT 1"));
+                }
+            }).pipe(
+                Effect.scoped,
+                Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: "INVALID SQL" })),
+            ),
+        );
+        const after = readdirSync("/dev/fd").length;
+
+        // Opening one failed SQLite database can allocate the database and WAL
+        // descriptors. Repeated retries must not retain one pair per attempt.
+        expect(after).toBeLessThanOrEqual(before + 2);
+    });
+
     test("serialises concurrent transactions instead of interleaving them on one connection", async () => {
         // A SQLite transaction belongs to the CONNECTION. Two fibers issuing
         // BEGIN/COMMIT against this shared handle would commit each other's work
@@ -293,7 +314,7 @@ describe("the judgment sidecar seam", () => {
             Effect.gen(function* () {
                 const doomed = j.transaction((transaction) =>
                     Effect.gen(function* () {
-                        yield* transaction.put("role", { id: "role:doomed", name: "doomed" });
+                        yield* transaction.put("role", { id: roleRowId("doomed"), name: "doomed" });
                         yield* Effect.yieldNow;
                         return yield* Effect.fail("no" as const);
                     }),
@@ -301,7 +322,7 @@ describe("the judgment sidecar seam", () => {
                 const kept = j.transaction((transaction) =>
                     Effect.gen(function* () {
                         yield* Effect.yieldNow;
-                        yield* transaction.put("role", { id: "role:kept", name: "kept" });
+                        yield* transaction.put("role", { id: roleRowId("kept"), name: "kept" });
                     }),
                 );
                 yield* Effect.all([Effect.ignore(doomed), kept], { concurrency: 2 });
@@ -311,7 +332,7 @@ describe("the judgment sidecar seam", () => {
                 );
             }),
         );
-        expect(surviving.map((r) => r.id)).toEqual(["role:kept"]);
+        expect(surviving.map((r) => r.id)).toEqual([roleRowId("kept")]);
     });
 
     test("keeps ordinary statements outside another fiber's transaction", async () => {
@@ -323,7 +344,7 @@ describe("the judgment sidecar seam", () => {
                     Effect.ignore(
                         j.transaction((transaction) =>
                             Effect.gen(function* () {
-                                yield* transaction.put("role", { id: "role:doomed", name: "doomed" });
+                                yield* transaction.put("role", { id: roleRowId("doomed"), name: "doomed" });
                                 yield* Deferred.succeed(started, undefined);
                                 yield* Deferred.await(finish);
                                 return yield* Effect.fail("no" as const);
@@ -334,7 +355,7 @@ describe("the judgment sidecar seam", () => {
 
                 yield* Deferred.await(started);
                 const ordinary = yield* Effect.forkChild(
-                    j.put("role", { id: "role:kept", name: "kept" }),
+                    j.put("role", { id: roleRowId("kept"), name: "kept" }),
                 );
                 yield* Effect.yieldNow;
                 yield* Deferred.succeed(finish, undefined);
@@ -348,18 +369,18 @@ describe("the judgment sidecar seam", () => {
             }),
         );
 
-        expect(surviving.map((r) => r.id)).toEqual(["role:kept"]);
+        expect(surviving.map((r) => r.id)).toEqual([roleRowId("kept")]);
     });
 
     test("commits a transaction that succeeds, visible to a SEPARATE connection", async () => {
         await run((j) =>
             j.transaction((transaction) =>
                 Effect.gen(function* () {
-                    yield* transaction.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                    yield* transaction.put("role", { id: roleRowId("reviewer"), name: "reviewer", weight: 2 });
                     yield* transaction.put("plays_role", {
                         id: "pr1",
                         in_id: "skill:tdd",
-                        out_id: "role:reviewer",
+                        out_id: roleRowId("reviewer"),
                         source: "user",
                     });
                 }),
@@ -372,5 +393,71 @@ describe("the judgment sidecar seam", () => {
         const n = other.query<{ n: number }, []>("SELECT count(*) AS n FROM plays_role").get()?.n;
         other.close();
         expect(n).toBe(1);
+    });
+
+    test("rolls back a deferred constraint failure before the next operation uses the connection", async () => {
+        const result = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.exec("PRAGMA foreign_keys = ON");
+                yield* j.exec("CREATE TABLE parent (id TEXT PRIMARY KEY)");
+                yield* j.exec(
+                    "CREATE TABLE child (id TEXT PRIMARY KEY, parent_id TEXT NOT NULL, " +
+                        "FOREIGN KEY(parent_id) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)",
+                );
+
+                const failedCommit = yield* Effect.exit(
+                    j.transaction((transaction) =>
+                        transaction.exec("INSERT INTO child (id, parent_id) VALUES (?, ?)", ["child-1", "missing"]),
+                    ),
+                );
+
+                const childCount = yield* j.first(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT count(*) AS n FROM child",
+                );
+                yield* j.transaction((transaction) =>
+                    transaction.exec("INSERT INTO parent (id) VALUES (?)", ["parent-1"]),
+                );
+                return { failedCommit, childCount };
+            }),
+        );
+
+        expect(Exit.isFailure(result.failedCommit)).toBe(true);
+        expect(Option.getOrNull(result.childCount)?.n).toBe(0);
+
+        const other = new Database(sidecarPath, { readonly: true });
+        const parentCount = other.query<{ n: number }, []>("SELECT count(*) AS n FROM parent").get()?.n;
+        other.close();
+        expect(parentCount).toBe(1);
+    });
+
+    test("closes and replaces the connection when rollback itself fails", async () => {
+        const result = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.exec("CREATE TEMP TABLE connection_marker (id INTEGER)");
+
+                // The body ends the transaction early. The release action then
+                // gets a real COMMIT failure followed by a real ROLLBACK failure.
+                const failedCleanup = yield* Effect.exit(
+                    j.transaction((transaction) => transaction.exec("ROLLBACK")),
+                );
+                const oldConnectionMarker = yield* Effect.exit(
+                    j.raw("SELECT id FROM connection_marker"),
+                );
+
+                yield* j.transaction((transaction) =>
+                    transaction.put("role", { id: roleRowId("after-reopen"), name: "after-reopen" }),
+                );
+                return { failedCleanup, oldConnectionMarker };
+            }),
+        );
+
+        expect(Exit.isFailure(result.failedCleanup)).toBe(true);
+        expect(Exit.isFailure(result.oldConnectionMarker)).toBe(true);
+
+        const other = new Database(sidecarPath, { readonly: true });
+        const roleCount = other.query<{ n: number }, []>("SELECT count(*) AS n FROM role").get()?.n;
+        other.close();
+        expect(roleCount).toBe(1);
     });
 });

--- a/packages/lib/src/sqlite/sidecar.test.ts
+++ b/packages/lib/src/sqlite/sidecar.test.ts
@@ -1,0 +1,339 @@
+// packages/lib/src/sqlite/sidecar.test.ts
+//
+// The judgment seam, against a REAL SQLite file in a temp directory - never
+// `:memory:`. WAL, `BEGIN IMMEDIATE`, busy timeouts and "does a second
+// connection see the commit" are all properties of a file-backed database, and
+// an in-memory one would pass every test here while hiding all four.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Effect, Option, Schema } from "effect";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import {
+    BooleanColumn,
+    Judgment,
+    JudgmentLayer,
+    TimestampColumn,
+    type JudgmentService,
+} from "./index.ts";
+
+let dir: string;
+let sidecarPath: string;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ax-judgment-"));
+    sidecarPath = join(dir, "judgment.sqlite");
+});
+
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+/** Run `body` against a real sidecar at `sidecarPath`. */
+const run = <A, E>(
+    body: (judgment: JudgmentService) => Effect.Effect<A, E, never>,
+): Promise<A> =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            return yield* body(judgment);
+        }).pipe(Effect.scoped, Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }))) as Effect.Effect<A, E>,
+    );
+
+const ProposalRow = Schema.Struct({
+    id: Schema.String,
+    title: Schema.String,
+    status: Schema.String,
+    frequency: Schema.Number,
+    created_at: TimestampColumn,
+});
+
+describe("the judgment sidecar seam", () => {
+    test("creates the database and applies the DDL on first use", async () => {
+        const tables = await run((j) =>
+            j.rows(Schema.Struct({ name: Schema.String }), "SELECT name FROM sqlite_master WHERE type='table'"),
+        );
+        expect(tables.map((t) => t.name)).toContain("proposal");
+    });
+
+    test("round-trips a row through put and rows", async () => {
+        const found = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.put("proposal", {
+                    id: "p1",
+                    form: "skill",
+                    title: "extract the worktree guard",
+                    hypothesis: "it fires often enough to be a skill",
+                    dedupe_sig: "sig-1",
+                    confidence: "high",
+                    frequency: 7,
+                });
+                return yield* j.rows(ProposalRow, "SELECT id, title, status, frequency, created_at FROM proposal");
+            }),
+        );
+        expect(found).toHaveLength(1);
+        expect(found[0]?.title).toBe("extract the worktree guard");
+        // The DDL's DEFAULTs apply to columns `put` did not name.
+        expect(found[0]?.status).toBe("open");
+        expect(found[0]?.frequency).toBe(7);
+        expect(found[0]?.created_at).toBeInstanceOf(Date);
+    });
+
+    test("put REPLACES a row with the same id rather than appending a duplicate", async () => {
+        const rows = await run((j) =>
+            Effect.gen(function* () {
+                const base = {
+                    id: "p1",
+                    form: "skill",
+                    hypothesis: "h",
+                    dedupe_sig: "sig-1",
+                    confidence: "high",
+                };
+                yield* j.put("proposal", { ...base, title: "first" });
+                yield* j.put("proposal", { ...base, title: "second" });
+                return yield* j.rows(ProposalRow, "SELECT id, title, status, frequency, created_at FROM proposal");
+            }),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.title).toBe("second");
+    });
+
+    test("first is about absence, not cardinality", async () => {
+        const [empty, present] = await run((j) =>
+            Effect.gen(function* () {
+                const before = yield* j.first(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM proposal WHERE id = ?",
+                    ["nope"],
+                );
+                yield* j.put("proposal", {
+                    id: "p1",
+                    form: "skill",
+                    title: "t",
+                    hypothesis: "h",
+                    dedupe_sig: "sig",
+                    confidence: "low",
+                });
+                const after = yield* j.first(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM proposal WHERE id = ?",
+                    ["p1"],
+                );
+                return [before, after] as const;
+            }),
+        );
+        expect(Option.isNone(empty)).toBe(true);
+        expect(Option.getOrNull(present)?.id).toBe("p1");
+    });
+
+    test("stores a Date parameter as an ISO-8601 UTC instant that decodes back to the same time", async () => {
+        const when = new Date("2026-08-15T09:41:07.123Z");
+        const [text, decoded] = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.put("retro", {
+                    id: "r1",
+                    session: "sess-1",
+                    source: "manual",
+                    tried: "the port",
+                    created_at: when,
+                });
+                const raw = yield* j.first(
+                    Schema.Struct({ created_at: Schema.String }),
+                    "SELECT created_at FROM retro",
+                );
+                const typed = yield* j.first(
+                    Schema.Struct({ created_at: TimestampColumn }),
+                    "SELECT created_at FROM retro",
+                );
+                return [Option.getOrNull(raw)?.created_at, Option.getOrNull(typed)?.created_at] as const;
+            }),
+        );
+        expect(text).toBe("2026-08-15T09:41:07.123Z");
+        expect(decoded?.getTime()).toBe(when.getTime());
+    });
+
+    test("stores a boolean parameter as 0/1 and decodes it back as a boolean", async () => {
+        const decoded = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.put("transcript_label_review", {
+                    id: "tlr1",
+                    candidate_id: "c1",
+                    label_family: "reaction",
+                    review_status: "reviewed",
+                    promotion_safe: true,
+                    reviewer: "necmttn",
+                    rationale: "matches two prior confirmations",
+                    evidence_paths_json: "[]",
+                });
+                return yield* j.first(
+                    Schema.Struct({ promotion_safe: BooleanColumn, raw: Schema.Number }),
+                    "SELECT promotion_safe, promotion_safe AS raw FROM transcript_label_review",
+                );
+            }),
+        );
+        expect(Option.getOrNull(decoded)?.promotion_safe).toBe(true);
+        expect(Option.getOrNull(decoded)?.raw).toBe(1);
+    });
+
+    test("refuses a batch whose rows carry no id, rather than appending duplicates", async () => {
+        const failure = await run((j) =>
+            Effect.flip(
+                j.putMany("skill_triage_decision", [{ skill_name: "tdd", decision: "keep" }]),
+            ),
+        );
+        expect(failure._tag).toBe("SidecarQueryError");
+        expect(failure.message).toContain("needs an `id` on every row");
+    });
+
+    test("refuses a ragged batch, rather than NULLing the columns a row omitted", async () => {
+        const failure = await run((j) =>
+            Effect.flip(
+                j.putMany("skill_triage_decision", [
+                    { id: "d1", skill_name: "tdd", decision: "keep", reason: "used weekly" },
+                    { id: "d2", skill_name: "brainstorming", decision: "keep" },
+                ]),
+            ),
+        );
+        expect(failure._tag).toBe("SidecarQueryError");
+        expect(failure.message).toContain("same columns");
+    });
+
+    test("refuses a table name it cannot safely quote", async () => {
+        const failure = await run((j) =>
+            Effect.flip(j.put("proposal; DROP TABLE proposal", { id: "x" })),
+        );
+        expect(failure._tag).toBe("SidecarQueryError");
+        expect(failure.message).toContain("cannot be a bound parameter");
+    });
+
+    test("writes a batch larger than one statement's worth of rows", async () => {
+        // PUT_BATCH_ROWS is 200; 450 forces three statements, and the last one is
+        // a different width than the first two.
+        const count = await run((j) =>
+            Effect.gen(function* () {
+                yield* j.putMany(
+                    "skill_triage_decision",
+                    Array.from({ length: 450 }, (_, i) => ({
+                        id: `d${i}`,
+                        skill_name: `skill-${i}`,
+                        decision: "keep",
+                    })),
+                );
+                return yield* j.first(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT count(*) AS n FROM skill_triage_decision",
+                );
+            }),
+        );
+        expect(Option.getOrNull(count)?.n).toBe(450);
+    });
+
+    test("rolls the whole transaction back when the body fails", async () => {
+        const rows = await run((j) =>
+            Effect.gen(function* () {
+                const attempt = j.transaction(
+                    Effect.gen(function* () {
+                        yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                        yield* j.put("plays_role", {
+                            id: "pr1",
+                            in_id: "skill:tdd",
+                            out_id: "role:reviewer",
+                            source: "user",
+                        });
+                        return yield* Effect.fail("the scaffold step failed" as const);
+                    }),
+                );
+                yield* Effect.flip(attempt);
+                // Neither half may survive: the role tag and the role it points
+                // at are one decision, and half of it is a dangling tag.
+                return yield* j.rows(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT (SELECT count(*) FROM role) + (SELECT count(*) FROM plays_role) AS n",
+                );
+            }),
+        );
+        expect(rows[0]?.n).toBe(0);
+    });
+
+    test("opens the sidecar in WAL mode, so a reader never blocks on a writer", async () => {
+        await run((j) => j.exec("SELECT 1"));
+        const other = new Database(sidecarPath, { readonly: true });
+        const mode = other.query<{ journal_mode: string }, []>("PRAGMA journal_mode").get()?.journal_mode;
+        other.close();
+        expect(mode).toBe("wal");
+    });
+
+    test("creates a missing parent directory rather than failing on first run", async () => {
+        // First run on a fresh machine has no `~/.ax` at all.
+        const nested = join(dir, "does", "not", "exist", "judgment.sqlite");
+        const n = await Effect.runPromise(
+            Effect.gen(function* () {
+                const j = yield* Judgment;
+                return yield* j.first(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT count(*) AS n FROM proposal",
+                );
+            }).pipe(
+                Effect.scoped,
+                Effect.provide(JudgmentLayer({ sidecarPath: nested, schemaSql: SIDECAR_SCHEMA_SQL })),
+            ),
+        );
+        expect(Option.getOrNull(n)?.n).toBe(0);
+    });
+
+    test("serialises concurrent transactions instead of interleaving them on one connection", async () => {
+        // A SQLite transaction belongs to the CONNECTION. Two fibers issuing
+        // BEGIN/COMMIT against this shared handle would commit each other's work
+        // and roll back each other's, so a failing transaction must not be able
+        // to take a succeeding one down with it - which is what happens if they
+        // overlap.
+        const surviving = await run((j) =>
+            Effect.gen(function* () {
+                const doomed = j.transaction(
+                    Effect.gen(function* () {
+                        yield* j.put("role", { id: "role:doomed", name: "doomed" });
+                        yield* Effect.yieldNow;
+                        return yield* Effect.fail("no" as const);
+                    }),
+                );
+                const kept = j.transaction(
+                    Effect.gen(function* () {
+                        yield* Effect.yieldNow;
+                        yield* j.put("role", { id: "role:kept", name: "kept" });
+                    }),
+                );
+                yield* Effect.all([Effect.ignore(doomed), kept], { concurrency: 2 });
+                return yield* j.rows(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM role ORDER BY id",
+                );
+            }),
+        );
+        expect(surviving.map((r) => r.id)).toEqual(["role:kept"]);
+    });
+
+    test("commits a transaction that succeeds, visible to a SEPARATE connection", async () => {
+        await run((j) =>
+            j.transaction(
+                Effect.gen(function* () {
+                    yield* j.put("role", { id: "role:reviewer", name: "reviewer", weight: 2 });
+                    yield* j.put("plays_role", {
+                        id: "pr1",
+                        in_id: "skill:tdd",
+                        out_id: "role:reviewer",
+                        source: "user",
+                    });
+                }),
+            ),
+        );
+        // Not through the seam: a second process is the case that matters (the
+        // CLI writes, the daemon reads), and a same-connection read would pass
+        // even if the commit never reached the file.
+        const other = new Database(sidecarPath, { readonly: true });
+        const n = other.query<{ n: number }, []>("SELECT count(*) AS n FROM plays_role").get()?.n;
+        other.close();
+        expect(n).toBe(1);
+    });
+});

--- a/packages/lib/src/sqlite/sidecar.test.ts
+++ b/packages/lib/src/sqlite/sidecar.test.ts
@@ -209,6 +209,91 @@ describe("the judgment sidecar seam", () => {
         expect(failure.message).toContain("cannot be a bound parameter");
     });
 
+    describe("one statement per call", () => {
+        // `bun:sqlite` prepares the FIRST statement and silently drops the rest.
+        // On a durable store that is a decision written and its replacement lost,
+        // reported as success - so the seam refuses instead.
+
+        test("refuses two statements in exec, and writes NEITHER", async () => {
+            const outcome = await run((j) =>
+                Effect.gen(function* () {
+                    const failure = yield* Effect.flip(
+                        j.exec(
+                            "INSERT INTO role (id, name) VALUES ('r1', 'first'); " +
+                                "INSERT INTO role (id, name) VALUES ('r2', 'second')",
+                        ),
+                    );
+                    const count = yield* j.first(
+                        Schema.Struct({ n: Schema.Number }),
+                        "SELECT count(*) AS n FROM role",
+                    );
+                    return { failure, count };
+                }),
+            );
+            expect(outcome.failure._tag).toBe("SidecarQueryError");
+            expect(outcome.failure.message).toContain("more than one statement");
+            // The refusal is the point: without it the first INSERT would land
+            // and the second would vanish, leaving a half-applied write.
+            expect(Option.getOrNull(outcome.count)?.n).toBe(0);
+        });
+
+        test("refuses two statements in raw", async () => {
+            const failure = await run((j) => Effect.flip(j.raw("SELECT 1; SELECT 2")));
+            expect(failure._tag).toBe("SidecarQueryError");
+            expect(failure.message).toContain("more than one statement");
+        });
+
+        test("refuses two statements inside a transaction body too", async () => {
+            const failure = await run((j) =>
+                Effect.flip(
+                    j.transaction((transaction) =>
+                        transaction.exec("DELETE FROM role; DELETE FROM plays_role"),
+                    ),
+                ),
+            );
+            expect(failure._tag).toBe("SidecarQueryError");
+            expect(failure.message).toContain("more than one statement");
+        });
+
+        test("allows a trailing semicolon, and a semicolon inside a value", async () => {
+            const found = await run((j) =>
+                Effect.gen(function* () {
+                    yield* j.exec("INSERT INTO role (id, name) VALUES (?, ?);", ["r1", "a-role"]);
+                    // The bound value carries a semicolon. It is data, not a
+                    // separator, and refusing it would push callers off bound
+                    // parameters - the opposite of what this seam wants.
+                    yield* j.put("plays_role", {
+                        id: "pr1",
+                        in_id: "skill:tdd",
+                        out_id: "r1",
+                        source: "user",
+                        rationale: "runs; then checks",
+                    });
+                    return yield* j.first(
+                        Schema.Struct({ rationale: Schema.String }),
+                        "SELECT rationale FROM plays_role WHERE id = ?",
+                        ["pr1"],
+                    );
+                }),
+            );
+            expect(Option.getOrNull(found)?.rationale).toBe("runs; then checks");
+        });
+
+        test("still applies the multi-statement DDL on open", async () => {
+            // The exemption that makes the guard usable at all: `schemaSql` is
+            // the whole sidecar DDL and runs on `database.exec`, not through the
+            // seam. If the guard had leaked into that path, no table would exist.
+            const tables = await run((j) =>
+                j.rows(
+                    Schema.Struct({ name: Schema.String }),
+                    "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+                ),
+            );
+            expect(tables.map((t) => t.name)).toContain("plays_role");
+            expect(tables.map((t) => t.name)).toContain("session_label");
+        });
+    });
+
     test("writes a batch larger than one statement's worth of rows", async () => {
         // PUT_BATCH_ROWS is 200; 450 forces three statements, and the last one is
         // a different width than the first two.
@@ -454,6 +539,73 @@ describe("the judgment sidecar seam", () => {
 
         expect(Exit.isFailure(result.failedCleanup)).toBe(true);
         expect(Exit.isFailure(result.oldConnectionMarker)).toBe(true);
+
+        const other = new Database(sidecarPath, { readonly: true });
+        const roleCount = other.query<{ n: number }, []>("SELECT count(*) AS n FROM role").get()?.n;
+        other.close();
+        expect(roleCount).toBe(1);
+    });
+
+    test("retries an operation that was queued behind a connection-killing transaction", async () => {
+        // The blast radius of a replaced connection must be the transaction that
+        // caused it - NOT whatever else was waiting on the permit. A queued
+        // operation is refused before it touches the dead handle, so nothing ran
+        // and the layer can safely run it again on a fresh connection.
+        const outcome = await run((j) =>
+            Effect.gen(function* () {
+                // Bound to the connection, so its absence later PROVES a
+                // different connection answered.
+                yield* j.exec("CREATE TEMP TABLE connection_marker (id INTEGER)");
+
+                const inTransaction = yield* Deferred.make<void>();
+                const release = yield* Deferred.make<void>();
+
+                const killer = yield* Effect.forkChild(
+                    Effect.exit(
+                        j.transaction((transaction) =>
+                            Effect.gen(function* () {
+                                yield* Deferred.succeed(inTransaction, undefined);
+                                yield* Deferred.await(release);
+                                // Ends the transaction from inside the body, so
+                                // the release action meets a real COMMIT failure
+                                // and then a real ROLLBACK failure.
+                                yield* transaction.exec("ROLLBACK");
+                            }),
+                        ),
+                    ),
+                );
+
+                yield* Deferred.await(inTransaction);
+                const queued = yield* Effect.forkChild(
+                    Effect.exit(j.put("role", { id: roleRowId("queued"), name: "queued" })),
+                );
+                // Let `queued` resolve the service and block on the permit, so it
+                // is genuinely waiting when the connection dies.
+                yield* Effect.yieldNow;
+                yield* Effect.yieldNow;
+                yield* Effect.yieldNow;
+                yield* Deferred.succeed(release, undefined);
+
+                const killerExit = yield* Fiber.join(killer);
+                const queuedExit = yield* Fiber.join(queued);
+                const markerExit = yield* Effect.exit(j.raw("SELECT id FROM connection_marker"));
+                const rows = yield* j.rows(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM role ORDER BY id",
+                );
+                return { killerExit, queuedExit, markerExit, rows };
+            }),
+        );
+
+        // The transaction that broke the connection still fails. Its body RAN,
+        // so it is never retried and never silently repeated.
+        expect(Exit.isFailure(outcome.killerExit)).toBe(true);
+        // The bystander does not.
+        expect(Exit.isSuccess(outcome.queuedExit)).toBe(true);
+        // The temp table is gone, so the retry really did use a NEW connection.
+        expect(Exit.isFailure(outcome.markerExit)).toBe(true);
+        // Written exactly once - not zero (dropped) and not twice (replayed).
+        expect(outcome.rows.map((r) => r.id)).toEqual([roleRowId("queued")]);
 
         const other = new Database(sidecarPath, { readonly: true });
         const roleCount = other.query<{ n: number }, []>("SELECT count(*) AS n FROM role").get()?.n;

--- a/packages/lib/src/sqlite/sidecar.ts
+++ b/packages/lib/src/sqlite/sidecar.ts
@@ -1,0 +1,454 @@
+// packages/lib/src/sqlite/sidecar.ts
+/**
+ * THE JUDGMENT SEAM. Every v2 read and every v2 write of durable judgment -
+ * proposals, verdicts, role tags and weights, retros, triage calls, label
+ * reviews, dogfood results, spar labels - goes through this module.
+ *
+ * READ IT AGAINST ITS SIBLING, `@ax/lib/duckdb/seam`. That one is deliberately
+ * ASYMMETRICAL: reads open a published snapshot read-only, writes happen only
+ * inside ingest under the ingest lock, and there is no other way to obtain a
+ * writer. This one is deliberately SYMMETRICAL - one service, read and write,
+ * available to any command at any time - and the difference is the entire reason
+ * the sidecar exists:
+ *
+ *   - The cache is REBUILDABLE and huge. Its writes are a batch job (ingest),
+ *     so serialising them behind a lock costs nothing and buys atomic publish.
+ *   - Judgment is DURABLE and tiny. Its writes are REQUEST-TIME: `ax improve
+ *     accept`, `ax skills tag`, `ax retro emit`, a dashboard triage click. There
+ *     is no ingest run to attach them to. Making a user take the ingest lock to
+ *     record a decision - or worse, wait for the next ingest - is not a policy,
+ *     it is a bug, and it is why several wave-2 CLI and dashboard ports were
+ *     blocked until this module existed.
+ *
+ * WHAT THIS SEAM OWNS THAT THE DDL CANNOT SAY:
+ *
+ *  1. PARAMETER NORMALISATION. SQLite has no Date and no boolean. A caller binds
+ *     a JS `Date` and it is stored as the ISO-8601 UTC text the DDL declares; a
+ *     caller binds `true` and it is stored as 1. Without this every writer would
+ *     hand-roll `.toISOString()` and `? 1 : 0`, and the first one to forget
+ *     writes a local-time string that reads back hours wrong (see
+ *     `TimestampColumn` in ./columns.ts for that failure in full).
+ *  2. TRANSACTIONS THAT SPAN AN EFFECT. `bun:sqlite`'s own `db.transaction()`
+ *     takes a SYNCHRONOUS function, which no Effect body is. {@link transaction}
+ *     drives `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` around an arbitrary effect
+ *     instead - see its docstring for why IMMEDIATE and why one permit.
+ *  3. Identifier quoting and validation, for the same reason the cache seam owns
+ *     it: a table or column name is the one part of a statement that cannot be a
+ *     bound parameter.
+ *
+ * WAL, AND WHY THE SIDECAR CAN BE OPEN IN TWO PROCESSES AT ONCE. `ax serve`
+ * holds the sidecar open for the dashboard while the user runs `ax improve
+ * accept` in a terminal. Under SQLite's default rollback journal the writer
+ * would block every reader for the duration of its transaction; under WAL,
+ * readers never block and never see a partial transaction. `busy_timeout` then
+ * covers the one case WAL does not - two WRITERS - by waiting rather than
+ * failing, because a judgment write that loses a millisecond race should retry,
+ * not report an error to the user.
+ *
+ * RULING R6: runtime module under `packages/lib/src/` - `node:fs` / `node:path`
+ * are banned; filesystem access goes through `FileSystem.FileSystem`. `bun:sqlite`
+ * is fine (this package is Bun-only regardless, as `bun:ffi` already is), and
+ * `node:os` `homedir()` is not banned - {@link sidecarPath}'s default uses it.
+ */
+import { BunFileSystem } from "@effect/platform-bun";
+import { Database } from "bun:sqlite";
+import { Context, Effect, FileSystem, Layer, Option, Schema, Semaphore } from "effect";
+import { homedir } from "node:os";
+import { posixPath } from "../shared/path.ts";
+import {
+    errorMessage,
+    SidecarDecodeError,
+    SidecarQueryError,
+    SidecarUnavailableError,
+    sqlExcerpt,
+    type JudgmentError,
+} from "./errors.ts";
+
+/**
+ * What a caller may bind. `Date` and `boolean` are in the list because the seam
+ * normalises them (see {@link toBindable}); `undefined` is NOT, so a row built
+ * from an optional field that turned out absent is a type error at the call site
+ * rather than a silent NULL in a judgment row.
+ */
+export type SidecarParam = string | number | bigint | boolean | Date | Uint8Array | null;
+
+/** A raw cell as SQLite hands it back. */
+export type SidecarValue = string | number | bigint | Uint8Array | null;
+
+export type SidecarRow = Readonly<Record<string, SidecarValue>>;
+
+export interface JudgmentService {
+    /** Every row, decoded through `schema`. Use the named column codecs in
+     *  `./columns.ts` so the decode contract is explicit at the call site. */
+    readonly rows: <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ) => Effect.Effect<ReadonlyArray<S["Type"]>, JudgmentError, S["DecodingServices"]>;
+    /** The first row, or `none`. A second row is NOT an error - callers that
+     *  want one row write `LIMIT 1`; this is about absence, not cardinality. */
+    readonly first: <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ) => Effect.Effect<Option.Option<S["Type"]>, JudgmentError, S["DecodingServices"]>;
+    /** Undecoded rows, for shapes no schema fits (a `PRAGMA`, a runtime-built
+     *  aggregate). */
+    readonly raw: (
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ) => Effect.Effect<ReadonlyArray<SidecarRow>, JudgmentError>;
+    /** Rows changed. */
+    readonly exec: (
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ) => Effect.Effect<number, JudgmentError>;
+    /** Upsert one row, keyed on `id`. */
+    readonly put: (
+        table: string,
+        row: Readonly<Record<string, SidecarParam>>,
+    ) => Effect.Effect<void, JudgmentError>;
+    /** {@link put} for many rows of the SAME SHAPE, batched into multi-row
+     *  INSERTs. Rows with differing column sets are a typed refusal, not a
+     *  silently-ragged insert. */
+    readonly putMany: (
+        table: string,
+        rows: ReadonlyArray<Readonly<Record<string, SidecarParam>>>,
+    ) => Effect.Effect<void, JudgmentError>;
+    /**
+     * Run `body` inside ONE transaction: committed if it succeeds, rolled back
+     * if it fails or is interrupted.
+     */
+    readonly transaction: <A, E, R>(
+        body: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | JudgmentError, R>;
+    /** The sidecar file this service is bound to (resolved, not the spelling). */
+    readonly path: string;
+}
+
+export class Judgment extends Context.Service<Judgment, JudgmentService>()("ax/Judgment") {}
+
+/** `AX_SIDECAR_PATH`, or `~/.ax/judgment.sqlite`.
+ *
+ *  NOT under `~/.ax/cache/`, and that placement is the contract: everything in
+ *  that directory is safe to delete and re-derive, and this file is the one
+ *  thing in ax that is not. */
+export const sidecarPath = (): string => {
+    const override = process.env.AX_SIDECAR_PATH?.trim();
+    return override ? override : posixPath.join(homedir(), ".ax", "judgment.sqlite");
+};
+
+/** The identifier shape this seam will emit. Anything else is refused rather
+ *  than quoted-and-hoped. */
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const quoteIdentifier = (
+    kind: "table" | "column",
+    name: string,
+): Effect.Effect<string, SidecarQueryError> =>
+    IDENTIFIER.test(name)
+        ? Effect.succeed(`"${name}"`)
+        : Effect.fail(
+              new SidecarQueryError({
+                  sql: "",
+                  message: `refusing to build a statement with the ${kind} name ${JSON.stringify(
+                      name,
+                  )}: a ${kind} name cannot be a bound parameter, so this seam only emits names matching ${IDENTIFIER}`,
+              }),
+          );
+
+/** How many rows one `putMany` statement carries. SQLite's default parameter
+ *  limit is 32766 (SQLITE_MAX_VARIABLE_NUMBER since 3.32), so 200 rows leaves
+ *  headroom for a table well past this schema's widest (dogfood_run, 19). */
+const PUT_BATCH_ROWS = 200;
+
+/**
+ * Normalise one bound value to something `bun:sqlite` accepts, applying the two
+ * conversions the DDL's types imply (see the TYPES block in schema.sidecar.sql).
+ */
+const toBindable = (value: SidecarParam): SidecarValue => {
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === "boolean") return value ? 1 : 0;
+    return value;
+};
+
+export interface JudgmentLayerOptions {
+    /**
+     * DDL applied on open. REQUIRED, and the caller supplies the text, because
+     * `@ax/lib` deliberately has no RUNTIME dependency on `@ax/schema` - the DDL
+     * lives in the schema package and importing it here would create a package
+     * cycle (see the note in ../stable-id.ts, and `CacheWriteOptions.schemaSql`,
+     * which is required for the same reason). Pass `SIDECAR_SCHEMA_SQL` from
+     * `@ax/schema/sidecar-ddl`; every statement in it is `IF NOT EXISTS`, so
+     * applying it on every open is idempotent and makes the sidecar
+     * self-healing. Pass `null` to skip it.
+     */
+    readonly schemaSql: string | null;
+    /** Defaults to {@link sidecarPath}. */
+    readonly sidecarPath?: string;
+    /** How long a write waits for another writer before failing. */
+    readonly busyTimeoutMs?: number;
+}
+
+const DEFAULT_BUSY_TIMEOUT_MS = 5_000;
+
+/** Build the service over an open database. Split out from the layer so the
+ *  service's behaviour is testable without the lazy-open machinery around it. */
+const serviceOver = (db: Database, path: string): JudgmentService => {
+    // ONE permit, held for the whole of a transaction. SQLite transactions are a
+    // property of the CONNECTION, not of a call: two fibers interleaving
+    // BEGIN/COMMIT on this shared handle would commit each other's work and roll
+    // back each other's. The permit makes "a transaction is exclusive on this
+    // connection" true rather than hoped-for. It is NOT held by ordinary
+    // statements, which are individually atomic and need no serialisation.
+    const txGate = Semaphore.makeUnsafe(1);
+
+    const bind = (params?: ReadonlyArray<SidecarParam>): SidecarValue[] =>
+        (params ?? []).map(toBindable);
+
+    const raw: JudgmentService["raw"] = (sql, params) =>
+        Effect.try({
+            try: () => db.query(sql).all(...bind(params)) as ReadonlyArray<SidecarRow>,
+            catch: (err) =>
+                new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+        });
+
+    const exec: JudgmentService["exec"] = (sql, params) =>
+        Effect.try({
+            try: () => db.query(sql).run(...bind(params)).changes,
+            catch: (err) =>
+                new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+        });
+
+    const rows: JudgmentService["rows"] = <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ) =>
+        raw(sql, params).pipe(
+            Effect.flatMap((all) =>
+                Schema.decodeUnknownEffect(Schema.Array(schema))(all).pipe(
+                    Effect.mapError(
+                        (issue) =>
+                            new SidecarDecodeError({ sql: sqlExcerpt(sql), message: String(issue) }),
+                    ),
+                ),
+            ),
+        ) as Effect.Effect<ReadonlyArray<S["Type"]>, JudgmentError, S["DecodingServices"]>;
+
+    const first = <S extends Schema.Top>(
+        schema: S,
+        sql: string,
+        params?: ReadonlyArray<SidecarParam>,
+    ): Effect.Effect<Option.Option<S["Type"]>, JudgmentError, S["DecodingServices"]> =>
+        Effect.map(rows(schema, sql, params), (all) =>
+            all.length === 0 ? Option.none<S["Type"]>() : Option.some(all[0]!),
+        );
+
+    /**
+     * One upsert covering `rows`, all of which must share `columns`.
+     *
+     * The conflict target is stated EXPLICITLY as `id`, exactly as the cache
+     * seam does and for the same two reasons: several of these tables carry a
+     * secondary unique index on top of the primary key (`proposal_dedupe_uq`,
+     * `retro_session_uq`, `experiment_proposal_uq`, ...), and a row that
+     * collides on such a NATURAL key while carrying a different id is a
+     * constraint violation the caller should SEE, not a silent overwrite of a
+     * different decision. `id TEXT PRIMARY KEY` on every table is a schema-wide
+     * invariant, so a row without one is refused rather than inserted
+     * un-upsertably.
+     */
+    const insertStatement = (
+        table: string,
+        columns: ReadonlyArray<string>,
+        rowCount: number,
+    ): Effect.Effect<string, SidecarQueryError> =>
+        Effect.gen(function* () {
+            const quotedTable = yield* quoteIdentifier("table", table);
+            const quotedColumns: string[] = [];
+            for (const column of columns) quotedColumns.push(yield* quoteIdentifier("column", column));
+
+            const placeholders = `(${columns.map(() => "?").join(", ")})`;
+            const updates = quotedColumns
+                .filter((column) => column !== '"id"')
+                .map((column) => `${column} = excluded.${column}`);
+            // A row that is nothing but its id has no column left to update, and
+            // `DO UPDATE SET` with an empty list is a syntax error.
+            const onConflict =
+                updates.length === 0 ? "DO NOTHING" : `DO UPDATE SET ${updates.join(", ")}`;
+
+            return `INSERT INTO ${quotedTable} (${quotedColumns.join(", ")}) VALUES ${Array.from(
+                { length: rowCount },
+                () => placeholders,
+            ).join(", ")} ON CONFLICT ("id") ${onConflict}`;
+        });
+
+    const putMany: JudgmentService["putMany"] = (table, rowsIn) =>
+        Effect.gen(function* () {
+            if (rowsIn.length === 0) return;
+
+            const columns = Object.keys(rowsIn[0]!);
+            if (!columns.includes("id")) {
+                return yield* new SidecarQueryError({
+                    sql: `INSERT INTO ${table}`,
+                    message:
+                        `putMany into ${table} needs an \`id\` on every row: every table in the judgment schema is ` +
+                        "keyed by `id TEXT PRIMARY KEY`, and the upsert names it as the conflict target. Rows given " +
+                        `were missing it, so re-recording the same decision would append a duplicate instead of ` +
+                        `replacing it. Got [${columns.join(", ")}].`,
+                });
+            }
+            const signature = [...columns].sort().join(",");
+            for (let i = 1; i < rowsIn.length; i += 1) {
+                const other = [...Object.keys(rowsIn[i]!)].sort().join(",");
+                if (other !== signature) {
+                    return yield* new SidecarQueryError({
+                        sql: `INSERT INTO ${table}`,
+                        message:
+                            `putMany requires every row to have the same columns, but row ${i} has [${other}] ` +
+                            `while row 0 has [${signature}]. Split them into separate putMany calls - a ragged ` +
+                            "batch would silently write NULLs into the columns a row omitted.",
+                    });
+                }
+            }
+
+            for (let start = 0; start < rowsIn.length; start += PUT_BATCH_ROWS) {
+                const batch = rowsIn.slice(start, start + PUT_BATCH_ROWS);
+                const sql = yield* insertStatement(table, columns, batch.length);
+                const params = batch.flatMap((row) => columns.map((column) => row[column]!));
+                yield* exec(sql, params);
+            }
+        });
+
+    const put: JudgmentService["put"] = (table, row) => putMany(table, [row]);
+
+    /**
+     * `BEGIN IMMEDIATE`, not a bare `BEGIN`.
+     *
+     * A bare `BEGIN` starts DEFERRED: SQLite takes no write lock until the first
+     * write statement, so a transaction that READS and then WRITES has to UPGRADE
+     * its lock mid-flight. If another connection wrote in between, that upgrade
+     * fails with SQLITE_BUSY and - crucially - `busy_timeout` does NOT apply to
+     * it, because waiting could deadlock. Every interesting judgment transaction
+     * has exactly that read-then-write shape (`ax improve accept` reads the
+     * proposal, then writes the experiment). IMMEDIATE takes the write lock up
+     * front, where `busy_timeout` DOES apply, so contention costs a wait instead
+     * of an error.
+     *
+     * Rollback runs on interruption as well as on failure (`onExit`, not
+     * `onError`): an interrupted fiber that left a transaction open would hold
+     * the write lock until the process exited.
+     */
+    const transaction: JudgmentService["transaction"] = <A, E, R>(body: Effect.Effect<A, E, R>) =>
+        txGate.withPermits(1)(
+            Effect.acquireUseRelease(
+                exec("BEGIN IMMEDIATE"),
+                () => body,
+                (_, exit) => Effect.ignore(exec(exit._tag === "Success" ? "COMMIT" : "ROLLBACK")),
+            ),
+        ) as Effect.Effect<A, E | JudgmentError, R>;
+
+    return { rows, first, raw, exec, put, putMany, transaction, path };
+};
+
+/**
+ * A `Judgment` over the sidecar at `options.sidecarPath`.
+ *
+ * NOTHING is opened at layer-build time, for the same reason `CacheReadLayer`
+ * opens nothing: `ax serve` and `ax mcp` build their layers at startup, and a
+ * daemon that failed to build a layer because `~/.ax` did not exist yet would be
+ * dead for the rest of its life. The first statement opens the database, creates
+ * the directory if needed, applies the DDL and remembers the handle. A FAILURE is
+ * deliberately not remembered.
+ */
+export const JudgmentLayer = (options: JudgmentLayerOptions): Layer.Layer<Judgment> =>
+    Layer.effect(Judgment)(
+        Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = options.sidecarPath ?? sidecarPath();
+            const schemaSql = options.schemaSql;
+            const busyTimeoutMs = options.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS;
+
+            let opened: JudgmentService | null = null;
+            let handle: Database | null = null;
+            // One permit, so a burst of concurrent first-statements opens the
+            // database ONCE instead of racing N opens.
+            const gate = Semaphore.makeUnsafe(1);
+
+            yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                    handle?.close();
+                    handle = null;
+                    opened = null;
+                }),
+            );
+
+            const openOnce: Effect.Effect<JudgmentService, SidecarUnavailableError> = Effect.suspend(() =>
+                opened !== null
+                    ? Effect.succeed(opened)
+                    : gate.withPermits(1)(
+                          Effect.gen(function* () {
+                              if (opened !== null) return opened;
+                              const dir = posixPath.dirname(path);
+                              yield* fs.makeDirectory(dir, { recursive: true }).pipe(
+                                  Effect.mapError(
+                                      (err) =>
+                                          new SidecarUnavailableError({
+                                              path,
+                                              message: `could not create the ax judgment directory at ${dir}: ${errorMessage(err)}`,
+                                          }),
+                                  ),
+                              );
+                              const db = yield* Effect.try({
+                                  try: () => {
+                                      const database = new Database(path, { create: true });
+                                      // WAL first: `journal_mode` is persistent
+                                      // in the FILE, so this is a no-op after the
+                                      // first ever open, and it is what lets the
+                                      // daemon read while the CLI writes.
+                                      database.exec("PRAGMA journal_mode = WAL");
+                                      database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
+                                      // NORMAL is the documented companion of WAL:
+                                      // a commit is durable across a process
+                                      // crash, and can lose only the last commits
+                                      // in a power loss. The sidecar is a local
+                                      // decision log, not a ledger; FULL would
+                                      // fsync on every judgment write.
+                                      database.exec("PRAGMA synchronous = NORMAL");
+                                      if (schemaSql !== null) database.exec(schemaSql);
+                                      return database;
+                                  },
+                                  catch: (err) =>
+                                      new SidecarUnavailableError({
+                                          path,
+                                          message: `could not open the ax judgment sidecar at ${path}: ${errorMessage(err)}`,
+                                      }),
+                              });
+                              handle = db;
+                              opened = serviceOver(db, path);
+                              return opened;
+                          }),
+                      ),
+            );
+
+            // The service is a thin forwarder onto the lazily-opened one. Each
+            // method re-resolves through `openOnce`, which is a memo hit after
+            // the first statement.
+            const rows: JudgmentService["rows"] = (schema, sql, params) =>
+                Effect.flatMap(openOnce, (s) => s.rows(schema, sql, params));
+            const first: JudgmentService["first"] = (schema, sql, params) =>
+                Effect.flatMap(openOnce, (s) => s.first(schema, sql, params));
+            const raw: JudgmentService["raw"] = (sql, params) =>
+                Effect.flatMap(openOnce, (s) => s.raw(sql, params));
+            const exec: JudgmentService["exec"] = (sql, params) =>
+                Effect.flatMap(openOnce, (s) => s.exec(sql, params));
+            const put: JudgmentService["put"] = (table, row) =>
+                Effect.flatMap(openOnce, (s) => s.put(table, row));
+            const putMany: JudgmentService["putMany"] = (table, rowsIn) =>
+                Effect.flatMap(openOnce, (s) => s.putMany(table, rowsIn));
+            const transaction: JudgmentService["transaction"] = (body) =>
+                Effect.flatMap(openOnce, (s) => s.transaction(body));
+
+            return { rows, first, raw, exec, put, putMany, transaction, path };
+        }),
+    ).pipe(Layer.provide(BunFileSystem.layer));

--- a/packages/lib/src/sqlite/sidecar.ts
+++ b/packages/lib/src/sqlite/sidecar.ts
@@ -35,6 +35,19 @@
  *  3. Identifier quoting and validation, for the same reason the cache seam owns
  *     it: a table or column name is the one part of a statement that cannot be a
  *     bound parameter.
+ *  4. ONE STATEMENT PER CALL. `bun:sqlite` prepares only the first statement in
+ *     a string and DISCARDS the rest without an error, so `exec("DELETE ...;
+ *     INSERT ...")` would delete a decision and never write its replacement, and
+ *     still report success. {@link singleStatement} refuses that instead - see
+ *     ./statement.ts. The layer's `schemaSql` is exempt by construction: it runs
+ *     on `database.exec`, which executes every statement.
+ *  5. RECOVERY AFTER A POISONED CONNECTION. A transaction whose COMMIT and then
+ *     ROLLBACK both fail closes the shared connection rather than leaving a
+ *     half-open one behind. Operations already queued behind it are refused with
+ *     `SidecarConnectionReplacedError` BEFORE they run a statement, and
+ *     {@link JudgmentLayer} retries each of them once on a fresh connection - so
+ *     the blast radius of that rare failure is the transaction that caused it,
+ *     not whatever else happened to be waiting.
  *
  * WAL, AND WHY THE SIDECAR CAN BE OPEN IN TWO PROCESSES AT ONCE. `ax serve`
  * holds the sidecar open for the dashboard while the user runs `ax improve
@@ -66,12 +79,14 @@ import { homedir } from "node:os";
 import { posixPath } from "../shared/path.ts";
 import {
     errorMessage,
+    SidecarConnectionReplacedError,
     SidecarDecodeError,
     SidecarQueryError,
     SidecarUnavailableError,
     sqlExcerpt,
     type JudgmentError,
 } from "./errors.ts";
+import { findExtraStatement } from "./statement.ts";
 
 /**
  * What a caller may bind. `Date` and `boolean` are in the list because the seam
@@ -184,6 +199,33 @@ const toBindable = (value: SidecarParam): SidecarValue => {
     return value;
 };
 
+/**
+ * ONE statement per call, refused loudly rather than truncated silently.
+ *
+ * `bun:sqlite`'s prepared-statement API compiles only the FIRST statement in the
+ * text and drops the rest with no error and no signal in `changes` - so
+ * `exec("DELETE ...; INSERT ...")` would delete a judgment row, never write its
+ * replacement, and return success. See ./statement.ts for the scanner and for
+ * why `schemaSql` (which legitimately carries the whole DDL) does NOT come
+ * through here: it runs on `database.exec`, which executes every statement.
+ */
+const singleStatement = (sql: string): Effect.Effect<void, SidecarQueryError> => {
+    const extra = findExtraStatement(sql);
+    return extra === null
+        ? Effect.void
+        : Effect.fail(
+              new SidecarQueryError({
+                  sql: sqlExcerpt(sql),
+                  message:
+                      "refusing to run more than one statement in a single call: this seam prepares the " +
+                      "statement, which compiles only the FIRST one and DISCARDS the rest without an error - " +
+                      `so everything from offset ${extra.separatorIndex} would be silently dropped. Split the ` +
+                      "call, and wrap the parts in `transaction` if they must be atomic. The dropped text " +
+                      `began: ${extra.excerpt}`,
+              }),
+          );
+};
+
 export interface JudgmentLayerOptions {
     /**
      * DDL applied on open. REQUIRED, and the caller supplies the text, because
@@ -215,22 +257,51 @@ const serviceOver = (db: Database, path: string, invalidate: () => void): Judgme
     // statements, which are individually atomic and need no serialisation.
     const txGate = Semaphore.makeUnsafe(1);
 
+    // Set when this service's own connection has been closed out from under it
+    // (see `rollbackOrInvalidate`). From that moment the handle is useless, and
+    // the honest answer to any further call is "nothing ran, open a new one".
+    let replaced = false;
+
+    /**
+     * Refuse BEFORE the first statement if the connection is already gone.
+     *
+     * The placement is the whole point, and it is why {@link SidecarConnectionReplacedError}
+     * can promise that NOTHING RAN. `replaced` is only ever set inside a
+     * transaction's release, which holds the permit - so a caller that finds it
+     * set must have been queued on the permit, which means its first statement
+     * had not been reached. `Effect.suspend` defers the read until the permit is
+     * actually held, rather than sampling it when the effect was built.
+     *
+     * Callers of the TRANSACTION BODY do not go through this: they run on a
+     * connection whose liveness was checked when the transaction opened.
+     */
+    const alive = <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E | SidecarConnectionReplacedError, R> =>
+        Effect.suspend<A, E | SidecarConnectionReplacedError, R>(() =>
+            replaced ? Effect.fail(new SidecarConnectionReplacedError({ path })) : effect,
+        );
+
     const bind = (params?: ReadonlyArray<SidecarParam>): SidecarValue[] =>
         (params ?? []).map(toBindable);
 
     const raw: JudgmentService["raw"] = (sql, params) =>
-        Effect.try({
-            try: () => db.query(sql).all(...bind(params)) as ReadonlyArray<SidecarRow>,
-            catch: (err) =>
-                new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
-        });
+        Effect.flatMap(singleStatement(sql), () =>
+            Effect.try({
+                try: () => db.query(sql).all(...bind(params)) as ReadonlyArray<SidecarRow>,
+                catch: (err) =>
+                    new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+            }),
+        );
 
     const exec: JudgmentService["exec"] = (sql, params) =>
-        Effect.try({
-            try: () => db.query(sql).run(...bind(params)).changes,
-            catch: (err) =>
-                new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
-        });
+        Effect.flatMap(singleStatement(sql), () =>
+            Effect.try({
+                try: () => db.query(sql).run(...bind(params)).changes,
+                catch: (err) =>
+                    new SidecarQueryError({ sql: sqlExcerpt(sql), message: errorMessage(err) }),
+            }),
+        );
 
     const rows: JudgmentService["rows"] = <S extends Schema.Top>(
         schema: S,
@@ -350,6 +421,11 @@ const serviceOver = (db: Database, path: string, invalidate: () => void): Judgme
      * Rollback runs on interruption as well as on failure. A failed COMMIT also
      * starts rollback. A failed rollback invalidates the shared connection
      * before the semaphore releases its permit.
+     *
+     * The caller of THIS transaction still hears the original commit error - it
+     * is not a `SidecarConnectionReplacedError` and is never retried, because its
+     * body DID run. Only the operations queued behind it get that error, and only
+     * they are retried.
      */
     const transactionService: JudgmentTransaction = { rows, first, raw, exec, put, putMany };
 
@@ -357,7 +433,12 @@ const serviceOver = (db: Database, path: string, invalidate: () => void): Judgme
         Effect.asVoid(exec("ROLLBACK")).pipe(
             Effect.catch((rollbackError) =>
                 Effect.try({
-                    try: invalidate,
+                    try: () => {
+                        // Marked BEFORE the close is attempted: whether or not
+                        // closing succeeds, this connection is not usable again.
+                        replaced = true;
+                        invalidate();
+                    },
                     catch: (closeError) =>
                         new SidecarQueryError({
                             sql: "ROLLBACK",
@@ -373,19 +454,21 @@ const serviceOver = (db: Database, path: string, invalidate: () => void): Judgme
         body: (transaction: JudgmentTransaction) => Effect.Effect<A, E, R>,
     ) =>
         txGate.withPermits(1)(
-            Effect.acquireUseRelease(
-                exec("BEGIN IMMEDIATE"),
-                () => body(transactionService),
-                (_, exit) =>
-                    Exit.isSuccess(exit)
-                        ? Effect.asVoid(exec("COMMIT")).pipe(
-                              Effect.catch((commitError) =>
-                                  rollbackOrInvalidate().pipe(
-                                      Effect.flatMap(() => Effect.fail(commitError)),
+            alive(
+                Effect.acquireUseRelease(
+                    exec("BEGIN IMMEDIATE"),
+                    () => body(transactionService),
+                    (_, exit) =>
+                        Exit.isSuccess(exit)
+                            ? Effect.asVoid(exec("COMMIT")).pipe(
+                                  Effect.catch((commitError) =>
+                                      rollbackOrInvalidate().pipe(
+                                          Effect.flatMap(() => Effect.fail(commitError)),
+                                      ),
                                   ),
-                              ),
-                          )
-                        : Effect.ignore(rollbackOrInvalidate()),
+                              )
+                            : Effect.ignore(rollbackOrInvalidate()),
+                ),
             ),
         ) as Effect.Effect<A, E | JudgmentError, R>;
 
@@ -393,18 +476,22 @@ const serviceOver = (db: Database, path: string, invalidate: () => void): Judgme
     // transaction, or it would become part of that transaction and share its
     // commit or rollback. Transaction bodies use `transactionService`, whose
     // methods do not acquire the permit again.
+    //
+    // `alive` sits INSIDE the permit and OUTSIDE the statement, so an operation
+    // that waited behind a transaction which killed the connection refuses
+    // before it touches the dead handle.
     const guardedRows: JudgmentService["rows"] = (schema, sql, params) =>
-        txGate.withPermits(1)(rows(schema, sql, params));
+        txGate.withPermits(1)(alive(rows(schema, sql, params)));
     const guardedFirst: JudgmentService["first"] = (schema, sql, params) =>
-        txGate.withPermits(1)(first(schema, sql, params));
+        txGate.withPermits(1)(alive(first(schema, sql, params)));
     const guardedRaw: JudgmentService["raw"] = (sql, params) =>
-        txGate.withPermits(1)(raw(sql, params));
+        txGate.withPermits(1)(alive(raw(sql, params)));
     const guardedExec: JudgmentService["exec"] = (sql, params) =>
-        txGate.withPermits(1)(exec(sql, params));
+        txGate.withPermits(1)(alive(exec(sql, params)));
     const guardedPut: JudgmentService["put"] = (table, row) =>
-        txGate.withPermits(1)(put(table, row));
+        txGate.withPermits(1)(alive(put(table, row)));
     const guardedPutMany: JudgmentService["putMany"] = (table, rowsIn) =>
-        txGate.withPermits(1)(putMany(table, rowsIn));
+        txGate.withPermits(1)(alive(putMany(table, rowsIn)));
 
     return {
         rows: guardedRows,
@@ -438,12 +525,17 @@ export const JudgmentLayer = (options: JudgmentLayerOptions): Layer.Layer<Judgme
 
             let opened: JudgmentService | null = null;
             let handle: Database | null = null;
+            // Set by the finalizer. `openOnce` would happily re-open the file
+            // after the scope closed, and that handle would have no finalizer
+            // left to close it - so a retry must not reach for one.
+            let released = false;
             // One permit, so a burst of concurrent first-statements opens the
             // database ONCE instead of racing N opens.
             const gate = Semaphore.makeUnsafe(1);
 
             yield* Effect.addFinalizer(() =>
                 Effect.sync(() => {
+                    released = true;
                     handle?.close();
                     handle = null;
                     opened = null;
@@ -515,23 +607,52 @@ export const JudgmentLayer = (options: JudgmentLayerOptions): Layer.Layer<Judgme
                       ),
             );
 
+            /**
+             * Run one operation against the CURRENT service, and run it again on
+             * a fresh connection if that one was replaced under it.
+             *
+             * WHY A RETRY IS SAFE HERE, AND ONLY HERE. A connection is replaced
+             * in exactly one place: a transaction whose COMMIT and then ROLLBACK
+             * both failed, in its release action, while it holds the transaction
+             * permit. So an operation can only meet a replaced connection by
+             * having WAITED on that permit - and the liveness check it then hits
+             * sits before its first statement (see `alive` in `serviceOver`).
+             * `SidecarConnectionReplacedError` therefore means "nothing ran", and
+             * re-running cannot double-apply a write. Any OTHER failure - a
+             * constraint, a decode, the self-invalidating transaction's own
+             * commit error - is not this error, and is passed straight through.
+             *
+             * ONCE, not a loop: a second replacement inside the retry is a
+             * sidecar that is failing repeatedly, and the caller should hear that
+             * rather than have it hidden behind another attempt.
+             */
+            const onCurrent = <A, E, R>(
+                use: (service: JudgmentService) => Effect.Effect<A, E, R>,
+            ): Effect.Effect<A, E | SidecarUnavailableError, R> =>
+                Effect.flatMap(openOnce, (service) =>
+                    use(service).pipe(
+                        Effect.catch((error) =>
+                            error instanceof SidecarConnectionReplacedError && !released
+                                ? Effect.flatMap(openOnce, use)
+                                : Effect.fail(error),
+                        ),
+                    ),
+                );
+
             // The service is a thin forwarder onto the lazily-opened one. Each
             // method re-resolves through `openOnce`, which is a memo hit after
             // the first statement.
             const rows: JudgmentService["rows"] = (schema, sql, params) =>
-                Effect.flatMap(openOnce, (s) => s.rows(schema, sql, params));
+                onCurrent((s) => s.rows(schema, sql, params));
             const first: JudgmentService["first"] = (schema, sql, params) =>
-                Effect.flatMap(openOnce, (s) => s.first(schema, sql, params));
-            const raw: JudgmentService["raw"] = (sql, params) =>
-                Effect.flatMap(openOnce, (s) => s.raw(sql, params));
-            const exec: JudgmentService["exec"] = (sql, params) =>
-                Effect.flatMap(openOnce, (s) => s.exec(sql, params));
-            const put: JudgmentService["put"] = (table, row) =>
-                Effect.flatMap(openOnce, (s) => s.put(table, row));
+                onCurrent((s) => s.first(schema, sql, params));
+            const raw: JudgmentService["raw"] = (sql, params) => onCurrent((s) => s.raw(sql, params));
+            const exec: JudgmentService["exec"] = (sql, params) => onCurrent((s) => s.exec(sql, params));
+            const put: JudgmentService["put"] = (table, row) => onCurrent((s) => s.put(table, row));
             const putMany: JudgmentService["putMany"] = (table, rowsIn) =>
-                Effect.flatMap(openOnce, (s) => s.putMany(table, rowsIn));
+                onCurrent((s) => s.putMany(table, rowsIn));
             const transaction: JudgmentService["transaction"] = (body) =>
-                Effect.flatMap(openOnce, (s) => s.transaction(body));
+                onCurrent((s) => s.transaction(body));
 
             return { rows, first, raw, exec, put, putMany, transaction, path };
         }),

--- a/packages/lib/src/sqlite/sidecar.ts
+++ b/packages/lib/src/sqlite/sidecar.ts
@@ -52,7 +52,16 @@
  */
 import { BunFileSystem } from "@effect/platform-bun";
 import { Database } from "bun:sqlite";
-import { Context, Effect, FileSystem, Layer, Option, Schema, Semaphore } from "effect";
+import {
+    Context,
+    Effect,
+    Exit,
+    FileSystem,
+    Layer,
+    Option,
+    Schema,
+    Semaphore,
+} from "effect";
 import { homedir } from "node:os";
 import { posixPath } from "../shared/path.ts";
 import {
@@ -197,7 +206,7 @@ const DEFAULT_BUSY_TIMEOUT_MS = 5_000;
 
 /** Build the service over an open database. Split out from the layer so the
  *  service's behaviour is testable without the lazy-open machinery around it. */
-const serviceOver = (db: Database, path: string): JudgmentService => {
+const serviceOver = (db: Database, path: string, invalidate: () => void): JudgmentService => {
     // ONE permit, held for the whole of a transaction. SQLite transactions are a
     // property of the CONNECTION, not of a call: two fibers interleaving
     // BEGIN/COMMIT on this shared handle would commit each other's work and roll
@@ -338,11 +347,27 @@ const serviceOver = (db: Database, path: string): JudgmentService => {
      * front, where `busy_timeout` DOES apply, so contention costs a wait instead
      * of an error.
      *
-     * Rollback runs on interruption as well as on failure (`onExit`, not
-     * `onError`): an interrupted fiber that left a transaction open would hold
-     * the write lock until the process exited.
+     * Rollback runs on interruption as well as on failure. A failed COMMIT also
+     * starts rollback. A failed rollback invalidates the shared connection
+     * before the semaphore releases its permit.
      */
     const transactionService: JudgmentTransaction = { rows, first, raw, exec, put, putMany };
+
+    const rollbackOrInvalidate = (): Effect.Effect<void, JudgmentError> =>
+        Effect.asVoid(exec("ROLLBACK")).pipe(
+            Effect.catch((rollbackError) =>
+                Effect.try({
+                    try: invalidate,
+                    catch: (closeError) =>
+                        new SidecarQueryError({
+                            sql: "ROLLBACK",
+                            message:
+                                `rollback failed (${rollbackError.message}); the connection was invalidated, ` +
+                                `but closing it also failed (${errorMessage(closeError)})`,
+                        }),
+                }),
+            ),
+        );
 
     const transaction: JudgmentService["transaction"] = <A, E, R>(
         body: (transaction: JudgmentTransaction) => Effect.Effect<A, E, R>,
@@ -352,9 +377,15 @@ const serviceOver = (db: Database, path: string): JudgmentService => {
                 exec("BEGIN IMMEDIATE"),
                 () => body(transactionService),
                 (_, exit) =>
-                    exit._tag === "Success"
-                        ? Effect.asVoid(exec("COMMIT"))
-                        : Effect.ignore(exec("ROLLBACK")),
+                    Exit.isSuccess(exit)
+                        ? Effect.asVoid(exec("COMMIT")).pipe(
+                              Effect.catch((commitError) =>
+                                  rollbackOrInvalidate().pipe(
+                                      Effect.flatMap(() => Effect.fail(commitError)),
+                                  ),
+                              ),
+                          )
+                        : Effect.ignore(rollbackOrInvalidate()),
             ),
         ) as Effect.Effect<A, E | JudgmentError, R>;
 
@@ -438,21 +469,32 @@ export const JudgmentLayer = (options: JudgmentLayerOptions): Layer.Layer<Judgme
                               const db = yield* Effect.try({
                                   try: () => {
                                       const database = new Database(path, { create: true });
-                                      // WAL first: `journal_mode` is persistent
-                                      // in the FILE, so this is a no-op after the
-                                      // first ever open, and it is what lets the
-                                      // daemon read while the CLI writes.
-                                      database.exec("PRAGMA journal_mode = WAL");
-                                      database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
-                                      // NORMAL is the documented companion of WAL:
-                                      // a commit is durable across a process
-                                      // crash, and can lose only the last commits
-                                      // in a power loss. The sidecar is a local
-                                      // decision log, not a ledger; FULL would
-                                      // fsync on every judgment write.
-                                      database.exec("PRAGMA synchronous = NORMAL");
-                                      if (schemaSql !== null) database.exec(schemaSql);
-                                      return database;
+                                      try {
+                                          // WAL first: `journal_mode` is persistent
+                                          // in the FILE, so this is a no-op after the
+                                          // first ever open, and it is what lets the
+                                          // daemon read while the CLI writes.
+                                          database.exec("PRAGMA journal_mode = WAL");
+                                          database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
+                                          // NORMAL is the documented companion of WAL:
+                                          // a commit is durable across a process
+                                          // crash, and can lose only the last commits
+                                          // in a power loss. The sidecar is a local
+                                          // decision log, not a ledger; FULL would
+                                          // fsync on every judgment write.
+                                          database.exec("PRAGMA synchronous = NORMAL");
+                                          if (schemaSql !== null) database.exec(schemaSql);
+                                          return database;
+                                      } catch (setupError) {
+                                          try {
+                                              database.close();
+                                          } catch (closeError) {
+                                              throw new Error(
+                                                  `sidecar setup failed (${errorMessage(setupError)}), and closing the local handle also failed (${errorMessage(closeError)})`,
+                                              );
+                                          }
+                                          throw setupError;
+                                      }
                                   },
                                   catch: (err) =>
                                       new SidecarUnavailableError({
@@ -461,7 +503,13 @@ export const JudgmentLayer = (options: JudgmentLayerOptions): Layer.Layer<Judgme
                                       }),
                               });
                               handle = db;
-                              opened = serviceOver(db, path);
+                              opened = serviceOver(db, path, () => {
+                                  if (handle === db) {
+                                      handle = null;
+                                      opened = null;
+                                  }
+                                  db.close();
+                              });
                               return opened;
                           }),
                       ),

--- a/packages/lib/src/sqlite/sidecar.ts
+++ b/packages/lib/src/sqlite/sidecar.ts
@@ -77,7 +77,7 @@ export type SidecarValue = string | number | bigint | Uint8Array | null;
 
 export type SidecarRow = Readonly<Record<string, SidecarValue>>;
 
-export interface JudgmentService {
+export interface JudgmentTransaction {
     /** Every row, decoded through `schema`. Use the named column codecs in
      *  `./columns.ts` so the decode contract is explicit at the call site. */
     readonly rows: <S extends Schema.Top>(
@@ -115,12 +115,15 @@ export interface JudgmentService {
         table: string,
         rows: ReadonlyArray<Readonly<Record<string, SidecarParam>>>,
     ) => Effect.Effect<void, JudgmentError>;
-    /**
-     * Run `body` inside ONE transaction: committed if it succeeds, rolled back
-     * if it fails or is interrupted.
-     */
+}
+
+export interface JudgmentService extends JudgmentTransaction {
+    /** Run `body` inside one transaction.
+     *
+     * Use the supplied service for every statement in `body`. Other operations
+     * wait until this transaction commits or rolls back. */
     readonly transaction: <A, E, R>(
-        body: Effect.Effect<A, E, R>,
+        body: (transaction: JudgmentTransaction) => Effect.Effect<A, E, R>,
     ) => Effect.Effect<A, E | JudgmentError, R>;
     /** The sidecar file this service is bound to (resolved, not the spelling). */
     readonly path: string;
@@ -339,16 +342,49 @@ const serviceOver = (db: Database, path: string): JudgmentService => {
      * `onError`): an interrupted fiber that left a transaction open would hold
      * the write lock until the process exited.
      */
-    const transaction: JudgmentService["transaction"] = <A, E, R>(body: Effect.Effect<A, E, R>) =>
+    const transactionService: JudgmentTransaction = { rows, first, raw, exec, put, putMany };
+
+    const transaction: JudgmentService["transaction"] = <A, E, R>(
+        body: (transaction: JudgmentTransaction) => Effect.Effect<A, E, R>,
+    ) =>
         txGate.withPermits(1)(
             Effect.acquireUseRelease(
                 exec("BEGIN IMMEDIATE"),
-                () => body,
-                (_, exit) => Effect.ignore(exec(exit._tag === "Success" ? "COMMIT" : "ROLLBACK")),
+                () => body(transactionService),
+                (_, exit) =>
+                    exit._tag === "Success"
+                        ? Effect.asVoid(exec("COMMIT"))
+                        : Effect.ignore(exec("ROLLBACK")),
             ),
         ) as Effect.Effect<A, E | JudgmentError, R>;
 
-    return { rows, first, raw, exec, put, putMany, transaction, path };
+    // Every operation uses the same connection. It must wait for an active
+    // transaction, or it would become part of that transaction and share its
+    // commit or rollback. Transaction bodies use `transactionService`, whose
+    // methods do not acquire the permit again.
+    const guardedRows: JudgmentService["rows"] = (schema, sql, params) =>
+        txGate.withPermits(1)(rows(schema, sql, params));
+    const guardedFirst: JudgmentService["first"] = (schema, sql, params) =>
+        txGate.withPermits(1)(first(schema, sql, params));
+    const guardedRaw: JudgmentService["raw"] = (sql, params) =>
+        txGate.withPermits(1)(raw(sql, params));
+    const guardedExec: JudgmentService["exec"] = (sql, params) =>
+        txGate.withPermits(1)(exec(sql, params));
+    const guardedPut: JudgmentService["put"] = (table, row) =>
+        txGate.withPermits(1)(put(table, row));
+    const guardedPutMany: JudgmentService["putMany"] = (table, rowsIn) =>
+        txGate.withPermits(1)(putMany(table, rowsIn));
+
+    return {
+        rows: guardedRows,
+        first: guardedFirst,
+        raw: guardedRaw,
+        exec: guardedExec,
+        put: guardedPut,
+        putMany: guardedPutMany,
+        transaction,
+        path,
+    };
 };
 
 /**

--- a/packages/lib/src/sqlite/statement.test.ts
+++ b/packages/lib/src/sqlite/statement.test.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/sqlite/statement.test.ts
+//
+// The scanner behind the seam's multi-statement refusal. Pure string walking, so
+// these run without a database - the round trip through a real sidecar (does the
+// refusal actually fire, and does the DDL path stay exempt) is in sidecar.test.ts.
+import { describe, expect, test } from "bun:test";
+import { findExtraStatement, isSingleStatement } from "./statement.ts";
+
+describe("findExtraStatement", () => {
+    test("accepts one statement, with or without a trailing semicolon", () => {
+        expect(isSingleStatement("SELECT 1")).toBe(true);
+        expect(isSingleStatement("SELECT 1;")).toBe(true);
+        expect(isSingleStatement("SELECT 1;   ")).toBe(true);
+        expect(isSingleStatement("SELECT 1;\n\n")).toBe(true);
+    });
+
+    test("accepts an empty or whitespace-only string", () => {
+        // Not this function's job to reject: SQLite reports an empty statement
+        // itself, and inventing a second error here would only confuse it.
+        expect(isSingleStatement("")).toBe(true);
+        expect(isSingleStatement("   \n ")).toBe(true);
+    });
+
+    test("finds the second statement, and points at where it starts", () => {
+        const sql = "DELETE FROM plays_role WHERE id = ?; INSERT INTO plays_role (id) VALUES (?)";
+        const extra = findExtraStatement(sql);
+        expect(extra).not.toBeNull();
+        expect(extra?.separatorIndex).toBe(sql.indexOf(";"));
+        expect(sql.slice(extra!.startIndex)).toStartWith("INSERT INTO plays_role");
+        expect(extra?.excerpt).toStartWith("INSERT INTO plays_role");
+    });
+
+    test("treats a bare `;;` as a second statement rather than a tidy no-op", () => {
+        // Nothing is lost by executing it, but it is a writer that lost track of
+        // its own string, and the seam should say so while it is cheap.
+        expect(isSingleStatement("SELECT 1;;")).toBe(false);
+    });
+
+    test("truncates a long excerpt so one enormous statement cannot bloat the error", () => {
+        const extra = findExtraStatement(`SELECT 1; SELECT '${"x".repeat(400)}'`);
+        expect(extra?.excerpt.length).toBeLessThanOrEqual(81);
+        expect(extra?.excerpt.endsWith("…")).toBe(true);
+    });
+
+    describe("a semicolon that is text, not a separator", () => {
+        test("inside a single-quoted string literal", () => {
+            expect(isSingleStatement("UPDATE role SET name = 'a; b' WHERE id = ?")).toBe(true);
+        });
+
+        test("inside a doubled-quote escape within a literal", () => {
+            // `'it''s; fine'` is ONE literal. A scanner that ended the run at the
+            // second quote would read `; fine'` as a separator plus a statement.
+            expect(isSingleStatement("UPDATE role SET name = 'it''s; fine' WHERE id = ?")).toBe(true);
+        });
+
+        test("inside a double-quoted identifier", () => {
+            expect(isSingleStatement('SELECT "weird;column" FROM role')).toBe(true);
+        });
+
+        test("inside a backtick identifier", () => {
+            expect(isSingleStatement("SELECT `weird;column` FROM role")).toBe(true);
+        });
+
+        test("inside a bracket identifier", () => {
+            expect(isSingleStatement("SELECT [weird;column] FROM role")).toBe(true);
+        });
+
+        test("inside a line comment", () => {
+            expect(isSingleStatement("SELECT 1 -- and; then\n")).toBe(true);
+        });
+
+        test("inside a block comment", () => {
+            expect(isSingleStatement("SELECT /* and; then */ 1")).toBe(true);
+        });
+    });
+
+    describe("comments after a separator", () => {
+        test("a trailing line comment is not a second statement", () => {
+            expect(isSingleStatement("SELECT 1; -- done\n")).toBe(true);
+        });
+
+        test("a trailing block comment is not a second statement", () => {
+            expect(isSingleStatement("SELECT 1; /* done */")).toBe(true);
+        });
+
+        test("a statement AFTER a comment still is one", () => {
+            expect(isSingleStatement("SELECT 1; -- note\nSELECT 2")).toBe(false);
+            expect(isSingleStatement("SELECT 1; /* note */ SELECT 2")).toBe(false);
+        });
+
+        test("an unterminated comment hides nothing executable", () => {
+            expect(isSingleStatement("SELECT 1; /* never closed")).toBe(true);
+        });
+    });
+
+    test("an unterminated literal swallows the rest instead of inventing a separator", () => {
+        // Invalid SQL either way; SQLite reports it. The scanner must not add a
+        // second, wrong diagnosis on top.
+        expect(isSingleStatement("SELECT 'open; still open")).toBe(true);
+    });
+
+    test("finds a third statement when the first separator was inside a literal", () => {
+        const sql = "UPDATE role SET name = 'a; b'; DROP TABLE role";
+        const extra = findExtraStatement(sql);
+        expect(sql.slice(extra!.startIndex)).toBe("DROP TABLE role");
+    });
+
+    test("the committed sidecar DDL is many statements", async () => {
+        // The DDL is exactly what the guard must NOT be applied to. It goes
+        // through `database.exec`, which runs every statement, and this pins the
+        // reason that exemption exists.
+        const { SIDECAR_SCHEMA_SQL } = await import("@ax/schema/sidecar-ddl");
+        expect(isSingleStatement(SIDECAR_SCHEMA_SQL)).toBe(false);
+    });
+});

--- a/packages/lib/src/sqlite/statement.ts
+++ b/packages/lib/src/sqlite/statement.ts
@@ -1,0 +1,146 @@
+// packages/lib/src/sqlite/statement.ts
+/**
+ * "Is this string ONE statement?" - the check that keeps a silent half-write out
+ * of the durable store.
+ *
+ * WHY THIS EXISTS. The seam runs a statement through `bun:sqlite`'s
+ * `db.query(sql)`, which prepares with `sqlite3_prepare_v2`. That call compiles
+ * the FIRST statement in the text and hands back a tail pointer for the rest;
+ * the prepared-statement API then simply ignores the tail. So
+ *
+ *     exec("DELETE FROM plays_role WHERE ...; INSERT INTO plays_role ...")
+ *
+ * deletes the row, never inserts the replacement, reports `changes` for the
+ * delete alone, and SUCCEEDS. Nothing anywhere says the second half was dropped.
+ * On a rebuildable cache that is a bad afternoon; on the judgment sidecar it is a
+ * decision the user made and can never get back.
+ *
+ * The layer's `schemaSql` is the one place that legitimately carries many
+ * statements, and it does NOT come through here: it runs on `database.exec`,
+ * which loops over the whole text by design (see the open path in ./sidecar.ts).
+ *
+ * WHY A SCANNER AND NOT `sql.includes(";")`. A semicolon is ordinary text inside
+ * a string literal, a quoted identifier, or a comment. `WHERE rationale = 'a; b'`
+ * is one statement, and refusing it would push callers into hand-rolled
+ * concatenation - the exact thing the seam's bound parameters exist to stop. So
+ * this walks the string, tracking the four SQLite quoting forms and both comment
+ * forms, and reports only a separator that has executable text after it. A
+ * TRAILING semicolon is fine, because nothing is lost to it.
+ *
+ * Pure, dependency-free and exhaustively tested next door: the interesting logic
+ * is a string walk, and it should be checkable without opening a database.
+ */
+
+/** Where a second statement begins, and what it looks like. */
+export interface ExtraStatement {
+    /** Index of the `;` that separates the statements. */
+    readonly separatorIndex: number;
+    /** Index of the first executable character AFTER that separator. */
+    readonly startIndex: number;
+    /** Short excerpt of the text that `sqlite3_prepare_v2` would drop. */
+    readonly excerpt: string;
+}
+
+const EXCERPT_LEN = 80;
+
+const excerptOf = (text: string): string =>
+    text.length > EXCERPT_LEN ? `${text.slice(0, EXCERPT_LEN)}…` : text;
+
+const isSpace = (char: string): boolean =>
+    char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\f" || char === "\v";
+
+/**
+ * Index just past a quoted run that starts at `start`.
+ *
+ * SQLite doubles the quote to escape it (`'it''s'`), and has no backslash escape,
+ * so a doubled quote continues the run rather than ending it. An UNTERMINATED run
+ * swallows the remainder: the text is not valid SQL either way, and treating the
+ * tail as literal means this function never invents a separator inside it.
+ */
+const skipQuoted = (sql: string, start: number, quote: string): number => {
+    let i = start + 1;
+    while (i < sql.length) {
+        if (sql[i] === quote) {
+            if (sql[i + 1] === quote) {
+                i += 2;
+                continue;
+            }
+            return i + 1;
+        }
+        i += 1;
+    }
+    return sql.length;
+};
+
+/** Index of the next character that is neither whitespace nor a comment, or -1
+ *  when only whitespace and comments remain. An unterminated comment returns -1
+ *  for the same reason: SQLite would execute nothing after it. */
+const nextExecutable = (sql: string, from: number): number => {
+    let i = from;
+    while (i < sql.length) {
+        const char = sql[i]!;
+        if (isSpace(char)) {
+            i += 1;
+            continue;
+        }
+        if (char === "-" && sql[i + 1] === "-") {
+            const newline = sql.indexOf("\n", i);
+            if (newline === -1) return -1;
+            i = newline + 1;
+            continue;
+        }
+        if (char === "/" && sql[i + 1] === "*") {
+            const end = sql.indexOf("*/", i + 2);
+            if (end === -1) return -1;
+            i = end + 2;
+            continue;
+        }
+        return i;
+    }
+    return -1;
+};
+
+/**
+ * The second statement in `sql`, or `null` when there is only one.
+ *
+ * Handles all four SQLite quoting forms (`'text'`, `"identifier"`, `` `identifier` ``,
+ * `[identifier]`) and both comment forms, so a semicolon inside any of them is
+ * text rather than a separator.
+ */
+export const findExtraStatement = (sql: string): ExtraStatement | null => {
+    let i = 0;
+    while (i < sql.length) {
+        const char = sql[i]!;
+        if (char === "'" || char === '"' || char === "`") {
+            i = skipQuoted(sql, i, char);
+            continue;
+        }
+        if (char === "[") {
+            // Bracket identifiers have no escape form in SQLite - the first `]`
+            // ends the run.
+            const end = sql.indexOf("]", i + 1);
+            i = end === -1 ? sql.length : end + 1;
+            continue;
+        }
+        if (char === "-" && sql[i + 1] === "-") {
+            const newline = sql.indexOf("\n", i);
+            i = newline === -1 ? sql.length : newline + 1;
+            continue;
+        }
+        if (char === "/" && sql[i + 1] === "*") {
+            const end = sql.indexOf("*/", i + 2);
+            i = end === -1 ? sql.length : end + 2;
+            continue;
+        }
+        if (char === ";") {
+            const start = nextExecutable(sql, i + 1);
+            if (start === -1) return null;
+            return { separatorIndex: i, startIndex: start, excerpt: excerptOf(sql.slice(start)) };
+        }
+        i += 1;
+    }
+    return null;
+};
+
+/** True when `sql` carries exactly one statement (a trailing `;` is still one). */
+export const isSingleStatement = (sql: string): boolean => findExtraStatement(sql) === null;

--- a/packages/lib/src/stable-id.test.ts
+++ b/packages/lib/src/stable-id.test.ts
@@ -8,6 +8,7 @@ import {
     derivedRowId,
     edgeRowId,
     encodeNaturalKey,
+    roleRowId,
     sessionRowId,
     skillRowId,
     stableId,
@@ -164,6 +165,12 @@ describe("determinism property", () => {
         // session is the carve-out - its id is the raw provider id, so it does
         // NOT delegate to stableId. turn (composite key) still does.
         expect(turnRowId("s1", 7)).toBe(stableId("turn", ["s1", 7]));
+        expect(roleRowId("verification")).toBe(stableId("role", ["verification"]));
+    });
+
+    test("roleRowId is a content hash, not a legacy record-id spelling", () => {
+        expect(roleRowId("verification")).toBe("2dccb07b2ef66960034bea9051444aba");
+        expect(roleRowId("verification")).not.toBe("role:verification");
     });
 
     test("sessionRowId is the provider session id verbatim, ignoring provider (P1-3)", () => {

--- a/packages/lib/src/stable-id.ts
+++ b/packages/lib/src/stable-id.ts
@@ -173,6 +173,18 @@ export function skillRowId(name: string): string {
     return stableId("skill", [name]);
 }
 
+/**
+ * A durable role, keyed on its normalized name.
+ *
+ * Role rows live in the SQLite judgment sidecar, but they use the same
+ * content-hash contract as cache rows. Every role writer must use this helper,
+ * so `plays_role.out_id` has one stable form across user, frontmatter and brief
+ * sources.
+ */
+export function roleRowId(name: string): string {
+    return stableId("role", [name]);
+}
+
 /** The provider-native row this derived row was built from: an existing
  *  graph row's own (already provider-native, already append-stable) id -
  *  never a file identity. */

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -15,6 +15,9 @@
     },
     "./schema.duckdb.sql": "./src/schema.duckdb.sql",
     "./duckdb-ddl": { "types": "./src/duckdb-ddl.ts", "import": "./src/duckdb-ddl.ts" },
+    "./schema.sidecar.sql": "./src/schema.sidecar.sql",
+    "./sidecar-ddl": { "types": "./src/sidecar-ddl.ts", "import": "./src/sidecar-ddl.ts" },
+    "./sidecar-tables": { "types": "./src/sidecar-tables.ts", "import": "./src/sidecar-tables.ts" },
     "./duckdb-tables": { "types": "./src/duckdb-tables.ts", "import": "./src/duckdb-tables.ts" },
     "./parse-duckdb-schema": { "types": "./src/parse-duckdb-schema.ts", "import": "./src/parse-duckdb-schema.ts" }
   },

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -1,10 +1,18 @@
 // packages/schema/src/duckdb-parity.test.ts
 //
-// Pins the Surreal -> DuckDB translation property: every `DEFINE FIELD` in
-// schema.surql must appear as a DuckDB column in schema.duckdb.sql with the
-// mapped type and matching nullability. This is a port of two throwaway
-// verification scripts (fidelity.ts / types.ts) that were both CLEAN over
-// all 138 tables / 1219 columns - the wave-2 seam port assumes this holds.
+// Pins the Surreal -> v2 translation property: every `DEFINE FIELD` in
+// schema.surql must appear as a column in the DDL of the engine that OWNS its
+// table, with the mapped type and matching nullability. This is a port of two
+// throwaway verification scripts (fidelity.ts / types.ts) that were both CLEAN
+// over all 138 tables / 1219 columns - the wave-2 seam port assumes this holds.
+//
+// TWO ENGINES, ONE PROPERTY. v1 had one destination; v2 has two - the
+// rebuildable DuckDB cache and the SQLite judgment sidecar (schema.sidecar.sql,
+// `c-sidecar-sqlite`). Fourteen tables moved to the sidecar, and the honest way
+// to keep the property is to follow them: each table is compared against ITS
+// engine's parser and ITS engine's type mapping, so the counts below stay at the
+// full 138/1218 rather than shrinking by the tables that changed home. Exempting
+// them instead would have quietly stopped checking a tenth of the schema.
 import { describe, expect, test } from "bun:test";
 import surql from "./schema.surql" with { type: "text" };
 import { accessorFor } from "@ax/lib/duckdb/row-decode";
@@ -16,10 +24,14 @@ import {
     parseDuckdbTables,
     parseSurrealTables,
 } from "./parse-duckdb-schema.ts";
+import { parseSqliteColumnDefs, parseSqliteColumns, parseSqliteTables } from "./sidecar-ddl.ts";
+import { SIDECAR_JUDGMENT_TABLES } from "./sidecar-tables.ts";
 
 // Expected table/column counts. Asserted explicitly so the property can never
 // silently shrink to comparing zero (or a handful of) tables/columns.
 const EXPECTED_TABLES_COMPARED = 138;
+/** Of those, how many the DuckDB cache still defines (138 - 14 judgment tables). */
+const EXPECTED_DUCKDB_TABLES = 124;
 // A7 (agent_event.raw prune): schema.surql's `agent_event.raw` field was
 // removed (ax never wrote it - buildAgentEventStatement already omitted it
 // from the CONTENT it upserts). schema.duckdb.sql's `agent_event.raw` column
@@ -102,6 +114,34 @@ function expectedDuckType(t: string): string {
     }
 }
 
+/** Maps a Surreal DEFINE FIELD TYPE to the SQLite type the sidecar must use.
+ *
+ *  SQLite has no BOOLEAN and no TIMESTAMP: a bool is an INTEGER holding 0 or 1,
+ *  and a datetime is TEXT holding an ISO-8601 UTC instant (see the TYPES block in
+ *  schema.sidecar.sql). Everything else follows the same JSON-in-text rule the
+ *  cache uses for arrays and objects. */
+function expectedSqliteType(t: string): string {
+    if (t.startsWith("record<")) return "TEXT";
+    if (t.startsWith("array<")) return "TEXT";
+    if (t === "object") return "TEXT";
+    switch (t) {
+        case "string":
+            return "TEXT";
+        case "int":
+            return "INTEGER";
+        case "float":
+            return "REAL";
+        case "number":
+            return "REAL";
+        case "bool":
+            return "INTEGER";
+        case "datetime":
+            return "TEXT";
+        default:
+            return `?${t}`;
+    }
+}
+
 /** `in` -> `in_id`, `out` -> `out_id`, everything else unchanged. */
 function renamedColumn(field: string): string {
     if (field === "in") return "in_id";
@@ -111,7 +151,35 @@ function renamedColumn(field: string): string {
 
 const relationByTable = new Map(parseSurrealTables(surql).map((t) => [t.table, t.relation] as const));
 const duckTables = parseDuckdbTables();
-const duckTableSet = new Set(duckTables);
+const sidecarTableSet = new Set(parseSqliteTables());
+/** Every table with a home in v2, whichever engine owns it. */
+const ownedTableSet = new Set([...duckTables, ...sidecarTableSet]);
+
+/** Which DDL owns `table`, and how to read it. One lookup, so no assertion below
+ *  can accidentally compare a moved table against the engine it LEFT. */
+interface OwningEngine {
+    readonly engine: "duckdb" | "sqlite";
+    readonly columns: (table: string) => readonly string[];
+    readonly columnDefs: (table: string) => readonly { name: string; type: string; notNull: boolean }[];
+    readonly expectedType: (surrealType: string) => string;
+}
+
+const DUCKDB_ENGINE: OwningEngine = {
+    engine: "duckdb",
+    columns: (t) => parseDuckdbColumns(t),
+    columnDefs: (t) => parseDuckdbColumnDefs(t),
+    expectedType: expectedDuckType,
+};
+
+const SQLITE_ENGINE: OwningEngine = {
+    engine: "sqlite",
+    columns: (t) => parseSqliteColumns(t),
+    columnDefs: (t) => parseSqliteColumnDefs(t),
+    expectedType: expectedSqliteType,
+};
+
+const engineFor = (table: string): OwningEngine =>
+    SIDECAR_JUDGMENT_TABLES.has(table) ? SQLITE_ENGINE : DUCKDB_ENGINE;
 
 // P1-1: Surreal `TYPE RELATION SCHEMAFULL` edges with no FROM/TO are untyped -
 // Surreal's own record id carries the endpoint table name inline, which a bare
@@ -131,20 +199,20 @@ const POLYMORPHIC_EDGE_EXTRA_COLUMNS: Readonly<Record<string, readonly string[]>
     telemetry_of: ["out_table"],
 };
 
-describe("column-set parity (Surreal field set == DuckDB column set)", () => {
+describe("column-set parity (Surreal field set == owning engine's column set)", () => {
     const surrealFields = surrealFieldsByTable();
 
-    test("every Surreal table's fields map exactly onto its DuckDB columns", () => {
+    test("every Surreal table's fields map exactly onto its owning engine's columns", () => {
         const problems: string[] = [];
         let checked = 0;
 
         for (const [table, fields] of surrealFields) {
-            if (!duckTableSet.has(table)) {
+            if (!ownedTableSet.has(table)) {
                 problems.push(`${table}: MISSING TABLE`);
                 continue;
             }
             checked += 1;
-            const cols = new Set(parseDuckdbColumns(table));
+            const cols = new Set(engineFor(table).columns(table));
             const expected = new Set<string>(["id"]);
             if (relationByTable.get(table) === true) {
                 expected.add("in_id");
@@ -164,12 +232,12 @@ describe("column-set parity (Surreal field set == DuckDB column set)", () => {
         // Fieldless relation tables (no DEFINE FIELD at all) still need id/in_id/out_id.
         for (const [table, isRel] of relationByTable) {
             if (!isRel || surrealFields.has(table)) continue;
-            if (!duckTableSet.has(table)) {
+            if (!ownedTableSet.has(table)) {
                 problems.push(`${table}: MISSING TABLE`);
                 continue;
             }
             checked += 1;
-            const cols = new Set(parseDuckdbColumns(table));
+            const cols = new Set(engineFor(table).columns(table));
             for (const want of ["id", "in_id", "out_id"]) {
                 if (!cols.has(want)) problems.push(`${table}.${want}: MISSING column`);
             }
@@ -180,24 +248,25 @@ describe("column-set parity (Surreal field set == DuckDB column set)", () => {
     });
 });
 
-describe("type + nullability parity (Surreal DEFINE FIELD TYPE == DuckDB column type/NOT NULL)", () => {
+describe("type + nullability parity (Surreal DEFINE FIELD TYPE == owning engine's column type/NOT NULL)", () => {
     const surrealTypes = surrealTypesByTable();
 
-    test("every column's DuckDB type matches its mapped Surreal type", () => {
+    test("every column's type matches its mapped Surreal type in the engine that owns it", () => {
         const problems: string[] = [];
         let checked = 0;
 
         for (const [table, inner] of surrealTypes) {
-            const defs = new Map(parseDuckdbColumnDefs(table).map((d) => [d.name, d] as const));
+            const engine = engineFor(table);
+            const defs = new Map(engine.columnDefs(table).map((d) => [d.name, d] as const));
             for (const [field, { t }] of inner) {
                 const want = renamedColumn(field);
                 const def = defs.get(want);
                 if (def === undefined) {
-                    problems.push(`${table}.${want}: no column`);
+                    problems.push(`${table}.${want}: no column in the ${engine.engine} DDL`);
                     continue;
                 }
                 checked += 1;
-                const exp = expectedDuckType(t);
+                const exp = engine.expectedType(t);
                 if (def.type !== exp) {
                     problems.push(`${table}.${want}: type ${def.type}, expected ${exp} (surreal ${t})`);
                 }
@@ -213,12 +282,13 @@ describe("type + nullability parity (Surreal DEFINE FIELD TYPE == DuckDB column 
         let checked = 0;
 
         for (const [table, inner] of surrealTypes) {
-            const defs = new Map(parseDuckdbColumnDefs(table).map((d) => [d.name, d] as const));
+            const engine = engineFor(table);
+            const defs = new Map(engine.columnDefs(table).map((d) => [d.name, d] as const));
             for (const [field, { opt }] of inner) {
                 const want = renamedColumn(field);
                 const def = defs.get(want);
                 if (def === undefined) {
-                    problems.push(`${table}.${want}: no column`);
+                    problems.push(`${table}.${want}: no column in the ${engine.engine} DDL`);
                     continue;
                 }
                 checked += 1;
@@ -349,6 +419,10 @@ describe("banned-type guard (FFI client compatibility)", () => {
 describe("parser sanity", () => {
     test("the DuckDB DDL is non-trivial and the parsers found real tables/columns", () => {
         expect(DUCKDB_SCHEMA_SQL.length).toBeGreaterThan(1000);
-        expect(duckTables.length).toBe(EXPECTED_TABLES_COMPARED);
+        expect(duckTables.length).toBe(EXPECTED_DUCKDB_TABLES);
+        // ...and the fourteen the cache gave up are all in the sidecar, so the
+        // 138 tables the property compares are still 138 tables that EXIST.
+        expect(ownedTableSet.size).toBeGreaterThanOrEqual(EXPECTED_TABLES_COMPARED);
+        expect([...SIDECAR_JUDGMENT_TABLES].filter((t) => !sidecarTableSet.has(t))).toEqual([]);
     });
 });

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -9,15 +9,28 @@ import {
     parseDuckdbTables,
     parseSurrealTables,
 } from "./duckdb-ddl.ts";
-import { DUCKDB_SCHEMA_TABLES, SIDECAR_JUDGMENT_TABLES } from "./duckdb-tables.ts";
+import { DUCKDB_SCHEMA_TABLES } from "./duckdb-tables.ts";
+import { SIDECAR_SCHEMA_SQL, parseSqliteColumns, parseSqliteTables } from "./sidecar-ddl.ts";
+import { SIDECAR_JUDGMENT_TABLES, SIDECAR_SCHEMA_TABLES } from "./sidecar-tables.ts";
 const surrealTables = parseSurrealTables(surql);
 const duckTables = parseDuckdbTables();
 const duckTableSet = new Set(duckTables);
+// v2 keeps the Surreal schema whole across TWO engines - the rebuildable
+// DuckDB cache and the SQLite judgment sidecar. Coverage assertions below ask
+// "does this table have a home", not "is it in this one file".
+const sidecarTableSet = new Set(parseSqliteTables());
+const ownedTableSet = new Set([...duckTables, ...sidecarTableSet]);
+const columnsOf = (table: string): readonly string[] =>
+    SIDECAR_JUDGMENT_TABLES.has(table) ? parseSqliteColumns(table) : parseDuckdbColumns(table);
 
 describe("coverage of the Surreal schema", () => {
-    test("every Surreal table has a DuckDB table of the same name", () => {
-        const missing = surrealTables.map((t) => t.table).filter((t) => !duckTableSet.has(t));
+    test("every Surreal table has a table of the same name in the engine that owns it", () => {
+        const missing = surrealTables.map((t) => t.table).filter((t) => !ownedTableSet.has(t));
         expect(missing).toEqual([]);
+        // ...and no table has BOTH homes, which would let a reader answer from
+        // whichever it opened, one of them empty.
+        const both = [...sidecarTableSet].filter((t) => duckTableSet.has(t));
+        expect(both).toEqual([]);
     });
 
     test("the DDL adds no table the Surreal schema never had", () => {
@@ -59,7 +72,7 @@ describe("edge tables", () => {
 
     test("every relation table becomes (id, in_id, out_id, …)", () => {
         for (const table of relationTables) {
-            const cols = parseDuckdbColumns(table);
+            const cols = columnsOf(table);
             expect(cols.slice(0, 3)).toEqual(["id", "in_id", "out_id"]);
         }
     });
@@ -74,6 +87,11 @@ describe("edge tables", () => {
         // actually served, so require one per side.
         const indexes = parseDuckdbIndexes();
         const uncovered = relationTables
+            // `plays_role` is a relation that moved to the sidecar; SQLite serves
+            // a leftmost-prefix seek off a composite index, so the single-column
+            // rule measured on DuckDB does not transfer. Its own indexes are
+            // asserted in sidecar-schema.test.ts against a live database.
+            .filter((table) => !SIDECAR_JUDGMENT_TABLES.has(table))
             .map((table) => {
                 const onTable = indexes.filter((i) => i.table === table);
                 return {
@@ -170,9 +188,14 @@ describe("arrays (P2-3, reverted)", () => {
             { table: "subagent_proposal", column: "example_task_patterns" },
             { table: "wrapped_card", column: "series" },
         ];
-        for (const { column } of scalarArrayColumns) {
-            expect(DUCKDB_SCHEMA_SQL).toMatch(new RegExp(`^\\s*${column}\\s+VARCHAR\\b`, "m"));
-            expect(DUCKDB_SCHEMA_SQL).not.toMatch(new RegExp(`^\\s*${column}\\s+\\w+\\[\\]`, "m"));
+        for (const { table, column } of scalarArrayColumns) {
+            // `subagent_proposal` moved to the sidecar, where the same rule holds
+            // with SQLite's spelling: JSON text, never a native list.
+            const inSidecar = SIDECAR_JUDGMENT_TABLES.has(table);
+            const sql = inSidecar ? SIDECAR_SCHEMA_SQL : DUCKDB_SCHEMA_SQL;
+            const scalarType = inSidecar ? "TEXT" : "VARCHAR";
+            expect(sql).toMatch(new RegExp(`^\\s*${column}\\s+${scalarType}\\b`, "m"));
+            expect(sql).not.toMatch(new RegExp(`^\\s*${column}\\s+\\w+\\[\\]`, "m"));
         }
     });
 
@@ -217,42 +240,24 @@ describe("manifest", () => {
     test("every entry carries a non-empty note and a known stage and kind", () => {
         for (const entry of DUCKDB_SCHEMA_TABLES) {
             expect(entry.note.length).toBeGreaterThan(0);
-            expect(["active", "conditional", "staged", "sidecar"]).toContain(entry.stage);
+            expect(["active", "conditional", "staged"]).toContain(entry.stage);
             expect(["node", "edge"]).toContain(entry.kind);
         }
     });
 
-    // Wave-0 finding P1-2: the DDL header says durable judgment lives in the
-    // SQLite sidecar and the DuckDB cache is REBUILDABLE, but the manifest had
-    // these tables marked `active` - a cache rebuild would erase user decisions.
-    // Every durable judgment table (proposals, verdicts, role tags + weights,
-    // retros, triage/label-review decisions, dogfood runs) must be `sidecar`.
-    test("every judgment table is marked stage: sidecar (durable, never rebuilt)", () => {
-        const JUDGMENT_TABLES = [
-            "proposal",
-            "skill_proposal",
-            "subagent_proposal",
-            "hook_proposal",
-            "guidance_proposal",
-            "automation_proposal",
-            "experiment",
-            "checkpoint",
-            "role",
-            "plays_role",
-            "retro",
-            "skill_triage_decision",
-            "transcript_label_review",
-            "dogfood_run",
-        ] as const;
-        const stageOf = new Map(DUCKDB_SCHEMA_TABLES.map((t) => [t.table, t.stage] as const));
-        for (const table of JUDGMENT_TABLES) {
-            expect(stageOf.get(table)).toBe("sidecar");
+    // Wave-0 finding P1-2 asked for a `stage: "sidecar"` FLAG on these fourteen
+    // tables, because the DDL header said durable judgment lives in the SQLite
+    // sidecar while the manifest still called them `active` - a cache rebuild
+    // would erase user decisions. `c-sidecar-sqlite` finishes that job: the flag
+    // is gone because the TABLES are gone, into schema.sidecar.sql. This is the
+    // stronger form of the same assertion - a table cannot be re-added to the
+    // cache DDL under a corrected flag, because there is no flag to correct.
+    test("the cache DDL defines no judgment table at all", () => {
+        const alsoInCache = [...SIDECAR_JUDGMENT_TABLES].filter((t) => duckTables.includes(t));
+        expect(alsoInCache).toEqual([]);
+        for (const entry of DUCKDB_SCHEMA_TABLES) {
+            expect(SIDECAR_JUDGMENT_TABLES.has(entry.table)).toBe(false);
         }
-        // The exported set and this explicit list must agree, and no OTHER table
-        // may be silently marked sidecar without being enumerated here.
-        expect([...SIDECAR_JUDGMENT_TABLES].sort()).toEqual([...JUDGMENT_TABLES].sort());
-        const sidecarInManifest = DUCKDB_SCHEMA_TABLES.filter((t) => t.stage === "sidecar").map((t) => t.table);
-        expect(sidecarInManifest.sort()).toEqual([...JUDGMENT_TABLES].sort());
     });
 
     test("kind matches the Surreal relation flag", () => {
@@ -270,7 +275,12 @@ describe("manifest", () => {
         const block = insights.slice(insights.indexOf("export const SCHEMA_TABLES"));
         const listed = [...block.matchAll(/\{\s*table:\s*"([\w]+)"/g)].map((m) => m[1]!);
         expect(listed.length).toBeGreaterThan(50);
-        const manifest = new Set(DUCKDB_SCHEMA_TABLES.map((t) => t.table));
+        // The union of the two manifests: `SCHEMA_TABLES` predates the split and
+        // still lists judgment tables, which now answer from the sidecar.
+        const manifest = new Set([
+            ...DUCKDB_SCHEMA_TABLES.map((t) => t.table),
+            ...SIDECAR_SCHEMA_TABLES.map((t) => t.table),
+        ]);
         expect(listed.filter((t) => !manifest.has(t))).toEqual([]);
     });
 });

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -13,44 +13,20 @@ export interface DuckdbTableSpec {
      * - `conditional` - active, but only written under a runtime gate (e.g. a
      *                   GitHub remote + working `gh`).
      * - `staged`      - reserved/not-yet-wired; also rebuildable.
-     * - `sidecar`     - DURABLE JUDGMENT that a cache rebuild MUST NOT erase
-     *                   (user/agent decisions: proposals, verdicts, role tags +
-     *                   weights, retros, triage/label-review decisions, dogfood
-     *                   runs). The DDL header says durable judgment lives in the
-     *                   SQLite sidecar; this flag is the machine-readable copy of
-     *                   that contract so nothing can treat these tables as
-     *                   rebuildable-from-transcripts. See SIDECAR_JUDGMENT_TABLES.
+     *
+     * There is no `sidecar` stage any more, and that is the point: durable
+     * judgment is not a FLAG on a cache table, it is a table in a different
+     * file and a different engine (schema.sidecar.sql, `SIDECAR_JUDGMENT_TABLES`
+     * in ./sidecar-tables.ts). Every table in THIS manifest is rebuildable.
      */
-    readonly stage: "active" | "conditional" | "staged" | "sidecar";
+    readonly stage: "active" | "conditional" | "staged";
     readonly note: string;
 }
 
-/**
- * Durable judgment tables (wave-3 `c-sidecar-sqlite`): user/agent DECISIONS that
- * cannot be re-derived from transcripts/git/skills, so a cache rebuild must not
- * drop them. Enumerated here as the single source of truth; the manifest below
- * marks each `stage: "sidecar"` and duckdb-schema.test.ts asserts the two agree.
- *
- * NOTE: "spar labels" (the wave-3 list) are `session.labels` VALUES stamped by
- * spar-score, i.e. a COLUMN on the (rebuildable) `session` table, not a table of
- * their own - there is nothing table-grained to mark here for them.
- */
-export const SIDECAR_JUDGMENT_TABLES: ReadonlySet<string> = new Set([
-    "proposal",
-    "skill_proposal",
-    "subagent_proposal",
-    "hook_proposal",
-    "guidance_proposal",
-    "automation_proposal",
-    "experiment",
-    "checkpoint",
-    "role",
-    "plays_role",
-    "retro",
-    "skill_triage_decision",
-    "transcript_label_review",
-    "dogfood_run",
-]);
+// Durable judgment tables moved OUT of this manifest with the DDL that defined
+// them: `SIDECAR_JUDGMENT_TABLES` now lives in ./sidecar-tables.ts, next to
+// schema.sidecar.sql. Keeping the enumeration here while the tables lived
+// elsewhere would have been a second source of truth for the boundary.
 
 /**
  * Hand-authored editorial metadata (kind/stage/note) keyed by table name -
@@ -105,7 +81,6 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     classifier_graph_node: { kind: "node", stage: "active", note: "Generic classifier graph nodes projected from package operations." },
     classifier_graph_edge: { kind: "node", stage: "active", note: "Generic classifier graph edges projected from package operations." },
     classifier_graph_fact: { kind: "node", stage: "active", note: "Generic classifier graph facts projected from package operations." },
-    transcript_label_review: { kind: "node", stage: "sidecar", note: "Human/agent review verdicts for mined transcript label candidates." },
     transcript_label_vector: { kind: "node", stage: "active", note: "Embedding vectors and nearest-neighbor refs for transcript label candidates." },
     semantic_signal: { kind: "node", stage: "active", note: "Reusable meanings promoted from analyzed turns." },
     diagnostic_event: { kind: "node", stage: "active", note: "Derived diagnostics from failed commands and friction." },
@@ -137,8 +112,6 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     ingest_event: { kind: "node", stage: "active", note: "Append-like ingest progress events." },
     query_sample: { kind: "node", stage: "staged", note: "Reserved query execution samples." },
     graph_health_check: { kind: "node", stage: "staged", note: "Persisted graph health check rows." },
-    role: { kind: "node", stage: "sidecar", note: "Skill role labels used for weighting and grouping." },
-    plays_role: { kind: "edge", stage: "sidecar", note: "Skill-to-role classification edges." },
     invoked: { kind: "edge", stage: "active", note: "Turn-to-skill invocation edges." },
     loaded: { kind: "edge", stage: "active", note: "Session-to-skill auto-load activations (subagent skills: frontmatter); separate from invoked." },
     proposed: { kind: "edge", stage: "active", note: "Skills mentioned but not invoked." },
@@ -169,26 +142,15 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     agent_event_child: { kind: "edge", stage: "active", note: "Provider-event parent-child edges." },
     used_model: { kind: "edge", stage: "active", note: "Session-to-agent-model usage edges." },
     agent_used_model: { kind: "edge", stage: "active", note: "Provider-session-to-agent-model usage edges." },
-    skill_triage_decision: { kind: "node", stage: "sidecar", note: "Dashboard keep/archive/review decisions per skill." },
     harness_hook_event: { kind: "node", stage: "active", note: "Native agent harness hook lifecycle events." },
     hook_command_invocation: { kind: "node", stage: "active", note: "Commands invoked by native harness hooks." },
     ax_invocation: { kind: "node", stage: "active", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
     feedback_case_type: { kind: "node", stage: "active", note: "Feedback backtest case definitions." },
     feedback_case_result: { kind: "node", stage: "active", note: "Feedback backtest results." },
     hook_fire: { kind: "node", stage: "active", note: "Runtime file-context hook decisions." },
-    proposal: { kind: "node", stage: "sidecar", note: "Polymorphic shortlist of repeated workflow improvement candidates." },
     directive_ngram: { kind: "node", stage: "active", note: "Per-user n-gram lift table: which user-turn markers predict captured outcomes (directive mining v2, #587)." },
-    skill_proposal: { kind: "node", stage: "sidecar", note: "Typed payload rows for skill-form proposals." },
-    subagent_proposal: { kind: "node", stage: "sidecar", note: "Typed payload rows for subagent-form proposals." },
-    hook_proposal: { kind: "node", stage: "sidecar", note: "Typed payload rows for hook-form proposals." },
-    guidance_proposal: { kind: "node", stage: "sidecar", note: "Typed payload rows for guidance-file proposals." },
-    automation_proposal: { kind: "node", stage: "sidecar", note: "Typed payload rows for automation-form proposals." },
     cites_evidence: { kind: "edge", stage: "active", note: "Proposal-to-evidence edges." },
-    experiment: { kind: "node", stage: "sidecar", note: "Accepted proposals and scaffold/verdict state." },
     opportunity: { kind: "edge", stage: "active", note: "Experiment trigger recurrence evidence edges." },
-    checkpoint: { kind: "node", stage: "sidecar", note: "Experiment measurement snapshots and user verdicts." },
-    dogfood_run: { kind: "node", stage: "sidecar", note: "Terminal dogfood scenario results." },
-    retro: { kind: "node", stage: "sidecar", note: "Structured session retrospectives." },
     reviewed: { kind: "edge", stage: "active", note: "Session-to-retro review edges." },
     ingest_file_state: { kind: "node", stage: "active", note: "Per-source ingest watermark (mtime/size/sha) for skip-unchanged re-ingest." },
     otel_metric_point: { kind: "node", stage: "active", note: "Harness OTLP metric data points (cost/token/usage)." },

--- a/packages/schema/src/parse-duckdb-schema.test.ts
+++ b/packages/schema/src/parse-duckdb-schema.test.ts
@@ -2,18 +2,20 @@
 import { describe, expect, test } from "bun:test";
 import { DUCKDB_TABLE_NAMES, parseDuckdbColumnDefs, parseDuckdbTables } from "./parse-duckdb-schema.ts";
 
-// Mirrors duckdb-parity.test.ts's EXPECTED_TABLES_COMPARED - kept as a
-// separate literal (not an import) so a change to either constant is a
-// visible two-file diff, not a silent shared mutation.
-const EXPECTED_TABLES_COMPARED = 138;
+// Mirrors duckdb-parity.test.ts's EXPECTED_DUCKDB_TABLES - kept as a separate
+// literal (not an import) so a change to either constant is a visible two-file
+// diff, not a silent shared mutation. It is 138 minus the fourteen judgment
+// tables that now live in schema.sidecar.sql; the FULL 138 is still compared
+// against the Surreal schema, across both engines, in duckdb-parity.test.ts.
+const EXPECTED_DUCKDB_TABLES = 124;
 
 describe("parse-duckdb-schema", () => {
     test("parseDuckdbTables finds every table in the committed DDL", () => {
-        expect(parseDuckdbTables().length).toBe(EXPECTED_TABLES_COMPARED);
+        expect(parseDuckdbTables().length).toBe(EXPECTED_DUCKDB_TABLES);
     });
 
     test("DUCKDB_TABLE_NAMES is parsed once from the committed DDL and matches parseDuckdbTables", () => {
-        expect(DUCKDB_TABLE_NAMES.size).toBe(EXPECTED_TABLES_COMPARED);
+        expect(DUCKDB_TABLE_NAMES.size).toBe(EXPECTED_DUCKDB_TABLES);
         expect([...DUCKDB_TABLE_NAMES].sort()).toEqual([...parseDuckdbTables()].sort());
     });
 

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -882,30 +882,15 @@ CREATE INDEX IF NOT EXISTS classifier_graph_fact_kind ON classifier_graph_fact(k
 CREATE INDEX IF NOT EXISTS classifier_graph_fact_subject ON classifier_graph_fact(subject);
 CREATE INDEX IF NOT EXISTS classifier_graph_fact_theme ON classifier_graph_fact(kind, predicate);
 
--- Transcript label-mining: reviewed-status rows and embedding/vector rows.
--- Graph facts themselves reuse classifier_graph_* (node/edge/fact); these two
--- tables hold the reviewed-status provenance and the vector refs that join
--- candidates back to promotion-safe graph facts. Writes are idempotent (UPSERT
--- keyed by candidate_id / vector id).
-CREATE TABLE IF NOT EXISTS transcript_label_review (
-    id VARCHAR PRIMARY KEY,
-    candidate_id VARCHAR NOT NULL,
-    graph_fact_id VARCHAR,
-    label_family VARCHAR NOT NULL,
-    review_status VARCHAR NOT NULL,
-    promotion_safe BOOLEAN NOT NULL,
-    reviewed_label VARCHAR,
-    reviewed_target VARCHAR,
-    reviewer VARCHAR NOT NULL,
-    rationale VARCHAR NOT NULL,
-    evidence_paths_json VARCHAR NOT NULL,  -- JSON-encoded
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS transcript_label_review_candidate ON transcript_label_review(candidate_id);
-CREATE INDEX IF NOT EXISTS transcript_label_review_graph_fact ON transcript_label_review(graph_fact_id);
-CREATE INDEX IF NOT EXISTS transcript_label_review_family ON transcript_label_review(label_family);
-CREATE INDEX IF NOT EXISTS transcript_label_review_status ON transcript_label_review(review_status);
-
+-- Transcript label-mining: embedding/vector rows. Graph facts themselves reuse
+-- classifier_graph_* (node/edge/fact); this table holds the vector refs that
+-- join candidates back to promotion-safe graph facts. Writes are idempotent
+-- (UPSERT keyed by vector id).
+--
+-- MOVED TO THE SIDECAR: `transcript_label_review`. The vectors are mined and
+-- re-derivable; the REVIEW of a candidate (who decided what, and whether it is
+-- promotion-safe) is judgment, so it lives in schema.sidecar.sql. Its
+-- `candidate_id` / `graph_fact_id` are refs INTO this cache.
 CREATE TABLE IF NOT EXISTS transcript_label_vector (
     id VARCHAR PRIMARY KEY,
     candidate_id VARCHAR NOT NULL,
@@ -1440,32 +1425,13 @@ CREATE TABLE IF NOT EXISTS graph_health_check (
 );
 CREATE INDEX IF NOT EXISTS graph_health_kind_created ON graph_health_check(kind, created_at);
 
--- ==== Skill roles (P3.1) ====
--- Multi-role natural: one skill -> many plays_role edges. Weighted query
--- joins invoked -> skill -> plays_role -> role.
-CREATE TABLE IF NOT EXISTS role (
-    id VARCHAR PRIMARY KEY,
-    name VARCHAR NOT NULL,
-    -- Surreal carried `VALUE $value ?? 1.0` here to stop a CONTENT-style upsert
-    -- from coercing weight to NONE. DuckDB has no NONE, and NOT NULL DEFAULT 1.0
-    -- gives the same guarantee; the Surreal repair UPDATE was one-time DML with
-    -- no legacy rows to repair in a fresh cache.
-    weight DOUBLE NOT NULL DEFAULT 1.0
-);
-CREATE UNIQUE INDEX IF NOT EXISTS role_name_uq ON role(name);
-
-CREATE TABLE IF NOT EXISTS plays_role (
-    id VARCHAR PRIMARY KEY,
-    in_id VARCHAR NOT NULL,  -- ref -> skill
-    out_id VARCHAR NOT NULL,  -- ref -> role
-    confidence DOUBLE NOT NULL DEFAULT 1.0,
-    source VARCHAR NOT NULL,
-    weight DOUBLE,
-    rationale VARCHAR,
-    since TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX IF NOT EXISTS plays_role_in ON plays_role(in_id);
-CREATE INDEX IF NOT EXISTS plays_role_out ON plays_role(out_id);
+-- ==== Skill roles (P3.1) - MOVED TO THE SIDECAR ====
+-- `role` (name + user-tuned weight) and `plays_role` (skill -> role) are both
+-- classifications a user or agent MADE, not facts derived from a transcript, so
+-- they live in schema.sidecar.sql. `plays_role.in_id` holds a skill id from THIS
+-- cache, which is why `ax skills weighted` joins across the two engines and why
+-- packages/lib/src/cache-integrity.ts counts the tags whose skill no longer
+-- exists after a re-derive.
 
 -- ==== Relations (taste graph) ====
 
@@ -1912,18 +1878,12 @@ CREATE INDEX IF NOT EXISTS agent_used_model_in ON agent_used_model(in_id);
 CREATE INDEX IF NOT EXISTS agent_used_model_out ON agent_used_model(out_id);
 
 -- ---------------------------------------------------------------------------
--- User-facing triage decisions on skills. The dashboard "Skill Triage" view
--- writes here; downstream queries can filter `archived` skills out of the
--- leaderboard. We never delete: keep history of decision flips with `decided_at`.
+-- MOVED TO THE SIDECAR: `skill_triage_decision`. The dashboard "Skill Triage"
+-- view's keep/archive/review call is a user decision, so it lives in
+-- schema.sidecar.sql; downstream queries still filter `archived` skills out of
+-- the leaderboard, now by joining the sidecar. It is keyed by skill NAME, not by
+-- a cache id, so it is the one judgment table that cannot dangle.
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS skill_triage_decision (
-    id VARCHAR PRIMARY KEY,
-    skill_name VARCHAR NOT NULL,
-    decision VARCHAR NOT NULL,  -- keep | archive | review
-    reason VARCHAR,
-    decided_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS skill_triage_decision_name ON skill_triage_decision(skill_name);
 
 -- ---------------------------------------------------------------------------
 -- Native agent-harness hook evidence. These rows describe the harness layer
@@ -2066,44 +2026,11 @@ CREATE INDEX IF NOT EXISTS hook_fire_by_ts ON hook_fire(ts);
 CREATE INDEX IF NOT EXISTS hook_fire_by_session ON hook_fire(session);
 CREATE INDEX IF NOT EXISTS hook_fire_by_file ON hook_fire(file);
 CREATE INDEX IF NOT EXISTS hook_fire_by_reason ON hook_fire(reason);
-CREATE TABLE IF NOT EXISTS proposal (
-    id VARCHAR PRIMARY KEY,
-    form VARCHAR NOT NULL,
-    -- skill | subagent | hook | guidance | automation
-    title VARCHAR NOT NULL,
-    hypothesis VARCHAR NOT NULL,
-    dedupe_sig VARCHAR NOT NULL,
-    frequency BIGINT NOT NULL DEFAULT 0,
-    confidence VARCHAR NOT NULL,
-    -- low | medium | high
-    status VARCHAR NOT NULL DEFAULT 'open',
-    -- open | accepted | rejected | superseded
-    -- mined (signal-derived) | agent (written via `ax improve propose`).
-    -- The VALUE clause coerces a NONE/absent write back to 'mined' so a bare
-    -- `UPDATE proposal SET ...` (accept/reject/housekeep/re-derive) that omits
-    -- `origin` can never re-coerce an old NONE row and crash with "Expected string
-    -- but found `NONE`" (issue #472). It tests `IS NONE` explicitly rather than the
-    -- broader `?? ` so an *explicit* NULL write still fails type coercion (a real
-    -- bug surfaces) instead of being silently relabeled 'mined'. DEFAULT still seeds
-    -- 'mined' on first create; an explicit origin='agent' write is preserved.
-    -- was: DEFINE FIELD OVERWRITE origin ... VALUE IF $value IS NONE THEN 'mined' ELSE $value END
-    -- (the NONE-coercion VALUE clause has no DuckDB equivalent and is dropped;
-    -- the DEFAULT alone covers the create-time seed)
-    origin VARCHAR NOT NULL DEFAULT 'mined',
-    hypothesis_template VARCHAR,
-    -- hypothesis with {{placeholders}} hydrated at serve time from
-    -- evidence_query's first row - numbers never expire
-    evidence_query VARCHAR,
-    -- read-only SurrealQL (SELECT/RETURN only, validated at write AND
-    -- serve) producing the row that fills hypothesis_template
-    reject_reason VARCHAR,
-    baseline VARCHAR,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS proposal_dedupe_uq ON proposal(dedupe_sig);
-CREATE INDEX IF NOT EXISTS proposal_status_freq ON proposal(status, frequency);
-CREATE INDEX IF NOT EXISTS proposal_form_status ON proposal(form, status, created_at);
+
+-- MOVED TO THE SIDECAR: `proposal`. The improve loop's shortlist is authored -
+-- mined by ingest, then accepted, rejected or superseded by a human - and a
+-- rejected proposal that a re-derive resurrected as `open` would ask the same
+-- question again forever. See schema.sidecar.sql.
 
 -- ==== Directive n-gram lift table (#587) ====
 -- Per-user lift table: which n-gram markers in user turns predict a captured
@@ -2125,69 +2052,10 @@ CREATE TABLE IF NOT EXISTS directive_ngram (
 CREATE UNIQUE INDEX IF NOT EXISTS directive_ngram_uq ON directive_ngram(ngram);
 CREATE INDEX IF NOT EXISTS directive_ngram_lift ON directive_ngram(lift);
 
--- ==== Per-form payload tables ====
--- One row per proposal of the matching form. Typed fields per form avoid
--- the JSON-blob trap that killed the prior orphan tables.
-
-CREATE TABLE IF NOT EXISTS skill_proposal (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    trigger_pattern VARCHAR NOT NULL,
-    suspected_gap VARCHAR NOT NULL,
-    proposed_behavior VARCHAR NOT NULL,
-    expected_impact VARCHAR
-);
-CREATE UNIQUE INDEX IF NOT EXISTS skill_proposal_uq ON skill_proposal(proposal);
-
-CREATE TABLE IF NOT EXISTS subagent_proposal (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    bounded_role VARCHAR NOT NULL,
-    delegation_trigger VARCHAR NOT NULL,
-    -- pattern matched against Task tool calls (see opportunity definition below)
-    example_task_patterns VARCHAR NOT NULL DEFAULT '[]'  -- JSON-encoded; P2-3 reverted: JSON, not native list
-);
-CREATE UNIQUE INDEX IF NOT EXISTS subagent_proposal_uq ON subagent_proposal(proposal);
-
-CREATE TABLE IF NOT EXISTS hook_proposal (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    event_name VARCHAR NOT NULL,
-    -- PreToolUse | PostToolUse | SessionStart | ...
-    target_tool VARCHAR,
-    hook_command VARCHAR NOT NULL,
-    recovery_path VARCHAR,
-    smoke_test_command VARCHAR,
-    disable_command VARCHAR,
-    failure_mode VARCHAR
-    -- fail_open | fail_closed
-);
-CREATE UNIQUE INDEX IF NOT EXISTS hook_proposal_uq ON hook_proposal(proposal);
-
-CREATE TABLE IF NOT EXISTS guidance_proposal (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    file_target VARCHAR NOT NULL,
-    -- e.g. "CLAUDE.md", "~/.claude/CLAUDE.md"
-    section VARCHAR,
-    suggested_text VARCHAR NOT NULL
-);
-CREATE UNIQUE INDEX IF NOT EXISTS guidance_proposal_uq ON guidance_proposal(proposal);
-
-CREATE TABLE IF NOT EXISTS automation_proposal (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    trigger_signal VARCHAR NOT NULL,
-    schedule VARCHAR,
-    -- cron expression, "weekly", etc; null = event-driven
-    action VARCHAR NOT NULL,
-    recovery_path VARCHAR,
-    smoke_test_command VARCHAR,
-    disable_command VARCHAR,
-    failure_mode VARCHAR
-    -- fail_open | fail_closed
-);
-CREATE UNIQUE INDEX IF NOT EXISTS automation_proposal_uq ON automation_proposal(proposal);
+-- MOVED TO THE SIDECAR: the five per-form payload tables (`skill_proposal`,
+-- `subagent_proposal`, `hook_proposal`, `guidance_proposal`,
+-- `automation_proposal`). One row per proposal of the matching form; they follow
+-- `proposal` because they ARE it, split by form.
 
 -- ==== Typed evidence edges ====
 -- Replaces the JSON-blob `evidence_refs` design that codex review flagged
@@ -2214,28 +2082,11 @@ CREATE INDEX IF NOT EXISTS cites_evidence_in ON cites_evidence(in_id);
 CREATE INDEX IF NOT EXISTS cites_evidence_out ON cites_evidence(out_id);
 CREATE INDEX IF NOT EXISTS cites_evidence_in_out ON cites_evidence(in_id, out_id);
 
--- ==== Experiment (created on accept) ====
--- One row per accepted proposal. `artifact` is a typed link to the
--- created skill row when form=skill; `artifact_path` carries the
--- on-disk path for hook/guidance/automation forms. `scaffolded_at`
--- records when the CLI wrote the stub file (Phase C3 scaffold-on-accept
--- fix for the manual-step dropout problem).
-CREATE TABLE IF NOT EXISTS experiment (
-    id VARCHAR PRIMARY KEY,
-    proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
-    artifact VARCHAR,  -- ref -> skill
-    artifact_path VARCHAR,
-    scaffolded_at TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    locked_verdict VARCHAR,
-    status VARCHAR NOT NULL DEFAULT 'task_emitted',
-    -- task_emitted | scaffolded | regressed | retired
-    task_path VARCHAR
-    -- absolute path to .ax/tasks/<id>.md while pending
-);
-CREATE INDEX IF NOT EXISTS experiment_status_idx ON experiment(status);
-CREATE UNIQUE INDEX IF NOT EXISTS experiment_proposal_uq ON experiment(proposal);
-CREATE INDEX IF NOT EXISTS experiment_created ON experiment(created_at);
+-- ==== Experiment (created on accept) - MOVED TO THE SIDECAR ====
+-- One row per accepted proposal, carrying the locked verdict. `opportunity`
+-- below stays HERE: it is the mined denominator (every recurrence of the
+-- trigger pattern), re-derived from transcripts on each ingest, and its `in_id`
+-- is a ref into the sidecar's `experiment`.
 
 -- ==== Opportunity (verdict denominator) ====
 -- Each time a proposal's trigger pattern recurs after experiment.created_at,
@@ -2260,94 +2111,21 @@ CREATE INDEX IF NOT EXISTS opportunity_in_ts ON opportunity(in_id, matched_at);
 CREATE INDEX IF NOT EXISTS opportunity_out ON opportunity(out_id);
 CREATE INDEX IF NOT EXISTS opportunity_in ON opportunity(in_id);
 
--- ==== Checkpoint (decision support, never auto-verdict) ====
--- One row per (experiment, kind) snapshot at +3 / +10 / +30 sessions
--- since experiment.created_at (see issue #83 - calendar days are the wrong
--- cadence when an agent ships eight sessions a day). Legacy day-based
--- rows (t+7 / t+30 / t+90) are preserved as historical data; the kind
--- field is a free-form string so the two cadences coexist.
--- `measured` is the aggregate {built, invoked, opportunities, addressed,
--- friction_delta}. `suggested` is the algorithm's verdict guess. The
--- human-confirmed `user_verdict` is what gets locked into experiment.
--- locked_verdict at +30s. Algorithm proposes, human decides.
-CREATE TABLE IF NOT EXISTS checkpoint (
-    id VARCHAR PRIMARY KEY,
-    experiment VARCHAR NOT NULL,  -- ref -> experiment (was: REFERENCE ON DELETE CASCADE)
-    kind VARCHAR NOT NULL,
-    -- current: +3s | +10s | +30s | adhoc
-    -- legacy:  t+7 | t+30 | t+90 (calendar-day windows, pre-#83)
-    -- measured: JSON-encoded object {opportunities, addressed, ratio, built,
-    -- current_frequency, baseline_frequency} - was TYPE object with typed
-    -- sub-fields (DuckDB has no nested-field DEFINE, folded to one JSON column)
-    -- Frequency disambiguation for opportunities=0 verdicts: if the cluster
-    -- frequency has grown since the proposal was accepted, the artifact is
-    -- being ignored (still firing). Otherwise the pattern self-resolved.
-    measured VARCHAR NOT NULL,  -- JSON
-    suggested VARCHAR,
-    -- adopted | ignored | regressed | no_longer_needed | partial
-    user_verdict VARCHAR,
-    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX IF NOT EXISTS checkpoint_experiment_kind ON checkpoint(experiment, kind, observed_at);
+-- MOVED TO THE SIDECAR: `checkpoint`. Its `measured` aggregate is computable
+-- from this cache, but `user_verdict` - the human's answer, which the algorithm
+-- only ever SUGGESTS - is not, and the two belong to the same row.
 
--- ==== dogfood_run (Phase C12) ====
--- One row per dogfood scenario invocation. Owned by src/dogfood/wterm.ts.
-CREATE TABLE IF NOT EXISTS dogfood_run (
-    id VARCHAR PRIMARY KEY,
-    run_id VARCHAR NOT NULL,
-    scenario VARCHAR NOT NULL,
-    driver VARCHAR NOT NULL,       -- wterm | future drivers
-    status VARCHAR NOT NULL,       -- passed | failed | error
-    agent VARCHAR,
-    command VARCHAR,
-    command_source VARCHAR,
-    transport VARCHAR,
-    requested_transport VARCHAR,
-    transport_fallback_reason VARCHAR,
-    success_marker VARCHAR,
-    marker_found BOOLEAN NOT NULL DEFAULT FALSE,
-    timed_out BOOLEAN NOT NULL DEFAULT FALSE,
-    timeout_seconds BIGINT,
-    transcript_artifact VARCHAR,  -- ref -> artifact
-    cwd VARCHAR,
-    started_at TIMESTAMP NOT NULL,
-    ended_at TIMESTAMP NOT NULL
-);
-CREATE UNIQUE INDEX IF NOT EXISTS dogfood_run_id_uq ON dogfood_run(run_id);
-CREATE INDEX IF NOT EXISTS dogfood_run_status_ts ON dogfood_run(status, ended_at);
-CREATE INDEX IF NOT EXISTS dogfood_run_scenario ON dogfood_run(scenario, ended_at);
+-- MOVED TO THE SIDECAR: `dogfood_run`. A scenario's pass/fail is an observation
+-- of a terminal session that no longer exists; nothing on disk re-derives it.
 
 -- =====================================================================
--- Phase B: retro table (2026-05-26)
+-- Phase B: retro - MOVED TO THE SIDECAR (2026-05-26; moved 2026-08-15)
 -- =====================================================================
--- A structured reflection emitted by an agent at session-end. Four
--- canonical fields: tried (what the agent attempted), worked (what
--- landed), failed (what didn't), next (the experiment to run next).
--- See docs/language.md "retro" for the canonical definition.
---
--- Source enum:
---   claude_stop_hook   - Claude Code Stop hook ran `ax retro emit`
---   codex_rollout      - extracted from a Codex rollout summary
---   heuristic          - generated by ax from turn data (no LLM call)
---   manual             - user typed `ax retro emit --tried=... --worked=...`
---
--- One retro per session (UNIQUE index). Re-emitting overwrites; the raw
--- field preserves the original JSON for audit.
-CREATE TABLE IF NOT EXISTS retro (
-    id VARCHAR PRIMARY KEY,
-    session VARCHAR NOT NULL,  -- ref -> session (was: REFERENCE ON DELETE CASCADE)
-    source VARCHAR NOT NULL,
-    tried VARCHAR NOT NULL,
-    worked VARCHAR,
-    failed VARCHAR,
-    next VARCHAR,
-    raw VARCHAR,        -- original JSON payload
-    repository VARCHAR,  -- ref -> repository
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS retro_session_uq ON retro(session);
-CREATE INDEX IF NOT EXISTS retro_source_ts ON retro(source, created_at);
-CREATE INDEX IF NOT EXISTS retro_repository_ts ON retro(repository, created_at);
+-- The structured session-end reflection (tried/worked/failed/next) is written
+-- BY an agent, not derived from what it did, so it lives in schema.sidecar.sql.
+-- `retro.session` and `retro.repository` are refs into this cache. The
+-- `reviewed` edge below stays here: it is re-derivable from the retro rows plus
+-- the sessions, and it is what `ax retro pending` traverses.
 
 -- Graph edge: session got a retro. Lets queries traverse both directions
 -- (session->reviewed->retro, retro<-reviewed<-session) and ask

--- a/packages/schema/src/schema.sidecar.sql
+++ b/packages/schema/src/schema.sidecar.sql
@@ -1,0 +1,318 @@
+-- ax judgment sidecar schema v2 - SQLite DDL.
+--
+-- WHAT LIVES HERE, AND WHY IT IS A SECOND FILE AT ALL. schema.duckdb.sql holds
+-- the REBUILDABLE cache: every row in it is derived from files on disk
+-- (transcripts, git, skills, the OTLP spool) and can be dropped and re-derived at
+-- any time. The rows below cannot. They are DECISIONS - a proposal an agent
+-- filed, a verdict a human locked, a role a user tagged a skill with, a retro
+-- written at session end, a triage call, a label review, a dogfood result, a spar
+-- stamp. Nothing on disk can reproduce them, so a cache rebuild must not be able
+-- to touch them. Two files, two engines, one home per table: a table defined in
+-- BOTH would let a reader answer from the empty one, which is precisely the
+-- silent-wrong-answer the v2 no-fallback rule exists to prevent.
+--
+-- WHY SQLITE AND NOT MORE DUCKDB. The cache is opened read-only through a
+-- published snapshot and written ONLY inside ingest under the ingest lock (see
+-- packages/lib/src/duckdb/seam.ts). Judgment writes are REQUEST-TIME: `ax improve
+-- accept`, `ax skills tag`, `ax retro emit`, a dashboard triage click. They do not
+-- run inside ingest and must not have to take the ingest lock to record a
+-- decision. SQLite is the right shape for that traffic - small, transactional,
+-- concurrent-reader-safe under WAL, and already a Bun built-in.
+--
+-- WHAT MUST NOT MOVE IN HERE. Deterministic, re-derivable rows, however
+-- decision-shaped they look. `feedback_case_type` / `feedback_case_result` are
+-- backtest OUTPUT (`ax hooks cases`), `opportunity` is a mined denominator,
+-- `cites_evidence` and `reviewed` are mined edges: all re-derive from the same
+-- inputs, so all stay in the cache. The list of tables that DO belong here is
+-- enumerated once, in sidecar-tables.ts, and sidecar-schema.test.ts asserts this
+-- file creates exactly that set.
+--
+-- ROW IDS. Same contract as the cache: `id TEXT PRIMARY KEY`, a content hash of
+-- the row's natural key (packages/lib/src/stable-id.ts). Never an autoincrement.
+-- A judgment row also carries REFERENCES INTO THE CACHE (retro.session,
+-- plays_role.in_id -> skill, experiment.artifact -> skill, ...) as plain TEXT
+-- holding the cache row's id. Those are the refs that can dangle when a re-derive
+-- drops a row, which is what packages/lib/src/cache-integrity.ts counts and what
+-- makes the cache's byte-identical-id property load-bearing rather than tidy.
+-- There are deliberately no FOREIGN KEYs to the cache - it is a different engine
+-- - and none between sidecar tables either, for the same reason the cache has
+-- none: writers arrive in whatever order the user acts in.
+--
+-- TYPES. SQLite has no BOOLEAN, no TIMESTAMP and no DOUBLE keyword worth using,
+-- so the translation from schema.duckdb.sql is fixed and total:
+--   VARCHAR   -> TEXT
+--   BIGINT    -> INTEGER
+--   DOUBLE    -> REAL
+--   BOOLEAN   -> INTEGER, 0 or 1 (packages/lib/src/sqlite/columns.ts decodes it)
+--   TIMESTAMP -> TEXT holding an ISO-8601 UTC instant, millisecond grain
+--
+-- TIMESTAMPS ARE ISO TEXT, NOT `CURRENT_TIMESTAMP`. SQLite's CURRENT_TIMESTAMP
+-- renders `YYYY-MM-DD HH:MM:SS`: no `T`, no `Z`, no milliseconds. `new Date()` of
+-- that string reads it as LOCAL time, so on any non-UTC host every default-stamped
+-- row would come back hours off - the same class of defect the cache seam pins UTC
+-- to prevent, arriving through the DDL instead of the connection. Every default
+-- below is therefore `strftime('%Y-%m-%dT%H:%M:%fZ','now')`, which is UTC by
+-- definition ('now' is UTC in SQLite) and parses correctly everywhere.
+
+-- ==== Proposals (the improve loop's shortlist) ====
+-- One row per candidate improvement. `form` selects which typed payload table
+-- below carries its form-specific fields. Written by `ax improve propose`
+-- (origin='agent') and by the ingest miner (origin='mined'); status is moved by
+-- `ax improve accept` / `reject` / `housekeep`.
+CREATE TABLE IF NOT EXISTS proposal (
+    id TEXT PRIMARY KEY,
+    form TEXT NOT NULL,
+    -- skill | subagent | hook | guidance | automation
+    title TEXT NOT NULL,
+    hypothesis TEXT NOT NULL,
+    dedupe_sig TEXT NOT NULL,
+    frequency INTEGER NOT NULL DEFAULT 0,
+    confidence TEXT NOT NULL,
+    -- low | medium | high
+    status TEXT NOT NULL DEFAULT 'open',
+    -- open | accepted | rejected | superseded
+    origin TEXT NOT NULL DEFAULT 'mined',
+    -- mined (signal-derived) | agent (written via `ax improve propose`)
+    hypothesis_template TEXT,
+    -- hypothesis with {{placeholders}} hydrated at serve time from
+    -- evidence_query's first row - numbers never expire
+    evidence_query TEXT,
+    -- read-only SQL (SELECT/RETURN only, validated at write AND serve)
+    -- producing the row that fills hypothesis_template
+    reject_reason TEXT,
+    baseline TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS proposal_dedupe_uq ON proposal(dedupe_sig);
+CREATE INDEX IF NOT EXISTS proposal_status_freq ON proposal(status, frequency);
+CREATE INDEX IF NOT EXISTS proposal_form_status ON proposal(form, status, created_at);
+
+-- ==== Per-form payload tables ====
+-- One row per proposal of the matching form. Typed fields per form, rather than
+-- a JSON blob on `proposal`, so a form's own fields stay queryable.
+CREATE TABLE IF NOT EXISTS skill_proposal (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    trigger_pattern TEXT NOT NULL,
+    suspected_gap TEXT NOT NULL,
+    proposed_behavior TEXT NOT NULL,
+    expected_impact TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS skill_proposal_uq ON skill_proposal(proposal);
+
+CREATE TABLE IF NOT EXISTS subagent_proposal (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    bounded_role TEXT NOT NULL,
+    delegation_trigger TEXT NOT NULL,
+    -- pattern matched against Task tool calls
+    example_task_patterns TEXT NOT NULL DEFAULT '[]'  -- JSON-encoded string[]
+);
+CREATE UNIQUE INDEX IF NOT EXISTS subagent_proposal_uq ON subagent_proposal(proposal);
+
+CREATE TABLE IF NOT EXISTS hook_proposal (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    event_name TEXT NOT NULL,
+    -- PreToolUse | PostToolUse | SessionStart | ...
+    target_tool TEXT,
+    hook_command TEXT NOT NULL,
+    recovery_path TEXT,
+    smoke_test_command TEXT,
+    disable_command TEXT,
+    failure_mode TEXT
+    -- fail_open | fail_closed
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hook_proposal_uq ON hook_proposal(proposal);
+
+CREATE TABLE IF NOT EXISTS guidance_proposal (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    file_target TEXT NOT NULL,
+    -- e.g. "CLAUDE.md", "~/.claude/CLAUDE.md"
+    section TEXT,
+    suggested_text TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS guidance_proposal_uq ON guidance_proposal(proposal);
+
+CREATE TABLE IF NOT EXISTS automation_proposal (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    trigger_signal TEXT NOT NULL,
+    schedule TEXT,
+    -- cron expression, "weekly", etc; null = event-driven
+    action TEXT NOT NULL,
+    recovery_path TEXT,
+    smoke_test_command TEXT,
+    disable_command TEXT,
+    failure_mode TEXT
+    -- fail_open | fail_closed
+);
+CREATE UNIQUE INDEX IF NOT EXISTS automation_proposal_uq ON automation_proposal(proposal);
+
+-- ==== Experiment (created on accept) ====
+-- One row per accepted proposal. `artifact` is the CACHE id of the created skill
+-- row when form=skill; `artifact_path` carries the on-disk path for the
+-- hook/guidance/automation forms.
+CREATE TABLE IF NOT EXISTS experiment (
+    id TEXT PRIMARY KEY,
+    proposal TEXT NOT NULL,  -- ref -> proposal.id
+    artifact TEXT,           -- ref -> cache skill.id
+    artifact_path TEXT,
+    scaffolded_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    locked_verdict TEXT,
+    status TEXT NOT NULL DEFAULT 'task_emitted',
+    -- task_emitted | scaffolded | regressed | retired
+    task_path TEXT
+    -- absolute path to .ax/tasks/<id>.md while pending
+);
+CREATE INDEX IF NOT EXISTS experiment_status_idx ON experiment(status);
+CREATE UNIQUE INDEX IF NOT EXISTS experiment_proposal_uq ON experiment(proposal);
+CREATE INDEX IF NOT EXISTS experiment_created ON experiment(created_at);
+
+-- ==== Checkpoint (decision support, never auto-verdict) ====
+-- One row per (experiment, kind) snapshot. `measured` is the aggregate JSON,
+-- `suggested` the algorithm's guess, `user_verdict` the human's answer - the
+-- judgment this whole table exists to keep. Algorithm proposes, human decides.
+CREATE TABLE IF NOT EXISTS checkpoint (
+    id TEXT PRIMARY KEY,
+    experiment TEXT NOT NULL,  -- ref -> experiment.id
+    kind TEXT NOT NULL,
+    -- current: +3s | +10s | +30s | adhoc ; legacy: t+7 | t+30 | t+90
+    measured TEXT NOT NULL,  -- JSON object
+    suggested TEXT,
+    -- adopted | ignored | regressed | no_longer_needed | partial
+    user_verdict TEXT,
+    observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS checkpoint_experiment_kind ON checkpoint(experiment, kind, observed_at);
+
+-- ==== Role registry + role tags ====
+-- `role.weight` is a user-tuned number and `plays_role` is a user/agent
+-- classification of a skill: both are judgment, and both are keyed against a
+-- CACHE skill id, so both can dangle after a re-derive.
+CREATE TABLE IF NOT EXISTS role (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS role_name_uq ON role(name);
+
+CREATE TABLE IF NOT EXISTS plays_role (
+    id TEXT PRIMARY KEY,
+    in_id TEXT NOT NULL,   -- ref -> cache skill.id
+    out_id TEXT NOT NULL,  -- ref -> role.id
+    confidence REAL NOT NULL DEFAULT 1.0,
+    source TEXT NOT NULL,
+    weight REAL,
+    rationale TEXT,
+    since TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS plays_role_in ON plays_role(in_id);
+CREATE INDEX IF NOT EXISTS plays_role_out ON plays_role(out_id);
+CREATE UNIQUE INDEX IF NOT EXISTS plays_role_in_out_uq ON plays_role(in_id, out_id);
+
+-- ==== Retro ====
+-- A structured reflection emitted at session end: tried / worked / failed / next.
+-- One retro per session; re-emitting overwrites, and `raw` preserves the original
+-- payload for audit.
+CREATE TABLE IF NOT EXISTS retro (
+    id TEXT PRIMARY KEY,
+    session TEXT NOT NULL,  -- ref -> cache session.id
+    source TEXT NOT NULL,
+    -- claude_stop_hook | codex_rollout | heuristic | manual
+    tried TEXT NOT NULL,
+    worked TEXT,
+    failed TEXT,
+    next TEXT,
+    raw TEXT,               -- original JSON payload
+    repository TEXT,        -- ref -> cache repository.id
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS retro_session_uq ON retro(session);
+CREATE INDEX IF NOT EXISTS retro_source_ts ON retro(source, created_at);
+CREATE INDEX IF NOT EXISTS retro_repository_ts ON retro(repository, created_at);
+
+-- ==== Skill triage decisions ====
+-- The dashboard's keep/archive/review call on a skill, by NAME rather than by
+-- cache id: the decision outlives an uninstall-and-reinstall of the skill.
+CREATE TABLE IF NOT EXISTS skill_triage_decision (
+    id TEXT PRIMARY KEY,
+    skill_name TEXT NOT NULL,
+    decision TEXT NOT NULL,  -- keep | archive | review
+    reason TEXT,
+    decided_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS skill_triage_decision_name ON skill_triage_decision(skill_name);
+
+-- ==== Transcript label review ====
+-- Reviewed-status provenance for mined label candidates: who reviewed a
+-- candidate, what they decided, and whether it is safe to promote into the graph.
+-- The candidate/vector/graph-fact rows themselves are mined and stay in the cache;
+-- only the REVIEW is judgment.
+CREATE TABLE IF NOT EXISTS transcript_label_review (
+    id TEXT PRIMARY KEY,
+    candidate_id TEXT NOT NULL,
+    graph_fact_id TEXT,
+    label_family TEXT NOT NULL,
+    review_status TEXT NOT NULL,
+    promotion_safe INTEGER NOT NULL,  -- 0 | 1
+    reviewed_label TEXT,
+    reviewed_target TEXT,
+    reviewer TEXT NOT NULL,
+    rationale TEXT NOT NULL,
+    evidence_paths_json TEXT NOT NULL,  -- JSON-encoded string[]
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS transcript_label_review_candidate ON transcript_label_review(candidate_id);
+CREATE INDEX IF NOT EXISTS transcript_label_review_graph_fact ON transcript_label_review(graph_fact_id);
+CREATE INDEX IF NOT EXISTS transcript_label_review_family ON transcript_label_review(label_family);
+CREATE INDEX IF NOT EXISTS transcript_label_review_status ON transcript_label_review(review_status);
+
+-- ==== Dogfood runs ====
+-- One row per dogfood scenario invocation: an observed pass/fail an agent or a
+-- human acted on, and nothing on disk re-derives it once the terminal is gone.
+CREATE TABLE IF NOT EXISTS dogfood_run (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    scenario TEXT NOT NULL,
+    driver TEXT NOT NULL,       -- wterm | future drivers
+    status TEXT NOT NULL,       -- passed | failed | error
+    agent TEXT,
+    command TEXT,
+    command_source TEXT,
+    transport TEXT,
+    requested_transport TEXT,
+    transport_fallback_reason TEXT,
+    success_marker TEXT,
+    marker_found INTEGER NOT NULL DEFAULT 0,  -- 0 | 1
+    timed_out INTEGER NOT NULL DEFAULT 0,     -- 0 | 1
+    timeout_seconds INTEGER,
+    transcript_artifact TEXT,   -- ref -> cache artifact.id
+    cwd TEXT,
+    started_at TEXT NOT NULL,
+    ended_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dogfood_run_id_uq ON dogfood_run(run_id);
+CREATE INDEX IF NOT EXISTS dogfood_run_status_ts ON dogfood_run(status, ended_at);
+CREATE INDEX IF NOT EXISTS dogfood_run_scenario ON dogfood_run(scenario, ended_at);
+
+-- ==== Session labels (spar stamps) ====
+-- The wave-3 list calls these "spar labels", and in v1 they were VALUES in
+-- `session.labels` - a JSON column on the `session` row itself. That column is
+-- rebuilt from the transcript on every re-derive, so `ax dojo spar-score`'s stamp
+-- (which is what excludes a variant run from behavioural analytics) survived only
+-- until the next ingest. Here it is a row of its own, keyed by the cache session
+-- id, and the label is applied at READ time by the analytics that care.
+-- Merge-union semantics come free: one row per (session, label).
+CREATE TABLE IF NOT EXISTS session_label (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,  -- ref -> cache session.id
+    label TEXT NOT NULL,
+    source TEXT,               -- what applied it, e.g. "spar-score"
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS session_label_uq ON session_label(session_id, label);
+CREATE INDEX IF NOT EXISTS session_label_label ON session_label(label);

--- a/packages/schema/src/schema.sidecar.sql
+++ b/packages/schema/src/schema.sidecar.sql
@@ -212,7 +212,10 @@ CREATE TABLE IF NOT EXISTS plays_role (
 );
 CREATE INDEX IF NOT EXISTS plays_role_in ON plays_role(in_id);
 CREATE INDEX IF NOT EXISTS plays_role_out ON plays_role(out_id);
-CREATE UNIQUE INDEX IF NOT EXISTS plays_role_in_out_uq ON plays_role(in_id, out_id);
+-- Source is part of the natural key. A user tag and a mined tag can classify
+-- the same skill-role pair at the same time. Each writer removes only its own
+-- source before it writes the current value.
+CREATE UNIQUE INDEX IF NOT EXISTS plays_role_in_out_source_uq ON plays_role(in_id, out_id, source);
 
 -- ==== Retro ====
 -- A structured reflection emitted at session end: tried / worked / failed / next.

--- a/packages/schema/src/sidecar-ddl.ts
+++ b/packages/schema/src/sidecar-ddl.ts
@@ -1,0 +1,54 @@
+// packages/schema/src/sidecar-ddl.ts
+/** The judgment sidecar's DDL text, and the ONLY regex that reads it.
+ *  Mirrors duckdb-ddl.ts for the cache half. */
+import SIDECAR_SCHEMA_SQL_TEXT from "./schema.sidecar.sql" with { type: "text" };
+
+export const SIDECAR_SCHEMA_SQL: string = SIDECAR_SCHEMA_SQL_TEXT;
+
+const stripQuotes = (name: string): string => name.replace(/^"|"$/g, "");
+
+/** Table names this DDL creates, in declaration order. */
+export function parseSqliteTables(sql: string = SIDECAR_SCHEMA_SQL): readonly string[] {
+    return [...sql.matchAll(/^CREATE TABLE IF NOT EXISTS\s+("?[A-Za-z_][\w]*"?)\s*\(/gm)].map((m) =>
+        stripQuotes(m[1]!),
+    );
+}
+
+export interface SqliteColumnDef {
+    readonly name: string;
+    readonly type: string;
+    readonly notNull: boolean;
+}
+
+/** Raw, comment-stripped column lines of one CREATE TABLE body. Same single-parse
+ *  discipline as duckdb-ddl.ts: one extractor, so two readers cannot diverge. */
+function sqliteTableBodyLines(table: string, sql: string): readonly string[] {
+    const re = new RegExp(`^CREATE TABLE IF NOT EXISTS\\s+"?${table}"?\\s*\\(([\\s\\S]*?)^\\);`, "m");
+    const body = re.exec(sql)?.[1];
+    if (body === undefined) return [];
+    return body
+        .split("\n")
+        .map((line) => line.replace(/--.*$/, "").trim())
+        .filter((line) => line.length > 0);
+}
+
+/** Column definitions (name, type, NOT NULL) of one CREATE TABLE body. */
+export function parseSqliteColumnDefs(
+    table: string,
+    sql: string = SIDECAR_SCHEMA_SQL,
+): readonly SqliteColumnDef[] {
+    return sqliteTableBodyLines(table, sql)
+        .map((line) => {
+            const parts = line.split(/\s+/);
+            const name = stripQuotes(parts[0]!);
+            const type = (parts[1] ?? "").replace(/,$/, "");
+            const notNull = /\bNOT NULL\b/.test(line);
+            return { name, type, notNull };
+        })
+        .filter((col) => col.name.length > 0 && !/^(PRIMARY|UNIQUE|CONSTRAINT|CHECK)$/i.test(col.name));
+}
+
+/** Column names of one CREATE TABLE body, in declaration order. */
+export function parseSqliteColumns(table: string, sql: string = SIDECAR_SCHEMA_SQL): readonly string[] {
+    return parseSqliteColumnDefs(table, sql).map((col) => col.name);
+}

--- a/packages/schema/src/sidecar-schema.test.ts
+++ b/packages/schema/src/sidecar-schema.test.ts
@@ -1,0 +1,161 @@
+// packages/schema/src/sidecar-schema.test.ts
+//
+// The SQLite judgment sidecar's DDL, exercised against a REAL SQLite database in
+// a temp directory. A `.sql` file that is never executed is a guess; every
+// assertion here loads the actual text through the actual engine.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import surql from "./schema.surql" with { type: "text" };
+import { DUCKDB_TABLE_NAMES } from "./parse-duckdb-schema.ts";
+import { SIDECAR_SCHEMA_SQL, parseSqliteColumns, parseSqliteTables } from "./sidecar-ddl.ts";
+import { SIDECAR_JUDGMENT_TABLES } from "./sidecar-tables.ts";
+
+// DEFINE FIELD [OVERWRITE] <name> ON [TABLE] <table> ... - same expression
+// duckdb-parity.test.ts uses for the cache half of the property.
+const FIELD_RE = /^DEFINE FIELD (?:OVERWRITE )?([\w]+)\s+ON\s+(?:TABLE\s+)?([\w]+)\b/gm;
+
+function surrealFieldsByTable(): Map<string, string[]> {
+    const out = new Map<string, string[]>();
+    for (const m of surql.matchAll(FIELD_RE)) {
+        const [, field, table] = m;
+        const list = out.get(table!) ?? [];
+        if (!list.includes(field!)) list.push(field!);
+        out.set(table!, list);
+    }
+    return out;
+}
+
+let dir: string;
+let db: Database;
+
+beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ax-sidecar-ddl-"));
+    db = new Database(join(dir, "judgment.sqlite"), { create: true });
+    db.exec(SIDECAR_SCHEMA_SQL);
+});
+
+afterAll(async () => {
+    db.close();
+    await rm(dir, { recursive: true, force: true });
+});
+
+const liveTables = (): ReadonlySet<string> =>
+    new Set(
+        db
+            .query<{ name: string }, []>(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            )
+            .all()
+            .map((r) => r.name),
+    );
+
+describe("the judgment sidecar DDL", () => {
+    test("creates exactly the judgment tables, and nothing else", () => {
+        expect([...liveTables()].sort()).toEqual([...SIDECAR_JUDGMENT_TABLES].sort());
+    });
+
+    test("is idempotent - applying it twice is not an error", () => {
+        expect(() => db.exec(SIDECAR_SCHEMA_SQL)).not.toThrow();
+        expect([...liveTables()].sort()).toEqual([...SIDECAR_JUDGMENT_TABLES].sort());
+    });
+
+    test("parseSqliteTables agrees with what SQLite actually created", () => {
+        expect([...parseSqliteTables(SIDECAR_SCHEMA_SQL)].sort()).toEqual([...liveTables()].sort());
+    });
+
+    test("keys every table by a TEXT id primary key", () => {
+        for (const table of SIDECAR_JUDGMENT_TABLES) {
+            const cols = db
+                .query<{ name: string; type: string; pk: number }, []>(`PRAGMA table_info(${table})`)
+                .all();
+            const pk = cols.filter((c) => c.pk > 0);
+            expect(pk.map((c) => c.name)).toEqual(["id"]);
+            expect(pk[0]?.type).toBe("TEXT");
+        }
+    });
+
+    test("stamps its default timestamps as millisecond ISO-8601 UTC, not SQLite's second-grain local form", () => {
+        // SQLite's own CURRENT_TIMESTAMP renders `YYYY-MM-DD HH:MM:SS` - no `T`,
+        // no `Z`, no milliseconds - which `new Date(...)` reads as LOCAL time.
+        // Every timestamp in this schema is a UTC instant, so the DDL stamps the
+        // ISO form instead. Checked on a real insert, not by reading the text.
+        db.exec(
+            "INSERT INTO skill_triage_decision (id, skill_name, decision) VALUES ('t-iso', 'iso-probe', 'keep')",
+        );
+        const row = db
+            .query<{ decided_at: string }, []>(
+                "SELECT decided_at FROM skill_triage_decision WHERE id = 't-iso'",
+            )
+            .get();
+        expect(row?.decided_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        expect(Math.abs(Date.parse(row!.decided_at) - Date.now())).toBeLessThan(60_000);
+    });
+
+    test("indexes both sides of the plays_role edge", () => {
+        // The cache's edge-index rule is asserted in duckdb-schema.test.ts and
+        // deliberately skips this table, since it lives here now. Read from
+        // sqlite_master rather than from the DDL text, so this checks what the
+        // engine BUILT.
+        const indexed = new Set(
+            db
+                .query<{ column_name: string }, []>(
+                    "SELECT ii.name AS column_name FROM pragma_index_list('plays_role') AS il, " +
+                        "pragma_index_info(il.name) AS ii",
+                )
+                .all()
+                .map((r) => r.column_name),
+        );
+        expect(indexed.has("in_id")).toBe(true);
+        expect(indexed.has("out_id")).toBe(true);
+    });
+
+    test("owns every judgment table ALONE - the cache DDL defines none of them", () => {
+        // One home per table. A table defined in both engines answers from
+        // whichever the reader happened to open, and the empty one answers with
+        // zero rows instead of an error.
+        const alsoInCache = [...SIDECAR_JUDGMENT_TABLES].filter((t) => DUCKDB_TABLE_NAMES.has(t));
+        expect(alsoInCache).toEqual([]);
+    });
+
+    test("carries every Surreal field of a judgment table that the cache DDL gave up", () => {
+        // duckdb-parity.test.ts pins "every DEFINE FIELD in schema.surql has a
+        // column in schema.duckdb.sql". Moving fourteen tables out of that file
+        // would silently drop them from the property; this is the other half, so
+        // no v1 field loses coverage by changing engines.
+        let compared = 0;
+        for (const [table, fields] of surrealFieldsByTable()) {
+            if (!SIDECAR_JUDGMENT_TABLES.has(table)) continue;
+            const columns = new Set(parseSqliteColumns(table));
+            for (const field of fields) {
+                // `in`/`out` are SQL keywords; the cache renamed them to
+                // in_id/out_id and the sidecar keeps that spelling.
+                const expected = field === "in" ? "in_id" : field === "out" ? "out_id" : field;
+                expect({ table, field, has: columns.has(expected) }).toEqual({
+                    table,
+                    field,
+                    has: true,
+                });
+                compared += 1;
+            }
+        }
+        // Never let the property shrink to comparing nothing.
+        expect(compared).toBeGreaterThanOrEqual(90);
+    });
+
+    test("holds spar labels as rows, not as a column on a rebuildable session", () => {
+        // `session.labels` lives on the DuckDB cache's `session` table, which a
+        // re-derive rewrites from the transcript - so a spar stamp written there
+        // is erased by the next ingest. The sidecar owns the stamp instead.
+        db.exec(
+            "INSERT INTO session_label (id, session_id, label) VALUES ('sl-1', 'sess-1', 'spar')",
+        );
+        expect(() =>
+            db.exec(
+                "INSERT INTO session_label (id, session_id, label) VALUES ('sl-2', 'sess-1', 'spar')",
+            ),
+        ).toThrow(/UNIQUE/);
+    });
+});

--- a/packages/schema/src/sidecar-tables.ts
+++ b/packages/schema/src/sidecar-tables.ts
@@ -1,0 +1,98 @@
+// packages/schema/src/sidecar-tables.ts
+/**
+ * Manifest of every table in schema.sidecar.sql - the SQLite judgment sidecar.
+ *
+ * The set below is the SINGLE SOURCE OF TRUTH for "what is judgment". It has two
+ * jobs, and the second is the load-bearing one:
+ *
+ *  1. It says what the sidecar owns, so nothing widens the boundary by accident
+ *     (`feedback_case_*` and `opportunity` are decision-SHAPED and still
+ *     re-derivable, so they stay in the cache - see schema.sidecar.sql's header).
+ *  2. It says what the CACHE must NOT define. A table defined in BOTH
+ *     schema.duckdb.sql and schema.sidecar.sql would give a reader two homes and
+ *     one of them empty, and an empty table answers a query with zero rows rather
+ *     than an error - the silent wrong answer the v2 no-fallback rule exists to
+ *     prevent. `duckdb-schema.test.ts` asserts the cache DDL defines none of
+ *     these; `sidecar-schema.test.ts` asserts the sidecar DDL defines all of them
+ *     and nothing else.
+ *
+ * `session_label` is here and was never a table in v1: the wave-3 backlog calls
+ * these "spar labels", and they were VALUES stamped into `session.labels`, a
+ * column on the rebuildable `session` row. See that table's comment in the DDL.
+ */
+import { parseSqliteTables, SIDECAR_SCHEMA_SQL } from "./sidecar-ddl.ts";
+
+export interface SidecarTableSpec {
+    readonly table: string;
+    readonly kind: "node" | "edge";
+    readonly note: string;
+}
+
+/** Table names parsed out of schema.sidecar.sql. */
+export const SIDECAR_TABLE_NAMES: ReadonlySet<string> = new Set(parseSqliteTables(SIDECAR_SCHEMA_SQL));
+
+/**
+ * Durable judgment tables: user/agent DECISIONS that cannot be re-derived from
+ * transcripts, git, skills or the OTLP spool, so a cache rebuild must not drop
+ * them. Enumerated explicitly rather than derived from the DDL, so ADDING a table
+ * to schema.sidecar.sql is a deliberate widening of the boundary that has to be
+ * written down in two places instead of one.
+ */
+export const SIDECAR_JUDGMENT_TABLES: ReadonlySet<string> = new Set([
+    "proposal",
+    "skill_proposal",
+    "subagent_proposal",
+    "hook_proposal",
+    "guidance_proposal",
+    "automation_proposal",
+    "experiment",
+    "checkpoint",
+    "role",
+    "plays_role",
+    "retro",
+    "skill_triage_decision",
+    "transcript_label_review",
+    "dogfood_run",
+    "session_label",
+]);
+
+/** Hand-authored editorial metadata, keyed by table name - content the DDL does
+ *  not carry. The manifest below is DERIVED from the parsed DDL, so an entry for
+ *  a table the DDL dropped (or a table with no entry) throws at import. */
+const TABLE_METADATA: Readonly<Record<string, Omit<SidecarTableSpec, "table">>> = {
+    proposal: { kind: "node", note: "Polymorphic shortlist of repeated workflow improvement candidates." },
+    skill_proposal: { kind: "node", note: "Typed payload rows for skill-form proposals." },
+    subagent_proposal: { kind: "node", note: "Typed payload rows for subagent-form proposals." },
+    hook_proposal: { kind: "node", note: "Typed payload rows for hook-form proposals." },
+    guidance_proposal: { kind: "node", note: "Typed payload rows for guidance-file proposals." },
+    automation_proposal: { kind: "node", note: "Typed payload rows for automation-form proposals." },
+    experiment: { kind: "node", note: "Accepted proposals and their scaffold/verdict state." },
+    checkpoint: { kind: "node", note: "Experiment measurement snapshots and the human-confirmed verdict." },
+    role: { kind: "node", note: "Skill role labels and their user-tuned weights." },
+    plays_role: { kind: "edge", note: "Skill-to-role classification edges (in_id = cache skill id)." },
+    retro: { kind: "node", note: "Structured session retrospectives (tried/worked/failed/next)." },
+    skill_triage_decision: { kind: "node", note: "Keep/archive/review decisions per skill NAME." },
+    transcript_label_review: { kind: "node", note: "Human/agent review verdicts for mined transcript label candidates." },
+    dogfood_run: { kind: "node", note: "Terminal dogfood scenario results." },
+    session_label: { kind: "node", note: "Labels stamped on a cache session (spar), durable across re-derive." },
+};
+
+function buildManifest(): readonly SidecarTableSpec[] {
+    const missingMetadata = [...SIDECAR_TABLE_NAMES].filter((table) => !(table in TABLE_METADATA));
+    if (missingMetadata.length > 0) {
+        throw new Error(
+            `sidecar-tables.ts: DDL table(s) with no TABLE_METADATA entry: ${missingMetadata.join(", ")}. ` +
+                "Add a { kind, note } entry for each before the manifest can build.",
+        );
+    }
+    const staleMetadata = Object.keys(TABLE_METADATA).filter((table) => !SIDECAR_TABLE_NAMES.has(table));
+    if (staleMetadata.length > 0) {
+        throw new Error(
+            `sidecar-tables.ts: TABLE_METADATA entry for table(s) no longer in the DDL: ${staleMetadata.join(", ")}. ` +
+                "Remove the stale entry (or the table was renamed and the entry needs the new name).",
+        );
+    }
+    return [...SIDECAR_TABLE_NAMES].map((table) => ({ table, ...TABLE_METADATA[table]! }));
+}
+
+export const SIDECAR_SCHEMA_TABLES: readonly SidecarTableSpec[] = buildManifest();


### PR DESCRIPTION
Typed SQLite judgment prerequisite slice: schema ownership, Effect service/layer, transactions, integrity checks, role read/write vertical, failure recovery, and no-Surreal process coverage. Independent Opus gate PASS with no P1/P2/P3 findings. 5,755 focused workspace tests pass; desktop Electron failures are environmental.