### PR TITLE
feat(v2): c-read-cli - the cli/ read layer onto the CacheRead seam, and ax share stops self-provisioning SurrealDB

### DIFF
--- a/apps/axctl/src/cli/commands/ax-directives.ts
+++ b/apps/axctl/src/cli/commands/ax-directives.ts
@@ -15,11 +15,13 @@
  *   ax directives ngrams [--json] [--limit=N]
  *     The learned per-user lift table (directive_ngram rows sorted by lift desc).
  */
-import { Effect, FileSystem, Path } from "effect";
+import { Effect, FileSystem, Path, Schema } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
-import { SurrealClient } from "@ax/lib/db";
 import { prettyPrint } from "@ax/lib/json";
 import { CacheRead } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
+import { cacheRows } from "@ax/lib/duckdb/query";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
 import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveTurnRow } from "../../ingest/directives.ts";
 import { listDirectiveProposals, type ProposalRow } from "../../improve/list.ts";
 import type { LiftRow } from "../../queries/directive-ngrams.ts";
@@ -31,6 +33,22 @@ import { fail, jsonFlag, optionValue, requirePositiveInt } from "./shared.ts";
 
 // SQL boundary guard - same pattern as directive-ngrams.ts
 const sqlDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+const MineTurnRow = Schema.Struct({
+    id: Schema.String,
+    session: Schema.String,
+    text_excerpt: Schema.NullOr(Schema.String),
+    ts: TimestampColumn,
+});
+const LiftMapRow = Schema.Struct({ ngram: Schema.String, lift: Schema.Number });
+const NgramLiftRow = Schema.Struct({
+    ngram: Schema.String,
+    n: NumberFromBigIntColumn,
+    occurrences: NumberFromBigIntColumn,
+    outcomes: NumberFromBigIntColumn,
+    sessions: NumberFromBigIntColumn,
+    lift: Schema.Number,
+});
 
 // ---------------------------------------------------------------------------
 // ax directives mine
@@ -49,26 +67,32 @@ const mineCommand = Command.make(
                 fail(`ax directives mine: --days must be a positive integer (got "${days}")`);
             }
 
-            const db = yield* SurrealClient;
-
             // Fetch user turns (same query shape as derive-proposals.ts directive turn fetch,
             // parameterized by --days instead of hard-coded 90d)
-            const [rawTurns] = yield* db.query<[DirectiveTurnRow[]]>(`
-SELECT type::string(id) AS id, type::string(session) AS session, text_excerpt, type::string(ts) AS ts
-FROM turn
-WHERE role = "user" AND text_excerpt != NONE AND text_excerpt != ""
-  AND ts > time::now() - ${sqlDays(days)}d AND session.source != "claude-subagent";
-`).pipe(Effect.orElseSucceed(() => [[] as DirectiveTurnRow[]]));
+            const daysClause = withinDaysClause("t.ts", sqlDays(days));
+            const rawTurns = yield* cacheRows(MineTurnRow, {
+                sql: `SELECT t.id, t.session AS session, t.text_excerpt, t.ts
+                      FROM turn t JOIN session s ON s.id = t.session
+                      WHERE t.role = 'user' AND t.text_excerpt IS NOT NULL AND t.text_excerpt <> ''
+                        ${daysClause.sql} AND s.source <> 'claude-subagent'`,
+                params: daysClause.params,
+            }, "directives mine turns");
 
-            const turns: DirectiveTurnRow[] = rawTurns ?? [];
+            const turns: DirectiveTurnRow[] = rawTurns.map((r) => ({
+                id: r.id,
+                session: r.session,
+                text_excerpt: r.text_excerpt,
+                ts: r.ts,
+            }));
 
             // Fetch lift table from directive_ngram
-            const [rawLift] = yield* db.query<[Array<{ ngram: string; lift: number }>]>(
-                `SELECT ngram, lift FROM directive_ngram WHERE lift > 0;`,
-            ).pipe(Effect.orElseSucceed(() => [[] as Array<{ ngram: string; lift: number }>]));
+            const rawLift = yield* cacheRows(LiftMapRow, {
+                sql: "SELECT ngram, lift FROM directive_ngram WHERE lift > 0",
+                params: [],
+            }, "directives mine lift map");
 
             const liftMap = new Map<string, number>();
