### PR TITLE
fix(duckdb): cast CURRENT_TIMESTAMP at 13 interval-arithmetic sites, and guard against the next one

### DIFF
--- a/apps/axctl/src/ingest/classifier-results.ts
+++ b/apps/axctl/src/ingest/classifier-results.ts
@@ -150,7 +150,7 @@ const fetchTurns = (write: CacheWriteService, sinceDays: number | undefined): Ef
             text_excerpt: Schema.NullOr(Schema.String), ts: TimestampColumn,
         }), `SELECT id, session, CAST(seq AS DOUBLE) AS seq, role, message_kind, text, text_excerpt, ts
 FROM turn
-${sinceDays === undefined ? "" : "WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"}
+${sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY session, seq`, sinceDays === undefined ? [] : [sinceDays]);
     });
 
@@ -163,7 +163,7 @@ const fetchToolCalls = (write: CacheWriteService, sinceDays: number | undefined)
             has_error: Schema.Boolean, ts: TimestampColumn,
         }), `SELECT id, session, CAST(seq AS DOUBLE) AS seq, name, command_norm, command_text, output_excerpt, error_text, has_error, ts
 FROM tool_call
-${sinceDays === undefined ? "" : "WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"}
+${sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY session, ts`, sinceDays === undefined ? [] : [sinceDays + 1]);
     });
 
@@ -174,7 +174,7 @@ const fetchEditedFiles = (write: CacheWriteService, sinceDays: number | undefine
             seq: Schema.NullOr(Schema.Number), ts: TimestampColumn,
         }), `SELECT e.in_id AS turn, e.out_id AS file, e.session, CAST(t.seq AS DOUBLE) AS seq, e.ts
              FROM edited e LEFT JOIN turn t ON t.id = e.in_id
-             ${sinceDays === undefined ? "" : "WHERE e.ts >= current_timestamp - (? * INTERVAL '1 day')"}
+             ${sinceDays === undefined ? "" : "WHERE e.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
              ORDER BY e.ts`, sinceDays === undefined ? [] : [sinceDays + 1]);
     });
 

--- a/apps/axctl/src/ingest/closure.ts
+++ b/apps/axctl/src/ingest/closure.ts
@@ -305,7 +305,7 @@ export const deriveClosure = (
             write.rows(Schema.Struct({ id: Schema.String, message: Schema.NullOr(Schema.String), repository: Schema.NullOr(Schema.String), ts: TimestampColumn }), `
 SELECT id, message, repository, ts
 FROM commit
-${opts.sinceDays === undefined ? "" : "WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"}
+${opts.sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY ts ASC`, opts.sinceDays === undefined ? [] : [opts.sinceDays]),
             write.rows(Schema.Struct({ in: Schema.String, out: Schema.String, path: Schema.String }), `
 SELECT t.in_id AS in, t.out_id AS out, f.path

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -132,7 +132,7 @@ export const rowsSql = (sinceDays: number | undefined): string => `
 SELECT id, session, name,
        input_json AS inputJson, output_excerpt AS outputExcerpt,
        length(output_json) AS bytes, ts
-FROM tool_call WHERE output_json IS NOT NULL ${sinceDays === undefined ? "" : "AND ts >= current_timestamp - (? * INTERVAL '1 day')"};
+FROM tool_call WHERE output_json IS NOT NULL ${sinceDays === undefined ? "" : "AND ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"};
 `;
 
 export interface DeriveContentTypeStats {

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -214,7 +214,7 @@ const fetchToolCalls = (write: CacheWriteService, sinceDays: number | undefined)
         }), `SELECT id, session, turn, name, command_norm, command_text, output_excerpt, error_text,
                     CAST(exit_code AS DOUBLE) AS exit_code, has_error, status, ts
 FROM tool_call
-${sinceDays === undefined ? "" : "WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"}
+${sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY ts DESC`, sinceDays === undefined ? [] : [sinceDays]);
     });
 
@@ -225,7 +225,7 @@ const fetchUserTurns = (write: CacheWriteService, sinceDays: number | undefined)
             text_excerpt: Schema.NullOr(Schema.String), ts: TimestampColumn, has_error: Schema.Boolean,
         }), `SELECT id, session, CAST(seq AS DOUBLE) AS seq, text_excerpt, ts, has_error
 FROM turn
-WHERE role = 'user' ${sinceDays === undefined ? "" : "AND ts >= current_timestamp - (? * INTERVAL '1 day')"}
+WHERE role = 'user' ${sinceDays === undefined ? "" : "AND ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY ts DESC`, sinceDays === undefined ? [] : [sinceDays]);
     });
 

--- a/apps/axctl/src/ingest/reaction-events.ts
+++ b/apps/axctl/src/ingest/reaction-events.ts
@@ -263,7 +263,7 @@ const fetchTurns = (write: CacheWriteService, sinceDays: number | undefined): Ef
         }), `SELECT t.id, t.session, CAST(t.seq AS DOUBLE) AS seq, t.role, s.source,
                     t.message_kind, t.intent_kind, t.text, t.text_excerpt, t.ts
              FROM turn t JOIN session s ON s.id = t.session
-             ${sinceDays === undefined ? "" : "WHERE t.ts >= current_timestamp - (? * INTERVAL '1 day')"}
+             ${sinceDays === undefined ? "" : "WHERE t.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
              ORDER BY t.session, t.seq`, sinceDays === undefined ? [] : [sinceDays]);
     });
 

