### PR TITLE
fix(v2): strip NUL bytes at the writer seam - ax ingest could not process real transcripts (#790)

### DIFF
--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -238,7 +238,7 @@ const bigintRangeMessage = (idx: number, value: bigint): string =>
     `parameter ${idx} (${value}) is outside the range this client can bind: DuckDB binds integers as a signed 64-bit int64 (${I64_MIN} to ${I64_MAX}), and a wider value would silently wrap. Pass it as text (and store the column as VARCHAR or HUGEINT) instead.`;
 
 const nulByteMessage = (idx: number): string =>
-    `parameter ${idx} contains a NUL byte (U+0000): this client binds VARCHAR through a NUL-terminated C string, so the value would be SILENTLY TRUNCATED at the first NUL on the way in - and the length-less read accessor cannot detect the truncation on the way back out (see readResult's fix-round-2 note). Strip or escape NUL bytes upstream before binding (writer enforcement lands with wave-2 writers, #790).`;
+    `parameter ${idx} contains a NUL byte (U+0000): this client binds VARCHAR through a NUL-terminated C string, so the value would be SILENTLY TRUNCATED at the first NUL on the way in - and the length-less read accessor cannot detect the truncation on the way back out (see readResult's fix-round-2 note). Strip or escape NUL bytes upstream before binding. #790: the ax write seam (@ax/lib/duckdb/seam, writerOver) already does this for every write it issues, so reaching this message means a write path bypassed the seam - or a READ parameter carried a NUL, which the seam deliberately does not scrub.`;
 
 /** Bind one prepared-statement parameter (1-based `idx`). Returns the
  *  `duckdb_state` from the underlying bind call so the caller can check it. */

--- a/packages/lib/src/duckdb/index.ts
+++ b/packages/lib/src/duckdb/index.ts
@@ -45,6 +45,7 @@ export type {
     CacheWriteError,
     CacheWriteOptions,
     CacheWriteService,
+    NulStripTotals,
 } from "./seam.ts";
 
 // The row-decode contract: what a column type MEANS to a caller.

--- a/packages/lib/src/duckdb/nul-strip.test.ts
+++ b/packages/lib/src/duckdb/nul-strip.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The pure half of the writer-side NUL guard. No database: this file pins the
+ * decision (strip, not escape; count values, not bytes) and the fast path.
+ */
+import { describe, expect, test } from "bun:test";
+import { NUL, hasNul, stripNul, stripNulParams } from "./nul-strip.ts";
+import type { DuckDbParam } from "./types.ts";
+
+describe("nul-strip", () => {
+    test("NUL is exactly U+0000, and nothing that merely looks like it", () => {
+        expect(NUL).toHaveLength(1);
+        expect(NUL.charCodeAt(0)).toBe(0);
+        // The six-character escape a JSON transcript actually carries is TEXT,
+        // and must survive untouched - it is not a NUL byte.
+        expect(hasNul("\\u0000")).toBe(false);
+        expect(stripNul("\\u0000")).toBe("\\u0000");
+    });
+
+    test("strips every NUL and leaves every other control character alone", () => {
+        expect(stripNul(`a${NUL}b${NUL}${NUL}c`)).toBe("abc");
+        expect(stripNul(`${NUL}`)).toBe("");
+        expect(stripNul("tab\there\nnewline\r")).toBe("tab\there\nnewline\r");
+    });
+
+    test("a clean parameter list is returned by REFERENCE, uncopied", () => {
+        const params: ReadonlyArray<DuckDbParam> = ["a", 1n, null, new Date(0), true];
+        const result = stripNulParams(params);
+        expect(result.values).toBe(0);
+        expect(result.params).toBe(params);
+    });
+
+    test("counts VALUES scrubbed, not NUL bytes, and copies without mutating the input", () => {
+        const dirty = `x${NUL}y${NUL}z`;
+        const params: ReadonlyArray<DuckDbParam> = ["clean", dirty, 7n, `${NUL}lead`, null];
+        const result = stripNulParams(params);
+
+        // Two values carried NULs; one of them carried two.
+        expect(result.values).toBe(2);
+        expect(result.params).not.toBe(params);
+        expect(result.params).toEqual(["clean", "xyz", 7n, "lead", null]);
+        // The caller's array is untouched - a writer may still need to report it.
+        expect(params[1]).toBe(dirty);
+    });
+
+    test("an empty list is a no-op", () => {
+        const result = stripNulParams([]);
+        expect(result.values).toBe(0);
+        expect(result.params).toEqual([]);
+    });
+});

--- a/packages/lib/src/duckdb/nul-strip.ts
+++ b/packages/lib/src/duckdb/nul-strip.ts
@@ -1,0 +1,96 @@
+/**
+ * Writer-side NUL-byte enforcement (#790), the missing half of the client's
+ * bind-time guard.
+ *
+ * WHY THIS EXISTS. `client.ts` binds every VARCHAR through a NUL-terminated C
+ * string, so a value containing U+0000 would be SILENTLY TRUNCATED at the first
+ * NUL on the way in, and the length-less read accessor (`duckdb_value_varchar`
+ * + `CString`) cannot detect that truncation on the way back out. The client
+ * therefore REFUSES such a bind with a typed `DuckDbQueryError` - correct, and
+ * it stays. But refusing is only half a contract: real transcripts DO carry
+ * escaped NULs (a JSON "\\u0000" in tool output, a binary blob that leaked into
+ * a text field), so with nothing enforcing the other half an unrestricted
+ * `ax ingest` died on `INSERT INTO "turn" - parameter 6743 contains a NUL
+ * byte`. This module is that other half: the write seam scrubs every bound text
+ * value, so nothing carrying a NUL ever reaches a bind, and the client's guard
+ * goes back to being the last line of defence rather than the first thing an
+ * operator meets.
+ *
+ * STRIP, NOT ESCAPE - and the trade-off that buys. The alternatives were an
+ * escape (the six literal characters "\\u0000", or a U+FFFD placeholder) and a
+ * strip. An escape preserves the information that a NUL was there, but it
+ * CHANGES THE STORED TEXT INTO SOMETHING NO SOURCE EVER CONTAINED: every reader
+ * sees the escape, the FTS/BM25 indexes tokenize it, `LIKE` / `match_bm25`
+ * queries have to know about it, and a transcript that literally spells
+ * "\\u0000" (agents write that string about this very bug) becomes
+ * indistinguishable from an escaped NUL. Stripping loses one code point that in
+ * transcript text is always noise - never a word, never punctuation, never
+ * anything a human wrote - and leaves the stored text identical to what a
+ * NUL-free transcript would have produced. The accepted cost: stored text is
+ * not a byte-exact copy of the source, and `"a" + NUL + "b"` becomes
+ * indistinguishable from a genuine `"ab"`. That cost is paid back by making the
+ * loss COUNTABLE rather than silent: {@link stripNulParams} reports how many
+ * values it touched, the write seam accumulates the total, and a run that
+ * scrubbed anything logs a warning naming the count.
+ *
+ * Pure and dependency-free on purpose, so the decision is unit-testable without
+ * a database.
+ */
+import type { DuckDbParam } from "./types.ts";
+
+/** U+0000, built from its code point rather than written as a literal. A raw
+ *  NUL byte in a source file is invisible in every editor, diff and code
+ *  review, and an editor or formatter that "cleans" the file would silently
+ *  delete it - the one module whose whole job is to remove NULs must not be
+ *  able to lose its own definition of one. */
+export const NUL: string = String.fromCharCode(0);
+
+/** True when `value` carries at least one U+0000 - the same question the
+ *  bind-time guard in `client.ts` asks, kept in one place. */
+export const hasNul = (value: string): boolean => value.includes(NUL);
+
+/** `value` with every U+0000 removed. Nothing else is touched: other control
+ *  characters (tabs, newlines, escape sequences) round-trip through a VARCHAR
+ *  bind perfectly well and are frequently meaningful in transcript text. */
+export const stripNul = (value: string): string => value.replaceAll(NUL, "");
+
+/** The outcome of scrubbing one statement's parameters. `values` counts bound
+ *  VALUES that carried at least one NUL, not the number of NUL bytes - "we
+ *  changed 3 of the things you asked us to store" is the fact an operator
+ *  needs, and one value can carry many NULs. */
+export interface NulStripResult {
+    readonly params: ReadonlyArray<DuckDbParam>;
+    readonly values: number;
+}
+
+/**
+ * Strip NUL bytes from every string parameter in `params`.
+ *
+ * Returns the ORIGINAL array (same reference, `values: 0`) when nothing needed
+ * scrubbing, which is the overwhelmingly common case - a 500-row `putMany` on a
+ * wide table binds thousands of parameters per statement, and allocating a
+ * parallel array for every one of them would tax the whole ingest to serve the
+ * rare row that actually carries a NUL.
+ */
+export const stripNulParams = (params: ReadonlyArray<DuckDbParam>): NulStripResult => {
+    let first = -1;
+    for (let i = 0; i < params.length; i += 1) {
+        const param = params[i];
+        if (typeof param === "string" && hasNul(param)) {
+            first = i;
+            break;
+        }
+    }
+    if (first < 0) return { params, values: 0 };
+
+    const scrubbed = params.slice();
+    let values = 0;
+    for (let i = first; i < scrubbed.length; i += 1) {
+        const param = scrubbed[i];
+        if (typeof param === "string" && hasNul(param)) {
+            scrubbed[i] = stripNul(param);
+            values += 1;
+        }
+    }
+    return { params: scrubbed, values };
+};

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -11,6 +11,7 @@ import { encodeLockPayload, withIngestLock } from "../ingest-lock.ts";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { TimestampColumn } from "./columns.ts";
 import { buildFtsIndexes, matchBm25Sql, type FtsTarget } from "./fts.ts";
+import { NUL } from "./nul-strip.ts";
 import {
     CacheRead,
     CacheReadLayer,
@@ -262,6 +263,97 @@ describe("CacheWrite: the semantics the DDL cannot express", () => {
             // 600 rows crosses the 500-row batch boundary.
             expect(value?.count).toBe(600n);
             expect(value?.ragged._tag).toBe("Failure");
+        });
+    });
+
+    /**
+     * #790, the half wave 2 shipped without. The client REFUSES to bind a
+     * VARCHAR carrying U+0000 (it would truncate silently at the first NUL and
+     * the length-less read accessor could never tell), and real transcripts
+     * carry them - so an unrestricted `ax ingest` died on
+     * `INSERT INTO "turn" - parameter 6743 contains a NUL byte`. The write seam
+     * now scrubs on the way in. Without that scrub every case below fails with
+     * that exact refusal.
+     */
+    dtest("strips NUL bytes out of every bound write value, and counts what it stripped", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-nul-");
+            // A genuine U+0000 in the middle of otherwise ordinary text - the
+            // shape a JSON transcript's "\\u0000" decodes to.
+            const dirty = `before${NUL}after`;
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("note", { id: "n1", body: dirty });
+                        // putMany's batched multi-row insert binds through the
+                        // same choke point...
+                        yield* write.putMany("note", [
+                            { id: "n2", body: `two${NUL}` },
+                            { id: "n3", body: "clean" },
+                        ]);
+                        // ...and so does a hand-written statement.
+                        yield* write.exec("UPDATE note SET body = ? WHERE id = ?", [
+                            `${NUL}lead${NUL}`,
+                            "n3",
+                        ]);
+
+                        const rows = yield* write.rows(
+                            Schema.Struct({
+                                id: Schema.String,
+                                body: Schema.String,
+                                len: Schema.BigInt,
+                            }),
+                            "SELECT id, body, length(body) AS len FROM note ORDER BY id",
+                        );
+                        return { rows, stripped: write.nulStripped() };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+
+            // Stored text is the NUL-free text - NOT truncated at the first NUL
+            // (which is what an unguarded bind would have stored), and NOT an
+            // escape sequence no source ever contained. `length` is read by
+            // DuckDB itself, so it proves what is IN the column rather than what
+            // the CString accessor could render.
+            expect(value?.rows).toEqual([
+                { id: "n1", body: "beforeafter", len: 11n },
+                { id: "n2", body: "two", len: 3n },
+                { id: "n3", body: "lead", len: 4n },
+            ]);
+
+            // Observable, not silent: three dirty values across three
+            // statements. `putMany` bound two rows and only ONE of them was
+            // dirty, so the clean row and every `id` parameter go uncounted -
+            // the number is "values we changed", not "values we looked at".
+            expect(value?.stripped).toEqual({ values: 3, statements: 3 });
+        });
+    });
+
+    dtest("a write with no NUL anywhere reports nothing stripped", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-nul-clean-");
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        // The six characters a transcript literally spells are
+                        // TEXT, and must survive byte-for-byte.
+                        yield* write.put("note", { id: "n1", body: "escaped \\u0000 stays" });
+                        const rows = yield* write.rows(
+                            Schema.Struct({ body: Schema.String }),
+                            "SELECT body FROM note",
+                        );
+                        return { rows, stripped: write.nulStripped() };
+                    }),
+                ),
+            );
+
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.rows[0]?.body).toBe("escaped \\u0000 stays");
+            expect(value?.stripped).toEqual({ values: 0, statements: 0 });
         });
     });
 

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -66,6 +66,7 @@ import {
     DuckDbUnsupportedTypeError,
     SnapshotPublishError,
 } from "./errors.ts";