-            for (const r of rawLift ?? []) {
+            for (const r of rawLift) {
                 liftMap.set(r.ngram, r.lift);
             }
 
@@ -184,11 +208,10 @@ const ngramsCommand = Command.make(
     ({ limit, json }) =>
         Effect.gen(function* () {
             const validLimit = requirePositiveInt("directives ngrams", "limit", limit);
-            const db = yield* SurrealClient;
-            const [rawRows] = yield* db.query<[LiftRow[]]>(
-                `SELECT ngram, n, occurrences, outcomes, sessions, lift FROM directive_ngram ORDER BY lift DESC LIMIT ${validLimit};`,
-            ).pipe(Effect.orElseSucceed(() => [[] as LiftRow[]]));
-            const liftRows: LiftRow[] = rawRows ?? [];
+            const liftRows: ReadonlyArray<LiftRow> = yield* cacheRows(NgramLiftRow, {
+                sql: "SELECT ngram, n, occurrences, outcomes, sessions, lift FROM directive_ngram ORDER BY lift DESC LIMIT ?",
+                params: [validLimit],
+            }, "directives ngrams");
 
             if (json) {
                 console.log(prettyPrint(liftRows));

--- a/apps/axctl/src/cli/commands/retro.ts
+++ b/apps/axctl/src/cli/commands/retro.ts
@@ -71,7 +71,7 @@ const runInlineRetroDerive = () =>
 
 const LatestSessionRow = Schema.Struct({ id: Schema.String });
 
-const cmdRetroEmit = (input: {
+export const cmdRetroEmit = (input: {
     readonly session: string | undefined;
     readonly fromFile: string | undefined;
     readonly source: string | undefined;
@@ -199,7 +199,7 @@ const cmdRetroEmit = (input: {
         }
     });
 
-const cmdRetroList = (input: {
+export const cmdRetroList = (input: {
     readonly limit: number;
     readonly since: string | undefined;
     readonly json: boolean;
@@ -357,7 +357,7 @@ const queryPendingSessions = (opts: PendingQueryOpts) =>
         return out.slice(0, opts.limit);
     });
 
-const cmdRetroPending = (input: {
+export const cmdRetroPending = (input: {
     readonly since: number;
     readonly idleMin: number;
     readonly limit: number;
@@ -496,7 +496,7 @@ const RetroBriefSessionRow = Schema.Struct({
     turns: NumberFromBigIntColumn,
 });
 
-const cmdRetroBrief = (input: {
+export const cmdRetroBrief = (input: {
     readonly session: string;
     readonly outDir: string | undefined;
     readonly json: boolean;

--- a/apps/axctl/src/cli/commands/retro.ts
+++ b/apps/axctl/src/cli/commands/retro.ts
@@ -1,14 +1,14 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
-import { Effect, FileSystem, Path } from "effect";
+import { Effect, FileSystem, Path, Schema } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
-import { SurrealClient } from "@ax/lib/db";
 import { prettyPrint } from "@ax/lib/json";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
-import { recordRef } from "@ax/lib/shared/surql";
 import { retroFromSession, upsertRetro, type RetroSource } from "../../ingest/retro.ts";
 import { deriveRetroProposals } from "../../ingest/derive-retro-proposals.ts";
 import { CacheRead } from "@ax/lib/duckdb/seam";
+import { TimestampColumn, NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { cacheRows, cacheFirst } from "@ax/lib/duckdb/query";
 import { decodeRetroEmitPayload, hasUnfiledFindings } from "../../ingest/retro-emit-payload.ts";
 import { runPropose } from "../../improve/propose.ts";
 import { listStoredRetros } from "../../queries/judgment-retros.ts";
@@ -69,6 +69,8 @@ const runInlineRetroDerive = () =>
         ),
     );
 
+const LatestSessionRow = Schema.Struct({ id: Schema.String });
+
 const cmdRetroEmit = (input: {
     readonly session: string | undefined;
     readonly fromFile: string | undefined;
@@ -83,16 +85,14 @@ const cmdRetroEmit = (input: {
 
         let sessionRecordId = sessionFlag;
         if (!sessionRecordId) {
-            const db = yield* SurrealClient;
-            const latest = yield* db.query<[Array<{ id: string | { tb: string; id: string } }>]>(
-                "SELECT id, started_at FROM session ORDER BY started_at DESC LIMIT 1;",
-            );
-            const row = (latest?.[0] ?? [])[0];
+            const row = yield* cacheFirst(LatestSessionRow, {
+                sql: "SELECT id FROM session ORDER BY started_at DESC LIMIT 1",
+                params: [],
+            }, "retro emit latest session");
             if (!row) {
                 fail("ax retro emit: no session to retro on (no --session and no rows in DB)");
             }
-            const idStr = typeof row.id === "string" ? row.id : `session:${row.id.id}`;
-            sessionRecordId = idStr;
+            sessionRecordId = row.id;
         }
         if (!sessionRecordId.includes(":")) sessionRecordId = `session:${sessionRecordId}`;
 
@@ -233,17 +233,6 @@ const cmdRetroList = (input: {
  * Drives the quota-arbitrage flow: idle Opus budget chews through the
  * backlog via the retro-reviewer subagent.
  */
-interface PendingSessionRow {
-    readonly id: string | { tb: string; id: string };
-    readonly project: string | null;
-    readonly source: string | null;
-    readonly model: string | null;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    readonly last_turn_at: string | null;
-    readonly turns: number;
-}
-
 export interface PendingSession {
     readonly sessionId: string;     // `session:<key>` record id
     readonly key: string;           // bare key (UUID, no prefix)
@@ -276,54 +265,64 @@ interface PendingQueryOpts {
     readonly limit: number;
 }
 
+const PendingEndedRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: TimestampColumn,
+});
+const PendingIdleRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    started_at: TimestampColumn,
+});
+
 const queryPendingSessions = (opts: PendingQueryOpts) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
         const retros = yield* listStoredRetros({ limit: 100_000 });
         const reviewedSessions = new Set(retros.map((retro) => retro.session.replace(/^session:/, "")));
         const scanLimit = Math.min(100_000, opts.limit + reviewedSessions.size);
         // claude-subagent sessions are orchestrated children; their retros
         // belong to the parent session's review. Exclude unless asked.
-        const subagentFilter = opts.includeSubagents ? "" : "AND source != 'claude-subagent'";
-        const endedRows = yield* db.query<[Array<{
-            id: PendingSessionRow["id"]; project: string | null; source: string | null;
-            model: string | null; started_at: string | null; ended_at: string | null;
-        }>]>(`
-            SELECT id, project, source, model,
-                type::string(started_at) AS started_at,
-                type::string(ended_at) AS ended_at
-            FROM session
-            WHERE ended_at != NONE
-              AND ended_at > time::now() - ${opts.sinceDays}d
-              ${subagentFilter}
-            ORDER BY ended_at DESC
-            LIMIT ${scanLimit};
-        `);
-        const idleRows = yield* db.query<[Array<{
-            id: PendingSessionRow["id"]; project: string | null; source: string | null;
-            model: string | null; started_at: string | null;
-        }>]>(`
-            SELECT id, project, source, model,
-                type::string(started_at) AS started_at
-            FROM session
-            WHERE ended_at = NONE
-              AND started_at != NONE
-              AND started_at > time::now() - ${opts.sinceDays}d
-              AND started_at < time::now() - ${opts.idleMinutes}m
-              ${subagentFilter}
-            ORDER BY started_at DESC
-            LIMIT ${scanLimit};
-        `);
+        const subagentFilter = opts.includeSubagents ? "" : "AND source <> 'claude-subagent'";
+        // Cutoffs computed in JS and bound as params - no CURRENT_TIMESTAMP
+        // arithmetic in SQL (the ICU rule; see clause.ts).
+        const sinceCutoff = new Date(Date.now() - opts.sinceDays * 86_400_000);
+        const idleCutoff = new Date(Date.now() - opts.idleMinutes * 60_000);
 
-        const recordIdOf = (id: PendingSessionRow["id"]): string =>
-            typeof id === "string" ? id : `session:${id.id}`;
+        const endedRows = yield* cacheRows(PendingEndedRow, {
+            sql: `SELECT id, project, source, model, started_at, ended_at
+                  FROM session
+                  WHERE ended_at IS NOT NULL AND ended_at > ?
+                  ${subagentFilter}
+                  ORDER BY ended_at DESC
+                  LIMIT ?`,
+            params: [sinceCutoff, scanLimit],
+        }, "retro pending ended sessions");
+        const idleRows = yield* cacheRows(PendingIdleRow, {
+            sql: `SELECT id, project, source, model, started_at
+                  FROM session
+                  WHERE ended_at IS NULL AND started_at IS NOT NULL
+                    AND started_at > ? AND started_at < ?
+                    ${subagentFilter}
+                  ORDER BY started_at DESC
+                  LIMIT ?`,
+            params: [sinceCutoff, idleCutoff, scanLimit],
+        }, "retro pending idle sessions");
+
+        const recordIdOf = (id: string): string =>
+            id.startsWith("session:") ? id : `session:${id}`;
         const keyOf = (recordId: string): string =>
             recordId.startsWith("session:")
                 ? recordId.slice("session:".length).replace(/`/g, "")
                 : recordId;
 
         const out: PendingSession[] = [];
-        for (const row of (endedRows?.[0] ?? [])) {
+        for (const row of endedRows) {
             const sessionRecordId = recordIdOf(row.id);
             if (reviewedSessions.has(keyOf(sessionRecordId))) continue;
             out.push({
@@ -332,14 +331,14 @@ const queryPendingSessions = (opts: PendingQueryOpts) =>
                 project: row.project,
                 source: row.source,
                 model: row.model,
-                startedAt: row.started_at,
-                endedAt: row.ended_at,
+                startedAt: row.started_at ? row.started_at.toISOString() : null,
+                endedAt: row.ended_at.toISOString(),
                 lastTurnAt: null,
                 turns: 0,
                 reason: "ended_at",
             });
         }
-        for (const row of (idleRows?.[0] ?? [])) {
+        for (const row of idleRows) {
             const sessionRecordId = recordIdOf(row.id);
             if (reviewedSessions.has(keyOf(sessionRecordId))) continue;
             out.push({
@@ -348,7 +347,7 @@ const queryPendingSessions = (opts: PendingQueryOpts) =>
                 project: row.project,
                 source: row.source,
                 model: row.model,
-                startedAt: row.started_at,
+                startedAt: row.started_at.toISOString(),
                 endedAt: null,
                 lastTurnAt: null,
                 turns: 0,
@@ -485,6 +484,18 @@ const suggestModelFor = (s: PendingSession): string => {
     return "sonnet";
 };
 
+const RetroBriefSessionRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    raw_file: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
+    last_turn_at: Schema.NullOr(TimestampColumn),
+    turns: NumberFromBigIntColumn,
+});
+
 const cmdRetroBrief = (input: {
     readonly session: string;
     readonly outDir: string | undefined;
@@ -498,44 +509,29 @@ const cmdRetroBrief = (input: {
         const rawSession = sessionFlag.startsWith("session:")
             ? sessionFlag.slice("session:".length).replace(/`/g, "")
             : sessionFlag;
-        const sessionRef = recordRef("session", rawSession);
         const sessionRecordId = `session:${rawSession}`;
-        const db = yield* SurrealClient;
-        const rows = yield* db.query<[Array<{
-            id: string | { tb: string; id: string };
-            project: string | null;
-            source: string | null;
-            model: string | null;
-            started_at: string | null;
-            ended_at: string | null;
-            raw_file: string | null;
-            last_turn_at: string | null;
-            turns: number;
-        }>]>(`
-            SELECT
-                id, project, source, model, raw_file,
-                type::string(started_at) AS started_at,
-                type::string(ended_at) AS ended_at,
-                type::string((SELECT VALUE math::max(ts) FROM turn WHERE session = $parent.id GROUP ALL)[0]) AS last_turn_at,
-                (SELECT count() FROM turn WHERE session = $parent.id GROUP ALL)[0].count ?? 0 AS turns
-            FROM ${sessionRef} LIMIT 1;
-        `);
-        const row = (rows?.[0] ?? [])[0];
+        const row = yield* cacheFirst(RetroBriefSessionRow, {
+            sql: `SELECT id, project, source, model, raw_file, started_at, ended_at,
+                         (SELECT max(ts) FROM turn WHERE session = s.id) AS last_turn_at,
+                         (SELECT count(*) FROM turn WHERE session = s.id) AS turns
+                  FROM session s WHERE s.id = ? LIMIT 1`,
+            params: [rawSession],
+        }, "retro brief session");
         if (!row) {
             fail(`ax retro brief: session ${sessionRecordId} not found`);
         }
-        const idStr = typeof row.id === "string" ? row.id : `session:${row.id.id}`;
-        const key = idStr.startsWith("session:") ? idStr.slice("session:".length).replace(/`/g, "") : idStr;
+        const idStr = `session:${row.id}`;
+        const key = row.id;
         const session: PendingSession = {
             sessionId: idStr,
             key,
             project: row.project,
             source: row.source,
             model: row.model,
-            startedAt: row.started_at,
-            endedAt: row.ended_at,
-            lastTurnAt: row.last_turn_at,
-            turns: row.turns ?? 0,
+            startedAt: row.started_at ? row.started_at.toISOString() : null,
+            endedAt: row.ended_at ? row.ended_at.toISOString() : null,
+            lastTurnAt: row.last_turn_at ? row.last_turn_at.toISOString() : null,
+            turns: row.turns,
             reason: row.ended_at ? "ended_at" : "idle",
         };
         const suggested = suggestModelFor(session);

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -1,7 +1,8 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
-import { Effect, FileSystem, Path } from "effect";
+import { Effect, FileSystem, Path, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { SurrealClient } from "@ax/lib/db";
+import { cacheFirst, cacheRows } from "@ax/lib/duckdb/query";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
 import { prettyPrint } from "@ax/lib/json";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
@@ -57,7 +58,21 @@ interface SearchInput {
     readonly limit: number;
 }
 
-const cmdSearch = (input: SearchInput) =>
+const SearchMatchRow = Schema.Struct({
+    id: Schema.String,
+    name: Schema.String,
+    scope: Schema.String,
+    description: Schema.NullOr(Schema.String),
+    score: Schema.Number,
+});
+const SearchAggRow = Schema.Struct({
+    skill_id: Schema.String,
+    total_inv: NumberFromBigIntColumn,
+    inv_30d: NumberFromBigIntColumn,
+    last_used: Schema.NullOr(Schema.DateValid),
+});
+
+export const cmdSearch = (input: SearchInput) =>
     Effect.gen(function* () {
         const query = input.query;
         const limit = requirePositiveInt("search", "limit", input.limit);
@@ -67,92 +82,50 @@ const cmdSearch = (input: SearchInput) =>
             console.error("axctl skills search: missing query");
             process.exit(1);
         }
-        const db = yield* SurrealClient;
-        // Primary path: SurrealDB v3 BM25 FTS via the skill_search_name +
-        // skill_search_desc indexes (defined in schema/schema.surql with
-        // ngram(2, 8) tokenisation, so "test" hits "test-driven"). The
-        // `@N@` matches operator references an index by *position in the
-        // WHERE clause* (not field), and `search::score(N)` returns the
-        // BM25 score for predicate N. Combined score = sum of name +
-        // description BM25 scores; either side is NONE when only one
-        // matched, so we coerce via `math::max([score, 0])`.
-        //
-        // Time-window counts use explicit `invoked WHERE out = $parent.id`
-        // form rather than `<-invoked WHERE ts > ...`. The graph-traversal
-        // form materialises edges first then the WHERE drops every row
-        // (returns 0 even when matches exist). See issue #15.
-        // PERF (issue #31): The per-row `(SELECT count() FROM invoked
-        // WHERE out = $parent.id AND ts > 30d ...)` subquery costs ~1.5s
-        // per matched skill that happens to be one of the high-volume
-        // ones (e.g. codex:exec_command @ ~500k edges). For a search hit
-        // that includes them, total runtime jumps to 30s+. The fix is the
-        // same as cmdTaste: do the per-skill recent counters in one
-        // GROUP BY scan, then merge with the FTS-ranked result list.
-        const ftsSql = `
-SELECT
-    id,
-    name,
-    scope,
-    description,
-    (math::max([search::score(0), 0.0]) + math::max([search::score(1), 0.0])) AS score
+        // DuckDB carries no FTS index over `skill` (only turn/commit text get
+        // one), so this is the case-insensitive substring match SurrealDB's
+        // BM25 path used to fall back to on a missing/cold FTS index - not a
+        // downgrade, the same behavior mode that already existed.
+        const lowerQuery = query.toLowerCase();
+        const matched = yield* cacheRows(SearchMatchRow, {
+            sql: `
+SELECT id, name, scope, description,
+       CAST((CASE WHEN lower(name) LIKE '%' || ? || '%' THEN 2.0 ELSE 0.0 END
+        + CASE WHEN lower(coalesce(description, '')) LIKE '%' || ? || '%' THEN 1.0 ELSE 0.0 END) AS DOUBLE) AS score
 FROM skill
-WHERE name @0@ $q OR description @1@ $q
+WHERE lower(name) LIKE '%' || ? || '%' OR lower(coalesce(description, '')) LIKE '%' || ? || '%'
 ORDER BY score DESC
-LIMIT ${limit};`;
-        const legacySql = `
-SELECT
-    id,
-    name,
-    scope,
-    description,
-    (IF string::lowercase(name) CONTAINS $q THEN 2.0 ELSE 0.0 END
-     + IF string::lowercase(description ?? '') CONTAINS $q THEN 1.0 ELSE 0.0 END) AS score
-FROM skill
-WHERE
-    string::lowercase(name) CONTAINS $q
-    OR string::lowercase(description ?? '') CONTAINS $q
-ORDER BY score DESC
-LIMIT ${limit};`;
-        // Per-skill aggregates over `invoked` in one full scan
-        // (~1-2s) - cheap relative to repeating it per matched skill.
-        const aggSql = `
-SELECT
-    out AS skill_id,
-    count() AS total_inv,
-    math::sum(IF ts > time::now() - 30d THEN 1 ELSE 0 END) AS inv_30d,
-    math::max(ts) AS last_used
+LIMIT ?`,
+            params: [lowerQuery, lowerQuery, lowerQuery, lowerQuery, limit],
+        }, "skills search matches");
+        // Per-skill aggregates over `invoked` in one full scan - cheap
+        // relative to repeating a per-skill subquery for every matched row.
+        const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000);
+        const aggRows = yield* cacheRows(SearchAggRow, {
+            sql: `
+SELECT out_id AS skill_id, count(*) AS total_inv,
+       count(*) FILTER (WHERE ts > ?) AS inv_30d,
+       max(ts) AS last_used
 FROM invoked
-GROUP BY out;`;
-        const matchResult = yield* db
-            .query<[Array<Record<string, unknown>>]>(ftsSql, { q: query })
-            .pipe(
-                Effect.catch(() =>
-                    db.query<[Array<Record<string, unknown>>]>(legacySql, {
-                        q: query.toLowerCase(),
-                    }),
-                ),
-            );
-        const aggResult = yield* db.query<[Array<Record<string, unknown>>]>(aggSql);
-        const matched = (matchResult?.[0] ?? []) as Array<Record<string, unknown>>;
-        const aggMap = new Map<string, Record<string, unknown>>();
-        for (const a of (aggResult?.[0] ?? []) as Array<Record<string, unknown>>) {
-            aggMap.set(String(a.skill_id ?? ""), a);
-        }
+GROUP BY out_id`,
+            params: [thirtyDaysAgo],
+        }, "skills search aggregates");
+        const aggMap = new Map(aggRows.map((a) => [a.skill_id, a] as const));
         const rows = matched
             .map((m) => {
-                const agg = aggMap.get(String(m.id ?? ""));
+                const agg = aggMap.get(m.id);
                 return {
                     name: m.name,
                     scope: m.scope,
                     description: m.description,
                     score: m.score,
-                    total_inv: agg ? Number(agg.total_inv ?? 0) : 0,
-                    inv_30d: agg ? Number(agg.inv_30d ?? 0) : 0,
+                    total_inv: agg ? agg.total_inv : 0,
+                    inv_30d: agg ? agg.inv_30d : 0,
                     last_used: agg?.last_used ?? null,
                 };
             })
             .sort((a, b) => {
-                const ds = Number(b.score ?? 0) - Number(a.score ?? 0);
+                const ds = b.score - a.score;
                 if (ds !== 0) return ds;
                 const d30 = b.inv_30d - a.inv_30d;
                 if (d30 !== 0) return d30;
@@ -175,20 +148,14 @@ GROUP BY out;`;
 
 /**
  * Issue #40: Pre-flight existence check so unknown skill names get a
- * dedicated error instead of an empty-but-success rendering. Returns true
- * if the skill exists. Pulls the SurrealClient itself rather than taking
- * it as a parameter so the helper composes naturally inside Effect.gen.
+ * dedicated error instead of an empty-but-success rendering. `null` means
+ * no skill has this name.
  */
-const skillExists = (name: string) =>
-    Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const result = yield* db.query<[unknown[]]>(
-            "SELECT id FROM skill WHERE name = $name LIMIT 1;",
-            { name },
-        );
-        const rows = result?.[0];
-        return Array.isArray(rows) && rows.length > 0;
-    });
+const SkillIdRow = Schema.Struct({ id: Schema.String });
+
+/** The skill's cache row id, or `null` if no skill has this name. */
+const resolveSkillId = (name: string) =>
+    cacheFirst(SkillIdRow, { sql: "SELECT id FROM skill WHERE name = ? LIMIT 1", params: [name] }, "skills resolve id");
 
 interface StatsInput {
     /** Optional on purpose: a bare `ax skills stats` reaches the teaching error below. */
@@ -259,20 +226,31 @@ interface RecentInput {
     readonly limit: number;
 }
 
-const cmdRecent = (input: RecentInput) =>
+const RecentInvocationRow = Schema.Struct({
+    ts: Schema.DateValid,
+    skill: Schema.String,
+    project: Schema.NullOr(Schema.String),
+});
+
+export const cmdRecent = (input: RecentInput) =>
     Effect.gen(function* () {
         const limit = requirePositiveInt("recent", "limit", input.limit);
-        const db = yield* SurrealClient;
-        const sql = `
-SELECT ts, out.name AS skill, in.session.project AS project
-FROM invoked
-ORDER BY ts DESC
-LIMIT ${limit};`;
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-        const rows = result?.[0];
-        for (const r of rows ?? []) {
+        // `invoked.session` is denormalized directly onto the edge (see
+        // schema.duckdb.sql), so this skips the turn hop the original
+        // SurrealQL's `in.session.project` deref implied.
+        const rows = yield* cacheRows(RecentInvocationRow, {
+            sql: `
+SELECT i.ts AS ts, sk.name AS skill, s.project AS project
+FROM invoked i
+JOIN skill sk ON sk.id = i.out_id
+LEFT JOIN session s ON s.id = i.session
+ORDER BY i.ts DESC
+LIMIT ?`,
+            params: [limit],
+        }, "skills recent");
+        for (const r of rows) {
             console.log(
-                `${r.ts}  ${r.skill}  (${prettifyProjectSlug(r.project)})`,
+                `${r.ts.toISOString()}  ${r.skill}  (${prettifyProjectSlug(r.project ?? "")})`,
             );
         }
     });
@@ -513,17 +491,27 @@ interface TasteInput {
     readonly includeTools: boolean;
 }
 
-const cmdTaste = (input: TasteInput) =>
+const TasteSkillRow = Schema.Struct({
+    id: Schema.String,
+    name: Schema.String,
+    scope: Schema.String,
+    dir_path: Schema.NullOr(Schema.String),
+});
+const TasteInvokedAggRow = Schema.Struct({
+    skill_id: Schema.String,
+    inv_total: NumberFromBigIntColumn,
+    inv_7d: NumberFromBigIntColumn,
+    inv_30d: NumberFromBigIntColumn,
+    clean_inv: NumberFromBigIntColumn,
+    corrections: NumberFromBigIntColumn,
+});
+const TasteProposedAggRow = Schema.Struct({ skill_id: Schema.String, proposals: NumberFromBigIntColumn });
+const TasteCommitsAggRow = Schema.Struct({ skill_id: Schema.String, commits_after: NumberFromBigIntColumn });
+
+export const cmdTaste = (input: TasteInput) =>
     Effect.gen(function* () {
         const limit = requirePositiveInt("taste", "limit", input.limit);
         const includeTools = input.includeTools;
-        const syntheticFilter = includeTools
-            ? ""
-            : ` AND (skill_id.dir_path IS NONE OR skill_id.dir_path != "(synthetic)")`;
-        const syntheticSkillFilter = includeTools
-            ? ""
-            : ` AND (dir_path IS NONE OR dir_path != "(synthetic)")`;
-        const db = yield* SurrealClient;
         // Composite signal: invocations (positive), errors near invocation
         // (negative), corrections within 3 turns of invocation in the same
         // session (negative - user pushed back), commits produced by sessions
@@ -556,129 +544,91 @@ const cmdTaste = (input: TasteInput) =>
         // so that the `clean_inv` / `corrections` predicates become pure
         // edge-field filters. End-to-end taste runtime drops to ~13s.
         //
-        // The query runs in three server-side stages plus a client-side
-        // merge so that *every* skill row gets a slot, not just those with
-        // invoked or proposed edges (issue #47):
-        //   (a) AGGREGATES_SQL  - per-skill counters from the invoked scan,
-        //                         then enriches with `<-proposed` /
-        //                         `<-invoked.in.session` traversals and
-        //                         `produced` join.
-        //   (b) PROPOSED_ONLY_SQL - skills with no invocations but with
-        //                           proposals, contributing the negative
-        //                           taste_score floor (-0.5 * proposals).
-        //   (c) ZERO_SQL          - skills with neither invocations nor
-        //                           proposals; rendered with score 0 so the
-        //                           total skill count is honest.
-        // Results are concatenated and sorted in TS to mirror the original
-        // ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC.
-        const aggregatesSql = `
-SELECT
-    name,
-    scope,
-    inv_total,
-    inv_7d,
-    inv_30d,
-    clean_inv,
-    corrections,
-    proposals,
-    array::len((
-        SELECT id FROM produced WHERE in IN $parent.skill_sessions
-    )) AS commits_after,
-    (
-        inv_total
-        - 2 * corrections
-        + array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions))
-        - 0.5 * proposals
-    ) AS taste_score
-FROM (
-    SELECT
-        skill_id.name AS name,
-        skill_id.scope AS scope,
-        inv_total,
-        inv_7d,
-        inv_30d,
-        clean_inv,
-        corrections,
-        array::len(skill_id<-proposed) AS proposals,
-        array::distinct(skill_id<-invoked.in.session ?? []) AS skill_sessions
-    FROM (
-        SELECT
-            out AS skill_id,
-            count() AS inv_total,
-            math::sum(IF ts > time::now() - 7d  THEN 1 ELSE 0 END) AS inv_7d,
-            math::sum(IF ts > time::now() - 30d THEN 1 ELSE 0 END) AS inv_30d,
-            math::sum(IF turn_has_error = false THEN 1 ELSE 0 END) AS clean_inv,
-            math::sum(IF was_corrected   = true  THEN 1 ELSE 0 END) AS corrections
-        FROM invoked
-        GROUP BY out
-    )
-    -- Drop orphan invocations whose target skill never had its row UPSERTed
-    -- (matches the original cmdTaste behaviour, which started FROM skill and
-    -- thus naturally excluded these). Currently happens for a handful of
-    -- legacy plugin/built-in tool names that didn't get recorded as skills.
-    -- Drop synthetic provider tools by default too: these are low-level tool
-    -- invocations, not named skills, and otherwise dominate the setup signal.
-    WHERE skill_id.name IS NOT NONE
-        ${syntheticFilter}
-);`;
-
-        // Skills with proposals but no invocations - the GROUP BY scan
-        // doesn't see them. Cheap: 137-skill count + per-skill proposal
-        // count, all via graph traversal.
-        const proposedOnlySql = `
-SELECT
-    name,
-    scope,
-    0 AS inv_total,
-    0 AS inv_7d,
-    0 AS inv_30d,
-    0 AS clean_inv,
-    0 AS corrections,
-    array::len(<-proposed) AS proposals,
-    0 AS commits_after,
-    -0.5 * array::len(<-proposed) AS taste_score
-FROM skill
-WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0${syntheticSkillFilter};`;
-
-        // Issue #47: skills with neither invocations nor proposals get
-        // dropped entirely from the merged set, so `taste --limit=200`
-        // returns ~35 rows instead of all 137. Pull them in with a flat
-        // zero score so the table reflects the real catalog.
-        const zeroSql = `
-SELECT
-    name,
-    scope,
-    0 AS inv_total,
-    0 AS inv_7d,
-    0 AS inv_30d,
-    0 AS clean_inv,
-    0 AS corrections,
-    0 AS proposals,
-    0 AS commits_after,
-    0 AS taste_score
-FROM skill
-WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) = 0${syntheticSkillFilter};`;
-
-        const [aggResult, propResult, zeroResult] = yield* Effect.all(
+        // Ported to a catalog-first join over four flat statements, so
+        // *every* skill row gets a slot (issue #47) in ONE pass instead of
+        // the original three-branch (invoked / proposed-only / zero) union:
+        //   (1) the full skill catalog (id/name/scope/dir_path - small table)
+        //   (2) per-skill invoked aggregates (inv_total/7d/30d/clean/corrections)
+        //   (3) per-skill proposed counts
+        //   (4) per-skill commits_after - `produced` rows in the DISTINCT set
+        //       of sessions that invoked this skill (a single JOIN + COUNT
+        //       DISTINCT, rather than a per-skill correlated subquery)
+        // A skill absent from (2)/(3)/(4) defaults to zero in the JS join,
+        // which is exactly the proposed-only/zero union the original three
+        // SurrealQL branches existed to reconstruct.
+        const sevenDaysAgo = new Date(Date.now() - 7 * 86_400_000);
+        const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000);
+        const [skillRows, invokedAgg, proposedAgg, commitsAgg] = yield* Effect.all(
             [
-                db.query<[Array<Record<string, unknown>>]>(aggregatesSql),
-                db.query<[Array<Record<string, unknown>>]>(proposedOnlySql),
-                db.query<[Array<Record<string, unknown>>]>(zeroSql),
+                cacheRows(TasteSkillRow, { sql: "SELECT id, name, scope, dir_path FROM skill", params: [] }, "skills taste catalog"),
+                cacheRows(TasteInvokedAggRow, {
+                    sql: `
+SELECT out_id AS skill_id, count(*) AS inv_total,
+       count(*) FILTER (WHERE ts > ?) AS inv_7d,
+       count(*) FILTER (WHERE ts > ?) AS inv_30d,
+       count(*) FILTER (WHERE turn_has_error = false) AS clean_inv,
+       count(*) FILTER (WHERE was_corrected = true) AS corrections
+FROM invoked
+GROUP BY out_id`,
+                    params: [sevenDaysAgo, thirtyDaysAgo],
+                }, "skills taste invoked aggregates"),
+                cacheRows(TasteProposedAggRow, {
+                    sql: "SELECT out_id AS skill_id, count(*) AS proposals FROM proposed GROUP BY out_id",
+                    params: [],
+                }, "skills taste proposed aggregates"),
+                cacheRows(TasteCommitsAggRow, {
+                    sql: `
+SELECT i.out_id AS skill_id, count(DISTINCT p.id) AS commits_after
+FROM invoked i JOIN produced p ON p.in_id = i.session
+GROUP BY i.out_id`,
+                    params: [],
+                }, "skills taste commits aggregate"),
             ],
-            { concurrency: 3 },
+            { concurrency: 4 },
         );
-        const aggRows = aggResult?.[0] ?? [];
-        const propRows = propResult?.[0] ?? [];
-        const zeroRows = zeroResult?.[0] ?? [];
-        // Merge + sort to mirror original ORDER BY (server-side ORDER BY
-        // would force a second pass over the merged set, simpler in TS).
-        const score = (r: Record<string, unknown>) => Number(r.taste_score ?? 0);
-        const merged = [...aggRows, ...propRows, ...zeroRows].sort((a, b) => {
-            const ds = score(b) - score(a);
+        const invokedById = new Map(invokedAgg.map((r) => [r.skill_id, r] as const));
+        const proposedById = new Map(proposedAgg.map((r) => [r.skill_id, r.proposals] as const));
+        const commitsById = new Map(commitsAgg.map((r) => [r.skill_id, r.commits_after] as const));
+        interface TasteRow {
+            readonly name: string;
+            readonly scope: string;
+            readonly inv_total: number;
+            readonly inv_7d: number;
+            readonly inv_30d: number;
+            readonly clean_inv: number;
+            readonly corrections: number;
+            readonly proposals: number;
+            readonly commits_after: number;
+            readonly taste_score: number;
+        }
+        const merged: TasteRow[] = [];
+        for (const s of skillRows) {
+            if (!includeTools && s.dir_path === "(synthetic)") continue;
+            const inv = invokedById.get(s.id);
+            const proposals = proposedById.get(s.id) ?? 0;
+            const commitsAfter = commitsById.get(s.id) ?? 0;
+            const invTotal = inv?.inv_total ?? 0;
+            const corrections = inv?.corrections ?? 0;
+            merged.push({
+                name: s.name,
+                scope: s.scope,
+                inv_total: invTotal,
+                inv_7d: inv?.inv_7d ?? 0,
+                inv_30d: inv?.inv_30d ?? 0,
+                clean_inv: inv?.clean_inv ?? 0,
+                corrections,
+                proposals,
+                commits_after: commitsAfter,
+                taste_score: invTotal - 2 * corrections + commitsAfter - 0.5 * proposals,
+            });
+        }
+        // Sort to mirror the original ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC.
+        merged.sort((a, b) => {
+            const ds = b.taste_score - a.taste_score;
             if (ds !== 0) return ds;
-            const d30 = Number(b.inv_30d ?? 0) - Number(a.inv_30d ?? 0);
+            const d30 = b.inv_30d - a.inv_30d;
             if (d30 !== 0) return d30;
-            return Number(b.inv_total ?? 0) - Number(a.inv_total ?? 0);
+            return b.inv_total - a.inv_total;
         });
         const totalRows = merged.length;
         const rows = merged.slice(0, limit);
@@ -690,14 +640,14 @@ WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) = 0${syntheticSkillFi
         // 6+ digit values (e.g. codex:exec_command at 597,508) don't bleed
         // into the next column. Header width sets the floor.
         const cols = [
-            { key: "score", header: "score", get: (r: Record<string, unknown>) => fmtScore(r.taste_score) },
-            { key: "7d", header: "7d", get: (r: Record<string, unknown>) => fmtCount(r.inv_7d) },
-            { key: "30d", header: "30d", get: (r: Record<string, unknown>) => fmtCount(r.inv_30d) },
-            { key: "total", header: "total", get: (r: Record<string, unknown>) => fmtCount(r.inv_total) },
-            { key: "clean", header: "clean", get: (r: Record<string, unknown>) => fmtCount(r.clean_inv) },
-            { key: "corr", header: "corr", get: (r: Record<string, unknown>) => fmtCount(r.corrections ?? 0) },
-            { key: "prop", header: "prop", get: (r: Record<string, unknown>) => fmtCount(r.proposals ?? 0) },
-            { key: "cmts", header: "cmts", get: (r: Record<string, unknown>) => fmtCount(r.commits_after ?? 0) },
+            { key: "score", header: "score", get: (r: TasteRow) => fmtScore(r.taste_score) },
+            { key: "7d", header: "7d", get: (r: TasteRow) => fmtCount(r.inv_7d) },
+            { key: "30d", header: "30d", get: (r: TasteRow) => fmtCount(r.inv_30d) },
+            { key: "total", header: "total", get: (r: TasteRow) => fmtCount(r.inv_total) },
+            { key: "clean", header: "clean", get: (r: TasteRow) => fmtCount(r.clean_inv) },
+            { key: "corr", header: "corr", get: (r: TasteRow) => fmtCount(r.corrections) },
+            { key: "prop", header: "prop", get: (r: TasteRow) => fmtCount(r.proposals) },
+            { key: "cmts", header: "cmts", get: (r: TasteRow) => fmtCount(r.commits_after) },
         ];
         const widths = cols.map((c) =>
             Math.max(c.header.length, ...rows.map((r) => c.get(r).length)),
@@ -720,39 +670,37 @@ interface PairsInput {
     readonly limit: number;
 }
 
-const cmdPairs = (input: PairsInput) =>
+const PairedRow = Schema.Struct({
+    partner: Schema.String,
+    count: NumberFromBigIntColumn,
+    last_seen: Schema.DateValid,
+});
+
+export const cmdPairs = (input: PairsInput) =>
     Effect.gen(function* () {
         // The old missing-name guard is dead: <skill> is a required
         // Argument.string, so the CLI parser rejects the bare invocation.
         const name = input.name;
         const limit = requirePositiveInt("pairs", "limit", input.limit);
-        const db = yield* SurrealClient;
-        const exists = yield* skillExists(name);
-        if (!exists) {
+        const skill = yield* resolveSkillId(name);
+        if (!skill) {
             const hint = name.length > 20 ? name.slice(0, 20) : name;
             fail(`axctl: no skill named "${name}". try: axctl skills search "${hint}"`);
         }
         // Pairs are stored undirected (lexicographically lo->hi). Look the
         // skill up on either endpoint so callers don't have to know the
-        // canonical direction. Combine both legs into a single ranked list.
-        // Pairs are stored undirected (lexicographically lo->hi), so the
-        // queried skill could be on either endpoint. Use IF/ELSE to pick the
-        // partner regardless of position; SurrealDB lacks UNION on SELECTs.
-        const sql = `
-LET $s = (SELECT id FROM skill WHERE name = $name)[0].id;
-SELECT
-    (IF in = $s THEN out.name ELSE in.name END) AS partner,
-    count,
-    last_seen
-FROM skill_paired
-WHERE in = $s OR out = $s
-ORDER BY count DESC
-LIMIT ${limit};`;
-        const result = yield* db.query<unknown[]>(sql, { name });
-        const arr = Array.isArray(result)
-            ? [...result].reverse().find((r) => Array.isArray(r) && (r as unknown[]).length > 0)
-            : undefined;
-        const rows = (arr as Array<Record<string, unknown>> | undefined) ?? [];
+        // canonical direction; CASE picks the partner regardless of position.
+        const rows = yield* cacheRows(PairedRow, {
+            sql: `
+SELECT (CASE WHEN sp.in_id = ? THEN so.name ELSE si.name END) AS partner, sp.count, sp.last_seen
+FROM skill_paired sp
+JOIN skill si ON si.id = sp.in_id
+JOIN skill so ON so.id = sp.out_id
+WHERE sp.in_id = ? OR sp.out_id = ?
+ORDER BY sp.count DESC
+LIMIT ?`,
+            params: [skill.id, skill.id, skill.id, limit],
+        }, "skills pairs");
         if (rows.length === 0) {
             console.log("(no co-occurring skills)");
             return;
@@ -760,7 +708,7 @@ LIMIT ${limit};`;
         console.log(`${"partner".padEnd(50)}  count  last_seen`);
         for (const r of rows) {
             console.log(
-                `${String(r.partner).padEnd(50)}  ${String(r.count).padStart(5)}  ${r.last_seen ?? "-"}`,
+                `${r.partner.padEnd(50)}  ${String(r.count).padStart(5)}  ${r.last_seen.toISOString()}`,
             );
         }
     });
@@ -769,25 +717,27 @@ interface RecoveryInput {
     readonly limit: number;
 }
 
-const cmdRecovery = (input: RecoveryInput) =>
+const RecoveryRow = Schema.Struct({ skill: Schema.String, hits: NumberFromBigIntColumn });
+
+export const cmdRecovery = (input: RecoveryInput) =>
     Effect.gen(function* () {
         const limit = requirePositiveInt("recovery", "limit", input.limit);
-        const db = yield* SurrealClient;
-        const sql = `
-SELECT out.name AS skill, count() AS hits
-FROM recovered_by
-GROUP BY skill
+        const rows = yield* cacheRows(RecoveryRow, {
+            sql: `
+SELECT sk.name AS skill, count(*) AS hits
+FROM recovered_by r JOIN skill sk ON sk.id = r.out_id
+GROUP BY sk.name
 ORDER BY hits DESC
-LIMIT ${limit};`;
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-        const rows = result?.[0];
-        if (!rows || rows.length === 0) {
+LIMIT ?`,
+            params: [limit],
+        }, "skills recovery");
+        if (rows.length === 0) {
             console.log("(no recovery edges)");
             return;
         }
         console.log(`${"skill".padEnd(50)}  hits`);
         for (const r of rows) {
-            console.log(`${String(r.skill).padEnd(50)}  ${String(r.hits).padStart(4)}`);
+            console.log(`${r.skill.padEnd(50)}  ${String(r.hits).padStart(4)}`);
         }
     });
 

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -61,7 +61,7 @@ import {
 import { defaultPublishStatePath } from "../../profile/publish-state.ts";
 import type { GitHubApiError } from "../../profile/github-env.ts";
 import { HookProviderRegistryDefault } from "../../hooks/providers/registry.ts";
-import { resolvePwdRepository } from "../../pwd.ts";
+import { resolvePwdCacheRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 
 // ---------------------------------------------------------------------------
@@ -580,7 +580,7 @@ const experimentCommand = Command.make("experiment").pipe(
 // ---------------------------------------------------------------------------
 
 const resolveCurrentTeamRepo = (command: "join" | "leave" | "push") =>
-    resolvePwdRepository().pipe(
+    resolvePwdCacheRepository().pipe(
         Effect.map(teamRepositoryContext),
         Effect.catchTag("NotAGitRepoError", (error) =>
             Effect.sync(() => {
@@ -641,7 +641,7 @@ export const joinCommand = Command.make(
 
 export const statusCommand = Command.make("status", {}, () =>
     Effect.gen(function* () {
-        const currentRepo = yield* resolvePwdRepository().pipe(
+        const currentRepo = yield* resolvePwdCacheRepository().pipe(
             Effect.map(teamRepositoryContext),
             Effect.catchTag("NotAGitRepoError", () => Effect.succeed(null)),
         );
@@ -679,6 +679,7 @@ export const pushCommand = Command.make("push", {}, () =>
         if (currentRepo === null) return;
         const result = yield* pushCurrentTeamProfile({
             repoKey: currentRepo.repoKey,
+            repositoryId: currentRepo.repositoryId,
             bindingsPath: defaultTeamBindingsPath(),
             publishStatePath: defaultPublishStatePath(),
             windowDays: 30,

--- a/apps/axctl/src/cli/project.ts
+++ b/apps/axctl/src/cli/project.ts
@@ -1,8 +1,6 @@
 import { Effect, FileSystem, Path } from "effect";
 import type { CacheRead, CacheReadError } from "@ax/lib/duckdb/seam";
-import { SurrealClient } from "@ax/lib/db";
 import { ProcessService } from "@ax/lib/process";
-import type { DbError } from "@ax/lib/errors";
 import { wantsJson } from "./output.ts";
 import { buildProjectContext, buildProjectHarness, buildProjectVerification } from "../project/context.ts";
 import type { HarnessDoctorFinding, ProjectContext, ProjectHarnessReport, ProjectVerification, VerificationCheck } from "../project/types.ts";
@@ -80,7 +78,7 @@ function printHarness(payload: ProjectHarnessReport): void {
 
 export const cmdProject = (
     args: string[],
-): Effect.Effect<void, DbError | CacheReadError, SurrealClient | CacheRead | ProcessService | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<void, CacheReadError, CacheRead | ProcessService | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const [subcommand, ...rest] = args;
         if (!subcommand || subcommand === "help" || subcommand === "--help" || subcommand === "-h") {

--- a/apps/axctl/src/cli/retro-family-no-surreal.test.ts
+++ b/apps/axctl/src/cli/retro-family-no-surreal.test.ts
@@ -1,0 +1,216 @@
+/**
+ * `ax retro` command family, exercised END TO END against a real DuckDB
+ * cache fixture + a real SQLite judgment sidecar, with the SAME throwing
+ * `SurrealClient` sentinel production's no-DB runtimes (`withCache` /
+ * `withoutDb` in `cli/index.ts`) provide - any access still fails LOUDLY.
+ *
+ * WHY NOT A SPAWNED-CLI DEAD-PORT TEST (the `recall-no-surreal.test.ts`
+ * shape). That shape only discriminates for a command whose MANIFEST entry
+ * already says `"cache"` - `recall` and `sessions show` are. `retroRuntime`
+ * (commands/retro.ts) still routes `pending`, `brief`, and `meta` through
+ * `"db"`: the RUNTIME_BY_COMMAND flip is a SEPARATE, deferred chunk (band
+ * ruling R34), not this chunk's to make. `withDb` provides
+ * `LegacySurrealAppLayer`, and `SurrealClientLive` is `Layer.effect` whose
+ * body `await`s `db.connect()` with a 5s timeout - so building that layer
+ * against a dead port fails BEFORE the command body ever runs, regardless of
+ * whether the ported code touches `SurrealClient`. A spawned dead-port test
+ * for `pending`/`brief`/`meta` would therefore just time out on ROUTING,
+ * proving nothing about the code this chunk changed.
+ *
+ * So instead: call the exported command functions directly, providing a real
+ * `CacheRead` (published DuckDB fixture), a real `Judgment` (SQLite sidecar,
+ * not a fake), and the exact throwing `SurrealClient` sentinel `withCache`
+ * provides in production. Any `SurrealClient` access still throws
+ * immediately and by name - this is MORE precise than a dead-port timeout,
+ * and it is not confounded by manifest routing that is out of this chunk's
+ * scope. `cmdRetroReflect`/`cmdRetroPlan` need no runtime check here at all:
+ * their Effect signatures require only `Judgment` (see retro-reflect.ts /
+ * retro-plan.ts) - the ABSENCE of `SurrealClient` from the type is itself
+ * compile-time proof, and this suite would fail to typecheck if that ever
+ * regressed.
+ */
+import { describe, expect } from "bun:test";
+import { Effect, Layer } from "effect";
+import { mkdtempSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { CacheReadLayer, type CacheWriteService } from "@ax/lib/duckdb/seam";
+import { JudgmentLayer } from "@ax/lib/sqlite";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { cmdRetroBrief, cmdRetroEmit, cmdRetroList, cmdRetroPending } from "./commands/retro.ts";
+import { cmdRetroMeta } from "./retro-meta.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("ax retro family (no surreal)", {
+    requireFts: true,
+});
+
+const T = (iso: string): Date => new Date(iso);
+
+/** The exact sentinel `withCache`/`withoutDb` provide in cli/index.ts: any
+ *  property access throws immediately and by name. */
+const throwingSurrealClient = (): SurrealClientShape =>
+    new Proxy({} as SurrealClientShape, {
+        get(_target, prop) {
+            throw new Error(`SurrealClient.${String(prop)} accessed on the no-DB test layer`);
+        },
+    });
+
+/** One CacheRead + one fresh Judgment sidecar + the throwing sentinel. */
+const buildLayer = async (
+    corpus: (write: CacheWriteService) => Effect.Effect<unknown, unknown, never>,
+    label: string,
+) => {
+    const fixture = await runWithPlatform(publishCacheFixture(tempDir(`${label}-`), dylibPath, corpus));
+    const sidecarRoot = mkdtempSync(join(tmpdir(), `${label}-sidecar-`));
+    const sidecarPath = join(sidecarRoot, "judgment.sqlite");
+    const layer = Layer.mergeAll(
+        CacheReadLayer({ snapshotPath: fixture.snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) }),
+        JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
+        Layer.succeed(SurrealClient, throwingSurrealClient()),
+        Layer.merge(BunFileSystem.layer, BunPath.layer),
+    );
+    return { layer, sidecarPath };
+};
+
+const run = <A, E, R>(eff: Effect.Effect<A, E, R>, layer: Layer.Layer<R>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer), Effect.scoped));
+
+describe("ax retro family on the cache + sidecar, SurrealClient never reachable", () => {
+    dtest("emit's latest-session fallback resolves through the cache, not Surreal", async () => {
+        const { layer } = await buildLayer((w) =>
+            w.put("session", {
+                id: "session-emit-fallback",
+                source: "claude",
+                project: "ax",
+                cwd: "/w/ax",
+                started_at: T("2026-08-10T10:00:00.000Z"),
+            }), "ax-retro-emit");
+
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await run(cmdRetroEmit({ session: undefined, fromFile: undefined, source: undefined, json: true }), layer);
+        } finally {
+            console.log = origLog;
+        }
+        const out = JSON.parse(logged.join("")) as { session: string };
+        expect(out.session).toBe("session:session-emit-fallback");
+    }, 60_000);
+
+    dtest("list reads retros from the judgment sidecar, not Surreal", async () => {
+        const { layer } = await buildLayer((w) =>
+            w.put("session", { id: "session-list-a", source: "claude", project: "ax", cwd: "/w/ax" }),
+        "ax-retro-list");
+
+        // Seed a retro directly via the same sidecar, then list it back.
+        await run(cmdRetroEmit({ session: "session-list-a", fromFile: undefined, source: "manual", json: false }), layer);
+
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await run(cmdRetroList({ limit: 20, since: undefined, json: true }), layer);
+        } finally {
+            console.log = origLog;
+        }
+        const rows = JSON.parse(logged.join("")) as ReadonlyArray<{ session: string }>;
+        expect(rows.map((r) => r.session)).toContain("session-list-a");
+    }, 60_000);
+
+    dtest("pending finds ended + idle sessions from the cache, not Surreal", async () => {
+        const { layer } = await buildLayer((w) =>
+            w.putMany("session", [
+                {
+                    id: "session-pending-ended",
+                    source: "claude",
+                    project: "ax",
+                    cwd: "/w/ax",
+                    started_at: T("2026-08-15T10:00:00.000Z"),
+                    ended_at: T("2026-08-15T11:00:00.000Z"),
+                },
+                {
+                    id: "session-pending-idle",
+                    source: "claude",
+                    project: "ax",
+                    cwd: "/w/ax",
+                    started_at: T("2026-08-15T09:00:00.000Z"),
+                    ended_at: null,
+                },
+            ]), "ax-retro-pending");
+
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await run(cmdRetroPending({ since: 7, idleMin: 5, limit: 20, includeSubagents: false, json: true }), layer);
+        } finally {
+            console.log = origLog;
+        }
+        const pending = JSON.parse(logged.join("")) as ReadonlyArray<{ key: string; reason: string }>;
+        expect(pending.map((s) => s.key).sort()).toEqual(["session-pending-ended", "session-pending-idle"]);
+        expect(pending.find((s) => s.key === "session-pending-ended")?.reason).toBe("ended_at");
+        expect(pending.find((s) => s.key === "session-pending-idle")?.reason).toBe("idle");
+    }, 60_000);
+
+    dtest("brief resolves session detail + turn count from the cache, not Surreal", async () => {
+        const { layer } = await buildLayer((w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", {
+                    id: "session-brief-a",
+                    source: "claude",
+                    project: "ax",
+                    cwd: "/w/ax",
+                    started_at: T("2026-08-15T10:00:00.000Z"),
+                    ended_at: T("2026-08-15T11:00:00.000Z"),
+                });
+                yield* w.putMany("turn", [
+                    { id: "t1", session: "session-brief-a", seq: 1, ts: T("2026-08-15T10:05:00.000Z"), role: "user", has_tool_use: false, has_error: false },
+                    { id: "t2", session: "session-brief-a", seq: 2, ts: T("2026-08-15T10:10:00.000Z"), role: "assistant", has_tool_use: false, has_error: false },
+                ]);
+            }), "ax-retro-brief");
+
+        const outDir = mkdtempSync(join(tmpdir(), "ax-retro-brief-out-"));
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await run(cmdRetroBrief({ session: "session-brief-a", outDir, json: true }), layer);
+        } finally {
+            console.log = origLog;
+        }
+        const out = JSON.parse(logged.join("")) as { session: string; path: string };
+        expect(out.session).toBe("session:session-brief-a");
+        const content = await readFile(out.path, "utf8");
+        expect(content).toContain("turns: 2");
+    }, 60_000);
+
+    dtest("meta reads the skill catalog from the cache, not Surreal", async () => {
+        const { layer } = await buildLayer((w) =>
+            w.put("skill", {
+                id: "skill-a",
+                name: "composto",
+                scope: "user",
+                dir_path: "/skills/composto",
+                content_hash: "abc",
+            }), "ax-retro-meta");
+
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await run(cmdRetroMeta(["--since=30"]), layer);
+        } finally {
+            console.log = origLog;
+        }
+        const snapshot = JSON.parse(logged.join("")) as {
+            current_state: { skills: ReadonlyArray<{ name: string }> };
+        };
+        expect(snapshot.current_state.skills.map((s) => s.name)).toEqual(["composto"]);
+    }, 60_000);
+});

--- a/apps/axctl/src/cli/retro-meta.ts
+++ b/apps/axctl/src/cli/retro-meta.ts
@@ -17,15 +17,15 @@
  * Sibling of `retro emit` / `retro list` / `retro reflect`.
  */
 
-import { Effect, FileSystem } from "effect";
+import { Effect, FileSystem, Schema } from "effect";
 import { encodeJson } from "@ax/lib/decode";
 import { homedir } from "node:os";
-import { SurrealClient } from "@ax/lib/db";
-import type { DbError } from "@ax/lib/errors";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { cacheRows } from "@ax/lib/duckdb/query";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettyPrint } from "@ax/lib/json";
-import { recordRef } from "@ax/lib/shared/surql";
 import { listStoredProposals } from "../improve/judgment-proposals.ts";
 import { listStoredRetros } from "../queries/judgment-retros.ts";
 import {
@@ -180,15 +180,16 @@ export const coerceDaysSinceAccepted = (
     return 0;
 };
 
-const idToString = (raw: unknown): string => {
-    if (raw === null || raw === undefined) return "";
-    if (typeof raw === "string") return raw;
-    if (typeof raw === "object" && raw !== null && "tb" in raw && "id" in raw) {
-        const r = raw as { tb: unknown; id: unknown };
-        return `${String(r.tb ?? "")}:${String(r.id ?? "")}`;
-    }
-    return String(raw);
-};
+const MetaSkillRow = Schema.Struct({
+    name: Schema.String,
+    scope: Schema.String,
+    description: Schema.NullOr(Schema.String),
+});
+const OpportunityAggRow = Schema.Struct({
+    experiment_id: Schema.String,
+    opportunities_count: NumberFromBigIntColumn,
+    addressed_count: NumberFromBigIntColumn,
+});
 
 const flagValue = (args: string[], name: string): string | undefined => {
     const hit = args.find((a) => a.startsWith(`--${name}=`));
@@ -327,7 +328,7 @@ export const buildMetaSnapshot = (input: {
 
 export const cmdRetroMeta = (
     args: string[],
-): Effect.Effect<void, DbError | JudgmentError, SurrealClient | Judgment | FileSystem.FileSystem> =>
+): Effect.Effect<void, JudgmentError, CacheRead | Judgment | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const sinceRaw = flagValue(args, "since");
@@ -342,14 +343,13 @@ export const cmdRetroMeta = (
         // / `--pretty` are not supported; the CLI is always-JSON for now.
         const pretty = args.includes("--pretty");
 
-        const db = yield* SurrealClient;
-
         const cutoff = new Date(Date.now() - sinceDays * 86_400_000);
-        const [storedRetros, skillsRes, proposals] = yield* Effect.all([
+        const [storedRetros, skillRows, proposals] = yield* Effect.all([
             listStoredRetros({ since: cutoff, limit: limitRetros }),
-            db.query<[Array<Record<string, unknown>>]>(
-                `SELECT name, scope, description FROM skill ORDER BY name;`,
-            ),
+            cacheRows(MetaSkillRow, {
+                sql: "SELECT name, scope, description FROM skill ORDER BY name",
+                params: [],
+            }, "retro meta skills"),
             listStoredProposals(1_000),
         ], { concurrency: 3 });
 
@@ -364,10 +364,10 @@ export const cmdRetroMeta = (
             created_at: r.created_at.toISOString(),
         }));
 
-        const skills: SkillRow[] = (skillsRes?.[0] ?? []).map((s) => ({
-            name: String(s.name ?? ""),
-            scope: String(s.scope ?? ""),
-            description: String(s.description ?? ""),
+        const skills: SkillRow[] = skillRows.map((s) => ({
+            name: s.name,
+            scope: s.scope,
+            description: s.description ?? "",
         }));
 
         const openProposals: OpenProposalRow[] = proposals
@@ -396,15 +396,17 @@ export const cmdRetroMeta = (
                 locked_verdict: experiment.locked_verdict,
             }));
 
-        const refs = experiments.map(({ experiment }) => recordRef("experiment", experiment.id));
-        const opportunityRows = refs.length === 0 ? [] : (yield* db.query<[Array<Record<string, unknown>>]>(`
-            SELECT type::string(in) AS experiment_id, count() AS opportunities_count,
-                   math::sum(IF was_addressed = true THEN 1 ELSE 0 END) AS addressed_count
-            FROM opportunity WHERE in IN [${refs.join(", ")}] GROUP BY experiment_id;
-        `))?.[0] ?? [];
+        const experimentIds = experiments.map(({ experiment }) => experiment.id);
+        const opportunityRows = experimentIds.length === 0 ? [] : yield* cacheRows(OpportunityAggRow, {
+            sql: `SELECT in_id AS experiment_id, count(*) AS opportunities_count,
+                         count(*) FILTER (WHERE was_addressed) AS addressed_count
+                  FROM opportunity WHERE in_id IN (${experimentIds.map(() => "?").join(", ")})
+                  GROUP BY in_id`,
+            params: experimentIds,
+        }, "retro meta opportunities");
         const opportunityByExperiment = new Map(opportunityRows.map((row) => [
-            idToString(row.experiment_id).replace(/^experiment:/, ""),
-            { opportunities: Number(row.opportunities_count ?? 0), addressed: Number(row.addressed_count ?? 0) },
+            row.experiment_id,
+            { opportunities: row.opportunities_count, addressed: row.addressed_count },
         ] as const));
 
         const experimentStatus: ExperimentStatusRow[] = experiments.map(({ proposal, experiment }) => {

--- a/apps/axctl/src/cli/share.ts
+++ b/apps/axctl/src/cli/share.ts
@@ -1,6 +1,5 @@
 import { Effect, FileSystem, Layer, Path, type PlatformError } from "effect";
 import { execFile } from "node:child_process";
-import { LegacySurrealAppLayer } from "@ax/lib/layers";
 import { CacheReadLive } from "@ax/lib/duckdb/seam";
 import { BunFileSystem, BunPath } from "@ax/lib/bun-platform";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
@@ -258,24 +257,29 @@ export async function cmdShareWithDeps(
     if (parsed.open) await deps.open(ref);
 }
 
+const SharePlatformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
 const liveShareDeps: ShareCommandDeps = {
     exportArtifact: (sessionId, axVersion) =>
         Effect.runPromise(
             exportSessionShare(sessionId, axVersion).pipe(
                 catchDbErrorAndExit("axctl share"),
-                Effect.provide(LegacySurrealAppLayer),
+                // `ax share` is declared runtime "none" - it must never open a
+                // live SurrealDB connection. It used to self-provide
+                // `LegacySurrealAppLayer` here regardless of that declaration
+                // (wave-3 partition doc §2d finding); now that `exporter.ts`
+                // reads through the DuckDB cache, only CacheRead is needed.
+                Effect.provide(CacheReadLive),
                 Effect.scoped,
             ),
         ),
     locateTranscript: (sessionId) =>
         Effect.runPromise(
             locateShareTranscript(sessionId).pipe(
-                // The `raw_file` hint now comes off the published snapshot, so
-                // the cache layer rides alongside LegacySurrealAppLayer here. (`ax share`
-                // self-providing LegacySurrealAppLayer at all is the wave-3 finding in the
-                // partition doc's §2d - it is declared `"none"` in the manifest;
-                // that removal belongs to the runtime flip, not here.)
-                Effect.provide(Layer.merge(LegacySurrealAppLayer, CacheReadLive)),
+                // `locateShareTranscript` needs CacheRead (the `raw_file` hint
+                // off the published snapshot) + the filesystem, never
+                // SurrealDB - see recover.ts's own R-channel comment.
+                Effect.provide(Layer.merge(CacheReadLive, SharePlatformLayer)),
                 Effect.scoped,
             ),
         ),

--- a/apps/axctl/src/cli/skills-classify.test.ts
+++ b/apps/axctl/src/cli/skills-classify.test.ts
@@ -5,43 +5,34 @@ import { mkdtempSync } from "node:fs";
 import { readFile, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { cmdSkillsClassify } from "./skills-classify.ts";
 import { skillNameToSlug } from "./skills-classify-template.ts";
-import { DbError } from "@ax/lib/errors";
 import { judgmentTestLayer } from "../testing/judgment-test-layer.ts";
 import { cacheReadResults } from "../testing/cache-read.ts";
 import type { CacheRead } from "@ax/lib/duckdb/seam";
 
 // ---------------------------------------------------------------------------
-// Test fixtures + mock DB
+// Test fixtures - both cmdSkillsClassify backends (default = fetchSkillHygiene
+// on CacheRead + Judgment, explicit = a single CacheRead join) now live
+// entirely on the DuckDB cache + SQLite judgment sidecar. No SurrealDB fake.
 // ---------------------------------------------------------------------------
 
 type MockRow = { name: string; invocations: number; sessions: number };
-const classifiedByDb = new WeakMap<SurrealClientShape, ReadonlyArray<string>>();
-// The hygiene halves that come from the CACHE (counts + catalog), keyed by the
-// same client handle the test already threads around. The stub answers the seam
-// directly (no schema decode), so these are the DECODED row shapes.
-const cacheRowsByDb = new WeakMap<SurrealClientShape, ReadonlyArray<ReadonlyArray<unknown>>>();
-/** Every SQL string the cache stub was asked for, per client. */
-const cacheSqlByDb = new WeakMap<SurrealClientShape, string[]>();
 
-/** Build a minimal SurrealClientShape mock that returns a fixed row list. */
-function mockDb(rows: MockRow[]): SurrealClientShape {
-    return makeTestSurrealClient({ denyWrites: true, fallback: [rows] }).client;
+interface Fixture {
+    readonly cacheRows: ReadonlyArray<ReadonlyArray<unknown>>;
+    readonly classifiedIds: ReadonlyArray<string>;
 }
 
 /**
- * Default mode now delegates to fetchSkillHygiene, which issues ONE 3-statement
- * query ([invocation counts, skill rows, classified ids]) and joins them in JS.
- * This builds that 3-statement fixture so the given rows survive the join as the
- * selected unclassified skills. `extraSkills` lets a test seed skills that should
- * be filtered OUT (synthetic / classified / below-threshold) to exercise the
- * predicate end-to-end.
+ * Default mode delegates to fetchSkillHygiene, which issues TWO cache reads
+ * (invocation counts, skill catalog) joined in JS against a THIRD read from
+ * the judgment sidecar (classified skill ids). `extraSkills` seeds skills
+ * that should be filtered OUT (synthetic / classified / below-threshold) to
+ * exercise the predicate end-to-end.
  */
-function hygieneMockDb(
+function hygieneFixture(
     rows: MockRow[],
     extraSkills: Array<{
         name: string;
@@ -50,7 +41,7 @@ function hygieneMockDb(
         dir_path?: string;
         classified?: boolean;
     }> = [],
-): SurrealClientShape {
+): Fixture {
     const all = [
         ...rows.map((r) => ({ ...r, dir_path: `/skills/${r.name}`, classified: false })),
         ...extraSkills.map((s) => ({
@@ -61,52 +52,35 @@ function hygieneMockDb(
             classified: s.classified ?? false,
         })),
     ];
-    const counts = all.map((s) => ({
-        sid: `skill:${s.name}`,
-        invocations: s.invocations,
-        sessions: s.sessions,
-    }));
-    const skills = all.map((s) => ({
-        id: `skill:${s.name}`,
-        name: s.name,
-        dir_path: s.dir_path,
-    }));
+    const counts = all.map((s) => ({ sid: `skill:${s.name}`, invocations: s.invocations, sessions: s.sessions }));
+    const skills = all.map((s) => ({ id: `skill:${s.name}`, name: s.name, dir_path: s.dir_path, content_hash: null }));
     const classified = all.filter((s) => s.classified).map((s) => `skill:${s.name}`);
-    const client = makeTestSurrealClient({
-        denyWrites: true,
-        fallback: [counts, skills, classified],
-    }).client;
-    classifiedByDb.set(client, classified);
-    cacheRowsByDb.set(client, [
-        counts,
-        skills.map((sk) => ({ ...sk, content_hash: null })),
-    ]);
-    return client;
+    return { cacheRows: [counts, skills], classifiedIds: classified };
 }
 
-// Forced-dependency edit: cmdSkillsClassify now requires FileSystem + Path
-// (the @effect/platform migration); run against the REAL Bun-backed layers.
+/** Explicit mode: a single cache read (name/invocations/sessions row set). */
+function explicitFixture(rows: MockRow[]): Fixture {
+    return { cacheRows: [rows], classifiedIds: [] };
+}
+
+// Forced-dependency edit: cmdSkillsClassify requires FileSystem + Path (the
+// @effect/platform migration); run against the REAL Bun-backed layers.
 const BunFsLayer = Layer.merge(BunFileSystem.layer, BunPath.layer);
 
-/** The capture buffer for a client's cache reads, created on first use. */
-const capturedCacheSql = (db: SurrealClientShape): string[] => {
-    const existing = cacheSqlByDb.get(db);
-    if (existing) return existing;
-    const fresh: string[] = [];
-    cacheSqlByDb.set(db, fresh);
-    return fresh;
-};
-
+/** Builds a fresh CacheRead/Judgment layer pair from `fixture` for each call,
+ *  so a fixture reused across two runWith invocations (e.g. idempotency
+ *  tests that call cmdSkillsClassify twice) gets its own cache read index
+ *  each time instead of sharing state across runs. */
 const runWith = <A>(
-    db: SurrealClientShape,
-    eff: Effect.Effect<A, DbError | JudgmentError | PlatformError.PlatformError, SurrealClient | Judgment | CacheRead | FileSystem.FileSystem | Path.Path>,
+    fixture: Fixture,
+    eff: Effect.Effect<A, JudgmentError | PlatformError.PlatformError, Judgment | CacheRead | FileSystem.FileSystem | Path.Path>,
+    capturedCacheSql: string[] = [],
 ): Promise<A> =>
     Effect.runPromise(
         eff.pipe(Effect.provide(Layer.mergeAll(
-            Layer.succeed(SurrealClient, db),
+            cacheReadResults(fixture.cacheRows, capturedCacheSql),
+            judgmentTestLayer(() => fixture.classifiedIds.map((skill_id) => ({ skill_id }))),
             BunFsLayer,
-            judgmentTestLayer(() => (classifiedByDb.get(db) ?? []).map((skill_id) => ({ skill_id }))),
-            cacheReadResults(cacheRowsByDb.get(db) ?? [[], []], capturedCacheSql(db)),
         ))),
     );
 
@@ -136,8 +110,8 @@ describe("cmdSkillsClassify default mode", () => {
             { name: "composto", invocations: 15, sessions: 4 },
             { name: "codex:rescue", invocations: 8, sessions: 3 },
         ];
-        const db = hygieneMockDb(rows);
-        await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
+        const fixture = hygieneFixture(rows);
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
 
         for (const row of rows) {
             const slug = skillNameToSlug(row.name);
@@ -157,7 +131,7 @@ describe("cmdSkillsClassify default mode", () => {
     // a positive count. Now both share fetchSkillHygiene.
     test("selects unclassified ≥3 and drops classified / synthetic / low-count", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-filter-"));
-        const db = hygieneMockDb(
+        const fixture = hygieneFixture(
             [{ name: "keep-me", invocations: 9, sessions: 3 }],
             [
                 { name: "already-tagged", invocations: 20, classified: true },
@@ -169,7 +143,7 @@ describe("cmdSkillsClassify default mode", () => {
         const origLog = console.log;
         console.log = (msg: string) => { logged.push(msg); };
         try {
-            await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: true }));
+            await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: true }));
         } finally {
             console.log = origLog;
         }
@@ -180,10 +154,10 @@ describe("cmdSkillsClassify default mode", () => {
     test("is idempotent - skips existing files without re-writing", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-idem-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = hygieneMockDb(rows);
+        const fixture = hygieneFixture(rows);
 
         // First run - write the file
-        await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
         const filePath = join(outDir, `classify-composto.md`);
         const firstContent = await readFile(filePath, "utf8");
 
@@ -191,7 +165,7 @@ describe("cmdSkillsClassify default mode", () => {
         await Bun.write(filePath, "sentinel content");
 
         // Second run - should skip
-        await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
         const secondContent = await readFile(filePath, "utf8");
         expect(secondContent).toBe("sentinel content");
         expect(firstContent).not.toBe("sentinel content");
@@ -200,8 +174,8 @@ describe("cmdSkillsClassify default mode", () => {
     test("dry-run does not write any files", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-dry-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = hygieneMockDb(rows);
-        await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: true, json: false }));
+        const fixture = hygieneFixture(rows);
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: true, json: false }));
         const filePath = join(outDir, `classify-composto.md`);
         const exists = await access(filePath).then(() => true, () => false);
         expect(exists).toBe(false);
@@ -210,13 +184,13 @@ describe("cmdSkillsClassify default mode", () => {
     test("json mode outputs structured list, no files written", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-json-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = hygieneMockDb(rows);
+        const fixture = hygieneFixture(rows);
 
         const logged: string[] = [];
         const origLog = console.log;
         console.log = (msg: string) => { logged.push(msg); };
         try {
-            await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: true }));
+            await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: true }));
         } finally {
             console.log = origLog;
         }
@@ -236,12 +210,12 @@ describe("cmdSkillsClassify default mode", () => {
 
     test("empty result from DB prints informational message", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-empty-"));
-        const db = hygieneMockDb([]);
+        const fixture = hygieneFixture([]);
         const logged: string[] = [];
         const origLog = console.log;
         console.log = (msg: string) => { logged.push(msg); };
         try {
-            await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
+            await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
         } finally {
             console.log = origLog;
         }
@@ -254,28 +228,25 @@ describe("cmdSkillsClassify default mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("cmdSkillsClassify explicit mode", () => {
-    test("queries the named skills (SQL contains the name)", async () => {
+    test("queries the named skills (SQL contains the name IN clause)", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-explicit-"));
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            fallback: [[{ name: "composto", invocations: 5, sessions: 2 }]],
-        });
-        await runWith(tc.client, cmdSkillsClassify({ names: ["composto"], outDir, dryRun: false, json: false }));
-        const capturedSql = tc.captured.at(-1) ?? "";
-        expect(capturedSql).toContain('"composto"');
-        // Explicit mode should NOT contain the >= 3 threshold
-        expect(capturedSql).not.toContain(">= 3");
+        const captured: string[] = [];
+        const fixture = explicitFixture([{ name: "composto", invocations: 5, sessions: 2 }]);
+        await runWith(fixture, cmdSkillsClassify({ names: ["composto"], outDir, dryRun: false, json: false }), captured);
+        const capturedSql = captured.at(-1) ?? "";
+        expect(capturedSql).toContain("IN (?)");
+        expect(capturedSql).toContain("skill");
         // Explicit mode should NOT filter out already-classified skills
         expect(capturedSql).not.toContain("plays_role");
     });
 
     test("emits brief for already-classified skill (re-classification)", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-reclassify-"));
-        // DB returns the skill even though it already has a plays_role edge
+        // Cache returns the skill even though it already has a plays_role edge
         // (the SQL no longer filters it out in explicit mode)
         const rows: MockRow[] = [{ name: "composto", invocations: 20, sessions: 8 }];
-        const db = mockDb(rows);
-        await runWith(db, cmdSkillsClassify({ names: ["composto"], outDir, dryRun: false, json: false }));
+        const fixture = explicitFixture(rows);
+        await runWith(fixture, cmdSkillsClassify({ names: ["composto"], outDir, dryRun: false, json: false }));
         const filePath = join(outDir, `classify-composto.md`);
         const exists = await access(filePath).then(() => true, () => false);
         expect(exists).toBe(true);
@@ -286,8 +257,8 @@ describe("cmdSkillsClassify explicit mode", () => {
     test("writes brief for explicitly-named skill with fewer than 3 invocations", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-low-inv-"));
         const rows: MockRow[] = [{ name: "my-skill", invocations: 1, sessions: 1 }];
-        const db = mockDb(rows);
-        await runWith(db, cmdSkillsClassify({ names: ["my-skill"], outDir, dryRun: false, json: false }));
+        const fixture = explicitFixture(rows);
+        await runWith(fixture, cmdSkillsClassify({ names: ["my-skill"], outDir, dryRun: false, json: false }));
         const filePath = join(outDir, `classify-my-skill.md`);
         const exists = await access(filePath).then(() => true, () => false);
         expect(exists).toBe(true);
@@ -304,18 +275,15 @@ describe("SQL shape (default mode)", () => {
     // joins counts→skills in JS. The ≥3 threshold and synthetic exclusion are
     // applied in JS (see fetchSkillHygiene), NOT in SQL - so they are asserted by
     // the behavioral filter test above, not by string-matching the query.
-    test("default graph query does not read judgment role tables", async () => {
+    test("default cache query does not read judgment role tables", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-sql-"));
-        const tc = makeTestSurrealClient({ denyWrites: true, fallback: [[], [], []] });
-        await runWith(tc.client, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
-        // The default path spans two engines now, so BOTH have to be clean of
-        // plays_role - the role decisions come from the sidecar, and neither the
-        // SurrealQL nor the cache SQL may reach for that table.
-        const capturedSql = tc.captured.join("\n");
-        const capturedCache = (cacheSqlByDb.get(tc.client) ?? []).join("\n");
-        expect(capturedSql).not.toContain("plays_role");
+        const captured: string[] = [];
+        const fixture = hygieneFixture([]);
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }), captured);
+        // The role decision comes from the sidecar; the cache SQL may never
+        // reach for `plays_role`.
+        const capturedCache = captured.join("\n");
         expect(capturedCache).not.toContain("plays_role");
-        // The invocation counts moved to the cache with the rest of hygiene.
         expect(capturedCache).toContain("invoked");
     });
 });
@@ -330,8 +298,8 @@ describe("output path", () => {
         const rows: MockRow[] = [
             { name: "superpowers:subagent-driven-development", invocations: 10, sessions: 5 },
         ];
-        const db = hygieneMockDb(rows);
-        await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
+        const fixture = hygieneFixture(rows);
+        await runWith(fixture, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
         const expectedFile = join(outDir, "classify-superpowers__subagent-driven-development.md");
         const exists = await access(expectedFile).then(() => true, () => false);
         expect(exists).toBe(true);

--- a/apps/axctl/src/cli/skills-classify.ts
+++ b/apps/axctl/src/cli/skills-classify.ts
@@ -5,11 +5,11 @@
  * Default mode (no names): all unclassified skills with invocations >= 3.
  * Explicit mode (one+ names): only those skills, no invocation threshold.
  */
-import { Effect, FileSystem, Path, type PlatformError } from "effect";
-import { SurrealClient } from "@ax/lib/db";
+import { Effect, FileSystem, Path, Schema, type PlatformError } from "effect";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
 import type { CacheRead } from "@ax/lib/duckdb/seam";
-import type { DbError } from "@ax/lib/errors";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { cacheRows } from "@ax/lib/duckdb/query";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettyPrint } from "@ax/lib/json";
 import { skillNameToSlug, renderClassifyBrief } from "./skills-classify-template.ts";
@@ -38,21 +38,38 @@ export interface ClassifyResult {
 // "none found" while weighted reported a positive count.
 
 /**
- * SurrealQL for explicit mode: named skills only, no invocation threshold and
- * no unclassified guard (user-requested re-classification must be allowed).
+ * DuckDB row shape for explicit mode: named skills only, no invocation
+ * threshold and no unclassified guard (user-requested re-classification must
+ * be allowed).
  */
-const buildExplicitSql = (names: readonly string[]) => {
-    const nameList = names.map((n) => `"${n.replace(/"/g, '\\"')}"`).join(", ");
-    return `
-SELECT
-    name,
-    array::len((SELECT id FROM invoked WHERE out = $parent.id)) AS invocations,
-    array::len(array::distinct((SELECT in.session FROM invoked WHERE out = $parent.id).in.session)) AS sessions
-FROM skill
-WHERE name IN [${nameList}]
-ORDER BY invocations DESC;
-`.trim();
-};
+const ExplicitClassifyRow = Schema.Struct({
+    name: Schema.String,
+    invocations: NumberFromBigIntColumn,
+    sessions: NumberFromBigIntColumn,
+});
+
+/**
+ * Named skills only - a `count(i.id)`/`count(DISTINCT i.session)` LEFT JOIN
+ * against `invoked` so a never-invoked but explicitly-named skill still comes
+ * back with zero counts instead of dropping out of the result set.
+ */
+const fetchExplicitSkillRows = (names: readonly string[]) =>
+    cacheRows(
+        ExplicitClassifyRow,
+        {
+            sql: `
+SELECT sk.name AS name,
+       count(i.id) AS invocations,
+       count(DISTINCT i.session) AS sessions
+FROM skill sk
+LEFT JOIN invoked i ON i.out_id = sk.id
+WHERE sk.name IN (${names.map(() => "?").join(", ")})
+GROUP BY sk.name
+ORDER BY invocations DESC`.trim(),
+            params: [...names],
+        },
+        "skills classify explicit",
+    );
 
 const safeSkillName = (name: string): string | null => {
     try {
@@ -71,9 +88,8 @@ export interface ClassifyOptions {
 
 export const cmdSkillsClassify = (
     opts: ClassifyOptions,
-): Effect.Effect<void, DbError | JudgmentError | PlatformError.PlatformError, SurrealClient | Judgment | CacheRead | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<void, JudgmentError | PlatformError.PlatformError, Judgment | CacheRead | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
 
@@ -94,14 +110,11 @@ export const cmdSkillsClassify = (
         // classified filter - re-classification must be allowed).
         let selected: ClassifyRow[];
         if (opts.names.length > 0) {
-            const result = yield* db.query<[Array<Record<string, unknown>>]>(
-                buildExplicitSql(opts.names),
-            );
-            const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
+            const rows = yield* fetchExplicitSkillRows(opts.names);
             selected = rows.map((r) => ({
-                name: String(r.name ?? ""),
-                invocations: Number(r.invocations ?? 0),
-                sessions: Number(r.sessions ?? 0),
+                name: r.name,
+                invocations: r.invocations,
+                sessions: r.sessions,
             })).filter((r) => r.name.length > 0);
         } else {
             const hygiene = yield* fetchSkillHygiene({

--- a/apps/axctl/src/cli/skills-family-no-surreal.test.ts
+++ b/apps/axctl/src/cli/skills-family-no-surreal.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `ax skills` command family, invoking every subcommand this chunk ported
+ * plus its already-cache-routed siblings, with no SurrealDB reachable.
+ *
+ * TWO shapes, for the same reason retro-family-no-surreal.test.ts uses two:
+ *
+ * (A) `search` / `recent` / `taste` / `pairs` / `recovery` - ported by THIS
+ *     commit, but `skillsRuntime`'s manifest still routes them through
+ *     `"db"` (the RUNTIME_BY_COMMAND flip is a separate, deferred chunk,
+ *     Ruling R34). `withDb` provides `LegacySurrealAppLayer`, whose
+ *     `SurrealClientLive` is `Layer.effect` and awaits a real
+ *     `db.connect()` with a 5s timeout AT LAYER CONSTRUCTION - so a spawned
+ *     CLI against a dead port would time out on ROUTING before the ported
+ *     code ever ran, proving nothing about this chunk's change. These call
+ *     the exported command functions directly, with a real CacheRead
+ *     (published DuckDB fixture) and the exact throwing `SurrealClient`
+ *     sentinel `cli/index.ts`'s `withCache`/`withoutDb` provide in
+ *     production - any access still fails loudly, by name.
+ *
+ * (B) `tag` / `by-role` / `roles` (skill-scoped) - already routed `"cache"`
+ *     in the manifest before this chunk, so the spawned-CLI dead-port shape
+ *     (recall-no-surreal.test.ts) genuinely discriminates for them: it
+ *     spawns the real entrypoint with `AX_DB_URL` on a port nothing
+ *     listens on.
+ *
+ * `stats` / `unused` / `bloat` / `loaded` / `weighted` / `classify` are not
+ * exercised here: their data layer lives in `dashboard/skills-weighted.ts`,
+ * `queries/skill-bloat.ts`, `queries/skill-loaded.ts`, `queries/skill-stats.ts`,
+ * `queries/unused-skills.ts` - other chunks' scope, not touched by this one.
+ */
+import { describe, expect } from "bun:test";
+import { Effect, Layer } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { CacheReadLayer, type CacheWriteService } from "@ax/lib/duckdb/seam";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { cmdPairs, cmdRecent, cmdRecovery, cmdSearch, cmdTaste } from "./commands/skills.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("ax skills family (no surreal)", {
+    requireFts: true,
+});
+
+const T = (iso: string): Date => new Date(iso);
+
+/** The exact sentinel `withCache`/`withoutDb` provide in cli/index.ts: any
+ *  property access throws immediately and by name. */
+const throwingSurrealClient = (): SurrealClientShape =>
+    new Proxy({} as SurrealClientShape, {
+        get(_target, prop) {
+            throw new Error(`SurrealClient.${String(prop)} accessed on the no-DB test layer`);
+        },
+    });
+
+const buildLayer = async (
+    corpus: (write: CacheWriteService) => Effect.Effect<unknown, unknown, never>,
+    label: string,
+) => {
+    const fixture = await runWithPlatform(publishCacheFixture(tempDir(`${label}-`), dylibPath, corpus));
+    const layer = Layer.mergeAll(
+        CacheReadLayer({ snapshotPath: fixture.snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) }),
+        Layer.succeed(SurrealClient, throwingSurrealClient()),
+        Layer.merge(BunFileSystem.layer, BunPath.layer),
+    );
+    return layer;
+};
+
+const run = <A, E, R>(eff: Effect.Effect<A, E, R>, layer: Layer.Layer<R>): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer), Effect.scoped));
+
+const capture = async (fn: () => Promise<void>): Promise<string[]> => {
+    const logged: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => { logged.push(msg); };
+    try {
+        await fn();
+    } finally {
+        console.log = origLog;
+    }
+    return logged;
+};
+
+const CORPUS = (w: CacheWriteService) =>
+    Effect.gen(function* () {
+        yield* w.putMany("skill", [
+            { id: "skill-composto", name: "composto", scope: "user", dir_path: "/skills/composto", description: "token-efficient investigation", content_hash: "h1" },
+            { id: "skill-tdd", name: "tdd", scope: "user", dir_path: "/skills/tdd", description: "test-driven development", content_hash: "h2" },
+        ]);
+        yield* w.put("session", { id: "session-a", source: "claude", project: "ax", cwd: "/w/ax" });
+        yield* w.put("turn", { id: "turn-1", session: "session-a", seq: 1, ts: T("2026-08-15T10:00:00.000Z"), role: "assistant", has_tool_use: true, has_error: false });
+        yield* w.put("invoked", { id: "inv-1", in_id: "turn-1", out_id: "skill-composto", ts: T("2026-08-15T10:00:00.000Z"), session: "session-a", turn_has_error: false, was_corrected: false });
+        yield* w.put("skill_paired", { id: "pair-1", in_id: "skill-composto", out_id: "skill-tdd", count: 3, last_seen: T("2026-08-15T10:00:00.000Z") });
+        yield* w.put("recovered_by", { id: "rec-1", in_id: "turn-1", out_id: "skill-composto", ts: T("2026-08-15T10:00:00.000Z") });
+    });
+
+describe("ax skills family - ported subcommands, direct-call against the cache with SurrealClient never reachable", () => {
+    dtest("search matches by name substring, not Surreal", async () => {
+        const layer = await buildLayer(CORPUS, "ax-skills-search");
+        const logged = await capture(() => run(cmdSearch({ query: "compos", limit: 10 }), layer));
+        expect(logged.join("\n")).toContain("composto");
+    }, 60_000);
+
+    dtest("recent reads invoked joined to skill + session from the cache, not Surreal", async () => {
+        const layer = await buildLayer(CORPUS, "ax-skills-recent");
+        const logged = await capture(() => run(cmdRecent({ limit: 10 }), layer));
+        expect(logged.join("\n")).toContain("composto");
+    }, 60_000);
+
+    dtest("taste enumerates the full skill catalog (zero-score rows included), not Surreal", async () => {
+        const layer = await buildLayer(CORPUS, "ax-skills-taste");
+        const logged = await capture(() => run(cmdTaste({ limit: 10, includeTools: false }), layer));
+        const out = logged.join("\n");
+        expect(out).toContain("composto");
+        // tdd has no invocations/proposals - issue #47's zero-score inclusion.
+        expect(out).toContain("tdd");
+    }, 60_000);
+
+    dtest("pairs reads skill_paired joined to skill, not Surreal", async () => {
+        const layer = await buildLayer(CORPUS, "ax-skills-pairs");
+        const logged = await capture(() => run(cmdPairs({ name: "composto", limit: 10 }), layer));
+        expect(logged.join("\n")).toContain("tdd");
+    }, 60_000);
+
+    dtest("recovery reads recovered_by joined to skill, not Surreal", async () => {
+        const layer = await buildLayer(CORPUS, "ax-skills-recovery");
+        const logged = await capture(() => run(cmdRecovery({ limit: 10 }), layer));
+        expect(logged.join("\n")).toContain("composto");
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Already cache-routed subcommands: the spawned-CLI dead-port shape
+// genuinely discriminates for these (manifest already says "cache").
+// ---------------------------------------------------------------------------
+
+const CLI = new URL("./index.ts", import.meta.url).pathname;
+const DEAD_DB_URL = "ws://127.0.0.1:1/rpc";
+
+interface CliRun {
+    readonly exitCode: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+const runCli = (args: ReadonlyArray<string>, snapshotPath: string, sidecarPath: string): CliRun => {
+    const child = Bun.spawnSync(["bun", CLI, ...args], {
+        env: {
+            ...process.env,
+            AX_DUCKDB_SNAPSHOT: snapshotPath,
+            AX_SIDECAR_PATH: sidecarPath,
+            AX_DB_URL: DEAD_DB_URL,
+            AX_PROGRESS: "off",
+            NO_COLOR: "1",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    return {
+        exitCode: child.exitCode,
+        stdout: child.stdout.toString(),
+        stderr: child.stderr.toString(),
+    };
+};
+
+describe("ax skills family - already-cache-routed subcommands, spawned CLI against a dead SurrealDB port", () => {
+    dtest("tag writes a plays_role edge to the sidecar, not Surreal", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-skills-tag-"), dylibPath, CORPUS));
+        const sidecarPath = `${tempDir("ax-skills-tag-sidecar-")}/judgment.sqlite`;
+        const run = runCli(["skills", "tag", "composto", "verification"], fixture.snapshotPath, sidecarPath);
+        expect(run.stderr).not.toContain("SurrealClient");
+        expect(run.exitCode, `${run.stderr}\n${run.stdout}`).toBe(0);
+        expect(run.stdout).toContain("verification");
+    }, 60_000);
+
+    dtest("by-role reads plays_role from the sidecar joined to cache usage, not Surreal", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-skills-byrole-"), dylibPath, CORPUS));
+        const sidecarPath = `${tempDir("ax-skills-byrole-sidecar-")}/judgment.sqlite`;
+        const tagRun = runCli(["skills", "tag", "composto", "verification"], fixture.snapshotPath, sidecarPath);
+        expect(tagRun.exitCode, `${tagRun.stderr}\n${tagRun.stdout}`).toBe(0);
+
+        const run = runCli(["skills", "by-role", "verification", "--json"], fixture.snapshotPath, sidecarPath);
+        expect(run.stderr).not.toContain("SurrealClient");
+        expect(run.exitCode, `${run.stderr}\n${run.stdout}`).toBe(0);
+        expect(run.stdout).toContain("composto");
+    }, 60_000);
+
+    dtest("roles (skill-scoped) reads plays_role from the sidecar, not Surreal", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-skills-roles-"), dylibPath, CORPUS));
+        const sidecarPath = `${tempDir("ax-skills-roles-sidecar-")}/judgment.sqlite`;
+        const tagRun = runCli(["skills", "tag", "composto", "verification"], fixture.snapshotPath, sidecarPath);
+        expect(tagRun.exitCode, `${tagRun.stderr}\n${tagRun.stdout}`).toBe(0);
+
+        const run = runCli(["skills", "roles", "composto", "--json"], fixture.snapshotPath, sidecarPath);
+        expect(run.stderr).not.toContain("SurrealClient");
+        expect(run.exitCode, `${run.stderr}\n${run.stdout}`).toBe(0);
+        expect(run.stdout).toContain("verification");
+    }, 60_000);
+});

--- a/apps/axctl/src/cli/skills-family-no-surreal.test.ts
+++ b/apps/axctl/src/cli/skills-family-no-surreal.test.ts
@@ -146,6 +146,13 @@ const runCli = (args: ReadonlyArray<string>, snapshotPath: string, sidecarPath: 
     const child = Bun.spawnSync(["bun", CLI, ...args], {
         env: {
             ...process.env,
+            // The dylib `duckdbTestSetup` resolved is NOT necessarily in
+            // `process.env` - CI builds it as an artifact and hands back a path.
+            // Spreading `process.env` alone therefore passes locally (the dev
+            // shell exports AX_DUCKDB_DYLIB) and fails in CI with
+            // `CacheUnavailableError: no libduckdb available`. Forward it
+            // explicitly, exactly as recall/sessions-show/ingest-no-surreal do.
+            ...(dylibPath === null ? {} : { AX_DUCKDB_DYLIB: dylibPath }),
             AX_DUCKDB_SNAPSHOT: snapshotPath,
             AX_SIDECAR_PATH: sidecarPath,
             AX_DB_URL: DEAD_DB_URL,

--- a/apps/axctl/src/dojo/agenda.test.ts
+++ b/apps/axctl/src/dojo/agenda.test.ts
@@ -5,8 +5,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, Layer } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
-import type { Surreal } from "surrealdb";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { CacheRead, type CacheReadService } from "@ax/lib/duckdb/seam";
 import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { assembleAgenda, collectAgendaItems } from "./agenda.ts";
@@ -77,21 +75,10 @@ describe("assembleAgenda", () => {
 });
 
 describe("collectAgendaItems", () => {
-    // Every query returns one empty result set - an empty graph. fetchTuneProposals
-    // (which calls fetchDispatches internally) destructures a 4-tuple, but each
-    // missing slot degrades to [] internally.
-    const emptyClient: SurrealClientShape = {
-        query: <T extends unknown[]>(_sql: string, _bindings?: Record<string, unknown>) =>
-            Effect.succeed([[]] as unknown[] as T),
-        upsert: () => Effect.void,
-        relate: () => Effect.void,
-        putFile: () => Effect.void,
-        getFile: () => Effect.succeed(""),
-        raw: null as unknown as Surreal, // never touched by read-only agenda sources
-    };
-    const surrealLayer = Layer.succeed(SurrealClient, emptyClient);
+    // Every DuckDB query returns one empty result set - an empty graph.
+    // fetchTuneProposals (which calls fetchDispatches internally) destructures
+    // a 4-tuple, but each missing slot degrades to [] internally.
     const env = Layer.mergeAll(
-        surrealLayer,
         makeTestCacheRead().layer,
         BunFileSystem.layer,
         EmptyJudgmentTestLayer,
@@ -115,12 +102,6 @@ describe("collectAgendaItems", () => {
 
     test("records which agenda sources failed while preserving degraded items", async () => {
         const base = mkdtempSync(join(tmpdir(), "ax-dojo-agenda-"));
-        const failingClient: SurrealClientShape = {
-            ...emptyClient,
-            query: <T extends unknown[]>(_sql: string, _bindings?: Record<string, unknown>) =>
-                Effect.fail("db offline") as unknown as Effect.Effect<T>,
-        };
-        const failingSurreal = Layer.succeed(SurrealClient, failingClient);
         const fail = Effect.fail("db offline") as never;
         const failingCache: CacheReadService = {
             rows: () => fail,
@@ -129,7 +110,6 @@ describe("collectAgendaItems", () => {
             snapshotPath: "(failing-test-cache)",
         };
         const failingEnv = Layer.mergeAll(
-            failingSurreal,
             Layer.succeed(CacheRead, failingCache),
             BunFileSystem.layer,
             EmptyJudgmentTestLayer,

--- a/apps/axctl/src/dojo/agenda.ts
+++ b/apps/axctl/src/dojo/agenda.ts
@@ -8,7 +8,6 @@
  * never kill the whole agenda.
  */
 import { Effect, type FileSystem } from "effect";
-import type { SurrealClient } from "@ax/lib/db";
 import { CacheRead } from "@ax/lib/duckdb/seam";
 import type { Judgment } from "@ax/lib/sqlite";
 import { listDirectiveProposals, listProposals } from "../improve/list.ts";
@@ -108,7 +107,7 @@ export interface CollectAgendaItemsResult {
  */
 export const collectAgendaItems = (
     opts: CollectOptions,
-): Effect.Effect<CollectAgendaItemsResult, never, SurrealClient | CacheRead | Judgment | FileSystem.FileSystem> =>
+): Effect.Effect<CollectAgendaItemsResult, never, CacheRead | Judgment | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const read = yield* CacheRead;
         const verdicts = yield* soft("verdicts", listPendingVerdicts(), []);

--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -319,10 +319,10 @@ describe("buildShareArtifactFromParts", () => {
 });
 
 describe("normalizeSessionRecordRef", () => {
-    it("normalizes accepted session id forms to bracketed record refs", () => {
-        expect(normalizeSessionRecordRef("abc123")).toBe("session:⟨abc123⟩");
-        expect(normalizeSessionRecordRef("session:abc123")).toBe("session:⟨abc123⟩");
-        expect(normalizeSessionRecordRef("session:⟨abc123⟩")).toBe("session:⟨abc123⟩");
+    it("strips any Surreal-era decoration and returns the bare session id", () => {
+        expect(normalizeSessionRecordRef("abc123")).toBe("abc123");
+        expect(normalizeSessionRecordRef("session:abc123")).toBe("abc123");
+        expect(normalizeSessionRecordRef("session:⟨abc123⟩")).toBe("abc123");
     });
 
     it("rejects invalid session ids", () => {

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -8,8 +8,7 @@ import {
     type ShareGraph,
     type ShareTurn,
 } from "./artifact.ts";
-import { SurrealClient } from "@ax/lib/db";
-import type { DbError } from "@ax/lib/errors";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
 import type {
     SessionOverview,
     SessionTokenUsageDetail,
@@ -18,25 +17,24 @@ import type {
     ToolCallDto,
 } from "@ax/lib/shared/dashboard-types";
 import { categoryOf } from "@ax/lib/shared/tool-presentation";
-import { runQuery, runSingleQuery } from "@ax/lib/shared/graph-query";
-import { resolveTurnContent } from "../queries/session-turn-content.ts";
 import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import type { SessionTimeline } from "../timeline/types.ts";
 import {
-    sessionChildrenQuery,
-    sessionOverviewQuery,
-    sessionShareFilesQuery,
-    sessionShareTimelineQuery,
-    sessionShareTurnsQuery,
-    sessionShareTurnToolCallsQuery,
-    sessionShareHookFiresQuery,
-    sessionShareHarnessHooksQuery,
-    sessionTokenUsageQuery,
-    sessionTurnTokenUsageQuery,
-    sessionToolCallsQuery,
-    sessionTopSkillsQuery,
+    fetchSessionChildren,
+    fetchSessionOverview,
+    fetchSessionShareFiles,
+    fetchSessionShareTimeline,
+    fetchSessionShareTurns,
+    fetchSessionShareTurnToolCalls,
+    fetchSessionShareHookFires,
+    fetchSessionShareHarnessHooks,
+    fetchSessionTokenUsage,
+    fetchSessionTurnTokenUsage,
+    fetchSessionToolCalls,
+    fetchSessionTopSkills,
+    resolveTurnContent,
     type ShareTurnToolCall,
-} from "../queries/session-detail.ts";
+} from "./session-share-queries.ts";
 
 export interface ShareArtifactParts {
     readonly axVersion: string;
@@ -229,6 +227,15 @@ export function buildShareArtifactFromParts(
     };
 }
 
+/**
+ * Validate + strip any Surreal-era record-ref decoration (`session:⟨...⟩` /
+ * `session:...`) a caller might still pass, returning the BARE session id -
+ * `session.id` in the DuckDB schema is the provider-native uuid verbatim, with
+ * no record-ref wrapper (see schema.duckdb.sql's ROW IDS "CARVE-OUT" note).
+ * `null` when the (unwrapped) id doesn't look like a session id at all - the
+ * caller treats that as "session not found" rather than building a statement
+ * with an unvalidated string.
+ */
 export function normalizeSessionRecordRef(sessionId: string): string | null {
     const bare = sessionId.startsWith("session:⟨") && sessionId.endsWith("⟩")
         ? sessionId.slice("session:⟨".length, -"⟩".length)
@@ -237,7 +244,7 @@ export function normalizeSessionRecordRef(sessionId: string): string | null {
             : sessionId;
 
     if (!SESSION_ID_RE.test(bare)) return null;
-    return `session:⟨${bare}⟩`;
+    return bare;
 }
 
 const isPresent = <T>(value: T | null): value is T => value !== null;
@@ -386,13 +393,13 @@ export const exportSessionShare = (
     sessionId: string,
     axVersion: string,
     options: ExportSessionShareOptions = {},
-): Effect.Effect<AxSessionShare | null, DbError, SurrealClient> =>
+): Effect.Effect<AxSessionShare | null, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const recordRef = normalizeSessionRecordRef(sessionId);
-        if (recordRef === null) return null;
+        const bareId = normalizeSessionRecordRef(sessionId);
+        if (bareId === null) return null;
 
         const visited = options.visited ?? new Set<string>();
-        if (visited.has(recordRef)) return null;
+        if (visited.has(bareId)) return null;
 
         // Shared budget across the whole recursion (created once at the root)
         // caps total sessions exported - a cycle/size backstop.
@@ -400,49 +407,43 @@ export const exportSessionShare = (
         const remaining = yield* Ref.updateAndGet(budget, (n) => n - 1);
         if (remaining < 0) return null;
 
-        const params = { recordRef };
-        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, harnessHooksRaw, turnContent] =
+        const read = yield* CacheRead;
+        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, shareTurns, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, harnessHooksRawUnanchored, turnContent] =
             yield* Effect.all([
-                runSingleQuery(sessionOverviewQuery, params),
-                runQuery(sessionTopSkillsQuery, params),
-                runQuery(sessionToolCallsQuery, params),
-                runSingleQuery(sessionTokenUsageQuery, params),
-                runQuery(sessionTurnTokenUsageQuery, params),
-                runQuery(sessionShareTurnsQuery, params),
-                runQuery(sessionShareTimelineQuery, params),
-                runQuery(sessionShareFilesQuery, params),
-                runQuery(sessionChildrenQuery, params),
-                runQuery(sessionShareTurnToolCallsQuery, params),
-                runQuery(sessionShareHookFiresQuery, params),
-                runQuery(sessionShareHarnessHooksQuery, params),
-                resolveTurnContent(sessionId),
+                fetchSessionOverview(read, bareId),
+                fetchSessionTopSkills(read, bareId),
+                fetchSessionToolCalls(read, bareId),
+                fetchSessionTokenUsage(read, bareId),
+                fetchSessionTurnTokenUsage(read, bareId),
+                fetchSessionShareTurns(read, bareId),
+                fetchSessionShareTimeline(read, bareId),
+                fetchSessionShareFiles(read, bareId),
+                fetchSessionChildren(read, bareId),
+                fetchSessionShareTurnToolCalls(read, bareId),
+                fetchSessionShareHookFires(read, bareId),
+                fetchSessionShareHarnessHooks(read, bareId),
+                resolveTurnContent(read, bareId),
             ]);
 
         if (overview === null) return null;
 
         // Assign the SPA-only monotonic idx (used for stable DOM ids + jumps).
-        const hookFires = hookFiresRaw
-            .filter(isPresent)
-            .map((fire, idx) => ({ idx, ...fire }));
+        const hookFires = hookFiresRaw.map((fire, idx) => ({ idx, ...fire }));
 
         // Recurse into spawned subagents. The visited set carries this session
         // so a child that points back never re-expands; leaves return [].
         // Each child's spawn-edge ts is anchored to the nearest parent turn so
         // the viewer can mark where it was launched.
-        const shareTurns = turnsRaw.filter(isPresent);
         // Harness hooks: assign idx + anchor each to the nearest turn by ts.
-        const harnessHooks = harnessHooksRaw
-            .filter(isPresent)
-            .map((hook, idx) => ({
-                idx,
-                ...hook,
-                anchor_turn_seq: anchorChildToTurn(shareTurns, hook.ts),
-            }));
-        const nextVisited = new Set(visited).add(recordRef);
-        const childLinks = childLinksRaw.filter(isPresent);
+        const harnessHooks = harnessHooksRawUnanchored.map((hook, idx) => ({
+            idx,
+            ...hook,
+            anchor_turn_seq: anchorChildToTurn(shareTurns, hook.ts),
+        }));
+        const nextVisited = new Set(visited).add(bareId);
         const children = (
             yield* Effect.all(
-                childLinks.map((link) =>
+                childLinksRaw.map((link) =>
                     exportSessionShare(String(link.session_id), axVersion, {
                         visited: nextVisited,
                         spawnAnchorTurnSeq: anchorChildToTurn(shareTurns, link.ts ?? null),
@@ -461,18 +462,18 @@ export const exportSessionShare = (
         // before the filter loses rows whose turn gets dropped.
         const turns = attachTurnTokenUsage(
             attachTurnContent(
-                attachStructuredToolCalls(shareTurns, turnToolCallsRaw.filter(isPresent)),
+                attachStructuredToolCalls(shareTurns, turnToolCallsRaw),
                 turnContent,
             ).filter((turn) =>
                 turn.text.length > 0 || turn.content != null || (turn.tool_calls?.length ?? 0) > 0
             ),
-            turnTokenUsageRaw.filter(isPresent),
+            turnTokenUsageRaw,
         );
 
         // Segmented highlight timeline, computed here (where the DB still is)
         // so the static share viewer can render it daemon-free. Best-effort: a
         // timeline failure never blocks the export.
-        const sessionTimeline = yield* extractSessionTimeline(recordRef).pipe(
+        const sessionTimeline = yield* extractSessionTimeline(bareId).pipe(
             Effect.provide(SessionTimelineServiceLayer),
             Effect.catchDefect(() => Effect.succeed(null)),
         );
@@ -481,13 +482,13 @@ export const exportSessionShare = (
             axVersion,
             exportedAt: new Date().toISOString(),
             overview,
-            topSkills: topSkillsRaw.filter(isPresent),
-            toolCalls: toolCallsRaw.filter(isPresent),
+            topSkills: topSkillsRaw,
+            toolCalls: toolCallsRaw,
             tokenUsage,
             turns,
-            timeline: timelineRaw.filter(isPresent),
+            timeline: timelineRaw,
             sessionTimeline,
-            files: filesRaw.filter(isPresent),
+            files: filesRaw,
             children,
             hookFires,
             harnessHooks,

--- a/apps/axctl/src/share/session-share-queries.ts
+++ b/apps/axctl/src/share/session-share-queries.ts
@@ -1,0 +1,702 @@
+/**
+ * DuckDB replacement for the eleven SurrealQL fan-out queries `share/exporter.ts`
+ * used to read from `apps/axctl/src/queries/session-detail.ts` +
+ * `apps/axctl/src/queries/session-turn-content.ts`.
+ *
+ * WHY THIS IS ITS OWN FILE RATHER THAN A PORT OF THOSE TWO. `queries/` belongs
+ * to a sibling wave-3 chunk (band 2, chunk 2b) - see the partition doc's file
+ * ownership table. This module does not import from either file; it re-derives
+ * the same row shapes directly against the DuckDB cache through {@link
+ * CacheRead}, so `ax share` stops depending on SurrealDB without editing a file
+ * this chunk does not own. The dashboard's own session-detail route keeps
+ * reading `queries/session-detail.ts` until 2b ports it - that is a separate,
+ * still-Surreal-backed read path, not a regression introduced here.
+ *
+ * SCOPE. Deliberately narrower than `session-detail.ts` + `session-turn-content.ts`
+ * combined: only the rows `exportSessionShare` actually reads. The content
+ * resolution below also skips the SurrealDB-specific "speculative direct record
+ * fetch" optimisation those files needed to dodge Surreal's slow `document IN
+ * [...]` membership scans (see session-turn-content.ts's module doc) - DuckDB
+ * has a real `content_block(document, seq)` / `content_atom(document, kind)`
+ * index, so a plain `document IN (...)` bulk fetch is already fast here.
+ */
+import { Effect, Schema } from "effect";
+import type { CacheReadService } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TimestampColumn, TextColumn, JsonArrayColumn } from "@ax/lib/duckdb/columns";
+import { decodeJsonOrNull } from "@ax/lib/decode";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
+import type {
+    HookFireDto,
+    InspectContentAtomDto,
+    InspectContentBlockDto,
+    InspectTurnContentDto,
+    SessionLink,
+    SessionOverview,
+    SessionTokenUsageDetail,
+    SessionToolCall,
+    SessionTopSkill,
+    TurnTokenUsageDetail,
+} from "@ax/lib/shared/dashboard-types";
+import type { ShareEvent, ShareFile, ShareHarnessHook, ShareTurn } from "./artifact.ts";
+
+const isoOrNull = (d: Date | null): string | null => (d === null ? null : d.toISOString());
+
+// ---------------------------------------------------------------------------
+// session overview
+// ---------------------------------------------------------------------------
+
+const OverviewRow = Schema.Struct({
+    id: TextColumn,
+    project: Schema.NullOr(TextColumn),
+    cwd: Schema.NullOr(TextColumn),
+    model: Schema.NullOr(TextColumn),
+    source: TextColumn,
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
+});
+
+const OVERVIEW_SQL = `
+SELECT id, project, cwd, model, source, started_at, ended_at
+FROM session
+WHERE id = ?
+LIMIT 1`;
+
+export const fetchSessionOverview = Effect.fn("share.fetchSessionOverview")(
+    function* (read: CacheReadService, sessionId: string) {
+        const row = yield* read.first(OverviewRow, OVERVIEW_SQL, [sessionId]);
+        if (row._tag === "None") return null;
+        const r = row.value;
+        const overview: SessionOverview = {
+            id: toBareSessionId(r.id),
+            project: r.project,
+            cwd: r.cwd,
+            model: r.model,
+            source: r.source,
+            started_at: isoOrNull(r.started_at),
+            ended_at: isoOrNull(r.ended_at),
+        };
+        return overview;
+    },
+);
+
+// ---------------------------------------------------------------------------
+// top skills
+// ---------------------------------------------------------------------------
+
+const TopSkillRow = Schema.Struct({
+    skill: TextColumn,
+    count: NumberFromBigIntColumn,
+    last_used: Schema.NullOr(TimestampColumn),
+});
+
+const TOP_SKILLS_SQL = `
+SELECT s.name AS skill, COUNT(*) AS count, MAX(i.ts) AS last_used
+FROM invoked i
+JOIN skill s ON s.id = i.out_id
+WHERE i.session = ?
+GROUP BY s.name
+ORDER BY count DESC
+LIMIT 20`;
+
+export const fetchSessionTopSkills = Effect.fn("share.fetchSessionTopSkills")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(TopSkillRow, TOP_SKILLS_SQL, [sessionId]);
+        return rows.map(
+            (r): SessionTopSkill => ({ skill: r.skill, count: r.count, last_used: isoOrNull(r.last_used) }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// tool calls (rollup by label)
+// ---------------------------------------------------------------------------
+
+const ToolCallRollupRow = Schema.Struct({
+    label: TextColumn,
+    count: NumberFromBigIntColumn,
+    failures: NumberFromBigIntColumn,
+    last_used: Schema.NullOr(TimestampColumn),
+});
+
+const TOOL_CALLS_SQL = `
+SELECT
+    COALESCE(command_norm, name) AS label,
+    COUNT(*) AS count,
+    SUM(CASE WHEN has_error THEN 1 ELSE 0 END) AS failures,
+    MAX(ts) AS last_used
+FROM tool_call
+WHERE session = ? AND COALESCE(command_norm, name) IS NOT NULL
+GROUP BY label
+ORDER BY count DESC
+LIMIT 25`;
+
+export const fetchSessionToolCalls = Effect.fn("share.fetchSessionToolCalls")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ToolCallRollupRow, TOOL_CALLS_SQL, [sessionId]);
+        return rows.map(
+            (r): SessionToolCall => ({
+                label: r.label,
+                count: r.count,
+                failures: r.failures,
+                last_used: isoOrNull(r.last_used),
+            }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// children (spawned subagents)
+// ---------------------------------------------------------------------------
+
+const ChildRow = Schema.Struct({
+    child: TextColumn,
+    project: Schema.NullOr(TextColumn),
+    started_at: Schema.NullOr(TimestampColumn),
+    nickname: Schema.NullOr(TextColumn),
+    tool: Schema.NullOr(TextColumn),
+    ts: TimestampColumn,
+});
+
+const CHILDREN_SQL = `
+SELECT sp.out_id AS child, s.project AS project, s.started_at AS started_at,
+    sp.nickname AS nickname, sp.tool AS tool, sp.ts AS ts
+FROM spawned sp
+LEFT JOIN session s ON s.id = sp.out_id
+WHERE sp.in_id = ?
+ORDER BY sp.ts ASC
+LIMIT 100`;
+
+export const fetchSessionChildren = Effect.fn("share.fetchSessionChildren")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ChildRow, CHILDREN_SQL, [sessionId]);
+        return rows.map(
+            (r): SessionLink => ({
+                session_id: toBareSessionId(r.child),
+                project: r.project,
+                started_at: isoOrNull(r.started_at),
+                nickname: r.nickname,
+                tool: r.tool,
+                ts: isoOrNull(r.ts),
+            }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// token usage (session-level + per-turn)
+// ---------------------------------------------------------------------------
+
+const SessionTokenUsageRow = Schema.Struct({
+    model: Schema.NullOr(TextColumn),
+    prompt_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    completion_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    cache_creation_input_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    cache_read_input_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    estimated_tokens: NumberFromBigIntColumn,
+    estimated_input_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_output_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cache_creation_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cache_read_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cost_usd: Schema.NullOr(Schema.Number),
+    pricing_source: Schema.NullOr(TextColumn),
+});
+
+const SESSION_TOKEN_USAGE_SQL = `
+SELECT model, prompt_tokens, completion_tokens, cache_creation_input_tokens,
+    cache_read_input_tokens, estimated_tokens, estimated_input_cost_usd,
+    estimated_output_cost_usd, estimated_cache_creation_cost_usd,
+    estimated_cache_read_cost_usd, estimated_cost_usd, pricing_source
+FROM session_token_usage
+WHERE session = ?
+LIMIT 1`;
+
+export const fetchSessionTokenUsage = Effect.fn("share.fetchSessionTokenUsage")(
+    function* (read: CacheReadService, sessionId: string) {
+        const row = yield* read.first(SessionTokenUsageRow, SESSION_TOKEN_USAGE_SQL, [sessionId]);
+        if (row._tag === "None") return null;
+        const r = row.value;
+        const usage: SessionTokenUsageDetail = { ...r };
+        return usage;
+    },
+);
+
+const TurnTokenUsageRow = Schema.Struct({
+    seq: NumberFromBigIntColumn,
+    model: Schema.NullOr(TextColumn),
+    prompt_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    completion_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    cache_creation_input_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    cache_read_input_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    fresh_input_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    estimated_tokens: NumberFromBigIntColumn,
+    estimated_input_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_output_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cache_creation_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cache_read_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_cost_usd: Schema.NullOr(Schema.Number),
+    pricing_source: Schema.NullOr(TextColumn),
+    usage_source: TextColumn,
+    usage_quality: TextColumn,
+});
+
+const TURN_TOKEN_USAGE_SQL = `
+SELECT seq, model, prompt_tokens, completion_tokens, cache_creation_input_tokens,
+    cache_read_input_tokens, fresh_input_tokens, estimated_tokens,
+    estimated_input_cost_usd, estimated_output_cost_usd,
+    estimated_cache_creation_cost_usd, estimated_cache_read_cost_usd,
+    estimated_cost_usd, pricing_source, usage_source, usage_quality
+FROM turn_token_usage
+WHERE session = ?
+ORDER BY seq ASC
+LIMIT 2000`;
+
+export const fetchSessionTurnTokenUsage = Effect.fn("share.fetchSessionTurnTokenUsage")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(TurnTokenUsageRow, TURN_TOKEN_USAGE_SQL, [sessionId]);
+        return rows.map((r): TurnTokenUsageDetail => ({ ...r }));
+    },
+);
+
+// ---------------------------------------------------------------------------
+// share turns (the transcript spine)
+// ---------------------------------------------------------------------------
+
+const EXCLUDED_MESSAGE_KINDS = ["system", "attachment", "queue-operation"];
+
+const ShareTurnRow = Schema.Struct({
+    id: TextColumn,
+    seq: NumberFromBigIntColumn,
+    ts: TimestampColumn,
+    role: TextColumn,
+    message_kind: Schema.NullOr(TextColumn),
+    intent_kind: Schema.NullOr(TextColumn),
+    text: Schema.NullOr(TextColumn),
+    text_excerpt: Schema.NullOr(TextColumn),
+    has_tool_use: Schema.Boolean,
+    has_error: Schema.Boolean,
+});
+
+const SHARE_TURNS_SQL = `
+SELECT id, seq, ts, role, message_kind, intent_kind, text, text_excerpt, has_tool_use, has_error
+FROM turn
+WHERE session = ? AND (message_kind IS NULL OR message_kind NOT IN (${EXCLUDED_MESSAGE_KINDS.map(() => "?").join(", ")}))
+ORDER BY seq ASC
+LIMIT 2000`;
+
+export const fetchSessionShareTurns = Effect.fn("share.fetchSessionShareTurns")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ShareTurnRow, SHARE_TURNS_SQL, [sessionId, ...EXCLUDED_MESSAGE_KINDS]);
+        return rows.map((r): ShareTurn => {
+            const text = r.text ?? r.text_excerpt ?? "";
+            return {
+                id: r.id,
+                seq: r.seq,
+                role: r.role,
+                text,
+                ts: r.ts.toISOString(),
+                ...(r.message_kind ? { message_kind: r.message_kind } : {}),
+                ...(r.intent_kind ? { intent_kind: r.intent_kind } : {}),
+                ...(r.text_excerpt ? { text_excerpt: r.text_excerpt } : {}),
+                has_tool_use: r.has_tool_use,
+                has_error: r.has_error,
+            };
+        });
+    },
+);
+
+// ---------------------------------------------------------------------------
+// share timeline (tool-call activity feed)
+// ---------------------------------------------------------------------------
+
+const ShareTimelineRow = Schema.Struct({
+    id: TextColumn,
+    ts: TimestampColumn,
+    title: TextColumn,
+    summary: Schema.NullOr(TextColumn),
+});
+
+const SHARE_TIMELINE_SQL = `
+SELECT id, ts, COALESCE(command_norm, name) AS title, output_excerpt AS summary
+FROM tool_call
+WHERE session = ?
+ORDER BY ts ASC
+LIMIT 200`;
+
+export const fetchSessionShareTimeline = Effect.fn("share.fetchSessionShareTimeline")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ShareTimelineRow, SHARE_TIMELINE_SQL, [sessionId]);
+        return rows.map(
+            (r): ShareEvent => ({
+                id: r.id,
+                kind: "tool_call",
+                actor: "agent",
+                title: r.title,
+                ts: r.ts.toISOString(),
+                ...(r.summary ? { summary: r.summary } : {}),
+            }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// share files (edited files)
+// ---------------------------------------------------------------------------
+
+const ShareFileRow = Schema.Struct({
+    path: TextColumn,
+    lang: Schema.NullOr(TextColumn),
+});
+
+const SHARE_FILES_SQL = `
+SELECT DISTINCT COALESCE(e.path_seen, f.path) AS path, f.lang AS lang
+FROM edited e
+JOIN turn t ON t.id = e.in_id
+LEFT JOIN file f ON f.id = e.out_id
+WHERE t.session = ?
+ORDER BY path ASC
+LIMIT 200`;
+
+export const fetchSessionShareFiles = Effect.fn("share.fetchSessionShareFiles")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ShareFileRow, SHARE_FILES_SQL, [sessionId]);
+        return rows
+            .filter((r) => r.path !== null && r.path.length > 0)
+            .map((r): ShareFile => ({ path: r.path, role: "edited", ...(r.lang ? { lang: r.lang } : {}) }));
+    },
+);
+
+// ---------------------------------------------------------------------------
+// per-turn tool calls
+// ---------------------------------------------------------------------------
+
+export interface ShareTurnToolCall {
+    readonly seq: number;
+    readonly name: string;
+    readonly command: string | null;
+    readonly input_json: string | null;
+    readonly output: string | null;
+    readonly has_error: boolean;
+}
+
+const ShareTurnToolCallRow = Schema.Struct({
+    seq: NumberFromBigIntColumn,
+    name: TextColumn,
+    command_norm: Schema.NullOr(TextColumn),
+    command_text: Schema.NullOr(TextColumn),
+    input_json: Schema.NullOr(TextColumn),
+    output_excerpt: Schema.NullOr(TextColumn),
+    has_error: Schema.Boolean,
+});
+
+const SHARE_TURN_TOOLCALLS_SQL = `
+SELECT seq, name, command_norm, command_text, input_json, output_excerpt, has_error
+FROM tool_call
+WHERE session = ? AND seq IS NOT NULL
+ORDER BY seq ASC
+LIMIT 4000`;
+
+export const fetchSessionShareTurnToolCalls = Effect.fn("share.fetchSessionShareTurnToolCalls")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(ShareTurnToolCallRow, SHARE_TURN_TOOLCALLS_SQL, [sessionId]);
+        return rows.map(
+            (r): ShareTurnToolCall => ({
+                seq: r.seq,
+                name: r.name,
+                command: r.command_norm ?? r.command_text,
+                input_json: r.input_json,
+                output: r.output_excerpt,
+                has_error: r.has_error,
+            }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// hook fires (file-context injection decisions)
+// ---------------------------------------------------------------------------
+
+export type ShareHookFire = Omit<HookFireDto, "idx">;
+
+const HookFireRow = Schema.Struct({
+    ts: TimestampColumn,
+    event: TextColumn,
+    file_path: TextColumn,
+    inject: Schema.Boolean,
+    reason: TextColumn,
+    latency_ms: NumberFromBigIntColumn,
+    injected_titles: JsonArrayColumn(Schema.String),
+});
+
+const HOOK_FIRES_SQL = `
+SELECT ts, event, file_path, inject, reason, latency_ms, injected_titles
+FROM hook_fire
+WHERE session = ?
+ORDER BY ts ASC
+LIMIT 2000`;
+
+export const fetchSessionShareHookFires = Effect.fn("share.fetchSessionShareHookFires")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(HookFireRow, HOOK_FIRES_SQL, [sessionId]);
+        return rows.map(
+            (r): ShareHookFire => ({
+                ts: r.ts.toISOString(),
+                event: r.event,
+                file_path: r.file_path,
+                inject: r.inject,
+                reason: r.reason,
+                latency_ms: r.latency_ms,
+                injected_titles: r.injected_titles,
+            }),
+        );
+    },
+);
+
+// ---------------------------------------------------------------------------
+// harness hooks (guardrail hooks that actually did something)
+// ---------------------------------------------------------------------------
+
+export type ShareHarnessHookRow = Omit<ShareHarnessHook, "idx" | "anchor_turn_seq">;
+
+const HARNESS_DETAIL_MAX = 600;
+const HARNESS_EFFECTS = ["blocked", "modified_input", "injected_context", "notified"];
+
+/** Pull `additionalContext` out of a hook's stdout JSON (the text the harness
+ *  actually saw injected), tolerating a missing/malformed payload. Duplicated
+ *  from `queries/session-detail.ts` (2b's file) rather than imported - see the
+ *  module doc for why this file does not import from `queries/`. */
+const extractInjectedContext = (stdout: string | null): string | null => {
+    if (!stdout) return null;
+    const parsed = decodeJsonOrNull(stdout);
+    if (!parsed || typeof parsed !== "object") return null;
+    const rec = parsed as Record<string, unknown>;
+    const hso = rec.hookSpecificOutput;
+    if (hso && typeof hso === "object" && typeof (hso as Record<string, unknown>).additionalContext === "string") {
+        return (hso as Record<string, unknown>).additionalContext as string;
+    }
+    return typeof rec.additionalContext === "string" ? rec.additionalContext : null;
+};
+
+const harnessHookDetail = (row: {
+    readonly blocking_error_excerpt: string | null;
+    readonly content_excerpt: string | null;
+    readonly stdout_excerpt: string | null;
+    readonly stderr_excerpt: string | null;
+}): string | undefined => {
+    const detail =
+        row.blocking_error_excerpt ??
+        row.content_excerpt ??
+        extractInjectedContext(row.stdout_excerpt) ??
+        row.stderr_excerpt;
+    if (!detail) return undefined;
+    const trimmed = detail.trim();
+    if (trimmed.length === 0) return undefined;
+    return trimmed.length > HARNESS_DETAIL_MAX ? `${trimmed.slice(0, HARNESS_DETAIL_MAX - 1)}…` : trimmed;
+};
+
+const HarnessHookRow = Schema.Struct({
+    ts: TimestampColumn,
+    event_name: TextColumn,
+    hook_name: TextColumn,
+    effect: TextColumn,
+    provider_status: TextColumn,
+    command: Schema.NullOr(TextColumn),
+    stdout_excerpt: Schema.NullOr(TextColumn),
+    content_excerpt: Schema.NullOr(TextColumn),
+    blocking_error_excerpt: Schema.NullOr(TextColumn),
+    stderr_excerpt: Schema.NullOr(TextColumn),
+});
+
+const HARNESS_HOOKS_SQL = `
+SELECT ts, event_name, hook_name, effect, provider_status, command,
+    stdout_excerpt, content_excerpt, blocking_error_excerpt, stderr_excerpt
+FROM hook_command_invocation
+WHERE session = ? AND effect IN (${HARNESS_EFFECTS.map(() => "?").join(", ")})
+ORDER BY ts ASC
+LIMIT 2000`;
+
+export const fetchSessionShareHarnessHooks = Effect.fn("share.fetchSessionShareHarnessHooks")(
+    function* (read: CacheReadService, sessionId: string) {
+        const rows = yield* read.rows(HarnessHookRow, HARNESS_HOOKS_SQL, [sessionId, ...HARNESS_EFFECTS]);
+        return rows.map((r): ShareHarnessHookRow => {
+            const detail = harnessHookDetail(r);
+            return {
+                ts: r.ts.toISOString(),
+                event_name: r.event_name,
+                hook_name: r.hook_name,
+                effect: r.effect,
+                status: r.provider_status,
+                ...(r.command ? { command: r.command } : {}),
+                ...(detail ? { detail } : {}),
+            };
+        });
+    },
+);
+
+// ---------------------------------------------------------------------------
+// dissected turn content (content_document / content_block / content_atom)
+// ---------------------------------------------------------------------------
+
+const ContentDocumentRow = Schema.Struct({
+    document_id: TextColumn,
+    parser_id: TextColumn,
+    parser_version: TextColumn,
+    blockset_hash: Schema.NullOr(TextColumn),
+    turn_seq: NumberFromBigIntColumn,
+});
+
+const CONTENT_DOCUMENTS_SQL = `
+SELECT d.id AS document_id, d.parser_id AS parser_id, d.parser_version AS parser_version,
+    d.blockset_hash AS blockset_hash, t.seq AS turn_seq
+FROM content_document d
+JOIN turn t ON t.id = d.turn
+WHERE d.source_kind = 'turn' AND d.session = ?
+ORDER BY turn_seq`;
+
+const ContentBlockRow = Schema.Struct({
+    document_id: TextColumn,
+    seq: NumberFromBigIntColumn,
+    parent_seq: Schema.NullOr(NumberFromBigIntColumn),
+    kind: TextColumn,
+    role: Schema.NullOr(TextColumn),
+    heading: Schema.NullOr(TextColumn),
+    text: Schema.NullOr(TextColumn),
+    text_excerpt: Schema.NullOr(TextColumn),
+    start_offset: Schema.NullOr(NumberFromBigIntColumn),
+    end_offset: Schema.NullOr(NumberFromBigIntColumn),
+    confidence: Schema.Number,
+});
+
+const ContentAtomRow = Schema.Struct({
+    document_id: TextColumn,
+    block_seq: NumberFromBigIntColumn,
+    kind: TextColumn,
+    value: TextColumn,
+    normalized: Schema.NullOr(TextColumn),
+    confidence: Schema.Number,
+    raw: Schema.NullOr(TextColumn),
+});
+
+const parseRawField = (raw: string | null): unknown => {
+    if (raw === null) return null;
+    try {
+        return JSON.parse(raw) as unknown;
+    } catch {
+        return raw;
+    }
+};
+
+/** Bulk `document IN (...)` fetch, chunked so one session's document count
+ *  never produces an unbounded bound-parameter list. */
+const CONTENT_CHUNK = 400;
+
+const chunk = <T>(items: ReadonlyArray<T>, size: number): ReadonlyArray<ReadonlyArray<T>> => {
+    const out: T[][] = [];
+    for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+    return out;
+};
+
+/**
+ * Resolve every turn's dissected content (structured message blocks + atoms)
+ * for a session, keyed by turn seq. Best-effort by design - the caller
+ * (`exportSessionShare`) already treats a failure here as "no structured
+ * content", not a fatal export error.
+ */
+export const resolveTurnContent = Effect.fn("share.resolveTurnContent")(
+    function* (read: CacheReadService, sessionId: string) {
+        const byTurn = new Map<number, InspectTurnContentDto>();
+
+        const documents = yield* read.rows(ContentDocumentRow, CONTENT_DOCUMENTS_SQL, [sessionId]);
+        if (documents.length === 0) return byTurn;
+
+        const turnSeqByDocId = new Map<string, number>();
+        const metaByDocId = new Map<string, (typeof documents)[number]>();
+        for (const d of documents) {
+            turnSeqByDocId.set(d.document_id, d.turn_seq);
+            metaByDocId.set(d.document_id, d);
+        }
+        const docIds = documents.map((d) => d.document_id);
+
+        const blockChunks = chunk(docIds, CONTENT_CHUNK);
+        const blockRows = (
+            yield* Effect.forEach(
+                blockChunks,
+                (ids) =>
+                    read.rows(
+                        ContentBlockRow,
+                        `SELECT document AS document_id, seq, parent_seq, kind, role, heading, text,
+                            text_excerpt, start_offset, end_offset, confidence
+                         FROM content_block
+                         WHERE document IN (${ids.map(() => "?").join(", ")})
+                         ORDER BY document, seq`,
+                        ids,
+                    ),
+                { concurrency: 4 },
+            )
+        ).flat();
+
+        const atomChunks = chunk(docIds, CONTENT_CHUNK);
+        const atomRows = (
+            yield* Effect.forEach(
+                atomChunks,
+                (ids) =>
+                    read.rows(
+                        ContentAtomRow,
+                        `SELECT ca.document AS document_id, cb.seq AS block_seq, ca.kind, ca.value,
+                            ca.normalized, ca.confidence, ca.raw
+                         FROM content_atom ca
+                         JOIN content_block cb ON cb.id = ca.block
+                         WHERE ca.document IN (${ids.map(() => "?").join(", ")})
+                         ORDER BY ca.document, cb.seq`,
+                        ids,
+                    ),
+                { concurrency: 4 },
+            )
+        ).flat();
+
+        const atomsByDocAndBlock = new Map<string, InspectContentAtomDto[]>();
+        for (const atom of atomRows) {
+            const key = `${atom.document_id}\0${atom.block_seq}`;
+            const list = atomsByDocAndBlock.get(key) ?? [];
+            list.push({
+                kind: atom.kind,
+                value: atom.value,
+                normalized: atom.normalized,
+                confidence: atom.confidence,
+                raw: parseRawField(atom.raw),
+            });
+            atomsByDocAndBlock.set(key, list);
+        }
+
+        const blocksByTurn = new Map<number, InspectContentBlockDto[]>();
+        for (const row of blockRows) {
+            const turnSeq = turnSeqByDocId.get(row.document_id);
+            if (turnSeq === undefined) continue;
+            const atoms = atomsByDocAndBlock.get(`${row.document_id}\0${row.seq}`) ?? [];
+            const blocks = blocksByTurn.get(turnSeq) ?? [];
+            blocks.push({
+                seq: row.seq,
+                parent_seq: row.parent_seq,
+                kind: row.kind,
+                role: row.role,
+                heading: row.heading,
+                text: row.text,
+                text_excerpt: row.text_excerpt,
+                start_offset: row.start_offset,
+                end_offset: row.end_offset,
+                confidence: row.confidence,
+                atoms,
+            });
+            blocksByTurn.set(turnSeq, blocks);
+            const meta = metaByDocId.get(row.document_id);
+            if (meta === undefined) continue;
+            byTurn.set(turnSeq, {
+                document_id: row.document_id,
+                parser_id: meta.parser_id,
+                parser_version: meta.parser_version,
+                blockset_hash: meta.blockset_hash,
+                blocks,
+            });
+        }
+        return byTurn;
+    },
+);

--- a/apps/axctl/src/team/team-bindings-commands.test.ts
+++ b/apps/axctl/src/team/team-bindings-commands.test.ts
@@ -26,6 +26,7 @@ const repo = (remote: string, root: string): TeamRepositoryContext => {
         name: remote.split("/").at(-1) ?? remote,
         repoRoot: root,
         remoteUrlNormalized: remote,
+        repositoryId: null,
     };
 };
 

--- a/apps/axctl/src/team/team-bindings-commands.ts
+++ b/apps/axctl/src/team/team-bindings-commands.ts
@@ -1,4 +1,4 @@
-import type { PwdResolution } from "../pwd.ts";
+import type { PwdCacheResolution } from "../pwd.ts";
 import {
     DEFAULT_TEAM_SHARE,
     bindingFor,
@@ -9,14 +9,19 @@ import {
 } from "./team-bindings-state.ts";
 
 export interface TeamRepositoryContext {
+    /** Git-derived key. Local-only identity: keys the `~/.ax/team-bindings.json`
+     *  file, independent of any DB schema or row-id recipe. */
     readonly repoKey: string;
     readonly name: string;
     readonly repoRoot: string;
     readonly remoteUrlNormalized: string | null;
+    /** The DuckDB cache's `repository` ROW id for this repo, or `null` when the
+     *  cache has never ingested it yet (nothing to build a profile from). */
+    readonly repositoryId: string | null;
 }
 
 export const teamRepositoryContext = (
-    resolution: PwdResolution,
+    resolution: PwdCacheResolution,
 ): TeamRepositoryContext => ({
     repoKey: resolution.identity.repositoryKey,
     name:
@@ -25,6 +30,7 @@ export const teamRepositoryContext = (
         resolution.repoRoot,
     repoRoot: resolution.repoRoot,
     remoteUrlNormalized: resolution.remoteUrlNormalized,
+    repositoryId: resolution.repositoryId,
 });
 
 type WriteLine = (line: string) => void;

--- a/apps/axctl/src/team/team-profile-queries.ts
+++ b/apps/axctl/src/team/team-profile-queries.ts
@@ -1,54 +1,56 @@
 /**
- * Repo-scoped queries for the TeamProfileV1 builder. Scoping strategy:
- * ONE indexed query resolves the repo's session ids
- * (`session_repository_started` index, same scoping as listSessionsHere);
- * everything else fetches per-row data keyed by the denormalized `session`
- * field and is filtered/aggregated against that id set in JS. Deref-free
- * SQL, JS joins (SurrealDB 3.x house rules). `session IN [list]` is a
- * non-indexed per-row membership test - never used here; tool_call is
- * fanned out per-session literal (hits tool_call_session_ts, ~1ms each,
- * same pattern as sessions-query.ts enrichSessions).
+ * Repo-scoped queries for the TeamProfileV1 builder, over the DuckDB cache
+ * through {@link CacheRead}. Scoping strategy: ONE indexed query resolves the
+ * repo's session ids (`session_repository_started` index, same scoping as
+ * listSessionsHere); everything else fetches per-row data keyed by the
+ * denormalized `session` column and is filtered/aggregated against that id
+ * set in JS. `session IN (...)` is never used here; tool_call is fanned out
+ * per-session (hits `tool_call_session_ts`, ~1ms each, same pattern as
+ * sessions-query.ts enrichSessions).
+ *
+ * `repository` is looked up ONCE by the caller (`pwd.ts`'s
+ * `resolvePwdCacheRepository` / `queries/repository-scope.ts`) and handed in
+ * as a resolved DuckDB row id - see that module's doc for why a reader cannot
+ * construct the id from git alone in v2 (content-hashed, not git-keyed).
  */
-import { Effect } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import { recordLiteral } from "@ax/lib/ids";
-
-const win = (d: number) => `${Math.max(1, Math.trunc(d))}d`;
+import { Effect, Schema } from "effect";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TextColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
 
 // --- repo session set --------------------------------------------------------
 
 export interface TeamSessionRow {
-    /** type::string(id) form, e.g. `session:⟨uuid⟩` - matches invoked/usage row keys */
     readonly id: string;
     readonly started_at: string;
     readonly source: string;
 }
 
-const TEAM_REPO_SESSIONS_SQL = (repoKey: string, d: number) => `
-SELECT
-    type::string(id) AS id,
-    type::string(started_at) AS started_at,
-    source
-FROM session
-WHERE repository = ${recordLiteral("repository", repoKey)}
-  AND started_at > time::now() - ${win(d)}
-  AND started_at IS NOT NONE;`;
+const TeamSessionDbRow = Schema.Struct({
+    id: TextColumn,
+    started_at: TimestampColumn,
+    source: TextColumn,
+});
 
 export const fetchTeamRepoSessions = Effect.fn("team.fetchTeamRepoSessions")(
-    function* (opts: { readonly repoKey: string; readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(
-                TEAM_REPO_SESSIONS_SQL(opts.repoKey, opts.windowDays),
-            )
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        return rows
-            .filter((r) => r.id != null && r.started_at != null)
-            .map((r) => ({
-                id: String(r.id),
-                started_at: String(r.started_at),
-                source: String(r.source ?? "claude"),
-            })) satisfies TeamSessionRow[];
+    function* (opts: { readonly repositoryId: string | null; readonly windowDays: number }) {
+        if (opts.repositoryId === null) return [] as TeamSessionRow[];
+        const read = yield* CacheRead;
+        const since = withinDaysClause("started_at", opts.windowDays);
+        const rows = yield* read.rows(
+            TeamSessionDbRow,
+            `SELECT id, started_at, source
+             FROM session
+             WHERE repository = ? AND started_at IS NOT NULL ${since.sql}`,
+            [opts.repositoryId, ...since.params],
+        );
+        return rows.map(
+            (r): TeamSessionRow => ({
+                id: r.id,
+                started_at: r.started_at.toISOString(),
+                source: r.source,
+            }),
+        );
     },
 );
 // --- per-session token usage (machine window; repo-filtered in JS) -----------
@@ -64,39 +66,46 @@ export interface SessionUsageRow {
     readonly cost_usd: number | null;
 }
 
-const SESSION_USAGE_SQL = (d: number) => `
-SELECT
-    type::string(session) AS session,
-    model,
-    prompt_tokens ?? 0 AS prompt_tokens,
-    completion_tokens ?? 0 AS completion_tokens,
-    estimated_cost_usd AS cost_usd
-FROM session_token_usage
-WHERE ts > time::now() - ${win(d)};`;
+const SessionUsageDbRow = Schema.Struct({
+    session: TextColumn,
+    model: Schema.NullOr(TextColumn),
+    prompt_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    completion_tokens: Schema.NullOr(NumberFromBigIntColumn),
+    cost_usd: Schema.NullOr(Schema.Number),
+});
 
 export const fetchSessionUsageRows = Effect.fn("team.fetchSessionUsageRows")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(SESSION_USAGE_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        return rows
-            .filter((r) => r.session != null)
-            .map((r) => ({
-                session: String(r.session),
-                model: r.model == null ? null : String(r.model),
-                prompt_tokens: Number(r.prompt_tokens ?? 0),
-                completion_tokens: Number(r.completion_tokens ?? 0),
-                cost_usd: r.cost_usd == null ? null : Number(r.cost_usd),
-            })) satisfies SessionUsageRow[];
+        const read = yield* CacheRead;
+        const since = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(
+            SessionUsageDbRow,
+            `SELECT session, model, prompt_tokens, completion_tokens, estimated_cost_usd AS cost_usd
+             FROM session_token_usage
+             WHERE 1 = 1 ${since.sql}`,
+            since.params,
+        );
+        return rows.map(
+            (r): SessionUsageRow => ({
+                session: r.session,
+                model: r.model,
+                prompt_tokens: r.prompt_tokens ?? 0,
+                completion_tokens: r.completion_tokens ?? 0,
+                cost_usd: r.cost_usd,
+            }),
+        );
     },
 );
 
-// --- tool-call command aggregate, per-session fan-out -------------------------
+// --- tool-call command aggregate, bulk IN-list ------------------------------
 // Classification (verification share) happens on the FULL command text in JS
 // (profile/tool-taxonomy.ts) - command text is never returned to the caller
 // beyond this module's aggregation input and never serialized into the
 // snapshot (counts-only privacy invariant, mirrors fetchWrappedCounts).
+//
+// One bulk `session IN (...)` query, chunked, rather than a per-session
+// fan-out: DuckDB has a real index on tool_call(session, ts) and no
+// Surreal-style membership-scan penalty for an IN-list (see clause.ts's doc).
 
 export interface ToolCmdRow {
     readonly cmd: string;
@@ -104,48 +113,50 @@ export interface ToolCmdRow {
     readonly failures: number;
 }
 
-const TOOL_AGG_FOR_SESSION_SQL = (sessionLit: string) => `
-SELECT
-    (command_text ?? command_norm ?? name) AS cmd,
-    count() AS count,
-    math::sum(IF has_error = true THEN 1 ELSE 0 END) AS failures
-FROM tool_call
-WHERE session = ${sessionLit}
-  AND (command_text ?? command_norm ?? name) IS NOT NONE
-GROUP BY cmd;`;
+const ToolAggDbRow = Schema.Struct({
+    cmd: TextColumn,
+    count: NumberFromBigIntColumn,
+    failures: NumberFromBigIntColumn,
+});
 
-/** `type::string(id)` output → clean backtick record literal (sessions-query.ts idiom). */
-const sessionLiteral = (id: string): string => {
-    let k = id.replace(/^session:/, "");
-    if (k.startsWith("⟨") && k.endsWith("⟩")) k = k.slice(1, -1);
-    else if (k.startsWith("`") && k.endsWith("`")) k = k.slice(1, -1);
-    return `session:\`${k}\``;
+/** Bound `session IN (...)` params per chunk, so a large session set never
+ *  produces an unbounded bound-parameter list. */
+const SESSION_CHUNK = 500;
+
+const chunkOf = <T>(items: ReadonlyArray<T>, size: number): ReadonlyArray<ReadonlyArray<T>> => {
+    const out: T[][] = [];
+    for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+    return out;
 };
-
-const TOOL_AGG_CONCURRENCY = 8;
 
 export const fetchToolCallAggBySession = Effect.fn("team.fetchToolCallAggBySession")(
     function* (opts: { readonly sessionIds: ReadonlyArray<string> }) {
         if (opts.sessionIds.length === 0) return [] as ToolCmdRow[];
-        const db = yield* SurrealClient;
-        const perSession = yield* Effect.forEach(
-            opts.sessionIds,
-            (id) =>
-                db.query<[Array<Record<string, unknown>>]>(
-                    TOOL_AGG_FOR_SESSION_SQL(sessionLiteral(id)),
-                ).pipe(Effect.map((r) => r?.[0] ?? [])),
-            { concurrency: TOOL_AGG_CONCURRENCY },
+        const read = yield* CacheRead;
+        const perChunk = yield* Effect.forEach(
+            chunkOf(opts.sessionIds, SESSION_CHUNK),
+            (ids) =>
+                read.rows(
+                    ToolAggDbRow,
+                    `SELECT COALESCE(command_text, command_norm, name) AS cmd,
+                        COUNT(*) AS count,
+                        SUM(CASE WHEN has_error THEN 1 ELSE 0 END) AS failures
+                     FROM tool_call
+                     WHERE session IN (${ids.map(() => "?").join(", ")})
+                       AND COALESCE(command_text, command_norm, name) IS NOT NULL
+                     GROUP BY cmd`,
+                    ids,
+                ),
+            { concurrency: 4 },
         );
-        // Merge per-session command rows into one cmd -> counts map.
+        // Merge per-chunk command rows into one cmd -> counts map.
         const merged = new Map<string, { count: number; failures: number }>();
-        for (const rows of perSession) {
+        for (const rows of perChunk) {
             for (const r of rows) {
-                const cmd = String(r.cmd ?? "");
-                if (cmd.length === 0) continue;
-                const cur = merged.get(cmd) ?? { count: 0, failures: 0 };
-                cur.count += Number(r.count ?? 0);
-                cur.failures += Number(r.failures ?? 0);
-                merged.set(cmd, cur);
+                const cur = merged.get(r.cmd) ?? { count: 0, failures: 0 };
+                cur.count += r.count;
+                cur.failures += r.failures;
+                merged.set(r.cmd, cur);
             }
         }
         return [...merged.entries()].map(([cmd, v]) => ({

--- a/apps/axctl/src/team/team-profile.test.ts
+++ b/apps/axctl/src/team/team-profile.test.ts
@@ -1,31 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { makeMockDb, type TestSurrealResponder } from "@ax/lib/testing/surreal";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { buildTeamProfile } from "./team-profile.ts";
 
-const REPO_A = "remote__github_com_acme_widgets__abc123";
+const REPO_A_ID = "repo-a-duckdb-row-id";
 
 // Two-repo fixture: repo A owns sessions a1/a2; session b1 belongs to another
-// repo. The session route answers ONLY repo-A rows (the SQL itself carries the
-// repository literal - asserted below); usage/invocation routes answer rows for
-// BOTH repos' sessions, so any b1 data reaching the output means the JS repo
-// filter is broken.
+// repo. The DuckDB session/usage/tool_call routes answer ONLY repo-A rows
+// (repository is a bound parameter, asserted below via capturedParams) - so
+// any b1 data reaching the output would mean the repo filter is broken.
 //
-// tool_call is fanned out per-session (one query per session id), and the
-// mock's route matching is a stateless SQL-substring test - a flat response
-// would answer BOTH the a1 and a2 queries identically, doubling every count.
-// Only session a1 carries tool-call activity in this fixture, so the
-// responder inspects the issued SQL for the session literal it's answering.
-const routes = new Map<string, TestSurrealResponder>([
-    ["FROM session\n", [[
-        { id: "session:⟨a1⟩", started_at: "2026-07-14T10:00:00Z", source: "claude" },
-        { id: "session:⟨a2⟩", started_at: "2026-07-15T09:00:00Z", source: "codex" },
-    ]]],
-    ["FROM session_token_usage", [[
-        { session: "session:⟨a1⟩", model: "fable", prompt_tokens: 1000, completion_tokens: 200, cost_usd: 3 },
-        { session: "session:⟨a2⟩", model: "haiku", prompt_tokens: 500, completion_tokens: 100, cost_usd: 1 },
-        { session: "session:⟨b1⟩", model: "fable", prompt_tokens: 9_000_000, completion_tokens: 9_000_000, cost_usd: 999 },
-    ]]],
+// `invoked` (skill invocations) is still Surreal-backed
+// (`profile/queries.ts`'s `fetchWindowedInvocations` is unported) and answers
+// rows for BOTH repos' sessions using Surreal-decorated session ids
+// (`session:⟨a1⟩`), matching what that reader still returns; the JS repo
+// filter in team-profile.ts normalizes those before comparing against the
+// (bare) DuckDB session-id set.
+const surrealRoutes = new Map<string, TestSurrealResponder>([
     ["FROM invoked", [[
         { session: "session:⟨a1⟩", skill: "tdd", ts: "2026-07-14T10:01:00Z" },
         { session: "session:⟨a1⟩", skill: "tdd", ts: "2026-07-14T10:30:00Z" },
@@ -33,41 +25,62 @@ const routes = new Map<string, TestSurrealResponder>([
         { session: "session:⟨a2⟩", skill: "review", ts: "2026-07-15T09:20:00Z" },
         { session: "session:⟨b1⟩", skill: "leaky-skill", ts: "2026-07-15T09:30:00Z" },
     ]]],
-    ["FROM tool_call", (sql: string) =>
-        sql.includes("session:`a1`")
-            ? [[
-                { cmd: "bun test", count: 10, failures: 1 },
-                { cmd: "Read", count: 20, failures: 0 },
-            ]]
-            : [[]],
-    ],
 ]);
+
+const capturedCacheParams: unknown[][] = [];
+
+const cacheRoutes = {
+    "FROM session\n": (
+        _sql: string,
+        params: ReadonlyArray<unknown> | undefined,
+    ) => {
+        capturedCacheParams.push([...(params ?? [])]);
+        return [
+            { id: "a1", started_at: "2026-07-14T10:00:00Z", source: "claude" },
+            { id: "a2", started_at: "2026-07-15T09:00:00Z", source: "codex" },
+        ];
+    },
+    "FROM session_token_usage": [
+        { session: "a1", model: "fable", prompt_tokens: 1000, completion_tokens: 200, cost_usd: 3 },
+        { session: "a2", model: "haiku", prompt_tokens: 500, completion_tokens: 100, cost_usd: 1 },
+        { session: "b1", model: "fable", prompt_tokens: 9_000_000, completion_tokens: 9_000_000, cost_usd: 999 },
+    ],
+    // ONE bulk `session IN (...)` query now (not per-session fan-out); only
+    // session a1 carries tool-call activity in this fixture.
+    "FROM tool_call": [
+        { cmd: "bun test", count: 10, failures: 1 },
+        { cmd: "Read", count: 20, failures: 0 },
+    ],
+};
 
 const run = (opts: {
     share: "public" | "anon";
     includeCost: boolean;
 }) => {
-    const { layer, captured } = makeMockDb(routes);
+    const surreal = makeMockDb(surrealRoutes);
+    const cache = makeTestCacheRead({ routes: cacheRoutes });
     const profile = Effect.runSync(
         buildTeamProfile({
             org: "acme",
-            repoKey: REPO_A,
+            repoKey: REPO_A_ID,
+            repositoryId: REPO_A_ID,
             windowDays: 30,
             share: opts.share,
             includeCost: opts.includeCost,
             env: { login: "necmttn", generatedAt: "2026-07-16T00:00:00Z" },
-        }).pipe(Effect.provide(layer)),
+        }).pipe(Effect.provide(Layer.merge(surreal.layer, cache.layer))),
     );
-    return { profile, captured };
+    return { profile, captured: surreal.captured, cacheCaptured: cache.captured };
 };
 
 describe("buildTeamProfile", () => {
     test("scopes the session query to the repo and aggregates only repo sessions", () => {
-        const { profile, captured } = run({ share: "public", includeCost: true });
+        capturedCacheParams.length = 0;
+        const { profile } = run({ share: "public", includeCost: true });
 
-        // The session query itself carries the repo literal (index-backed scoping).
-        const sessionSql = captured.find((sql) => sql.includes("FROM session\n"));
-        expect(sessionSql).toContain(`repository:\`${REPO_A}\``);
+        // The session query is scoped by a BOUND repository parameter
+        // (DuckDB row id), not a spliced literal.
+        expect(capturedCacheParams[0]?.[0]).toBe(REPO_A_ID);
 
         // Aggregates cover ONLY repo-A sessions - b1's rows never leak through.
         expect(profile.stats.sessions).toBe(2);
@@ -95,16 +108,10 @@ describe("buildTeamProfile", () => {
             verification_calls: 10,
         });
 
-        // tool_call fan-out is per-session literal (indexed), never IN [list].
-        const toolSqls = captured.filter((sql) => sql.includes("FROM tool_call"));
-        expect(toolSqls).toHaveLength(2);
-        expect(toolSqls[0]).toContain("session:`a1`");
-        expect(toolSqls[1]).toContain("session:`a2`");
-
         expect(profile.v).toBe(1);
         expect(profile.login).toBe("necmttn");
         expect(profile.org).toBe("acme");
-        expect(profile.repo_key).toBe(REPO_A);
+        expect(profile.repo_key).toBe(REPO_A_ID);
     });
 
     test("share=anon strips login (null) and carries no github identity", () => {
@@ -147,17 +154,31 @@ describe("buildTeamProfile", () => {
     });
 
     test("empty repo window yields a valid zero snapshot", () => {
-        const { layer } = makeMockDb(new Map());
+        const surreal = makeMockDb(new Map());
+        const cache = makeTestCacheRead();
         const profile = Effect.runSync(
             buildTeamProfile({
-                org: "acme", repoKey: REPO_A, windowDays: 30,
+                org: "acme", repoKey: REPO_A_ID, repositoryId: REPO_A_ID, windowDays: 30,
                 share: "public", includeCost: true,
                 env: { login: "necmttn", generatedAt: "2026-07-16T00:00:00Z" },
-            }).pipe(Effect.provide(layer)),
+            }).pipe(Effect.provide(Layer.merge(surreal.layer, cache.layer))),
         );
         expect(profile.stats.sessions).toBe(0);
         expect(profile.activity.daily).toEqual([]);
         expect(profile.skills).toEqual([]);
         expect(profile.spend.cost_usd).toBe(0);
+    });
+
+    test("repositoryId=null (repo never ingested) yields a valid zero snapshot", () => {
+        const surreal = makeMockDb(new Map());
+        const cache = makeTestCacheRead();
+        const profile = Effect.runSync(
+            buildTeamProfile({
+                org: "acme", repoKey: REPO_A_ID, repositoryId: null, windowDays: 30,
+                share: "public", includeCost: true,
+                env: { login: "necmttn", generatedAt: "2026-07-16T00:00:00Z" },
+            }).pipe(Effect.provide(Layer.merge(surreal.layer, cache.layer))),
+        );
+        expect(profile.stats.sessions).toBe(0);
     });
 });

--- a/apps/axctl/src/team/team-profile.ts
+++ b/apps/axctl/src/team/team-profile.ts
@@ -10,6 +10,7 @@
 import { Effect } from "effect";
 import { fetchWindowedInvocations } from "../profile/queries.ts";
 import { isVerificationTool } from "../profile/tool-taxonomy.ts";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
 import {
     fetchSessionUsageRows,
     fetchTeamRepoSessions,
@@ -27,23 +28,32 @@ const day = (iso: string): string => iso.slice(0, 10);
 export const buildTeamProfile = Effect.fn("team.buildTeamProfile")(
     function* (opts: {
         readonly org: string;
+        /** Git-derived key, carried into the output `repo_key` field only -
+         *  never used to query the DB (see `repositoryId`). */
         readonly repoKey: string;
+        /** The DuckDB cache's `repository` row id, or `null` when the cache has
+         *  never ingested this repo - the profile then has zero sessions. */
+        readonly repositoryId: string | null;
         readonly windowDays: number;
         readonly share: TeamShare;
         readonly includeCost: boolean;
         readonly env: TeamProfileEnv;
     }) {
-        const { org, repoKey, windowDays, share, includeCost, env } = opts;
+        const { org, repoKey, repositoryId, windowDays, share, includeCost, env } = opts;
 
         // 1. Repo session set (indexed; the ONLY query that names the repo).
-        const sessions = yield* fetchTeamRepoSessions({ repoKey, windowDays });
+        const sessions = yield* fetchTeamRepoSessions({ repositoryId, windowDays });
         const sessionIds = new Set(sessions.map((s) => s.id));
 
         // 2. Machine-window per-row fetches, repo-filtered in JS.
         const usageAll = yield* fetchSessionUsageRows({ windowDays });
         const usage = usageAll.filter((u) => sessionIds.has(u.session));
         const invocationsAll = yield* fetchWindowedInvocations({ windowDays });
-        const invocations = invocationsAll.filter((i) => sessionIds.has(i.session));
+        // fetchWindowedInvocations is still Surreal-backed (unported -
+        // profile/queries.ts) and returns Surreal-decorated session ids
+        // (`session:⟨uuid⟩`); `sessionIds` above comes off the ported,
+        // DuckDB-bare `fetchTeamRepoSessions`. Normalize before comparing.
+        const invocations = invocationsAll.filter((i) => sessionIds.has(toBareSessionId(i.session)));
 
         // 3. Per-session indexed tool_call fan-out (repo-scoped by construction).
         // Sorted for deterministic query order (Set iteration order is

--- a/apps/axctl/src/team/team-push.test.ts
+++ b/apps/axctl/src/team/team-push.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { makeMockDb } from "@ax/lib/testing/surreal";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { Effect, Layer } from "effect";
 import { GitHubEnvTest } from "../profile/github-env.ts";
 import { savePublishState } from "../profile/publish-state.ts";
@@ -22,6 +23,7 @@ describe("pushCurrentTeamProfile", () => {
         const outcome = await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey: "repo-unbound",
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,
@@ -31,7 +33,7 @@ describe("pushCurrentTeamProfile", () => {
                     onSuccess: (value) => ({ ok: true as const, value }),
                     onFailure: (error) => ({ ok: false as const, error }),
                 }),
-                Effect.provide(Layer.merge(github.layer, db.layer)),
+                Effect.provide(Layer.mergeAll(github.layer, db.layer, makeTestCacheRead().layer)),
             ),
         );
 
@@ -63,11 +65,12 @@ describe("pushCurrentTeamProfile", () => {
         const firstResult = await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey,
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,
                 generatedAt: "2026-07-16T00:00:00Z",
-            }).pipe(Effect.provide(Layer.merge(first.layer, db.layer))),
+            }).pipe(Effect.provide(Layer.mergeAll(first.layer, db.layer, makeTestCacheRead().layer))),
         );
 
         expect(firstResult.file).toBe(".ax-team/alice.json");
@@ -93,11 +96,12 @@ describe("pushCurrentTeamProfile", () => {
         await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey,
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,
                 generatedAt: "2026-07-16T00:00:00Z",
-            }).pipe(Effect.provide(Layer.merge(second.layer, db.layer))),
+            }).pipe(Effect.provide(Layer.mergeAll(second.layer, db.layer, makeTestCacheRead().layer))),
         );
 
         expect(second.calls.map(({ method, path: callPath }) => `${method} ${callPath}`)).toEqual([
@@ -135,11 +139,12 @@ describe("pushCurrentTeamProfile", () => {
         const result = await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey,
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,
                 generatedAt: "2026-07-16T00:00:00Z",
-            }).pipe(Effect.provide(Layer.merge(github.layer, db.layer))),
+            }).pipe(Effect.provide(Layer.mergeAll(github.layer, db.layer, makeTestCacheRead().layer))),
         );
 
         expect(result.anonymous).toBe(true);
@@ -180,11 +185,12 @@ describe("pushCurrentTeamProfile", () => {
             login: "alice",
         });
         const db = makeMockDb(new Map());
-        const layer = Layer.merge(github.layer, db.layer);
+        const layer = Layer.mergeAll(github.layer, db.layer, makeTestCacheRead().layer);
 
         await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey: "repo-one",
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,
@@ -194,6 +200,7 @@ describe("pushCurrentTeamProfile", () => {
         await Effect.runPromise(
             pushCurrentTeamProfile({
                 repoKey: "repo-two",
+                repositoryId: null,
                 bindingsPath,
                 publishStatePath,
                 windowDays: 30,

--- a/apps/axctl/src/team/team-push.ts
+++ b/apps/axctl/src/team/team-push.ts
@@ -40,6 +40,10 @@ const snapshotFilename = (input: {
 export const pushCurrentTeamProfile = Effect.fn("team.pushCurrentTeamProfile")(
     function* (input: {
         readonly repoKey: string;
+        /** The DuckDB cache's `repository` row id (null when never ingested -
+         *  the pushed profile then has zero sessions, same as an unmatched
+         *  Surreal record used to). */
+        readonly repositoryId: string | null;
         readonly bindingsPath: string;
         readonly publishStatePath: string;
         readonly windowDays: number;
@@ -76,6 +80,7 @@ export const pushCurrentTeamProfile = Effect.fn("team.pushCurrentTeamProfile")(
         const profile = yield* buildTeamProfile({
             org: binding.org,
             repoKey: input.repoKey,
+            repositoryId: input.repositoryId,
             windowDays: input.windowDays,
             // Bindings call named sharing "full"; TeamProfileV1 calls it "public".
             share: anonymous ? "anon" : "public",

--- a/apps/axctl/src/timeline/service.ts
+++ b/apps/axctl/src/timeline/service.ts
@@ -4,44 +4,39 @@
  * to clean shapes, and hands them to the pure `buildTimeline` derivation. All
  * the logic lives in `derive.ts` (testable without a DB); this layer is just
  * I/O + composition.
+ *
+ * DuckDB port (wave 3, chunk 2d). `./queries.ts` (the SQL-builder + mapper
+ * module this file used to call) belongs to a sibling chunk (band 2, 2b) and
+ * still emits SurrealQL, so this file does NOT call into it for SQL or execution
+ * - only its exported ROW TYPES are imported (type-only, erased at compile
+ * time, zero runtime coupling) so `derive.ts`'s pure inputs stay unchanged. The
+ * queries themselves are re-derived here directly against the DuckDB cache
+ * through {@link CacheRead}.
  */
-import { Context, Effect, Layer } from "effect";
-import { SurrealClient } from "@ax/lib/db";
+import { Context, Effect, Layer, Schema } from "effect";
+import { CacheRead, type CacheReadService } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TextColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
 import { buildTimeline } from "./derive.ts";
 import type { SessionTimeline } from "./types.ts";
-import {
-    asksSql,
-    commitsSql,
-    compactionsSql,
-    correctionsSql,
-    costSql,
-    editsSql,
-    editStatsSql,
-    healthSql,
-    lastAssistantSql,
-    mapAsk,
-    mapCommit,
-    mapCompaction,
-    intentCorrectionsSql,
-    mapCorrection,
-    mapIntentCorrection,
-    mapCost,
-    mapEdit,
-    mapEditStat,
-    mapHealth,
-    mapLastTurn,
-    mapOverview,
-    mapPlan,
-    mapSkill,
-    mapToolCall,
-    overviewSql,
-    plansSql,
-    sessionRef,
-    skillsSql,
-    toolCallsSql,
+import type {
+    AskRow,
+    CommitRow,
+    CompactionRow,
+    CorrectionRow,
+    CostRow,
+    EditRow,
+    EditStatRow,
+    HealthRow,
+    LastTurnRow,
+    OverviewRow,
+    PlanRow,
+    SkillRow,
+    ToolCallRow,
 } from "./queries.ts";
 
 const present = <T>(x: T | null): x is T => x !== null;
+const isoOrNull = (d: Date | null): string | null => (d === null ? null : d.toISOString());
 
 export interface SessionTimelineShape {
     readonly extract: (sessionId: string) => Effect.Effect<SessionTimeline>;
@@ -52,72 +47,238 @@ export class SessionTimelineService extends Context.Service<
     SessionTimelineShape
 >()("ax/SessionTimelineService") {}
 
+// ---------------------------------------------------------------------------
+// Row schemas + DuckDB SQL, one per input `buildTimeline` needs. Re-derived
+// from the ROW SHAPES `./queries.ts` documents (its SurrealQL is not reused -
+// see the module doc).
+// ---------------------------------------------------------------------------
+
+const HealthDbRow = Schema.Struct({
+    turns: NumberFromBigIntColumn,
+    user_turns: NumberFromBigIntColumn,
+    assistant_turns: NumberFromBigIntColumn,
+    tool_calls: NumberFromBigIntColumn,
+    tool_errors: NumberFromBigIntColumn,
+    user_corrections: NumberFromBigIntColumn,
+    interruptions: NumberFromBigIntColumn,
+    estimated_tokens: NumberFromBigIntColumn,
+});
+const HEALTH_SQL = `
+SELECT turns, user_turns, assistant_turns, tool_calls, tool_errors, user_corrections, interruptions, estimated_tokens
+FROM session_health WHERE session = ? LIMIT 1`;
+
+const OverviewDbRow = Schema.Struct({
+    source: Schema.NullOr(TextColumn),
+    model: Schema.NullOr(TextColumn),
+    project: Schema.NullOr(TextColumn),
+    cwd: Schema.NullOr(TextColumn),
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
+});
+const OVERVIEW_SQL = `SELECT source, model, project, cwd, started_at, ended_at FROM session WHERE id = ? LIMIT 1`;
+
+const CostDbRow = Schema.Struct({
+    estimated_cost_usd: Schema.NullOr(Schema.Number),
+    estimated_tokens: NumberFromBigIntColumn,
+});
+const COST_SQL = `SELECT estimated_cost_usd, estimated_tokens FROM session_token_usage WHERE session = ? LIMIT 1`;
+
+const ToolCallDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    name: TextColumn,
+    command_norm: Schema.NullOr(TextColumn),
+    command_text: Schema.NullOr(TextColumn),
+    output_excerpt: Schema.NullOr(TextColumn),
+    error_text: Schema.NullOr(TextColumn),
+    has_error: Schema.Boolean,
+    call_id: Schema.NullOr(TextColumn),
+});
+const TOOL_CALLS_SQL = `
+SELECT seq, ts, name, command_norm, SUBSTRING(COALESCE(input_json, ''), 1, 1600) AS command_text,
+    output_excerpt, error_text, has_error, call_id
+FROM tool_call WHERE session = ? ORDER BY seq ASC LIMIT 6000`;
+
+const EditDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    path: Schema.NullOr(TextColumn),
+    edit_kind: Schema.NullOr(TextColumn),
+    tool: TextColumn,
+});
+const EDITS_SQL = `
+SELECT t.seq AS seq, e.ts AS ts, e.path_seen AS path, e.edit_kind AS edit_kind, e.tool AS tool
+FROM edited e JOIN turn t ON t.id = e.in_id
+WHERE t.session = ? ORDER BY seq ASC LIMIT 2000`;
+
+const EditStatDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    name: TextColumn,
+    input_json: Schema.NullOr(TextColumn),
+});
+const EDIT_STATS_SQL = `
+SELECT seq, name, SUBSTRING(COALESCE(input_json, ''), 1, 32000) AS input_json
+FROM tool_call WHERE session = ? AND name IN ('Edit', 'Write', 'NotebookEdit') ORDER BY seq ASC LIMIT 2000`;
+
+const SkillDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    name: TextColumn,
+});
+const SKILLS_SQL = `
+SELECT t.seq AS seq, i.ts AS ts, s.name AS name
+FROM invoked i JOIN turn t ON t.id = i.in_id JOIN skill s ON s.id = i.out_id
+WHERE i.session = ? ORDER BY seq ASC LIMIT 2000`;
+
+const CorrectionDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    target: Schema.NullOr(TextColumn),
+    user_text: Schema.NullOr(TextColumn),
+});
+const CORRECTIONS_SQL = `
+SELECT t.seq AS seq, re.ts AS ts, re.target AS target, re.user_text AS user_text
+FROM reaction_event re JOIN turn t ON t.id = re.user_turn
+WHERE re.session = ? AND (re.polarity = 'revise' OR re.reaction_type = 'correction')
+ORDER BY seq ASC LIMIT 500`;
+
+const IntentCorrectionDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    user_text: Schema.NullOr(TextColumn),
+});
+const INTENT_CORRECTIONS_SQL = `
+SELECT seq, ts, text_excerpt AS user_text
+FROM turn WHERE session = ? AND intent_kind = 'correction' ORDER BY seq ASC LIMIT 500`;
+
+const PlanDbRow = Schema.Struct({
+    ts: Schema.NullOr(TimestampColumn),
+    summary: Schema.NullOr(TextColumn),
+    items: Schema.NullOr(TextColumn),
+});
+const PLANS_SQL = `SELECT ts, summary, items FROM plan_snapshot WHERE session = ? ORDER BY ts ASC LIMIT 500`;
+
+const CommitDbRow = Schema.Struct({
+    ts: Schema.NullOr(TimestampColumn),
+    sha: Schema.NullOr(TextColumn),
+    message: Schema.NullOr(TextColumn),
+});
+const COMMITS_SQL = `
+SELECT c.ts AS ts, c.sha AS sha, c.message AS message
+FROM produced p JOIN "commit" c ON c.id = p.out_id
+WHERE p.in_id = ? AND p.kind = 'commit' ORDER BY ts ASC LIMIT 200`;
+
+const AskDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    text: Schema.NullOr(TextColumn),
+});
+const ASKS_SQL = `
+SELECT seq, ts, text_excerpt AS text
+FROM turn WHERE session = ? AND role = 'user' AND message_kind = 'task' ORDER BY seq ASC LIMIT 1000`;
+
+const CompactionDbRow = Schema.Struct({
+    ts: TimestampColumn,
+});
+const COMPACTIONS_SQL = `SELECT ts FROM compaction WHERE session = ? ORDER BY ts ASC LIMIT 200`;
+
+const LastTurnDbRow = Schema.Struct({
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: Schema.NullOr(TimestampColumn),
+    text_excerpt: Schema.NullOr(TextColumn),
+});
+const LAST_ASSISTANT_SQL = `
+SELECT seq, ts, text_excerpt FROM turn WHERE session = ? AND role = 'assistant' ORDER BY seq DESC LIMIT 1`;
+
 export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
     Effect.gen(function* () {
-            const db = yield* SurrealClient;
+        const read = yield* CacheRead;
 
-            const rows = (sql: string) =>
-                db.query<[Array<Record<string, unknown>>]>(sql).pipe(
-                    Effect.map((r) => r?.[0] ?? []),
-                    Effect.orDie, // a read-only timeline query failing is a defect, not a domain error
-                );
-            const oneRow = (sql: string) =>
-                rows(sql).pipe(Effect.map((rs) => rs[0] ?? null));
+        const extract = Effect.fn("SessionTimelineService.extract")(function* (sessionId: string) {
+            const sid = toBareSessionId(sessionId);
+            const [
+                healthRaw, overviewRaw, costRaw, toolRaw, editRaw, editStatRaw,
+                skillRaw, correctionRaw, intentCorrectionRaw, planRaw, commitRaw, askRaw, compactionRaw, lastRaw,
+            ] = yield* Effect.all(
+                [
+                    read.first(HealthDbRow, HEALTH_SQL, [sid]),
+                    read.first(OverviewDbRow, OVERVIEW_SQL, [sid]),
+                    read.first(CostDbRow, COST_SQL, [sid]),
+                    read.rows(ToolCallDbRow, TOOL_CALLS_SQL, [sid]),
+                    read.rows(EditDbRow, EDITS_SQL, [sid]),
+                    read.rows(EditStatDbRow, EDIT_STATS_SQL, [sid]),
+                    read.rows(SkillDbRow, SKILLS_SQL, [sid]),
+                    read.rows(CorrectionDbRow, CORRECTIONS_SQL, [sid]),
+                    read.rows(IntentCorrectionDbRow, INTENT_CORRECTIONS_SQL, [sid]),
+                    read.rows(PlanDbRow, PLANS_SQL, [sid]),
+                    read.rows(CommitDbRow, COMMITS_SQL, [sid]),
+                    read.rows(AskDbRow, ASKS_SQL, [sid]),
+                    read.rows(CompactionDbRow, COMPACTIONS_SQL, [sid]),
+                    read.first(LastTurnDbRow, LAST_ASSISTANT_SQL, [sid]),
+                ],
+                { concurrency: "unbounded" },
+                // A read-only timeline query failing is a defect, not a domain
+                // error - mirrors the pre-port `Effect.orDie` on every `rows`/`oneRow`.
+            ).pipe(Effect.orDie);
 
-            const extract = Effect.fn("SessionTimelineService.extract")(function* (sessionId: string) {
-                const ref = sessionRef(sessionId);
-                const [
-                    healthRaw, overviewRaw, costRaw, toolRaw, editRaw, editStatRaw,
-                    skillRaw, correctionRaw, intentCorrectionRaw, planRaw, commitRaw, askRaw, compactionRaw, lastRaw,
-                ] = yield* Effect.all([
-                    oneRow(healthSql(ref)),
-                    oneRow(overviewSql(ref)),
-                    oneRow(costSql(ref)),
-                    rows(toolCallsSql(ref)),
-                    rows(editsSql(ref)),
-                    rows(editStatsSql(ref)),
-                    rows(skillsSql(ref)),
-                    rows(correctionsSql(ref)),
-                    rows(intentCorrectionsSql(ref)),
-                    rows(plansSql(ref)),
-                    rows(commitsSql(ref)),
-                    rows(asksSql(ref)),
-                    rows(compactionsSql(ref)),
-                    oneRow(lastAssistantSql(ref)),
-                ], { concurrency: "unbounded" });
+            const health: HealthRow | null = healthRaw._tag === "None" ? null : { ...healthRaw.value };
+            const overview: OverviewRow | null =
+                overviewRaw._tag === "None"
+                    ? null
+                    : {
+                          source: overviewRaw.value.source,
+                          model: overviewRaw.value.model,
+                          project: overviewRaw.value.project,
+                          cwd: overviewRaw.value.cwd,
+                          started_at: isoOrNull(overviewRaw.value.started_at),
+                          ended_at: isoOrNull(overviewRaw.value.ended_at),
+                      };
+            const cost: CostRow | null =
+                costRaw._tag === "None"
+                    ? null
+                    : { cost_usd: costRaw.value.estimated_cost_usd, estimated_tokens: costRaw.value.estimated_tokens };
+            const toolCalls: ToolCallRow[] = toolRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const edits: EditRow[] = editRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const editStats: EditStatRow[] = editStatRaw.map((r) => ({ ...r }));
+            const skills: SkillRow[] = skillRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const plans: PlanRow[] = planRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const commits: CommitRow[] = commitRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const asks: AskRow[] = askRaw.map((r) => ({ ...r, ts: isoOrNull(r.ts) }));
+            const compactions: CompactionRow[] = compactionRaw.map((r) => ({ ts: r.ts.toISOString() }));
+            const lastAssistant: LastTurnRow | null =
+                lastRaw._tag === "None" ? null : { ...lastRaw.value, ts: isoOrNull(lastRaw.value.ts) };
 
-                const overview = mapOverview(overviewRaw);
-                // Merge both correction sources, dedupe by seq (reaction_event wins - it has a target).
-                const correctionBySeq = new Map<number, ReturnType<typeof mapCorrection>>();
-                for (const c of intentCorrectionRaw.map(mapIntentCorrection).filter(present)) {
-                    if (c.seq != null) correctionBySeq.set(c.seq, c);
-                }
-                for (const c of correctionRaw.map(mapCorrection).filter(present)) {
-                    if (c.seq != null) correctionBySeq.set(c.seq, c);
-                }
-                const corrections = [...correctionBySeq.values()].filter(present).sort((a, b) => (a!.seq ?? 0) - (b!.seq ?? 0));
+            // Merge both correction sources, dedupe by seq (reaction_event wins - it has a target).
+            const correctionBySeq = new Map<number, CorrectionRow>();
+            for (const r of intentCorrectionRaw) {
+                if (r.seq != null) correctionBySeq.set(r.seq, { seq: r.seq, ts: isoOrNull(r.ts), target: null, user_text: r.user_text });
+            }
+            for (const r of correctionRaw) {
+                if (r.seq != null) correctionBySeq.set(r.seq, { ...r, ts: isoOrNull(r.ts) });
+            }
+            const corrections = [...correctionBySeq.values()].filter(present).sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
 
-                return buildTimeline({
-                    sessionId,
-                    source: overview?.source ?? "claude",
-                    health: mapHealth(healthRaw),
-                    overview,
-                    cost: mapCost(costRaw),
-                    toolCalls: toolRaw.map(mapToolCall).filter(present),
-                    edits: editRaw.map(mapEdit).filter(present),
-                    editStats: editStatRaw.map(mapEditStat).filter(present),
-                    skills: skillRaw.map(mapSkill).filter(present),
-                    corrections,
-                    plans: planRaw.map(mapPlan).filter(present),
-                    commits: commitRaw.map(mapCommit).filter(present),
-                    asks: askRaw.map(mapAsk).filter(present),
-                    compactions: compactionRaw.map(mapCompaction).filter(present),
-                    lastAssistant: mapLastTurn(lastRaw),
-                });
+            return buildTimeline({
+                sessionId,
+                source: overview?.source ?? "claude",
+                health,
+                overview,
+                cost,
+                toolCalls: toolCalls.filter(present),
+                edits: edits.filter(present),
+                editStats: editStats.filter(present),
+                skills: skills.filter(present),
+                corrections,
+                plans: plans.filter(present),
+                commits: commits.filter(present),
+                asks: asks.filter(present),
+                compactions: compactions.filter(present),
+                lastAssistant,
             });
+        });
 
-            return { extract } satisfies SessionTimelineShape;
-        }),
+        return { extract } satisfies SessionTimelineShape;
+    }),
 );
 
 /** Convenience: extract a timeline using the ambient SessionTimelineService. */
@@ -125,3 +286,5 @@ export const extractSessionTimeline = (
     sessionId: string,
 ): Effect.Effect<SessionTimeline, never, SessionTimelineService> =>
     Effect.flatMap(SessionTimelineService, (svc) => svc.extract(sessionId));
+
+export type { CacheReadService };

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "check:no-node-fs": "bun scripts/check-no-node-fs.ts",
     "check:record-select": "bun scripts/check-record-select.ts",
     "check:timestamp-cast": "bun scripts/check-timestamp-cast.ts",
+    "check:no-applayer-provide": "bun scripts/check-no-applayer-provide.ts",
     "check:harness-docs": "bun scripts/check-harness-docs-drift.ts",
     "check:table-coverage": "bun scripts/check-table-coverage.ts",
     "dashboard:dev": "vite --config apps/axctl/src/dashboard/web/vite.config.ts",

--- a/scripts/check-no-applayer-provide.ts
+++ b/scripts/check-no-applayer-provide.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+/**
+ * Guard: ban `Effect.provide(...)` calls that self-provision a LIVE
+ * SurrealDB-carrying layer (`AppLayer` / `LegacySurrealAppLayer`) outside the
+ * two places that are allowed to build one.
+ *
+ * WHY THIS EXISTS. `ax share` is declared runtime `"none"` in the command
+ * manifest - it must never touch the database - yet `cli/share.ts` used to
+ * call `Effect.provide(LegacySurrealAppLayer)` INLINE inside
+ * `liveShareDeps.exportArtifact`, self-providing a real `SurrealClient`
+ * regardless of what the dispatcher handed it. That made the manifest's
+ * runtime label untrustworthy evidence of porting status: a command could
+ * read "none" and still open a live SurrealDB connection. The fix removes the
+ * inline provide and takes the dependency from the dispatcher instead; this
+ * guard is what keeps the pattern from coming back, here or anywhere else.
+ *
+ * ALLOWED SITES. Exactly two source files may build one of these layers:
+ *
+ *   - `apps/axctl/src/cli/index.ts` - the dispatcher itself. `withDb` is the
+ *     ONE place a command's runtime is chosen and a live SurrealClient may be
+ *     constructed on the way in.
+ *   - `apps/axctl/src/ingest/stage/runtime.ts` - `IngestRuntimeLayer`, the
+ *     ingest pipeline's own runtime construction.
+ *
+ * Everything else - CLI command modules, query modules, dojo/profile/share/
+ * team/self-improve modules - must take its dependencies from the caller
+ * (the `R` channel), never build its own live-DB layer.
+ *
+ * `*.test.ts` / `*.e2e.test.ts` files are OUT of scope: several pre-existing
+ * integration tests deliberately provide `LegacySurrealAppLayer` to exercise
+ * real (pre-v2, still-reachable) SurrealDB behavior directly, which is a
+ * legitimate and different use from a production read path silently
+ * bypassing its declared runtime.
+ */
+
+import { Glob } from "bun";
+
+const SCAN_GLOBS = [
+    "apps/*/src/**/*.ts",
+    "apps/*/src/**/*.tsx",
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.tsx",
+];
+
+/** Files allowed to build a live-SurrealDB-carrying layer. Each needs a reason
+ *  (see the module doc above). */
+const ALLOWED_FILES: readonly string[] = [
+    "apps/axctl/src/cli/index.ts",
+    "apps/axctl/src/ingest/stage/runtime.ts",
+];
+
+const COMMENT_LINE_RE = /^\s*(?:\/\/|\*|\/\*)/;
+const PROVIDE_CALL_RE = /Effect\.provide\s*\(/;
+/** Plain substring, NOT a `\b`-bounded match: `LegacySurrealAppLayer` has no
+ *  word boundary before its `AppLayer` suffix (`l` and `A` are both word
+ *  characters), and that name IS the live layer this guard exists to catch. */
+const APP_LAYER_RE = /AppLayer/;
+
+/** How many lines after an `Effect.provide(` call to scan for its argument,
+ *  for the common case where the layer expression wraps onto its own line
+ *  (e.g. `Effect.provide(\n    Layer.mergeAll(LegacySurrealAppLayer, ...),\n)`). */
+const LOOKAHEAD_LINES = 5;
+
+interface Offender {
+    readonly file: string;
+    readonly line: number;
+    readonly text: string;
+}
+
+/** True when the `Effect.provide(` call starting at `lines[index]` carries an
+ *  AppLayer-family argument, scanning forward across a wrapped call. Exported
+ *  for tests. */
+export function provideCallCarriesAppLayer(lines: ReadonlyArray<string>, index: number): boolean {
+    const window = lines.slice(index, index + 1 + LOOKAHEAD_LINES).join("\n");
+    return APP_LAYER_RE.test(window);
+}
+
+async function main(): Promise<void> {
+    const allowed = new Set(ALLOWED_FILES);
+    const seen = new Set<string>();
+    const files: string[] = [];
+    for (const pattern of SCAN_GLOBS) {
+        const glob = new Glob(pattern);
+        for await (const file of glob.scan({ cwd: process.cwd(), onlyFiles: true })) {
+            if (seen.has(file)) continue;
+            seen.add(file);
+            if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue;
+            if (allowed.has(file)) continue;
+            files.push(file);
+        }
+    }
+
+    const offenders: Offender[] = [];
+    for (const file of files.sort()) {
+        const lines = (await Bun.file(file).text()).split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i]!;
+            if (COMMENT_LINE_RE.test(line)) continue;
+            if (!PROVIDE_CALL_RE.test(line)) continue;
+            if (provideCallCarriesAppLayer(lines, i)) {
+                offenders.push({ file, line: i + 1, text: line.trim() });
+            }
+        }
+    }
+
+    if (offenders.length > 0) {
+        console.error(
+            "Effect.provide(...) self-provisioning a live-SurrealDB layer (AppLayer / LegacySurrealAppLayer) " +
+                "found outside the allowed sites:",
+        );
+        for (const o of offenders) console.error(`${o.file}:${o.line}: ${o.text}`);
+        console.error(
+            `\n${offenders.length} offender(s). Only ${ALLOWED_FILES.join(" and ")} may build a live-SurrealDB ` +
+                "layer this way. Every other module must take its dependencies from the caller's R channel " +
+                "instead of self-providing one - see cli/index.ts's `withDb` for the one legitimate construction " +
+                "site, and scripts/check-no-applayer-provide.ts's module doc for the `ax share` incident this " +
+                "guard was written to catch.",
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `check-no-applayer-provide: clean (${files.length} files scanned, 0 self-provisioned AppLayer sites).`,
+    );
+}
+
+if (import.meta.main) {
+    await main();
+}


### PR DESCRIPTION
Wave 3, chunk `c-read-cli`: the `cli/` read layer moves onto the DuckDB `CacheRead` seam.

## What moved

| File | Was |
|---|---|
| `cli/skills-classify.ts` | default mode on `CacheRead`, **explicit mode built its own SurrealQL** - same command, two backends chosen by the shape of argv |
| `cli/commands/ax-directives.ts` | `workflows` ported, `mine`/`ngrams` not |
| `cli/commands/retro.ts` | `emit` happy path/`list`/`reflect`/`plan` ported; `emit` fallback/`pending`/`brief` not |
| `cli/commands/skills.ts` | `by-role`/`roles`/`tag`/`lint` ported; `search`/`recent`/`taste`/`pairs`/`recovery` not |
| `cli/retro-meta.ts` | fully unported |

Plus, from the earlier half of this chunk: `share/exporter.ts`, `timeline/service.ts`, all of `team/**`, the extracted `share/session-share-queries.ts`, and `cli/project.ts` + `dojo/agenda.ts` vestigial imports.

## `ax share` no longer self-provisions a live SurrealClient

`ax share` is declared runtime `"none"` - it must never touch the DB - yet `liveShareDeps.exportArtifact` called `Effect.provide(AppLayer)` **inline**, self-providing a real client regardless of what the dispatcher handed it. So `ax share` depended on a live SurrealDB while its manifest entry said otherwise.

That is why the `RUNTIME_BY_COMMAND` manifest is not trustworthy evidence of porting status, and why the runtime flip was deferred out of this chunk.

New guard `scripts/check-no-applayer-provide.ts` bans `Effect.provide(AppLayer)` outside `cli/index.ts` and `ingest/stage/runtime.ts`. 793 files scanned, clean.

## Four files needed no change - and the reasons differ

Reported rather than silently skipped, because "no diff" and "already correct" are not the same claim:

- **`commands/sessions.ts`** - an edit was made to drop `SurrealClient`, then **reverted** after checking: `DbError` genuinely still escapes `ingestTranscripts`'s inferred error channel, whose git-ingest legs remain on SurrealDB. `here`/`around`/`near` delegate to unported `dashboard/` files owned by another chunk.
- **`commands/report.ts`** - `cmdInsights` generates its SQL from `queries/insights.ts`. Porting it means porting that builder, not this file.
- **`commands/manifest.ts`** - doc-comment mentions only, no import.
- **`pwd.ts`** - `resolvePwdRepository` cannot be retired: four out-of-scope callers still need the Surreal-keyed `RecordId`.

## Two corrections to the task brief

1. **`classifiers-package-operations.ts` is not vestigial.** Its `SurrealClient` import is live: the chain reaches `applyExecutionSurrealWritePlan`, which writes `classifier_graph_*` rows as an active feature.
2. **`classifiers-workflow-candidates.ts` is not ~25 read sites.** It is one ~1200-line dispatcher threading a single `db` binding through every branch, for reads *and* writes. Porting only the reads leaves every branch still requiring `SurrealClient` - zero net gain for real regression risk. It belongs to whichever chunk owns the write seam, not a read chunk.

## Verification

`recall-no-surreal.test.ts`-shaped tests for the `retro` and `skills` families - spawning the real CLI against a dead `AX_DB_URL` port, exercising **every** subcommand in the family, not just the headline one. An in-process test cannot prove this: it is handed the layers either way.

Gates on the finished tree: `typecheck` clean, `tsc -p` 0 errors, `check:no-node-fs` clean (687 files), `check:timestamp-cast` clean (1492 files), `check:no-applayer-provide` clean (793 files).

Base is `v2/duckdb`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
