### PR TITLE
fix(duckdb): drop the duplicate daysAgoExpr that broke v2/duckdb typecheck

### DIFF
--- a/packages/lib/src/duckdb/clause.ts
+++ b/packages/lib/src/duckdb/clause.ts
@@ -97,24 +97,6 @@ export const untilClause = (
     until: string | Date | null | undefined,
 ): Clause => boundClause(column, "<=", until);
 
-/**
- * "N days before now", as a TIMESTAMP - the right-hand side of every windowed
- * read. Binds one parameter: the day count.
- *
- * BOTH CASTS ARE LOad-BEARING against the vendored DuckDB build, and the plain
- * spelling `CURRENT_TIMESTAMP - (? * INTERVAL '1 day')` does not run at all:
- *
- *  - `CURRENT_TIMESTAMP` is a TIMESTAMPTZ, and TIMESTAMPTZ minus INTERVAL is
- *    resolved by the ICU extension, which is not in the static build ax ships.
- *    The binder reports "No function matches '-(TIMESTAMP WITH TIME ZONE,
- *    INTERVAL)'". Casting to a naive TIMESTAMP - which is what every `ts`
- *    column in the schema is, and what the seam pins to UTC - uses core
- *    arithmetic instead.
- *  - `CAST(? AS INTEGER)` because a bound day count has no declared type at
- *    bind time, and the multiplication has to resolve to an INTERVAL.
- */
-export const daysAgoExpr = "CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')";
-
 const requireCount = (name: string, value: number): void => {
     if (!Number.isInteger(value) || value < 0) {
         throw new RangeError(


### PR DESCRIPTION
`v2/duckdb` does not typecheck. This restores it.

## What happened

#805 (`w2-read-snapshot`) and #806 (`w2-cli-mcp`) each added `daysAgoExpr` to
`packages/lib/src/duckdb/clause.ts`, in different regions of the file. The two
declarations are byte-identical — deliberately, so the symbol would merge without
a conflict — and that is exactly why git merged both copies silently and produced
two block-scoped declarations of one name:

```
clause.ts(116,14): error TS2451: Cannot redeclare block-scoped variable 'daysAgoExpr'.
clause.ts(165,14): error TS2451: Cannot redeclare block-scoped variable 'daysAgoExpr'.
```

Neither PR could have caught this on its own. Each was green against a base that
did not yet contain the other's copy, and GitHub reported both as CLEAN because
the conflict is semantic, not textual.

## Why nothing caught it automatically

`v2/duckdb` has no CI of its own. `verify` runs on `pull_request`, so it tests
each PR against the base; a push to the integration branch triggers only `Bench`.
The breakage was found by running the gates locally against the merged tip after
the last merge.

## The fix

Deletes the FIRST block, keeps the second. The survivor is the better of the two:
it documents both `daysAgoExpr` and `hoursAgoExpr`, records that the binder error
was confirmed against a real DuckDB connection rather than inferred from the
docs, and sits directly above `withinDaysClause` / `withinHoursClause`, its two
consumers. Removing the first block also drops its `LOad-BEARING` typo.

No behaviour change — the two strings were identical, so every call site already
interpolated this exact text.

## Verification, on the merged tip

- `bun run typecheck` — 0 errors (was 2)
- `bunx tsc --noEmit -p tsconfig.json` — 0 errors (was 2)
- `bun run check:no-node-fs` — clean, 686 files
- `bun run check:timestamp-cast` — clean, 1488 files
- `bun test apps/axctl packages scripts` — 5638 pass, 0 fail, against the custom
  static DuckDB build (`icu installed=false`) with `AX_DUCKDB_REQUIRE_FTS=1`

## Follow-up worth considering

An integration branch that four PRs merge into, with no gate of its own, will hit
this class again. Running `verify` on pushes to `v2/duckdb` would have caught it
within minutes of #806 rather than by hand afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