--- a/apps/axctl/src/ingest/turn-analysis.ts
+++ b/apps/axctl/src/ingest/turn-analysis.ts
@@ -505,7 +505,7 @@ const fetchTurns = (write: CacheWriteService, sinceDays: number | undefined): Ef
         }), `SELECT t.id, t.session, CAST(t.seq AS DOUBLE) AS seq, t.role, s.source,
                     t.message_kind, t.intent_kind, t.text, t.text_excerpt, t.ts
              FROM turn t JOIN session s ON s.id = t.session
-             ${sinceDays === undefined ? "" : "WHERE t.ts >= current_timestamp - (? * INTERVAL '1 day')"}
+             ${sinceDays === undefined ? "" : "WHERE t.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
              ORDER BY t.session, t.seq`, sinceDays === undefined ? [] : [sinceDays]);
     });
 

--- a/apps/axctl/src/ingest/turn-content-blocks.ts
+++ b/apps/axctl/src/ingest/turn-content-blocks.ts
@@ -104,7 +104,7 @@ const fetchTurnRows = (
         return yield* write.rows(Row, `
 SELECT id, session, agent_event, CAST(seq AS DOUBLE) AS seq, role, message_kind, intent_kind, text, text_excerpt, has_tool_use, has_error, ts
 FROM turn
-${sinceDays === undefined ? "" : "WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"}
+${sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
 ORDER BY session, seq`, sinceDays === undefined ? [] : [sinceDays]);
     });
 

--- a/apps/axctl/src/otel/correlate.ts
+++ b/apps/axctl/src/otel/correlate.ts
@@ -30,7 +30,7 @@ export const correlateOrphanOtel = (write: CacheWriteService) =>
             const rows = yield* write.rows(
                 TelemetryRow,
                 `SELECT id, session_id FROM ${table}
-                 WHERE observed_at > current_timestamp - INTERVAL '${SCAN_WINDOW_DAYS} days'
+                 WHERE observed_at > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '${SCAN_WINDOW_DAYS} days'
                    AND session_id IS NOT NULL
                  QUALIFY row_number() OVER (PARTITION BY session_id ORDER BY observed_at DESC) = 1`,
             );

