### PR TITLE
fix(v2): ax ingest completes end-to-end - two blockers and a silent third

### DIFF
--- a/apps/axctl/src/ingest/classifier-results.test.ts
+++ b/apps/axctl/src/ingest/classifier-results.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { classifierEvidenceRefsForWindows, deriveClassifierResultsFromRows } from "./classifier-results.ts";
+import { Effect, Schema } from "effect";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import {
+    classifierEvidenceRefsForWindows,
+    deriveAndPersistClassifierResults,
+    deriveClassifierResultsFromRows,
+} from "./classifier-results.ts";
 import type { ClassifierTurnRow } from "../classifiers/event-window.ts";
 
 const row = (
@@ -129,5 +136,60 @@ describe("classifier results derive", () => {
                 kind: "recent_edited_file",
             }),
         ]));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DuckDB coverage for the SQL half of this stage.
+//
+// The pure builders above are fed hand-written `ClassifierEditedFileRow`s, so
+// they cannot see whether `fetchEditedFiles` actually PRODUCES those rows. It
+// did not: the projection read `e.session` off `edited`, a column the DDL does
+// not define (`edited` is a turn->file edge; the session lives on the joined
+// `turn`). That is a binder error on every run, and once the column name is
+// right the second failure mode is the one this suite pins - a query that runs
+// and hands back NULL sessions, which silently drops every `recent_edited_file`
+// ref instead of erroring.
+// ---------------------------------------------------------------------------
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("classifier results edited files", { requireFts: true });
+
+describe("fetchEditedFiles on real DuckDB", () => {
+    dtest("reads the session off the joined turn and links recent edited files", async () => {
+        let evidence: ReadonlyArray<{ readonly out_id: string; readonly kind: string | null }> = [];
+        await runWithPlatform(publishCacheFixture(tempDir("ax-classifier-edited-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                const ts = new Date("2026-05-30T00:01:00Z");
+                yield* write.put("session", { id: "s1", source: "claude", started_at: ts });
+                yield* write.put("turn", {
+                    id: "a1", session: "s1", seq: 1, ts, role: "assistant",
+                    text: "I used pip.", text_excerpt: "I used pip.",
+                });
+                yield* write.put("turn", {
+                    id: "t1", session: "s1", seq: 2, ts: new Date("2026-05-30T00:02:00Z"),
+                    role: "tool_result", message_kind: "tool_result",
+                    text: "ERROR: dependency resolution failed",
+                    text_excerpt: "ERROR: dependency resolution failed",
+                });
+                yield* write.put("turn", {
+                    id: "u1", session: "s1", seq: 3, ts: new Date("2026-05-30T00:03:00Z"),
+                    role: "user", text: "can you use UV ?", text_excerpt: "can you use UV ?",
+                });
+                yield* write.put("file", { id: "f1", path: "pyproject.toml" });
+                yield* write.put("edited", {
+                    id: "e1", in_id: "a1", out_id: "f1", tool: "Edit", ts,
+                });
+
+                yield* deriveAndPersistClassifierResults(write, { sinceDays: undefined });
+
+                evidence = yield* write.rows(
+                    Schema.Struct({ out_id: Schema.String, kind: Schema.NullOr(Schema.String) }),
+                    "SELECT out_id, kind FROM cites_evidence WHERE out_table = 'file' ORDER BY kind",
+                );
+            }),
+        ));
+        // `recent_edited_file` is reachable ONLY through the session+seq path,
+        // so its presence is proof the `session` column decoded non-null.
+        expect(evidence.map((e) => e.kind)).toContain("recent_edited_file");
+        expect(evidence.every((e) => e.out_id === "f1")).toBe(true);
     });
 });