+import { stripNulParams } from "./nul-strip.ts";
 import type { DuckDbParam, QueryResult } from "./types.ts";
 
 /**
@@ -142,8 +143,25 @@ export interface CacheWriteService extends CacheReadService {
         table: string,
         rows: ReadonlyArray<Readonly<Record<string, DuckDbParam>>>,
     ) => Effect.Effect<void, CacheWriteError>;
+    /**
+     * How much this writer has had to scrub so far - see {@link nulStripTotals}
+     * and `./nul-strip.ts`. Sanitising data behind a caller's back is exactly
+     * the failure class this seam exists to prevent, so the mutation is
+     * COUNTABLE: `withCacheWrite` logs a warning naming these numbers whenever
+     * either is non-zero, and a caller (an ingest run reporting on itself) can
+     * read them directly.
+     */
+    readonly nulStripped: () => NulStripTotals;
     /** The live database being written (not the snapshot). */
     readonly livePath: string;
+}
+
+/** Running totals of writer-side NUL stripping for one `withCacheWrite` body. */
+export interface NulStripTotals {
+    /** Bound text values that carried at least one U+0000 and were scrubbed. */
+    readonly values: number;
+    /** Statements at least one of those values belonged to. */
+    readonly statements: number;
 }
 
 /**
@@ -591,7 +609,14 @@ export const withCacheWrite = <A, E, R>(
                     if (options.schemaSql !== null) yield* conn.exec(options.schemaSql);
 
                     const write = writerOver(conn, options.livePath, target);
-                    const value = yield* body(write);
+                    // Reported on EVERY exit path (`ensuring`), not just a
+                    // successful one: a body that scrubbed rows and then failed
+                    // for an unrelated reason still changed data on the way
+                    // through, and that is precisely when an operator needs to
+                    // know it happened.
+                    const value = yield* body(write).pipe(
+                        Effect.ensuring(reportNulStripped(write, options.livePath)),
+                    );
 
                     // Publish LAST and only on success: a failed ingest must
                     // leave the previous snapshot exactly as it was. A
@@ -606,6 +631,26 @@ export const withCacheWrite = <A, E, R>(
                     return value;
                 }),
             (conn) => conn.close.pipe(Effect.andThen(Effect.sync(opened.close))),
+        );
+    });
+
+/**
+ * Say out loud what the writer changed. Silent sanitisation is the failure mode
+ * this whole guard exists to avoid, so a run that stripped NUL bytes says so -
+ * once, with totals, rather than a line per value (a single ingest can scrub
+ * thousands, and a warning per row would bury everything else).
+ *
+ * A no-op when nothing was scrubbed, which is the normal case.
+ */
+const reportNulStripped = (write: CacheWriteService, livePath: string): Effect.Effect<void> =>
+    Effect.suspend(() => {
+        const totals = write.nulStripped();
+        if (totals.values === 0) return Effect.void;
+        return Effect.logWarning(
+            `ax cache: stripped NUL bytes (U+0000) from ${totals.values} text value(s) across ` +
+                `${totals.statements} statement(s) while writing ${livePath}. DuckDB VARCHARs are bound ` +
+                "through a NUL-terminated C string, so such a value would otherwise be silently truncated " +
+                "at the first NUL; the rest of each value was stored intact.",
         );
     });
 