--- a/apps/axctl/src/otel/retention.ts
+++ b/apps/axctl/src/otel/retention.ts
@@ -12,15 +12,21 @@ export interface OtelRetentionResult {
 
 /** Keep 30 days of OTLP rows and remove relation rows without a target. */
 export const retainRecentOtel = Effect.fn("otel.retention")(function* (write: CacheWriteService) {
+    // The CAST is load-bearing: `CURRENT_TIMESTAMP` is TIMESTAMPTZ, and
+    // TIMESTAMPTZ - INTERVAL is resolved by the ICU extension, which the shipped
+    // static build does not carry - so the uncast form is a binder error there.
+    // `observed_at` is a naive UTC TIMESTAMP (schema.duckdb.sql UTC CONTRACT) and
+    // the seam pins connections to UTC, so the cast preserves meaning.
+    const cutoff = "CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '30 days'";
     const deletedByTable: Record<string, number> = {};
     for (const table of OTEL_TABLES) {
         const rows = yield* write.rows(
             CountRow,
-            `SELECT count(*) AS count FROM ${table} WHERE observed_at < current_timestamp - INTERVAL '30 days'`,
+            `SELECT count(*) AS count FROM ${table} WHERE observed_at < ${cutoff}`,
         );
         deletedByTable[table] = rows[0]?.count ?? 0;
         yield* write.exec(
-            `DELETE FROM ${table} WHERE observed_at < current_timestamp - INTERVAL '30 days'`,
+            `DELETE FROM ${table} WHERE observed_at < ${cutoff}`,
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "check:release-announcements": "bun scripts/check-release-announcements.ts",
     "check:no-node-fs": "bun scripts/check-no-node-fs.ts",
     "check:record-select": "bun scripts/check-record-select.ts",
+    "check:timestamp-cast": "bun scripts/check-timestamp-cast.ts",
     "check:harness-docs": "bun scripts/check-harness-docs-drift.ts",
     "check:table-coverage": "bun scripts/check-table-coverage.ts",
     "dashboard:dev": "vite --config apps/axctl/src/dashboard/web/vite.config.ts",

--- a/scripts/check-timestamp-cast.test.ts
+++ b/scripts/check-timestamp-cast.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { isUncastTimestampArithmetic, stripComments } from "./check-timestamp-cast.ts";
+
+describe("isUncastTimestampArithmetic", () => {
+    test("flags the lowercase literal-interval form (the spelling every site used)", () => {
+        expect(
+            isUncastTimestampArithmetic(
+                "`SELECT count(*) FROM t WHERE observed_at < current_timestamp - INTERVAL '30 days'`",
+            ),
+        ).toBe(true);
+    });
+
+    test("flags the uppercase spelling too - SQL keywords are case-insensitive", () => {
+        expect(isUncastTimestampArithmetic("WHERE ts < CURRENT_TIMESTAMP - INTERVAL '1 day'")).toBe(true);
+    });
+
+    test("flags the parameterized form", () => {
+        expect(
+            isUncastTimestampArithmetic(`"WHERE ts >= current_timestamp - (? * INTERVAL '1 day')"`),
+        ).toBe(true);
+    });
+
+    test("flags CURRENT_TIMESTAMP on the right of the operator", () => {
+        expect(isUncastTimestampArithmetic("SELECT ts - current_timestamp AS delta FROM turn")).toBe(true);
+    });
+
+    test("accepts the cast literal-interval form", () => {
+        expect(
+            isUncastTimestampArithmetic(
+                "WHERE observed_at < CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '30 days'",
+            ),
+        ).toBe(false);
+    });
+
+    test("accepts the cast parameterized form", () => {
+        expect(
+            isUncastTimestampArithmetic(
+                "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')",
+            ),
+        ).toBe(false);
+    });
+
+    test("accepts DEFAULT CURRENT_TIMESTAMP in DDL - an assignment, not arithmetic", () => {
+        expect(isUncastTimestampArithmetic("    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP")).toBe(false);
+    });
+
+    test("accepts a bare CURRENT_TIMESTAMP bound as an INSERT value", () => {
+        expect(isUncastTimestampArithmetic("`(${placeholders}, CURRENT_TIMESTAMP)`")).toBe(false);
+    });
+
+    test("does not flag prose that merely discusses the banned shape", () => {
+        // Both comment styles, including the SQL `--` marker that would
+        // otherwise look like the operator in the right-hand rule.
+        expect(isUncastTimestampArithmetic("-- CURRENT_TIMESTAMP - INTERVAL needs ICU")).toBe(false);
+        expect(isUncastTimestampArithmetic("// current_timestamp - INTERVAL '1 day' is banned")).toBe(false);
+        expect(isUncastTimestampArithmetic(" * `CURRENT_TIMESTAMP` is a TIMESTAMPTZ")).toBe(false);
+    });
+});
+
+describe("stripComments", () => {
+    test("drops the commented tail but keeps preceding code", () => {
+        expect(stripComments("SELECT 1 -- current_timestamp - INTERVAL")).toBe("SELECT 1 ");
+    });
+
+    test("drops whole jsdoc continuation lines", () => {
+        expect(stripComments(" * current_timestamp - INTERVAL")).toBe("");
+    });
+});

--- a/scripts/check-timestamp-cast.ts
+++ b/scripts/check-timestamp-cast.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+/**
+ * Guard: ban `CURRENT_TIMESTAMP` INTERVAL ARITHMETIC that is not wrapped in
+ * `CAST(CURRENT_TIMESTAMP AS TIMESTAMP)`.
+ *
+ * WHY THIS EXISTS. DuckDB's `CURRENT_TIMESTAMP` is a TIMESTAMP WITH TIME ZONE.
+ * Subtracting an INTERVAL from a TIMESTAMPTZ resolves only through the ICU
+ * extension, and the static DuckDB build ax ships does NOT carry ICU. So the
+ * uncast form is not a wrong answer - the statement does not bind at all:
+ *
+ *     Binder Error: No function matches the given name and argument types
+ *     '(TIMESTAMP WITH TIME ZONE, INTERVAL)'
+ *
+ * Every TIMESTAMP column in packages/schema/src/schema.duckdb.sql is a NAIVE
+ * UTC timestamp (see its "UTC CONTRACT" block - TIMESTAMPTZ is banned there),
+ * and the seam pins every connection to UTC, so casting the clock down to a
+ * naive TIMESTAMP compares like with like and preserves meaning.
+ *
+ * WHY A REPO CHECK AND NOT A TEST. The dylib the test suite resolves by default
+ * DOES carry ICU, so no ordinary `bun test` run can fail on this class. That is
+ * exactly how thirteen sites accumulated behind a green suite. Only a run
+ * against the ICU-less build reproduces it:
+ *
+ *     AX_DUCKDB_DYLIB=~/.cache/ax-duckdb/dist/duckdb bun test <paths>
+ *
+ * WHY CASE-INSENSITIVE. SQL keywords are case-insensitive and every one of the
+ * thirteen sites spelled it lowercase. Prior sweeps grepped for the uppercase
+ * spelling only, found nothing, and declared the class clean.
+ *
+ * SCOPE. Arithmetic only (the proven defect class), in both operand orders.
+ * Bare `DEFAULT CURRENT_TIMESTAMP` in DDL and a bare `CURRENT_TIMESTAMP` bound
+ * as an INSERT value are fine: those are assignments into a naive column, which
+ * DuckDB casts without ICU.
+ */
+
+import { Glob } from "bun";
+
+const SCAN_GLOBS = [
+    "apps/*/src/**/*.ts",
+    "apps/*/src/**/*.tsx",
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.tsx",
+    "packages/*/src/**/*.sql",
+    "scripts/**/*.ts",
+];
+
+/** Files legitimately allowed to contain the bare form. Each entry needs a reason. */
+const EXCLUDED_FILES: readonly string[] = [
+    // This guard itself: its documentation quotes the banned shape.
+    "scripts/check-timestamp-cast.ts",
+    // This guard's own tests: the banned shape IS the fixture there.
+    "scripts/check-timestamp-cast.test.ts",
+];
+
+// NOTE: other *.test.ts files are deliberately IN scope. Test SQL runs against
+// the same ICU-less build in CI's `verify` job, so a bad spelling in a test is
+// a real failure, not a false positive.
+
+/**
+ * `CURRENT_TIMESTAMP` on the LEFT of `-`/`+`.
+ *
+ * The correct form does NOT match: in
+ * `CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '30 days'` the token that
+ * precedes the operator is `)`, not the keyword.
+ */
+const LHS_RE = /current_timestamp\s*[-+]/i;
+
+/**
+ * `CURRENT_TIMESTAMP` on the RIGHT of `-`/`+` (e.g. `ts - current_timestamp`).
+ * The wrapped form reads `- CAST(CURRENT_TIMESTAMP ...`, so the character after
+ * the operator is `C` of `CAST` and this does not match either.
+ */
+const RHS_RE = /[-+]\s*current_timestamp\b/i;
+
+/**
+ * Remove line comments before matching, so PROSE that merely discusses the
+ * banned shape is not flagged. Several files legitimately explain this bug in
+ * comments, and a `-- CURRENT_TIMESTAMP is a TIMESTAMPTZ` line would otherwise
+ * trip the right-hand rule on the comment marker itself.
+ */
+export function stripComments(line: string): string {
+    const trimmed = line.trimStart();
+    // JSDoc/block-comment continuation lines.
+    if (trimmed.startsWith("*") || trimmed.startsWith("/*")) return "";
+    const sqlComment = line.indexOf("--");
+    const tsComment = line.indexOf("//");
+    const cut = [sqlComment, tsComment].filter((i) => i >= 0).sort((a, b) => a - b)[0];
+    return cut === undefined ? line : line.slice(0, cut);
+}
+
+/** The line matcher, exported for tests. True when `line` does uncast arithmetic. */
+export function isUncastTimestampArithmetic(line: string): boolean {
+    const code = stripComments(line);
+    return LHS_RE.test(code) || RHS_RE.test(code);
+}
+
+interface Offender {
+    readonly file: string;
+    readonly line: number;
+    readonly text: string;
+}
+
+async function main(): Promise<void> {
+    const excluded = new Set(EXCLUDED_FILES);
+    const seen = new Set<string>();
+    const files: string[] = [];
+    for (const pattern of SCAN_GLOBS) {
+        const glob = new Glob(pattern);
+        for await (const file of glob.scan({ cwd: process.cwd(), onlyFiles: true })) {
+            if (seen.has(file)) continue;
+            seen.add(file);
+            if (excluded.has(file)) continue;
+            files.push(file);
+        }
+    }
+
+    const offenders: Offender[] = [];
+    for (const file of files.sort()) {
+        const lines = (await Bun.file(file).text()).split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (isUncastTimestampArithmetic(lines[i]!)) {
+                offenders.push({ file, line: i + 1, text: lines[i]!.trim() });
+            }
+        }
+    }
+
+    if (offenders.length > 0) {
+        console.error("Uncast CURRENT_TIMESTAMP interval arithmetic found:");
+        for (const o of offenders) console.error(`${o.file}:${o.line}: ${o.text}`);
+        console.error(
+            `\n${offenders.length} offender(s). DuckDB's CURRENT_TIMESTAMP is a TIMESTAMPTZ and ` +
+                "TIMESTAMPTZ +/- INTERVAL needs the ICU extension, which the shipped static build " +
+                "does not carry - these statements fail to BIND at runtime.\n" +
+                "Fix: wrap the clock in CAST(CURRENT_TIMESTAMP AS TIMESTAMP), e.g.\n" +
+                "  CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '30 days'\n" +
+                "  CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')\n" +
+                "Verify against the ICU-less build:\n" +
+                "  AX_DUCKDB_DYLIB=~/.cache/ax-duckdb/dist/duckdb bun test <paths>",
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `check-timestamp-cast: clean (${files.length} files scanned, 0 uncast CURRENT_TIMESTAMP arithmetic).`,
+    );
+}
+
+if (import.meta.main) {
+    await main();
+}


### PR DESCRIPTION
Fixes the three tests currently RED on `v2/duckdb`, and the ten silently-broken queries beside them that no test covers.

## The defect

DuckDB's `CURRENT_TIMESTAMP` is a `TIMESTAMP WITH TIME ZONE`. TIMESTAMPTZ-minus-INTERVAL is resolved by the **ICU extension**, which is not in the static build ax ships. So the query does not run at all:

```
Binder Error: No function matches the given name and argument types
  '-(TIMESTAMP WITH TIME ZONE, INTERVAL)'
```

`duckdb_extensions()` on the shipped build reports `icu installed=false loaded=false`.

## Why it survived

**Every previous sweep grepped case-sensitively for `CURRENT_TIMESTAMP`. All 13 sites spell it lowercase.** SQL keywords are case-insensitive; the greps were not. `rg -n "CURRENT_TIMESTAMP\s*[-+]"` returns 0. `rg -in` returns 13.

The suite could not catch it either: the default test dylib is the official prebuilt, which HAS ICU. Only CI's `verify` job (`AX_DUCKDB_REQUIRE_FTS: 1`, static build) exercises the shipped configuration — which is why exactly the three sites with an ICU-touching test went red and the other ten stayed invisible.

## What changed

- **3 literal-interval sites** — `otel/retention.ts` ×2, `otel/correlate.ts`. These are the CI reds.
- **10 parameterized sites** on `sinceDays` paths — `ingest/{turn-content-blocks,reaction-events,classifier-results ×3,closure,outcomes ×2,turn-analysis,derive-content-types}.ts`. Every `--since` windowed ingest query was failing to bind in production.
- **A guard**: `scripts/check-timestamp-cast.ts` + test, wired as `bun run check:timestamp-cast`. It greps **case-insensitively** and exits non-zero on unguarded interval arithmetic. Observed failing against the pre-fix tree: exit 1, exactly 13 offenders.

`clause.ts` is deliberately untouched — three chunk branches are mid-merge against it with colliding helpers.

## Verified on the build that actually ships

`AX_DUCKDB_DYLIB=<static build> bun test` → 70 otel + 1053 ingest pass / 0 fail, including all three formerly-red tests. Default dylib: 1123 pass / 0 fail. `typecheck` 0 · `tsc --noEmit -p tsconfig.json` 0 · `check:no-node-fs` 0 · `check:timestamp-cast` 0.

## Two things measured rather than assumed

- **`CAST(? AS INTEGER)` is not load-bearing for the reason usually given.** Measured 2×2 against the real site's SQL: an uncast `?` with a *numeric* bind runs fine — DuckDB infers INTEGER. Only `CAST(CURRENT_TIMESTAMP AS TIMESTAMP)` fixes the binder error. The integer cast is kept on the narrower true ground that an uncast *string* bind fails `*(STRING_LITERAL, INTERVAL)`.
- **No site changes meaning.** Each column was checked against `schema.duckdb.sql` as a naive `TIMESTAMP`; the seam pins connections to UTC, so both operands are naive UTC.

## Known gaps

- The 10 parameterized sites have **no ICU-less test coverage** — they are verified by the guard and by the experiment above, not by a regression test.
- The guard runs locally only until a follow-up wires it into `verify`; that one-line workflow change is held back because the repo token lacks the `workflow` OAuth scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)