--- a/apps/axctl/src/ingest/classifier-results.ts
+++ b/apps/axctl/src/ingest/classifier-results.ts
@@ -172,7 +172,14 @@ const fetchEditedFiles = (write: CacheWriteService, sinceDays: number | undefine
         return yield* write.rows(Schema.Struct({
             turn: Schema.String, file: Schema.String, session: Schema.NullOr(Schema.String),
             seq: Schema.NullOr(Schema.Number), ts: TimestampColumn,
-        }), `SELECT e.in_id AS turn, e.out_id AS file, e.session, CAST(t.seq AS DOUBLE) AS seq, e.ts
+        // `edited` is a turn->file edge and carries NO session column of its own
+        // (see the DDL) - the session hangs off the turn it points at, which is
+        // why the join is here at all. Reading `e.session` was a binder error on
+        // every run; taking `t.session` matches the sibling projection in
+        // derive-run-evidence.ts. The join stays a LEFT join so an edge whose
+        // turn is outside the window still yields its per-turn file ref (the
+        // session+seq path below simply skips it).
+        }), `SELECT e.in_id AS turn, e.out_id AS file, t.session AS session, CAST(t.seq AS DOUBLE) AS seq, e.ts
              FROM edited e LEFT JOIN turn t ON t.id = e.in_id
              ${sinceDays === undefined ? "" : "WHERE e.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
              ORDER BY e.ts`, sinceDays === undefined ? [] : [sinceDays + 1]);

--- a/apps/axctl/src/ingest/claude-config.test.ts
+++ b/apps/axctl/src/ingest/claude-config.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, FileSystem, Layer, Path } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import type { GuidanceConfigArtifact } from "./claude-config.ts";
 import {
+    fetchPreviousArtifacts,
     buildClaudeMdGuidanceRevisionStatements,
     buildGuidanceConfigPersistenceStatements,
     buildGuidanceConfigReconcileStatements,
@@ -578,5 +582,50 @@ describe("claudeConfigStage", () => {
         expect(claudeConfigStage.meta.key).toBe("claude-config");
         expect(claudeConfigStage.meta.deps).toEqual(["skills", "commands", "agent-def"]);
         expect(claudeConfigStage.meta.tags).toEqual(["ingest"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DuckDB coverage for the guidance-revision "previous artifact" read.
+//
+// Same defect family as the run-evidence BIGINT crash, but SILENT: `bytes` is
+// BIGINT, `write.raw` applies no column decoder, and the `typeof === "number"`
+// guard in `fetchPreviousArtifacts` reads FALSE for a `bigint` - so every
+// guidance_revision was written with `prev_bytes` NULL and nothing failed. This
+// case reads the value back through the real column, which is the only way to
+// see it.
+// ---------------------------------------------------------------------------
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("claude-config previous artifacts", { requireFts: true });
+
+describe("fetchPreviousArtifacts on real DuckDB", () => {
+    dtest("decodes the BIGINT bytes column as a number", async () => {
+        const record: GuidanceConfigArtifact = {
+            provider: "claude", kind: "memory", scope: "user",
+            safePath: "~/CLAUDE.md", pathHash: "ph-1",
+            authorityKind: "user", authorityHash: "ah-1",
+            contentHash: "ch-new", parseStatus: "ok",
+            bytes: 4_096, tokenEstimate: 1_024,
+            commandHashes: [], hookEventNames: [], matcherCount: 0,
+            mcpServerNames: [], envKeys: [], enabledToolCount: null,
+            model: null, reasoningEffort: null, outputStyle: null,
+            permissionAllowCount: 0, permissionAskCount: 0, permissionDenyCount: 0,
+            observedAt: new Date("2026-05-30T00:00:00Z"), metadata: {},
+        };
+        let previous: unknown;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-claude-config-prev-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* write.put("guidance_config_artifact", {
+                    id: "gca-1", provider: "claude", kind: "memory", scope: "user",
+                    safe_path: "~/CLAUDE.md", path_hash: "ph-1",
+                    authority_kind: "user", authority_hash: "ah-1",
+                    content_hash: "ch-old", parse_status: "ok",
+                    bytes: 4_000, token_estimate: 1_000, matcher_count: 0,
+                    permission_allow_count: 0, permission_ask_count: 0, permission_deny_count: 0,
+                    observed_at: new Date("2026-05-29T00:00:00Z"),
+                });
+                previous = (yield* fetchPreviousArtifacts(write, [record])).get("ph-1");
+            }),
+        ));
+        expect(previous).toEqual({ content_hash: "ch-old", bytes: 4_000 });
     });
 });

--- a/apps/axctl/src/ingest/claude-config.ts
+++ b/apps/axctl/src/ingest/claude-config.ts
@@ -875,14 +875,26 @@ export const buildClaudeMdGuidanceRevisionStatements = (
 const claudeMdRecords = (records: readonly GuidanceConfigArtifact[]): GuidanceConfigArtifact[] =>
     records.filter(isClaudeMdArtifact);
 
-const fetchPreviousArtifacts = (
+/**
+ * The previously-stored CLAUDE.md artifacts for these path hashes, keyed by
+ * path hash - the "before" side of the guidance-revision diff.
+ *
+ * `bytes` is CAST to DOUBLE rather than selected bare. `write.raw` applies no
+ * column decoder, so a BIGINT cell arrives as a JS `bigint`, and the
+ * `typeof row.bytes === "number"` guard below then reads FALSE and stores
+ * `null` - no error, no warning, just `guidance_revision.prev_bytes` empty on
+ * every revision forever. Casting at the projection is what makes the guard
+ * tell the truth. (Exported for the real-DuckDB test that pins this; it is
+ * otherwise internal to the stage.)
+ */
+export const fetchPreviousArtifacts = (
     write: CacheWriteService,
     records: readonly GuidanceConfigArtifact[],
 ): Effect.Effect<Map<string, PreviousGuidanceConfigArtifact>, CacheWriteError> =>
     Effect.gen(function* () {
         const hashes = uniqueSorted(claudeMdRecords(records).map((record) => record.pathHash));
         if (hashes.length === 0) return new Map();
-        const res = yield* write.raw(`SELECT path_hash, content_hash, bytes FROM ${GUIDANCE_CONFIG_ARTIFACT_TABLE} WHERE provider = 'claude' AND path_hash IN (${hashes.map(() => "?").join(",")})`, hashes);
+        const res = yield* write.raw(`SELECT path_hash, content_hash, CAST(bytes AS DOUBLE) AS bytes FROM ${GUIDANCE_CONFIG_ARTIFACT_TABLE} WHERE provider = 'claude' AND path_hash IN (${hashes.map(() => "?").join(",")})`, hashes);
         const out = new Map<string, PreviousGuidanceConfigArtifact>();
         for (const row of res.rows as Array<Record<string, unknown>>) {
             const pathHash = typeof row.path_hash === "string" ? row.path_hash : null;

--- a/apps/axctl/src/ingest/derive-run-evidence.test.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import {
     buildLineage,
+    deriveRunEvidence,
     buildRunEvidenceEvents,
     buildRunEvidenceRefs,
     pickEarliestPerSession,
@@ -320,5 +324,46 @@ describe("runEvidenceStage wiring", () => {
             "tool_observation", "verification", "boundary", "task_state",
             "objective", "policy_decision", "repo_state", "derived_summary",
         ]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Real-DuckDB coverage for the SQL half of this stage.
+//
+// The builders above are exercised with hand-written rows whose numbers are JS
+// `number`s. The stage does not get its rows that way: it reads them through
+// `write.raw`, which applies NO column decoder, so a BIGINT column arrives as a
+// JS `bigint`. `compaction.tokens_before` is BIGINT, it lands in the boundary
+// event's `attrs`, and `attrs` is written through `jsonParam` -> JSON.stringify,
+// which THROWS on a bigint. The fix is at the read boundary (project the column
+// as DOUBLE) rather than at the write boundary: a JSON.stringify replacer that
+// coerced bigints would hide this instance and leave every other raw reader
+// handing `bigint` to code whose types say `number`.
+// ---------------------------------------------------------------------------
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("run evidence bigint", { requireFts: true });
+
+describe("deriveRunEvidence on real DuckDB", () => {
+    dtest("projects BIGINT columns as numbers so boundary attrs serialize", async () => {
+        let stats: unknown;
+        let attrs: string | null = null;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-run-evidence-bigint-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                const ts = new Date("2026-05-30T00:01:00Z");
+                yield* write.put("session", { id: "s1", source: "claude", started_at: ts });
+                yield* write.put("compaction", {
+                    id: "c1", session: "s1", harness: "claude", ts,
+                    trigger: "auto", strategy: "summarize", source_confidence: "explicit",
+                    summary: "compacted the history", tokens_before: 123_456,
+                });
+                stats = yield* deriveRunEvidence(write, undefined);
+                attrs = (yield* write.rows(
+                    Schema.Struct({ attrs: Schema.NullOr(Schema.String) }),
+                    "SELECT attrs FROM run_evidence_event WHERE kind = 'boundary'",
+                ))[0]?.attrs ?? null;
+            }),
+        ));
+        expect(stats).toMatchObject({ written: 2 });
+        // A `number`, not the `"123456n"`/throw a bigint would produce.
+        expect(JSON.parse(attrs ?? "{}")).toMatchObject({ tokens_before: 123_456 });
     });
 });

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -521,9 +521,17 @@ export const commandOutcomeSql = (since: number | undefined): string =>
     `SELECT id, session, tool_call AS toolCall, CAST(ts AS VARCHAR) AS ts, kind, status, command_norm AS commandNorm
      FROM command_outcome WHERE session IS NOT NULL ${sinceAnd(since)}`;
 
+// `tokens_before` is BIGINT and this stage reads through `write.raw`, which
+// applies no column decoder - so the cell arrives as a JS `bigint`, not the
+// `number` CompactionRow declares. It then lands in the boundary event's
+// `attrs`, and `jsonParam` (JSON.stringify) THROWS on a bigint, killing the
+// whole ingest run. Projecting as DOUBLE fixes the decode where the value is
+// read, which is the only place that can also make the declared type true;
+// coercing at the write boundary would silence this one crash and leave every
+// other consumer of the row holding a bigint behind a `number` type.
 const compactionSql = (since: number | undefined): string =>
     `SELECT id, session, CAST(ts AS VARCHAR) AS ts,
-            trigger, strategy, tokens_before AS tokensBefore, summary
+            trigger, strategy, CAST(tokens_before AS DOUBLE) AS tokensBefore, summary
      FROM compaction WHERE session IS NOT NULL ${sinceAnd(since)}`;
 
 const planSnapshotSql = (since: number | undefined): string =>
@@ -554,8 +562,12 @@ const editToolCallSql = (since: number | undefined): string => {
 // Objective: the run's stated goal. `task`-kind user turns only (real prompts,
 // not context/control wrappers); earliest-per-session is picked in JS by seq.
 const objectiveSql = (since: number | undefined): string =>
+    // `turn.seq` is BIGINT for the same reason as `tokens_before` above; it is
+    // only compared (min-per-session) today rather than serialized, so it does
+    // not crash - which is exactly why it is cast here too, before some later
+    // reader puts a value its type says is a `number` into an attrs bag.
     `SELECT id, session, CAST(ts AS VARCHAR) AS ts,
-            seq, text_excerpt AS textExcerpt
+            CAST(seq AS DOUBLE) AS seq, text_excerpt AS textExcerpt
      FROM turn WHERE session IS NOT NULL AND role = 'user' AND message_kind = 'task' ${sinceAnd(since)}`;
 
 // Policy decisions: hook invocations whose effect is a real intervention.


### PR DESCRIPTION
**`ax ingest` now completes end-to-end over real transcripts.** It could not before.

Three blockers stood in a row, each invisible until the one ahead of it was removed. #812 cleared the first (the NUL-byte bind refusal). This clears the other two, and a third of the same family found on the way out.

Every fixture-backed suite in the repo passed throughout. Only running the real command over real data surfaced any of them.

## 1. `classifier-results` selected a column that does not exist

`apps/axctl/src/ingest/classifier-results.ts` projected `e.session` off `edited` - a turn→file edge with no `session` column. A binder error on every ingest.

The session hangs off the joined `turn`, exactly as the sibling projection in `derive-run-evidence.ts` already reads it. Left-joined, so an edge whose turn falls outside the window still yields its per-turn ref.

The test asserts the session comes back **populated**, not merely that the query stops erroring - the `recent_edited_file` ref is only reachable through the session+seq path, so an empty-but-quiet result would be the same bug wearing a different face.

## 2. `derive-run-evidence` threw on a BigInt

`write.raw` applies no column decoder, so BIGINT cells arrive as JS bigints. `compaction.tokens_before` reached `jsonParam` (`JSON.stringify`) inside the boundary event's attrs and threw.

**Fixed at the READ boundary**, by projecting the column as DOUBLE. A `JSON.stringify` replacer would have silenced this one call site and left every other `write.raw` reader holding a bigint behind a `number` type - the fix that hides the defect class instead of removing it. `turn.seq` is cast for the same reason, before anyone downstream serializes it.

## 3. The same defect, SILENT - found while fixing 2

`guidance_config_artifact.bytes` is BIGINT and `fetchPreviousArtifacts` reads it through `write.raw`. The cell arrived as a bigint, so the `typeof row.bytes === "number"` guard read FALSE and stored null.

**Every `guidance_revision.prev_bytes` was written NULL, with no error and no warning.** Projecting the column as DOUBLE is what makes that guard tell the truth.

It is invisible on a first ingest, since no previous artifact exists - so the test seeds the `before` row directly and reads it back through the real column.

## The pattern worth keeping

All three are one family: **`write.raw` returns undecoded BIGINT**. Two of the three were silent, and the loud one was only loud because `JSON.stringify` happens to refuse bigints. Anywhere else the value would have flowed on as a wrong `number`.

## Verification

**Unrestricted full-history `ax ingest` completes, exit 0** - the check that no fixture could stand in for.

Gates on the rebased branch, against the ICU-less custom static build with `AX_DUCKDB_REQUIRE_FTS=1`:

- `bun run typecheck` - 0 errors
- `bunx tsc --noEmit -p tsconfig.json` - 0 errors
- `check-no-node-fs` - clean, 686 files
- `check-timestamp-cast` - clean, 1488 files
- `bun test apps/axctl packages scripts` - **5644 pass / 13 skip / 0 fail**

Both fixes are pinned by real-DuckDB tests, not fakes.

Base is `v2/duckdb`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