@@ -628,7 +673,38 @@ const writerOver = (
     // writer must keep reading the LIVE database it is writing.
     const reader = readerOver((use) => use(conn), target);
 
-    const exec: CacheWriteService["exec"] = (sql, params) => conn.exec(sql, params);
+    /**
+     * THE NUL CHOKE POINT (#790). Every write this seam issues - `exec`, `put`,
+     * `putMany` - funnels through here, and it is the narrowest place that can
+     * hold the rule: it is the last code that owns the parameter array before
+     * `client.ts` binds it, and it is on the writer's side of the read/write
+     * split, so the READ path (`reader` above, sharing this same connection) is
+     * untouched. Scrubbing per call site instead would mean auditing every one
+     * of the ~90 modules that hold a `CacheWriteService` and re-auditing every
+     * new one.
+     *
+     * The strip itself, and why strip rather than escape, lives in
+     * `./nul-strip.ts`. What lives here is the ACCOUNTING: a silent sanitiser
+     * is how the original defect class got here, so the counts are kept and
+     * reported (see `nulStripped` on the service and the warning in
+     * `withCacheWrite`).
+     */
+    let nulValues = 0;
+    let nulStatements = 0;
+    const execScrubbed = (
+        sql: string,
+        params?: ReadonlyArray<DuckDbParam>,
+    ): Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError> => {
+        if (params === undefined || params.length === 0) return conn.exec(sql, params);
+        const stripped = stripNulParams(params);
+        if (stripped.values > 0) {
+            nulValues += stripped.values;
+            nulStatements += 1;
+        }
+        return conn.exec(sql, stripped.params);
+    };
+
+    const exec: CacheWriteService["exec"] = (sql, params) => execScrubbed(sql, params);
 
     /**
      * One upsert covering `rows`, all of which must share `columns`.
@@ -728,11 +804,13 @@ const writerOver = (
                 const batch = rows.slice(start, start + PUT_BATCH_ROWS);
                 const sql = yield* insertStatement(table, columns, stamped, batch.length);
                 const params = batch.flatMap((row) => columns.map((column) => row[column]));
-                yield* conn.exec(sql, params);
+                yield* execScrubbed(sql, params);
             }
         });
 
     const put: CacheWriteService["put"] = (table, row) => putMany(table, [row]);
 
-    return { ...reader, exec, put, putMany, livePath };
+    const nulStripped = (): NulStripTotals => ({ values: nulValues, statements: nulStatements });
+
+    return { ...reader, exec, put, putMany, nulStripped, livePath };
 };

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -95,8 +95,15 @@
 --
 -- NUL-BYTE CONTRACT. Text columns must never contain NUL bytes - the FFI
 -- client's CString decode truncates at the first NUL, silently dropping
--- everything after it. Ingest writers must strip or escape NUL bytes before
--- insert (enforcement lands with the wave-2 writers, not in this DDL).
+-- everything after it. This is ENFORCED, not merely asked for, and NOT by this
+-- DDL: the write seam (`packages/lib/src/duckdb/seam.ts`, `writerOver`) strips
+-- U+0000 out of every bound text value on its way to a bind, using
+-- `packages/lib/src/duckdb/nul-strip.ts`, and counts what it stripped so the
+-- run can report it. An individual ingest writer therefore does NOT need to
+-- pre-scrub its rows. The bind-time refusal in `client.ts` stays behind that as
+-- the last line of defence - if it ever fires again, a write path has found a
+-- way around the seam. Superseded when the pointer-based read path (#788) makes
+-- an embedded NUL round-trip safely.
 --
 -- SEMANTICS (P2-2): `VALUE time::now()` cannot be expressed in DDL. Surreal's
 -- `VALUE` clause OVERWRITES whatever the caller supplies, on every create AND every


### PR DESCRIPTION
**Ship blocker.** `ax ingest` could not process real transcripts.

```
INSERT INTO "turn" - parameter 6743 contains a NUL byte
```

Found by running an unrestricted ingest over real data, not by a fixture. Every
fixture-backed suite in the repo passed while ingest could not complete.

## Why the guard is right, and what was missing

`packages/lib/src/duckdb/client.ts:241` refuses to bind a string containing
U+0000. That is correct: this client binds VARCHAR through a NUL-terminated C
string, so the value would be **silently truncated at the first NUL on the way
in**, and the length-less read accessor cannot detect the truncation on the way
back out. Turning silent data loss into a loud typed failure was the right call.

The guard's own message named the missing half - *"Strip or escape NUL bytes
upstream before binding (writer enforcement lands with wave-2 writers, #790)"* -
and **wave 2 shipped without that enforcement**. So the loud failure fired on real
transcripts and took ingest down.

This adds the writer-side half. It is the stopgap #790 describes, superseded when
the pointer-based read path (#788) lands.

## Choke point

`writerOver` in `packages/lib/src/duckdb/seam.ts` - a single `execScrubbed(sql,
params)` that `exec`, `put`, and `putMany` all funnel through. It is the last code
owning the parameter array before `client.ts` binds it, and it sits on the
writer's side of the read/write split, so the read path is untouched.

`withCacheWrite` is the only way to obtain a `CacheWriteService` and ~90 modules
hold one, so per-call-site scrubbing would mean auditing all of them forever. The
strip itself is a pure module (`nul-strip.ts`) that returns the caller's array by
reference when clean - the common case.

## Strip, not escape

Escaping (a literal backslash-u-0000, or U+FFFD) puts text into storage that no
source contained: readers see it, FTS/BM25 tokenizes it, and a transcript that
literally spells that escape becomes indistinguishable from an escaped NUL.

**Accepted cost:** stored text is not byte-exact, and `a` + NUL + `b` becomes
indistinguishable from a genuine `ab`.

## Observable, not silent

A sanitiser that silently mutates data is how this defect class arrived. This one
counts values and statements scrubbed, exposes them via
`CacheWriteService.nulStripped()`, and `withCacheWrite` logs one warning naming
both on **every** exit path (`Effect.ensuring`) - silent only at zero.

## The DDL contract line was untrue

`schema.duckdb.sql` claimed enforcement "lands with the wave-2 writers". Rewritten
to name the seam. `client.ts`'s message updated the same way; the guard logic
itself is untouched.

## Verification

**Test can fail - verified by running.** With `seam.ts` stashed back to base, the
new real-DuckDB seam test dies with the original `parameter 2 contains a NUL byte`
refusal; restored, it passes. It asserts the decoded string *and* `length()` as
computed by DuckDB, so it proves what is actually in the column.

**Real ingest - verified.** Unrestricted `ax ingest --since=1` over real
transcripts, under a temp `AX_DATA_DIR` and `AX_DUCKDB_SNAPSHOT`:

- the NUL error is gone
- **6 values scrubbed across 5 statements**
- **69,866 turns + 21,083 tool_calls** landed
- DuckDB's own `contains(text, chr(0))` returns **0**

Gates: typecheck 0, `tsc -p tsconfig.json` 0, `check:no-node-fs` clean,
`check:timestamp-cast` clean, `bun test apps/axctl packages scripts` 5645 pass /
0 fail against the custom static build with `AX_DUCKDB_REQUIRE_FTS=1`.

## Two further blockers this unmasked (not fixed here)

The NUL failure was hiding them; ingest still does not complete:

1. `apps/axctl/src/ingest/classifier-results.ts:175` selects `e.session` from
   `edited`, which has no such column - confirmed against the DDL at
   `schema.duckdb.sql:1496`. The sibling query in `derive-run-evidence.ts:542`
   gets it right with `t.session` off the joined `turn`.
2. With that patched locally, `derive-run-evidence.ts:651` dies on
   `JSON.stringify cannot serialize BigInt`.

Both reverted from this tree and tracked separately.

Base is `v2/duckdb`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
