### PR TITLE
feat(v2): c-read-context - the file-context hook stops opening a SurrealDB socket on every fire

### DIFF
--- a/apps/axctl/src/classifiers/label-mining-service.test.ts
+++ b/apps/axctl/src/classifiers/label-mining-service.test.ts
@@ -4,8 +4,9 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { makeTestSurrealClient, type TestSurrealClient } from "@ax/lib/testing/surreal";
+import { SurrealClient } from "@ax/lib/db";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { EmptyJudgmentTestLayer } from "../testing/judgment-test-layer.ts";
 import type { Judgment } from "@ax/lib/sqlite";
 import {
@@ -13,6 +14,17 @@ import {
     LabelMiningService,
     LabelMiningServiceLive,
 } from "./label-mining-service.ts";
+
+/**
+ * `SurrealClient` is still resolved once at `LabelMiningServiceLive` layer
+ * construction (see the module doc comment on the layer - it backs ONLY the
+ * `projectReviewed --apply` write path). None of the cases below exercise
+ * that path, so a client that dies if ever queried is enough to prove it: a
+ * passing suite is evidence the read paths never touch it.
+ */
+const deadSurrealClient = SurrealClient.of({
+    query: () => Effect.die("label-mining-service.test.ts: SurrealClient must not be queried by a read path"),
+} as never);
 
 /**
  * Persisted-turn fake rows. The service reads transcript windows from the

--- a/apps/axctl/src/classifiers/label-mining-service.test.ts
+++ b/apps/axctl/src/classifiers/label-mining-service.test.ts
@@ -47,21 +47,28 @@ interface FakeWindowRow {
     readonly prev_evidence_path?: string | null;
 }
 
-function clientWithWindows(rows: readonly FakeWindowRow[]): TestSurrealClient {
-    return makeTestSurrealClient({ fallback: [rows] });
+/**
+ * All window fixtures below carry `prev_turn_id`/`prev_text` inline, which is
+ * exactly the case `miningReport` treats as "already has a previous turn" (see
+ * the merge loop's comment in label-mining-service.ts) - so the service never
+ * fires the second (prev-turn batch) query, and one canned response is enough.
+ */
+function windowsCacheRead(rows: readonly FakeWindowRow[]) {
+    return makeTestCacheRead({ fallback: rows });
 }
 
 const runWithDb = <A>(
     effect: Effect.Effect<
         A,
         unknown,
-        LabelMiningService | SurrealClient | Judgment | FileSystem.FileSystem | Path.Path
+        LabelMiningService | SurrealClient | CacheRead | Judgment | FileSystem.FileSystem | Path.Path
     >,
-    client: SurrealClientShape,
+    cacheReadLayer: Layer.Layer<CacheRead>,
 ): Promise<A> =>
     Effect.runPromise(effect.pipe(Effect.provide(LabelMiningServiceLive.pipe(
         Layer.provideMerge(Layer.mergeAll(
-            Layer.succeed(SurrealClient, client),
+            Layer.succeed(SurrealClient, deadSurrealClient),
+            cacheReadLayer,
             EmptyJudgmentTestLayer,
             BunFileSystem.layer,
             BunPath.layer,
@@ -124,13 +131,13 @@ const approvalWindow = (n: number): FakeWindowRow => ({
 
 describe("LabelMiningService.miningReport", () => {
     test("reads transcript windows from persisted turns", async () => {
-        const tc = clientWithWindows([correctionWindow(1)]);
+        const tc = windowsCacheRead([correctionWindow(1)]);
         await runWithDb(
             Effect.gen(function* () {
                 const svc = yield* LabelMiningService;
                 return yield* svc.miningReport({ sinceDays: 14, limit: 500, reviewLimit: 80 });
             }),
-            tc.client,
+            tc.layer,
         );
 
         expect(tc.captured.at(-1)).toContain("FROM turn");
@@ -151,7 +158,7 @@ describe("LabelMiningService.miningReport", () => {
                 const svc = yield* LabelMiningService;
                 return yield* svc.miningReport({ sinceDays: 14, limit: 500, reviewLimit: 80 });
             }),
-            clientWithWindows(rows).client,
+            windowsCacheRead(rows).layer,
         );
 
         expect(report.schema).toBe("ax.transcript_label_mining_report.v1");
@@ -179,7 +186,7 @@ describe("LabelMiningService.miningReport", () => {
                 const svc = yield* LabelMiningService;
                 return yield* svc.miningReport({ sinceDays: 14, limit: 500, reviewLimit: 500 });
             }),
-            clientWithWindows(rows).client,
+            windowsCacheRead(rows).layer,
         );
 
         expect(EXPORT_REVIEW_LIMIT).toBe(80);
@@ -193,7 +200,7 @@ describe("LabelMiningService.miningReport", () => {
                 const svc = yield* LabelMiningService;
                 return yield* svc.miningReport({ sinceDays: 14, limit: 500, reviewLimit: 80 });
             }),
-            clientWithWindows([correctionWindow(1), directionWindow(2)]).client,
+            windowsCacheRead([correctionWindow(1), directionWindow(2)]).layer,
         );
 
         expect(report.review_rows.length).toBeGreaterThan(0);
@@ -218,7 +225,7 @@ describe("LabelMiningService.miningReport", () => {
                 const svc = yield* LabelMiningService;
                 return yield* svc.miningReport({ sinceDays: 14, limit: 10, reviewLimit: 80 });
             }),
-            clientWithWindows(rows).client,
+            windowsCacheRead(rows).layer,
         );
 
         expect(report.candidate_count).toBe(10);
@@ -234,7 +241,7 @@ describe("LabelMiningService.writeMiningReport", () => {
                 const svc = yield* LabelMiningService;
                 return yield* svc.writeMiningReport({ sinceDays: 14, limit: 500, reviewLimit: 80, out });
             }),
-            clientWithWindows([correctionWindow(1), directionWindow(2), verificationWindow(3)]).client,
+            windowsCacheRead([correctionWindow(1), directionWindow(2), verificationWindow(3)]).layer,
         );
 
         const saved = JSON.parse(readFileSync(out, "utf8"));

--- a/apps/axctl/src/classifiers/label-mining-service.ts
+++ b/apps/axctl/src/classifiers/label-mining-service.ts
@@ -9,6 +9,10 @@ import {
     TimestampColumn,
     type JudgmentError,
 } from "@ax/lib/sqlite";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
+import type { DuckDbParam } from "@ax/lib/duckdb/types";
 import { stableId } from "@ax/lib/stable-id";
 import { prettyPrint } from "@ax/lib/json";
 import {
@@ -48,7 +52,7 @@ export class LabelMiningReportWriteError extends Schema.TaggedErrorClass<LabelMi
     message: Schema.String,
 }) {}
 
-export type LabelMiningError = DbError | JudgmentError | LabelMiningReportWriteError;
+export type LabelMiningError = DbError | CacheReadError | JudgmentError | LabelMiningReportWriteError;
 
 export interface LabelMiningReportInput {
     /** Lookback window in days for transcript turns. */
@@ -296,9 +300,9 @@ interface TranscriptWindowRow {
     readonly user_intent_kind?: string | null;
     readonly user_text?: string | null;
     readonly user_evidence_path?: string | null;
-    readonly prev_turn_id?: string | null;
-    readonly prev_text?: string | null;
-    readonly prev_evidence_path?: string | null;
+    readonly prev_turn_id?: string | null | undefined;
+    readonly prev_text?: string | null | undefined;
+    readonly prev_evidence_path?: string | null | undefined;
 }
 
 const str = (value: unknown): string => (typeof value === "string" ? value : String(value ?? ""));
@@ -326,28 +330,41 @@ const EXCLUDED_INTENT_KINDS = [
  * `session` + `seq - 1` so correction/direction candidates carry the assistant
  * action they reacted to.
  */
-const transcriptWindowSql = (sinceDays: number, limit: number): string => `
+interface DuckDbQuery {
+    readonly sql: string;
+    readonly params: ReadonlyArray<DuckDbParam>;
+}
+
+const transcriptWindowQuery = (sinceDays: number, limit: number): DuckDbQuery => {
+    const sinceClause = withinDaysClause("t.ts", Math.max(0, Math.trunc(sinceDays)));
+    const excludedPlaceholders = EXCLUDED_INTENT_KINDS.map(() => "?").join(", ");
+    const sql = `
 SELECT
-    type::string(id) AS window_key,
-    type::string(id) AS subject_id,
-    type::string(session) AS session_id,
-    type::string(id) AS user_turn_id,
-    ts,
-    seq AS user_seq,
-    role AS user_role,
-    message_kind AS user_message_kind,
-    intent_kind AS user_intent_kind,
-    text AS user_text,
-    type::string(id) AS user_evidence_path
-FROM turn
-WHERE role = 'user'
-    AND message_kind = 'task'
-    AND session.source != 'claude-subagent'
-    AND (intent_kind IS NONE OR intent_kind NOT IN ${JSON.stringify([...EXCLUDED_INTENT_KINDS])})
-    AND text IS NOT NONE
-    AND ts >= time::now() - ${Math.max(0, Math.trunc(sinceDays))}d
-ORDER BY ts DESC
-LIMIT ${Math.max(1, Math.trunc(limit))};`.trim();
+    t.id AS window_key,
+    t.id AS subject_id,
+    t.session AS session_id,
+    t.id AS user_turn_id,
+    t.seq AS user_seq,
+    t.role AS user_role,
+    t.message_kind AS user_message_kind,
+    t.intent_kind AS user_intent_kind,
+    t.text AS user_text,
+    t.id AS user_evidence_path
+FROM turn t
+JOIN session s ON s.id = t.session
+WHERE t.role = 'user'
+    AND t.message_kind = 'task'
+    AND s.source <> 'claude-subagent'
+    AND (t.intent_kind IS NULL OR t.intent_kind NOT IN (${excludedPlaceholders}))
+    AND t.text IS NOT NULL
+    ${sinceClause.sql}
+ORDER BY t.ts DESC
+LIMIT ?`.trim();
+    return {
+        sql,
+        params: [...EXCLUDED_INTENT_KINDS, ...sinceClause.params, Math.max(1, Math.trunc(limit))],
+    };
+};
 
 /**
  * Batch-fetch the immediately-preceding turn for each user-turn window, keyed by
@@ -355,22 +372,73 @@ LIMIT ${Math.max(1, Math.trunc(limit))};`.trim();
  * keeps the previous-assistant join fast on large `turn` tables. The unique
  * index `turn_session_seq` answers each `(session, seq)` membership cheaply.
  */
-const prevTurnSql = (sessionIds: readonly string[], prevSeqs: readonly number[]): string => `
+const prevTurnQuery = (sessionIds: readonly string[], prevSeqs: readonly number[]): DuckDbQuery => {
+    const uniqueSessions = [...new Set(sessionIds)];
+    const uniqueSeqs = [...new Set(prevSeqs)];
+    const sql = `
 SELECT
-    type::string(id) AS prev_turn_id,
-    type::string(session) AS prev_session_id,
+    id AS prev_turn_id,
+    session AS prev_session_id,
     seq AS prev_seq,
     text AS prev_text
 FROM turn
-WHERE type::string(session) IN ${JSON.stringify([...new Set(sessionIds)])}
-    AND seq IN ${JSON.stringify([...new Set(prevSeqs)])};`.trim();
+WHERE session IN (${uniqueSessions.map(() => "?").join(", ")})
+    AND seq IN (${uniqueSeqs.map(() => "?").join(", ")})`.trim();
+    return { sql, params: [...uniqueSessions, ...uniqueSeqs] };
+};
 
-interface PrevTurnRow {
-    readonly prev_turn_id?: string | null;
-    readonly prev_session_id?: string | null;
-    readonly prev_seq?: number | null;
-    readonly prev_text?: string | null;
-}
+/**
+ * DuckDB decode contract for {@link transcriptWindowQuery}'s result rows. The
+ * `prev_*` fields are `optional` because the real read query never selects
+ * them - only test fixtures supply a previous turn inline (see the merge loop
+ * in `miningReport` below).
+ */
+const CacheTranscriptWindowRow = Schema.Struct({
+    window_key: Schema.NullOr(Schema.String),
+    subject_id: Schema.NullOr(Schema.String),
+    session_id: Schema.NullOr(Schema.String),
+    user_turn_id: Schema.NullOr(Schema.String),
+    user_seq: Schema.NullOr(NumberFromBigIntColumn),
+    user_role: Schema.NullOr(Schema.String),
+    user_message_kind: Schema.NullOr(Schema.String),
+    user_intent_kind: Schema.NullOr(Schema.String),
+    user_text: Schema.NullOr(Schema.String),
+    user_evidence_path: Schema.NullOr(Schema.String),
+    prev_turn_id: Schema.optional(Schema.NullOr(Schema.String)),
+    prev_text: Schema.optional(Schema.NullOr(Schema.String)),
+    prev_evidence_path: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+/** DuckDB decode contract for {@link prevTurnQuery}'s result rows. */
+const CachePrevTurnRow = Schema.Struct({
+    prev_turn_id: Schema.NullOr(Schema.String),
+    prev_session_id: Schema.NullOr(Schema.String),
+    prev_seq: Schema.NullOr(NumberFromBigIntColumn),
+    prev_text: Schema.NullOr(Schema.String),
+});
+
+/** DuckDB decode contract for the reviewed `classifier_graph_fact` read. */
+const CacheGraphFactRow = Schema.Struct({
+    graph_id: Schema.String,
+    kind: Schema.String,
+    subject: Schema.String,
+    predicate: Schema.String,
+    object: Schema.NullOr(Schema.String),
+    value_json: Schema.NullOr(Schema.String),
+    properties_json: Schema.String,
+    source_kind: Schema.String,
+});
+
+/** DuckDB decode contract for the `transcript_label_vector` read. */
+const CacheVectorRow = Schema.Struct({
+    id: Schema.String,
+    candidate_id: Schema.String,
+    embedding_model: Schema.NullOr(Schema.String),
+    embedding_dim: Schema.NullOr(NumberFromBigIntColumn),
+    embedding_ref: Schema.NullOr(Schema.String),
+    nearest_reviewed_candidate_ids_json: Schema.NullOr(Schema.String),
+    nearest_scores_json: Schema.NullOr(Schema.String),
+});
 
 const rowToWindow = (row: TranscriptWindowRow): EventWindowLike | null => {
     const userTurnId = str(row.user_turn_id ?? row.subject_id);
@@ -500,7 +568,7 @@ FROM transcript_label_review;`.trim();
 /** Read all reviewed-source classifier graph facts. */
 const reviewedFactSql = `
 SELECT
-    type::string(graph_id) AS graph_id,
+    graph_id,
     kind,
     subject,
     predicate,
@@ -509,19 +577,19 @@ SELECT
     properties_json,
     source_kind
 FROM classifier_graph_fact
-WHERE source_kind = '${REVIEWED_SOURCE_KIND}';`.trim();
+WHERE source_kind = ?`.trim();
 
 /** Read persisted vector rows for re-projection. */
 const vectorProjectionSql = `
 SELECT
-    record::id(id) AS id,
+    id,
     candidate_id,
     embedding_model,
     embedding_dim,
     embedding_ref,
     nearest_reviewed_candidate_ids_json,
     nearest_scores_json
-FROM transcript_label_vector;`.trim();
+FROM transcript_label_vector`.trim();
 
 interface VectorTableRow {
     readonly id: string;
@@ -607,20 +675,31 @@ const writeReport = (
         );
     });
 
-export const LabelMiningServiceLive: Layer.Layer<LabelMiningService, never, SurrealClient | Judgment> =
+/**
+ * `db` (SurrealClient) is retained ONLY for `projectReviewed`'s apply-write
+ * path: the UPSERT statements it plays back are built by
+ * `projectReviewedLabelsToGraph` in `./label-mining.ts` (owned by a different
+ * wave-3 chunk), which emits SurrealQL-specific syntax (`UPSERT table:id SET
+ * ...`). Porting that write to DuckDB would mean rewriting that builder, which
+ * is out of this chunk's file ownership - and even ported, a CLI-invoked apply
+ * cannot obtain a `CacheWriteService` at all (writes are ingest-lock-gated;
+ * `label-mining --project-reviewed --apply` never runs under ingest). See the
+ * chunk report for the full argument; every READ in this file is on `CacheRead`.
+ */
+export const LabelMiningServiceLive: Layer.Layer<LabelMiningService, never, SurrealClient | CacheRead | Judgment> =
     Layer.effect(
         LabelMiningService,
         Effect.gen(function* () {
             const db = yield* SurrealClient;
+            const read = yield* CacheRead;
             const judgment = yield* Judgment;
 
             const miningReport = Effect.fn("LabelMiningService.miningReport")(function* (
                 input: LabelMiningReportInput,
             ) {
                 const reviewLimit = Math.min(input.reviewLimit, EXPORT_REVIEW_LIMIT);
-                const sql = transcriptWindowSql(input.sinceDays, input.limit);
-                const [rows] = yield* db.query<[TranscriptWindowRow[]]>(sql);
-                const windowRows = rows ?? [];
+                const windowQuery = transcriptWindowQuery(input.sinceDays, input.limit);
+                const windowRows = yield* read.rows(CacheTranscriptWindowRow, windowQuery.sql, windowQuery.params);
 
                 // Batch-fetch previous turns in ONE statement (correlated subquery
                 // per row is O(rows * full-scan) on a large `turn` table).
@@ -641,10 +720,9 @@ export const LabelMiningServiceLive: Layer.Layer<LabelMiningService, never, Surr
                     }
                 }
                 if (sessionIds.length > 0) {
-                    const [prevRows] = yield* db.query<[PrevTurnRow[]]>(
-                        prevTurnSql(sessionIds, prevSeqs),
-                    );
-                    for (const prev of prevRows ?? []) {
+                    const prevQuery = prevTurnQuery(sessionIds, prevSeqs);
+                    const prevRows = yield* read.rows(CachePrevTurnRow, prevQuery.sql, prevQuery.params);
+                    for (const prev of prevRows) {
                         if (
                             prev.prev_session_id != null &&
                             typeof prev.prev_seq === "number" &&
@@ -709,10 +787,10 @@ export const LabelMiningServiceLive: Layer.Layer<LabelMiningService, never, Surr
                 input: LabelMiningSelfImproveInput,
             ) {
                 const reviewRows = yield* judgment.rows(ReviewTableRowSchema, reviewTableSql);
-                const [factRows] = yield* db.query<[LabelMiningGraphFactRow[]]>(reviewedFactSql);
+                const factRows = yield* read.rows(CacheGraphFactRow, reviewedFactSql, [REVIEWED_SOURCE_KIND]);
                 const result = buildSelfImproveQuery({
                     review_rows: [...reviewRows],
-                    fact_rows: factRows ?? [],
+                    fact_rows: [...factRows],
                 });
                 if (input.out === undefined) return result;
                 const withPath: LabelMiningSelfImproveResult = { ...result, out_path: input.out };
@@ -724,13 +802,15 @@ export const LabelMiningServiceLive: Layer.Layer<LabelMiningService, never, Surr
                 input: LabelMiningProjectInput,
             ) {
                 const reviewRows = yield* judgment.rows(ReviewTableRowSchema, reviewTableSql);
-                const [vectorRows] = yield* db.query<[VectorTableRow[]]>(vectorProjectionSql);
+                const vectorRows = yield* read.rows(CacheVectorRow, vectorProjectionSql);
                 const reviews = reviewRows.map(reviewRowToReviewedLabel);
                 const candidates = reviewRows.map(reviewRowToCandidate);
-                const vectors = (vectorRows ?? []).map(vectorRowToVector);
+                const vectors = vectorRows.map(vectorRowToVector);
                 const projection = projectReviewedLabelsToGraph({ candidates, reviews, vectors });
 
                 if (input.apply) {
+                    // `db` (SurrealClient) is intentionally still used here - see the
+                    // module doc comment on LabelMiningServiceLive.
                     for (const statement of projection.statements.filter((sql) => !sql.startsWith("UPSERT transcript_label_review:"))) {
                         yield* db.query(statement);
                     }

--- a/apps/axctl/src/classifiers/package-service.test.ts
+++ b/apps/axctl/src/classifiers/package-service.test.ts
@@ -1031,58 +1031,61 @@ describe("ClassifierPackageService", () => {
             skipped_proposal_count: 1,
             failures: [],
         })}\n`);
-        const tc = makeTestSurrealClient({
-            fallback: [
-                [
-                    {
-                        graph_id: "classifier_operation:session-section-chunks/blind-review-refresh",
-                        kind: "classifier_operation",
-                        label: "blind-review-refresh",
-                        properties_json: JSON.stringify({ package_key: "session-section-chunks", operation_kind: "review", expensive: false }),
-                    },
-                    {
-                        graph_id: "classifier_lifecycle:workflow_candidate_review_pipeline",
-                        kind: "classifier_lifecycle",
-                        label: "workflow candidate review pipeline lifecycle",
-                        properties_json: "{}",
-                    },
-                ],
-                [
-                    {
-                        graph_id: "edge:run",
-                        kind: "ran_operation",
-                        from_id: "classifier_execution:.ax/experiments/run.json",
-                        to_id: "classifier_operation:session-section-chunks/blind-review-refresh",
-                        evidence_path: ".ax/experiments/run.json",
-                        properties_json: "{}",
-                    },
-                    {
-                        graph_id: "edge:lifecycle",
-                        kind: "has_evidence",
-                        from_id: "classifier_lifecycle:workflow_candidate_review_pipeline",
-                        to_id: "artifact:.ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
-                        evidence_path: ".ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
-                        properties_json: JSON.stringify({ lifecycle_key: "review_pipeline_lifecycle" }),
-                    },
-                ],
-                [
-                    {
-                        graph_id: "fact:phase",
-                        kind: "classifier_lifecycle_status",
-                        subject: "classifier_lifecycle:workflow_candidate_review_pipeline",
-                        predicate: "review_pipeline_recommended_action_execution_phase",
-                        value_json: "\"bind_inputs\"",
-                        evidence_edges_json: JSON.stringify(["edge:lifecycle"]),
-                        properties_json: JSON.stringify({
-                            lifecycle_key: "review_pipeline_lifecycle",
-                            artifact_path: ".ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
-                        }),
-                    },
-                ],
+        const tc = graphHealthCacheRead(
+            [
+                {
+                    graph_id: "classifier_operation:session-section-chunks/blind-review-refresh",
+                    kind: "classifier_operation",
+                    label: "blind-review-refresh",
+                    properties_json: JSON.stringify({ package_key: "session-section-chunks", operation_kind: "review", expensive: false }),
+                    source_kind: "classifier_package_execution",
+                },
+                {
+                    graph_id: "classifier_lifecycle:workflow_candidate_review_pipeline",
+                    kind: "classifier_lifecycle",
+                    label: "workflow candidate review pipeline lifecycle",
+                    properties_json: "{}",
+                    source_kind: "classifier_package_execution",
+                },
             ],
-        });
+            [
+                {
+                    graph_id: "edge:run",
+                    kind: "ran_operation",
+                    from_id: "classifier_execution:.ax/experiments/run.json",
+                    to_id: "classifier_operation:session-section-chunks/blind-review-refresh",
+                    evidence_path: ".ax/experiments/run.json",
+                    properties_json: "{}",
+                    source_kind: "classifier_package_execution",
+                },
+                {
+                    graph_id: "edge:lifecycle",
+                    kind: "has_evidence",
+                    from_id: "classifier_lifecycle:workflow_candidate_review_pipeline",
+                    to_id: "artifact:.ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
+                    evidence_path: ".ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
+                    properties_json: JSON.stringify({ lifecycle_key: "review_pipeline_lifecycle" }),
+                    source_kind: "classifier_package_execution",
+                },
+            ],
+            [
+                {
+                    graph_id: "fact:phase",
+                    kind: "classifier_lifecycle_status",
+                    subject: "classifier_lifecycle:workflow_candidate_review_pipeline",
+                    predicate: "review_pipeline_recommended_action_execution_phase",
+                    value_json: "\"bind_inputs\"",
+                    evidence_edges_json: JSON.stringify(["edge:lifecycle"]),
+                    properties_json: JSON.stringify({
+                        lifecycle_key: "review_pipeline_lifecycle",
+                        artifact_path: ".ax/experiments/workflow-candidate-review-pipeline-lifecycle-current.json",
+                    }),
+                    source_kind: "classifier_package_execution",
+                },
+            ],
+        );
 
-        const result = await runWithServiceAndDb(Effect.gen(function* () {
+        const result = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             const input = {
                 workflowStatusPath: statusPath,
@@ -1095,7 +1098,7 @@ describe("ClassifierPackageService", () => {
             const report = yield* packages.lifecycleInsightReport(input);
             const routing = yield* packages.lifecycleRoutingSummaryReport(input);
             return { report, routing };
-        }), tc.client);
+        }), tc.layer);
         const { report, routing } = result;
 
         expect(report.schema).toBe("ax.classifier_lifecycle_insight_report.v1");

--- a/apps/axctl/src/classifiers/package-service.test.ts
+++ b/apps/axctl/src/classifiers/package-service.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import {
     ClassifierPackageOperationNotFound,
     ClassifierPackageService,
@@ -41,6 +43,37 @@ const runWithServiceAndDb = <A>(
         Effect.provideService(SurrealClient, db),
         Effect.provide(BunFsLayer),
     ));
+
+/**
+ * `executionGraphHealth` (package-service.ts) reads through `CacheRead` now -
+ * three separate `.rows()` calls (node/edge/fact), possibly repeated several
+ * times per report (lifecycle insight fans out into multiple graph-health
+ * reads). `routes` (substring-matched, not consumed) is the right fixture
+ * shape here: every call to any of the three queries gets the SAME canned
+ * rows, exactly like the old SurrealQL fake's `fallback` array did for its
+ * one multi-statement query.
+ */
+const runWithServiceAndCacheRead = <A>(
+    effect: Effect.Effect<A, unknown, ClassifierPackageService | CacheRead | FileSystem.FileSystem | Path.Path>,
+    cacheReadLayer: Layer.Layer<CacheRead>,
+): Promise<A> =>
+    Effect.runPromise(effect.pipe(
+        Effect.provide(ClassifierPackageServiceLive),
+        Effect.provide(cacheReadLayer),
+        Effect.provide(BunFsLayer),
+    ));
+
+const graphHealthCacheRead = (
+    nodes: ReadonlyArray<unknown>,
+    edges: ReadonlyArray<unknown>,
+    facts: ReadonlyArray<unknown>,
+) => makeTestCacheRead({
+    routes: [
+        { match: "FROM classifier_graph_node", rows: nodes },
+        { match: "FROM classifier_graph_edge", rows: edges },
+        { match: "FROM classifier_graph_fact", rows: facts },
+    ],
+});
 
 function writeTempManifest(command: string): string {
     const path = join(mkdtempSync(join(tmpdir(), "ax-package-manifest-")), "ax.classifier.json");
@@ -658,47 +691,45 @@ describe("ClassifierPackageService", () => {
     });
 
     test("queries classifier graph health through the service layer", async () => {
-        const tc = makeTestSurrealClient({
-            fallback: (sql) => {
-                expect(sql).toContain("FROM classifier_graph_node");
-                return [
-                    [
-                        {
-                            graph_id: "classifier_operation:demo/refresh",
-                            kind: "classifier_operation",
-                            label: "refresh",
-                            properties_json: JSON.stringify({ package_key: "demo", operation_kind: "review", expensive: false }),
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "edge:run",
-                            kind: "ran_operation",
-                            from_id: "classifier_execution:.ax/experiments/run.json",
-                            to_id: "classifier_operation:demo/refresh",
-                            evidence_path: ".ax/experiments/run.json",
-                            properties_json: "{}",
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "fact:run",
-                            kind: "classifier_operation_execution",
-                            subject: "classifier_execution:.ax/experiments/run.json",
-                            predicate: "completed_with_decision",
-                            value_json: "\"executed\"",
-                            evidence_edges_json: JSON.stringify(["edge:run"]),
-                            properties_json: "{}",
-                        },
-                    ],
-                ];
-            },
-        });
+        const tc = graphHealthCacheRead(
+            [
+                {
+                    graph_id: "classifier_operation:demo/refresh",
+                    kind: "classifier_operation",
+                    label: "refresh",
+                    properties_json: JSON.stringify({ package_key: "demo", operation_kind: "review", expensive: false }),
+                    source_kind: "classifier_package_execution",
+                },
+            ],
+            [
+                {
+                    graph_id: "edge:run",
+                    kind: "ran_operation",
+                    from_id: "classifier_execution:.ax/experiments/run.json",
+                    to_id: "classifier_operation:demo/refresh",
+                    evidence_path: ".ax/experiments/run.json",
+                    properties_json: "{}",
+                    source_kind: "classifier_package_execution",
+                },
+            ],
+            [
+                {
+                    graph_id: "fact:run",
+                    kind: "classifier_operation_execution",
+                    subject: "classifier_execution:.ax/experiments/run.json",
+                    predicate: "completed_with_decision",
+                    value_json: "\"executed\"",
+                    evidence_edges_json: JSON.stringify(["edge:run"]),
+                    properties_json: "{}",
+                    source_kind: "classifier_package_execution",
+                },
+            ],
+        );
 
-        const report = await runWithServiceAndDb(Effect.gen(function* () {
+        const report = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             return yield* packages.executionGraphHealthReport();
-        }), tc.client);
+        }), tc.layer);
 
         expect(report.schema).toBe("ax.classifier_package_execution_graph_health_report.v1");
         expect(report.decision).toBe("healthy");
@@ -707,37 +738,34 @@ describe("ClassifierPackageService", () => {
     });
 
     test("summarizes graph query suggestion repair routing through the service layer", async () => {
-        const tc = makeTestSurrealClient({
-            fallback: (sql) => {
-                expect(sql).toContain("FROM classifier_graph_node");
-                return [
-                    [],
-                    [
-                        {
-                            graph_id: "edge:review",
-                            kind: "has_lifecycle_fact",
-                            from_id: "classifier_lifecycle:workflow_candidate_proposal",
-                            to_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
-                            evidence_path: ".ax/experiments/workflow-candidate-proposal-review-current.json",
-                            properties_json: "{}",
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
-                            kind: "classifier_lifecycle_status",
-                            subject: "classifier_lifecycle:workflow_candidate_proposal",
-                            predicate: "review_pipeline_recommended_action_execution_phase",
-                            value_json: "\"bind_inputs\"",
-                            evidence_edges_json: "[\"edge:review\"]",
-                            properties_json: "{\"source_kind\":\"review_pipeline_lifecycle\"}",
-                        },
-                    ],
-                ];
-            },
-        });
+        const tc = graphHealthCacheRead(
+            [],
+            [
+                {
+                    graph_id: "edge:review",
+                    kind: "has_lifecycle_fact",
+                    from_id: "classifier_lifecycle:workflow_candidate_proposal",
+                    to_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
+                    evidence_path: ".ax/experiments/workflow-candidate-proposal-review-current.json",
+                    properties_json: "{}",
+                    source_kind: "review_pipeline_lifecycle",
+                },
+            ],
+            [
+                {
+                    graph_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
+                    kind: "classifier_lifecycle_status",
+                    subject: "classifier_lifecycle:workflow_candidate_proposal",
+                    predicate: "review_pipeline_recommended_action_execution_phase",
+                    value_json: "\"bind_inputs\"",
+                    evidence_edges_json: "[\"edge:review\"]",
+                    properties_json: "{\"source_kind\":\"review_pipeline_lifecycle\"}",
+                    source_kind: "review_pipeline_lifecycle",
+                },
+            ],
+        );
 
-        const summary = await runWithServiceAndDb(Effect.gen(function* () {
+        const summary = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             return yield* packages.executionGraphQuerySuggestionRoutingSummary({
                 query: {
@@ -746,7 +774,7 @@ describe("ClassifierPackageService", () => {
                     value_equals: "execute",
                 },
             });
-        }), tc.client);
+        }), tc.layer);
 
         expect(summary.has_suggestion).toBe(true);
         expect(summary.query_match_status).toBe("no_match");
@@ -766,37 +794,34 @@ describe("ClassifierPackageService", () => {
 
     test("writes graph query suggestion routing summaries through the service layer", async () => {
         const out = join(mkdtempSync(join(tmpdir(), "ax-query-routing-summary-")), "nested", "summary.json");
-        const tc = makeTestSurrealClient({
-            fallback: (sql) => {
-                expect(sql).toContain("FROM classifier_graph_node");
-                return [
-                    [],
-                    [
-                        {
-                            graph_id: "edge:review",
-                            kind: "has_lifecycle_fact",
-                            from_id: "classifier_lifecycle:workflow_candidate_proposal",
-                            to_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
-                            evidence_path: ".ax/experiments/workflow-candidate-proposal-review-current.json",
-                            properties_json: "{}",
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
-                            kind: "classifier_lifecycle_status",
-                            subject: "classifier_lifecycle:workflow_candidate_proposal",
-                            predicate: "review_pipeline_recommended_action_execution_phase",
-                            value_json: "\"bind_inputs\"",
-                            evidence_edges_json: "[\"edge:review\"]",
-                            properties_json: "{\"source_kind\":\"review_pipeline_lifecycle\"}",
-                        },
-                    ],
-                ];
-            },
-        });
+        const tc = graphHealthCacheRead(
+            [],
+            [
+                {
+                    graph_id: "edge:review",
+                    kind: "has_lifecycle_fact",
+                    from_id: "classifier_lifecycle:workflow_candidate_proposal",
+                    to_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
+                    evidence_path: ".ax/experiments/workflow-candidate-proposal-review-current.json",
+                    properties_json: "{}",
+                    source_kind: "review_pipeline_lifecycle",
+                },
+            ],
+            [
+                {
+                    graph_id: "classifier_lifecycle_fact:workflow_candidate_proposal/review_pipeline_recommended_action_execution_phase",
+                    kind: "classifier_lifecycle_status",
+                    subject: "classifier_lifecycle:workflow_candidate_proposal",
+                    predicate: "review_pipeline_recommended_action_execution_phase",
+                    value_json: "\"bind_inputs\"",
+                    evidence_edges_json: "[\"edge:review\"]",
+                    properties_json: "{\"source_kind\":\"review_pipeline_lifecycle\"}",
+                    source_kind: "review_pipeline_lifecycle",
+                },
+            ],
+        );
 
-        const summary = await runWithServiceAndDb(Effect.gen(function* () {
+        const summary = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             return yield* packages.writeExecutionGraphQuerySuggestionRoutingSummaryReport({
                 out,
@@ -806,7 +831,7 @@ describe("ClassifierPackageService", () => {
                     value_equals: "execute",
                 },
             });
-        }), tc.client);
+        }), tc.layer);
         const saved = await Bun.file(out).json();
 
         expect(summary.suggestion?.repair.execution_status).toBe("ready_to_execute");
@@ -816,64 +841,61 @@ describe("ClassifierPackageService", () => {
     });
 
     test("summarizes boundary replay posture through the service layer", async () => {
-        const tc = makeTestSurrealClient({
-            fallback: (sql) => {
-                expect(sql).toContain("FROM classifier_graph_node");
-                return [
-                    [],
-                    [
-                        {
-                            graph_id: "edge:boundary",
-                            kind: "reported_boundary_miss",
-                            from_id: "artifact:boundary",
-                            to_id: "classifier_boundary_miss:workflow",
-                            evidence_path: ".ax/experiments/boundary-review-deterministic-replay-workflow-candidate-current.json",
-                            properties_json: "{}",
-                            source_kind: "boundary_replay_deterministic_projection",
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "fact:boundary:covered",
-                            kind: "classifier_boundary_replay",
-                            subject: "classifier_boundary_miss:workflow",
-                            predicate: "covered_by_deterministic",
-                            value_json: JSON.stringify(true),
-                            evidence_edges_json: JSON.stringify(["edge:boundary"]),
-                            properties_json: JSON.stringify({
-                                classifier_key: "correction-event",
-                                actual: "correction_or_rejection_signal",
-                                target: "workflow_state",
-                            }),
-                            source_kind: "boundary_replay_deterministic_projection",
-                        },
-                        {
-                            graph_id: "fact:boundary:label",
-                            kind: "classifier_boundary_replay",
-                            subject: "classifier_boundary_miss:workflow",
-                            predicate: "deterministic_label",
-                            object: "classifier_deterministic_result:workflow",
-                            value_json: JSON.stringify({ label: "correction", target: "workflow_state" }),
-                            evidence_edges_json: JSON.stringify(["edge:boundary"]),
-                            properties_json: JSON.stringify({
-                                classifier_key: "correction-event",
-                                target: "workflow_state",
-                                confidence: 0.84,
-                                signals: ["correction:workflow_state"],
-                            }),
-                            source_kind: "boundary_replay_deterministic_projection",
-                        },
-                    ],
-                ];
-            },
-        });
+        const tc = graphHealthCacheRead(
+            [],
+            [
+                {
+                    graph_id: "edge:boundary",
+                    kind: "reported_boundary_miss",
+                    from_id: "artifact:boundary",
+                    to_id: "classifier_boundary_miss:workflow",
+                    evidence_path: ".ax/experiments/boundary-review-deterministic-replay-workflow-candidate-current.json",
+                    properties_json: "{}",
+                    source_kind: "boundary_replay_deterministic_projection",
+                },
+            ],
+            [
+                {
+                    graph_id: "fact:boundary:covered",
+                    kind: "classifier_boundary_replay",
+                    subject: "classifier_boundary_miss:workflow",
+                    predicate: "covered_by_deterministic",
+                    value_json: JSON.stringify(true),
+                    evidence_edges_json: JSON.stringify(["edge:boundary"]),
+                    properties_json: JSON.stringify({
+                        classifier_key: "correction-event",
+                        actual: "correction_or_rejection_signal",
+                        target: "workflow_state",
+                    }),
+                    source_kind: "boundary_replay_deterministic_projection",
+                },
+                {
+                    graph_id: "fact:boundary:label",
+                    kind: "classifier_boundary_replay",
+                    subject: "classifier_boundary_miss:workflow",
+                    predicate: "deterministic_label",
+                    object: "classifier_deterministic_result:workflow",
+                    value_json: JSON.stringify({ label: "correction", target: "workflow_state" }),
+                    evidence_edges_json: JSON.stringify(["edge:boundary"]),
+                    properties_json: JSON.stringify({
+                        classifier_key: "correction-event",
+                        target: "workflow_state",
+                        confidence: 0.84,
+                        signals: ["correction:workflow_state"],
+                    }),
+                    source_kind: "boundary_replay_deterministic_projection",
+                },
+            ],
+        );
 
-        const summary = await runWithServiceAndDb(Effect.gen(function* () {
+        const summary = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             return yield* packages.boundaryReplaySummaryReport();
-        }), tc.client);
+        }), tc.layer);
 
-        expect(tc.captured).toHaveLength(1);
+        // executionGraphHealth now fires THREE separate CacheRead queries
+        // (node/edge/fact) instead of one multi-statement SurrealQL call.
+        expect(tc.captured).toHaveLength(3);
         expect(summary).toMatchObject({
             status: "reviewed_deterministic_facts_available",
             production_posture: "deterministic_and_reviewed_graph_facts_only",
@@ -889,45 +911,40 @@ describe("ClassifierPackageService", () => {
 
     test("writes boundary replay posture summaries through the service layer", async () => {
         const out = join(mkdtempSync(join(tmpdir(), "ax-boundary-replay-summary-")), "nested", "summary.json");
-        const tc = makeTestSurrealClient({
-            fallback: (sql) => {
-                expect(sql).toContain("FROM classifier_graph_node");
-                return [
-                    [],
-                    [
-                        {
-                            graph_id: "edge:boundary",
-                            kind: "reported_boundary_miss",
-                            from_id: "artifact:boundary",
-                            to_id: "classifier_boundary_miss:workflow",
-                            evidence_path: ".ax/experiments/boundary-review-deterministic-replay-workflow-candidate-current.json",
-                            properties_json: "{}",
-                            source_kind: "boundary_replay_deterministic_projection",
-                        },
-                    ],
-                    [
-                        {
-                            graph_id: "fact:boundary:covered",
-                            kind: "classifier_boundary_replay",
-                            subject: "classifier_boundary_miss:workflow",
-                            predicate: "covered_by_deterministic",
-                            value_json: JSON.stringify(true),
-                            evidence_edges_json: JSON.stringify(["edge:boundary"]),
-                            properties_json: JSON.stringify({
-                                classifier_key: "correction-event",
-                                target: "workflow_state",
-                            }),
-                            source_kind: "boundary_replay_deterministic_projection",
-                        },
-                    ],
-                ];
-            },
-        });
+        const tc = graphHealthCacheRead(
+            [],
+            [
+                {
+                    graph_id: "edge:boundary",
+                    kind: "reported_boundary_miss",
+                    from_id: "artifact:boundary",
+                    to_id: "classifier_boundary_miss:workflow",
+                    evidence_path: ".ax/experiments/boundary-review-deterministic-replay-workflow-candidate-current.json",
+                    properties_json: "{}",
+                    source_kind: "boundary_replay_deterministic_projection",
+                },
+            ],
+            [
+                {
+                    graph_id: "fact:boundary:covered",
+                    kind: "classifier_boundary_replay",
+                    subject: "classifier_boundary_miss:workflow",
+                    predicate: "covered_by_deterministic",
+                    value_json: JSON.stringify(true),
+                    evidence_edges_json: JSON.stringify(["edge:boundary"]),
+                    properties_json: JSON.stringify({
+                        classifier_key: "correction-event",
+                        target: "workflow_state",
+                    }),
+                    source_kind: "boundary_replay_deterministic_projection",
+                },
+            ],
+        );
 
-        const summary = await runWithServiceAndDb(Effect.gen(function* () {
+        const summary = await runWithServiceAndCacheRead(Effect.gen(function* () {
             const packages = yield* ClassifierPackageService;
             return yield* packages.writeBoundaryReplaySummaryReport({ out });
-        }), tc.client);
+        }), tc.layer);
         const saved = JSON.parse(readFileSync(out, "utf8"));
 
         expect(summary.status).toBe("reviewed_deterministic_facts_available");

--- a/apps/axctl/src/classifiers/package-service.ts
+++ b/apps/axctl/src/classifiers/package-service.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, FileSystem, Layer, Path, Schema } from "effect";
 import { prettyPrint } from "@ax/lib/json";
 import { SurrealClient } from "@ax/lib/db";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import {
     applyExecutionSurrealWritePlanReport,

--- a/apps/axctl/src/classifiers/package-service.ts
+++ b/apps/axctl/src/classifiers/package-service.ts
@@ -15,7 +15,6 @@ import {
     buildExecutionFactProjectionReport,
     buildExecutionSurrealWritePlanReport,
     buildOperationsReport,
-    classifierGraphHealthSql,
     discoverClassifierPackageManifestPaths,
     discoverClassifierPackageExecutionReportPaths,
     executeOperationPlanReport,
@@ -49,9 +48,7 @@ import {
     type ClassifierLifecycleInsightReport,
     type ClassifierLifecycleRoutingSummaryReport,
     type ClassifierGraphHealthQuery,
-    type ClassifierGraphEdgeRow,
     type ClassifierGraphFactRow,
-    type ClassifierGraphNodeRow,
     type ClassifierPackageOperationPreflightReport,
     type ClassifierPackageOperationDryRunReport,
     type ClassifierPackageOperationExecutionReport,
@@ -425,34 +422,34 @@ export interface ClassifierPackageServiceShape {
     ) => Effect.Effect<ClassifierPackageExecutionSurrealApplyReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
     readonly executionGraphHealthReport: (
         input?: ClassifierPackageExecutionGraphHealthInput,
-    ) => Effect.Effect<ClassifierPackageExecutionGraphHealthReport, ClassifierPackageReportWriteError, SurrealClient>;
+    ) => Effect.Effect<ClassifierPackageExecutionGraphHealthReport, ClassifierPackageReportWriteError, CacheRead>;
     readonly executionGraphQuerySuggestionRoutingSummary: (
         input?: ClassifierPackageExecutionGraphHealthInput,
-    ) => Effect.Effect<ClassifierGraphQuerySuggestionRoutingSummary, ClassifierPackageReportWriteError, SurrealClient>;
+    ) => Effect.Effect<ClassifierGraphQuerySuggestionRoutingSummary, ClassifierPackageReportWriteError, CacheRead>;
     readonly writeExecutionGraphQuerySuggestionRoutingSummaryReport: (
         input: ClassifierGraphQuerySuggestionRoutingSummaryWriteInput,
-    ) => Effect.Effect<ClassifierGraphQuerySuggestionRoutingSummary, ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierGraphQuerySuggestionRoutingSummary, ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly boundaryReplaySummaryReport: (
         input?: ClassifierBoundaryReplaySummaryInput,
-    ) => Effect.Effect<ClassifierGraphBoundaryReplaySummary, ClassifierPackageReportWriteError, SurrealClient>;
+    ) => Effect.Effect<ClassifierGraphBoundaryReplaySummary, ClassifierPackageReportWriteError, CacheRead>;
     readonly writeBoundaryReplaySummaryReport: (
         input: ClassifierBoundaryReplaySummaryWriteInput,
-    ) => Effect.Effect<ClassifierGraphBoundaryReplaySummary, ClassifierPackageReportWriteError, SurrealClient>;
+    ) => Effect.Effect<ClassifierGraphBoundaryReplaySummary, ClassifierPackageReportWriteError, CacheRead>;
     readonly writeExecutionGraphHealthReport: (
         input: ClassifierPackageExecutionGraphHealthWriteInput,
-    ) => Effect.Effect<ClassifierPackageExecutionGraphHealthReport, ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierPackageExecutionGraphHealthReport, ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly lifecycleInsightReport: (
         input?: ClassifierLifecycleInsightInput,
-    ) => Effect.Effect<ClassifierLifecycleInsightReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierLifecycleInsightReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly writeLifecycleInsightReport: (
         input: ClassifierLifecycleInsightWriteInput,
-    ) => Effect.Effect<ClassifierLifecycleInsightReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierLifecycleInsightReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly lifecycleRoutingSummaryReport: (
         input?: ClassifierLifecycleInsightInput,
-    ) => Effect.Effect<ClassifierLifecycleRoutingSummaryReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierLifecycleRoutingSummaryReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly writeLifecycleRoutingSummaryReport: (
         input: ClassifierLifecycleRoutingSummaryWriteInput,
-    ) => Effect.Effect<ClassifierLifecycleRoutingSummaryReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, SurrealClient | FileSystem.FileSystem>;
+    ) => Effect.Effect<ClassifierLifecycleRoutingSummaryReport, ClassifierPackageLoadError | ClassifierPackageReportWriteError, CacheRead | FileSystem.FileSystem>;
     readonly pendingReviewTaskListReport: (
         input: ClassifierPendingReviewTaskListInput,
     ) => Effect.Effect<WorkflowCandidateGuidancePendingReviewTaskListReport, ClassifierPackageLoadError, FileSystem.FileSystem | Path.Path>;
@@ -470,6 +467,50 @@ export interface ClassifierPackageServiceShape {
 export class ClassifierPackageService extends Context.Service<ClassifierPackageService, ClassifierPackageServiceShape>()(
     "ax/ClassifierPackageService",
 ) {}
+
+/**
+ * DuckDB read for `executionGraphHealth`. `classifierGraphHealthSql()` in
+ * `./package-operations.ts` (a different wave-3 chunk's file) stays SurrealQL
+ * - it also backs `applyExecutionSurrealWritePlanReport`'s write statements,
+ * which this chunk does not own - so the CacheRead port is a fresh, local
+ * query set rather than a rewrite of that shared builder.
+ */
+const CLASSIFIER_GRAPH_NODE_SQL =
+    "SELECT graph_id, kind, label, properties_json, source_kind FROM classifier_graph_node ORDER BY graph_id";
+const CLASSIFIER_GRAPH_EDGE_SQL =
+    "SELECT graph_id, kind, from_id, to_id, evidence_path, properties_json, source_kind FROM classifier_graph_edge ORDER BY graph_id";
+const CLASSIFIER_GRAPH_FACT_SQL =
+    "SELECT graph_id, kind, subject, predicate, object, value_json, evidence_edges_json, properties_json, source_kind FROM classifier_graph_fact ORDER BY graph_id";
+
+const CacheGraphNodeRow = Schema.Struct({
+    graph_id: Schema.String,
+    kind: Schema.String,
+    label: Schema.String,
+    properties_json: Schema.String,
+    source_kind: Schema.String,
+});
+
+const CacheGraphEdgeRow = Schema.Struct({
+    graph_id: Schema.String,
+    kind: Schema.String,
+    from_id: Schema.String,
+    to_id: Schema.String,
+    evidence_path: Schema.String,
+    properties_json: Schema.String,
+    source_kind: Schema.String,
+});
+
+const CacheGraphFactRow = Schema.Struct({
+    graph_id: Schema.String,
+    kind: Schema.String,
+    subject: Schema.String,
+    predicate: Schema.String,
+    object: Schema.NullOr(Schema.String),
+    value_json: Schema.NullOr(Schema.String),
+    evidence_edges_json: Schema.String,
+    properties_json: Schema.String,
+    source_kind: Schema.String,
+});
 
 export const ClassifierPackageServiceLive: Layer.Layer<ClassifierPackageService, never, FileSystem.FileSystem | Path.Path> = Layer.effect(
     ClassifierPackageService,
@@ -756,17 +797,28 @@ export const ClassifierPackageServiceLive: Layer.Layer<ClassifierPackageService,
         const executionGraphHealth = Effect.fn("ClassifierPackageService.executionGraphHealthReport")(function* (
             input?: ClassifierPackageExecutionGraphHealthInput,
         ) {
-            const db = yield* SurrealClient;
-            const result = yield* db.query<[ClassifierGraphNodeRow[], ClassifierGraphEdgeRow[], ClassifierGraphFactRow[]]>(classifierGraphHealthSql()).pipe(
-                Effect.mapError((error) => ClassifierPackageReportWriteError.make({
-                    path: "classifier_graph_*",
-                    message: errorMessage(error),
-                })),
-            );
+            const read = yield* CacheRead;
+            const mapReadError = (error: CacheReadError) => ClassifierPackageReportWriteError.make({
+                path: "classifier_graph_*",
+                message: errorMessage(error),
+            });
+            const nodes = yield* read.rows(CacheGraphNodeRow, CLASSIFIER_GRAPH_NODE_SQL).pipe(Effect.mapError(mapReadError));
+            const edges = yield* read.rows(CacheGraphEdgeRow, CLASSIFIER_GRAPH_EDGE_SQL).pipe(Effect.mapError(mapReadError));
+            const facts = yield* read.rows(CacheGraphFactRow, CLASSIFIER_GRAPH_FACT_SQL).pipe(Effect.mapError(mapReadError));
             return buildExecutionGraphHealthReport({
-                nodes: result[0] ?? [],
-                edges: result[1] ?? [],
-                facts: result[2] ?? [],
+                nodes: [...nodes],
+                edges: [...edges],
+                facts: facts.map((fact): ClassifierGraphFactRow => ({
+                    graph_id: fact.graph_id,
+                    kind: fact.kind,
+                    subject: fact.subject,
+                    predicate: fact.predicate,
+                    ...(fact.object === null ? {} : { object: fact.object }),
+                    ...(fact.value_json === null ? {} : { value_json: fact.value_json }),
+                    evidence_edges_json: fact.evidence_edges_json,
+                    properties_json: fact.properties_json,
+                    source_kind: fact.source_kind,
+                })),
                 ...(input?.query === undefined ? {} : { query: input.query }),
             });
         });

--- a/apps/axctl/src/cli/classifiers-package-operations.test.ts
+++ b/apps/axctl/src/cli/classifiers-package-operations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { ClassifierPackageService, type ClassifierQualityStatusReport } from "../classifiers/package-service.ts";
 import {
     renderClassifierLifecycleRouteExecutionText,
@@ -209,6 +210,7 @@ describe("classifiers package-operations format", () => {
                 } as never).pipe(
                     Effect.provideService(ClassifierPackageService, service),
                     Effect.provideService(SurrealClient, {} as SurrealClientShape),
+                    Effect.provide(makeTestCacheRead().layer),
                     Effect.provide(BunFileSystem.layer),
                 ),
             );
@@ -313,6 +315,7 @@ describe("classifiers package-operations format", () => {
             } as never).pipe(
                 Effect.provideService(ClassifierPackageService, service),
                 Effect.provideService(SurrealClient, {} as SurrealClientShape),
+                Effect.provide(makeTestCacheRead().layer),
                 Effect.provide(BunFileSystem.layer),
             ),
         );
@@ -388,6 +391,7 @@ describe("classifiers package-operations format", () => {
                 } as never).pipe(
                     Effect.provideService(ClassifierPackageService, service),
                     Effect.provideService(SurrealClient, {} as SurrealClientShape),
+                    Effect.provide(makeTestCacheRead().layer),
                     Effect.provide(BunFileSystem.layer),
                 ),
             );

--- a/apps/axctl/src/cli/classifiers-package-operations.ts
+++ b/apps/axctl/src/cli/classifiers-package-operations.ts
@@ -1,5 +1,6 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 import type { SurrealClient } from "@ax/lib/db";
+import type { CacheRead } from "@ax/lib/duckdb/seam";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import { prettyPrint } from "@ax/lib/json";
 import {
@@ -1147,7 +1148,11 @@ const serviceErrorText = (error: unknown): string => {
 
 export const runClassifiersPackageOperations = (
     input: ClassifierPackageOperationsCommandInput,
-): Effect.Effect<void, never, ClassifierPackageService | SurrealClient | FileSystem.FileSystem> =>
+// `CacheRead` joins `SurrealClient` here rather than replacing it: the read half
+// of `ClassifierPackageService` moved to the DuckDB seam (wave 3, `c-read-context`)
+// while `applyExecutionSurrealWritePlan` still emits SurrealQL, so this operation
+// genuinely needs both until the write plan is ported.
+): Effect.Effect<void, never, ClassifierPackageService | SurrealClient | CacheRead | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const packages = yield* ClassifierPackageService;
         if (input.applyWritePlan) {
@@ -1436,7 +1441,9 @@ export const runClassifiersLifecycle = (
         readonly out?: string;
         readonly json: boolean;
     },
-): Effect.Effect<void, PlatformError.PlatformError, ClassifierPackageService | SurrealClient | FileSystem.FileSystem> =>
+// Fully ported: this report path reads through the DuckDB seam only, so
+// `SurrealClient` is gone rather than joined (contrast the operation above).
+): Effect.Effect<void, PlatformError.PlatformError, ClassifierPackageService | CacheRead | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const packages = yield* ClassifierPackageService;

--- a/apps/axctl/src/context/file-context-pack.test.ts
+++ b/apps/axctl/src/context/file-context-pack.test.ts
@@ -1,234 +1,189 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect } from "bun:test";
 import { Effect } from "effect";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { publishCacheFixture, readThroughFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { buildFileContextPack } from "./file-context-pack.ts";
 
-// Lean prior-session loader: the pack composes the SAME single loader the hook
-// uses. The stub answers its multi-query shape - an indexed `edited` aggregate,
-// a refListSource session-meta fetch, and batched produced/delivery_outcome/
-// session_health/turn reads - instead of the retired per-row-subquery loader.
-function fakeContextLayer() {
-    const turnCountRows = [
-        ...Array.from({ length: 3 }, (_, i) => ({
-            session: "session:s1",
-            role: "user",
-            intent_kind: i === 0 ? "correction" : "organic_task",
-        })),
-        ...Array.from({ length: 8 }, () => ({ session: "session:s1", role: "assistant", intent_kind: null })),
-    ];
-    return makeTestSurrealClient({
-        denyWrites: true,
-        fallback: (sql) => {
-            if (sql.includes("FROM file")) {
-                return [[
-                    { id: "file:f1", path: "src/ingest/codex.ts", repo: "ax", repository: "repository:ax" },
-                    { id: "file:f2", path: "schema/schema.surql", repo: "ax", repository: "repository:ax" },
-                ]];
-            }
-            if (sql.includes("FROM read_file")) {
-                return [[
-                    {
-                        kind: "read_file",
-                        evidence: "command_norm:sed",
-                        path_seen: "schema/schema.surql",
-                        ts: "2026-05-10T00:00:00.000Z",
-                        path: "schema/schema.surql",
-                        tool_name: "exec_command",
-                        command_norm: "sed",
-                        turn: { seq: 7, intent_kind: "organic_task", session: { id: "session:s1", source: "codex" } },
-                    },
-                ]];
-            }
-            if (sql.includes("FROM searched_file")) {
-                return [[
-                    {
-                        kind: "searched_file",
-                        evidence: "command_norm:rg",
-                        path_seen: "src/ingest/codex.ts",
-                        ts: "2026-05-10T00:01:00.000Z",
-                        path: "src/ingest/codex.ts",
-                        tool_name: "exec_command",
-                        command_norm: "rg",
-                        turn: { seq: 8, intent_kind: "organic_task", session: { id: "session:s1", source: "codex" } },
-                    },
-                    {
-                        kind: "searched_file",
-                        evidence: "command_norm:rg",
-                        path_seen: "src/ingest/codex.ts",
-                        ts: "2026-05-10T00:02:00.000Z",
-                        path: "src/ingest/codex.ts",
-                        tool_name: "exec_command",
-                        command_norm: "rg",
-                        turn: { seq: 9, intent_kind: "organic_task", session: { id: "session:s1", source: "codex" } },
-                    },
-                ]];
-            }
-            if (sql.includes("FROM touched") && sql.includes("SELECT out.path")) {
-                return [[
-                    { path: "package.json" },
-                    { path: "package.json" },
-                    { path: "src/ingest/codex.ts" },
-                ]];
-            }
-            if (sql.includes("FROM touched")) {
-                return [[
-                    {
-                        id: "touched:e1",
-                        ts: "2026-05-10T00:00:00.000Z",
-                        file: { id: "file:f1", path: "src/ingest/codex.ts" },
-                        commit: {
-                            id: "commit:c1",
-                            sha: "abc123456789",
-                            message: "fix ingest intent",
-                            sessions: [{ id: "session:s1", source: "codex", cwd: "/repo" }],
-                        },
-                    },
-                    {
-                        id: "touched:e2",
-                        ts: "2026-05-10T00:00:01.000Z",
-                        file: { id: "file:f2", path: "schema/schema.surql" },
-                        commit: {
-                            id: "commit:c1",
-                            sha: "abc123456789",
-                            message: "fix ingest intent",
-                            sessions: [{ id: "session:s1", source: "codex", cwd: "/repo" }],
-                        },
-                    },
-                ]];
-            }
-            if (sql.includes("FROM mentioned_file") || sql.includes("FROM mentioned_symbol") || sql.includes("FROM mentioned_error")) {
-                return [[
-                    {
-                        id: "turn:tool",
-                        session: "session:s1",
-                        source: "codex",
-                        seq: 10,
-                        intent_kind: "tool_call",
-                        text_excerpt: "",
-                        score: 10,
-                        why: "tool_output: src/ingest/codex.ts",
-                    },
-                    {
-                        id: "turn:user",
-                        session: "session:s1",
-                        source: "codex",
-                        seq: 2,
-                        intent_kind: "preference",
-                        text_excerpt: "please fix the ingest intent bug",
-                        score: 8,
-                        why: "text: src/ingest/codex.ts",
-                    },
-                ]];
-            }
-            // Lean prior-session loader: indexed edited aggregate. `file` is the
-            // PATH (out.path), not the record id - top_files renders paths.
-            if (sql.includes("FROM edited")) {
-                return [[
-                    { session: "session:s1", file: "src/ingest/codex.ts", weight: 7, last_seen: "2026-05-10T00:03:00.000Z" },
-                    { session: "session:s1", file: "schema/schema.surql", weight: 2, last_seen: "2026-05-10T00:03:00.000Z" },
-                ]];
-            }
-            if (sql.includes("FROM produced")) {
-                return [[{ in: "session:s1" }]];
-            }
-            if (sql.includes("FROM delivery_outcome")) {
-                return [[
-                    {
-                        session: "session:s1",
-                        status: "merged_to_main",
-                        review_pain: "moderate",
-                        pr_size: "small",
-                        pr_title: "Fix Codex ingest intent",
-                    },
-                ]];
-            }
-            if (sql.includes("FROM session_health")) {
-                return [[{ session: "session:s1", interruptions: 0 }]];
-            }
-            // refListSource session-meta fetch: `FROM [session:s1].map(|$r| $r.*)...`
-            if (sql.includes(".map(|$r| $r.")) {
-                return [[
-                    {
-                        id: "session:s1",
-                        project: "ax",
-                        source: "codex",
-                        started_at: "2026-05-10T00:00:00.000Z",
-                        ended_at: "2026-05-10T00:20:00.000Z",
-                    },
-                ]];
-            }
-            // Lean per-session turn-count read.
-            if (sql.includes("FROM turn") && sql.includes("role IN ['user','assistant']")) {
-                return [turnCountRows];
-            }
-            // Lean per-session title read (single-quoted intent list).
-            if (sql.includes("FROM turn") && sql.includes("intent_kind IN ['organic_task'")) {
-                return [[
-                    { session: "session:s1", text_excerpt: "can we fix ingest intent bug in codex transcript", seq: 2, intent_kind: "preference" },
-                ]];
-            }
-            // loadProducedSessionTurns (message_kind = "task", double-quoted).
-            if (sql.includes("FROM turn")) {
-                return [[
-                    {
-                        id: "turn:old",
-                        session: "session:s1",
-                        source: "codex",
-                        seq: 1,
-                        ts: "2026-05-10T00:00:00.000Z",
-                        message_kind: "task",
-                        intent_kind: "organic_task",
-                        text_excerpt: "unrelated old work",
-                    },
-                    {
-                        id: "turn:relevant",
-                        session: "session:s1",
-                        source: "codex",
-                        seq: 2,
-                        ts: "2026-05-10T00:00:01.000Z",
-                        message_kind: "task",
-                        intent_kind: "preference",
-                        text_excerpt: "can we fix ingest intent bug in codex transcript",
-                    },
-                ]];
-            }
-            return [[]];
-        },
-    }).layer;
-}
+/**
+ * `buildFileContextPack` composes seven joins across file-evidence.ts (files,
+ * read_file/searched_file, touched, mentioned_file, edited+session-aggregate,
+ * produced+delivery_outcome+session_health, touched-neighbor). The old
+ * testing/surreal.ts fake answered each by matching SQL TEXT, which is not
+ * evidence any of those joins are correct - only that the row-shaping code
+ * downstream works on canned data. This is a REAL published DuckDB snapshot,
+ * so a wrong JOIN (wrong column, wrong direction, missing subagent filter)
+ * fails here the same way it would against production.
+ */
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("file-context-pack (duckdb)", { requireFts: true });
 
-describe("file context pack", () => {
-    test("builds a compact pack with ranked user context and deduped evidence", async () => {
-        const pack = await Effect.runPromise(
+const T = (iso: string): Date => new Date(iso);
+
+const CORPUS = (w: CacheWriteService) =>
+    Effect.gen(function* () {
+        yield* w.put("session", {
+            id: "session:s1",
+            source: "codex",
+            project: "ax",
+            cwd: "/repo",
+            started_at: T("2026-05-10T00:00:00.000Z"),
+            ended_at: T("2026-05-10T00:20:00.000Z"),
+        });
+        // Decoy subagent session - every join below must filter it out.
+        yield* w.put("session", {
+            id: "session:s2",
+            source: "claude-subagent",
+            project: "ax",
+            cwd: "/repo",
+        });
+
+        yield* w.putMany("file", [
+            { id: "file:a", path: "src/ingest/codex.ts", repo: "ax", repository: "repository:ax" },
+            { id: "file:b", path: "schema/schema.surql", repo: "ax", repository: "repository:ax" },
+        ]);
+
+        yield* w.putMany("turn", [
+            {
+                id: "turn:t1", session: "session:s1", seq: 1, ts: T("2026-05-10T00:00:10.000Z"),
+                role: "user", message_kind: "task", intent_kind: "organic_task",
+                text: "please look at src/ingest/codex.ts ingest bug",
+                text_excerpt: "please look at src/ingest/codex.ts ingest bug",
+                has_tool_use: false, has_error: false,
+            },
+            {
+                id: "turn:t2", session: "session:s1", seq: 2, ts: T("2026-05-10T00:01:00.000Z"),
+                role: "user", message_kind: "task", intent_kind: "preference",
+                text: "use uv for python deps in codex ingest",
+                text_excerpt: "use uv for python deps in codex ingest",
+                has_tool_use: true, has_error: false,
+            },
+            {
+                id: "turn:t3", session: "session:s1", seq: 3, ts: T("2026-05-10T00:01:30.000Z"),
+                role: "assistant", message_kind: "assistant", intent_kind: null,
+                text: "done", text_excerpt: "done",
+                has_tool_use: false, has_error: false,
+            },
+            // Decoy: same file, but under the subagent session.
+            {
+                id: "turn:t4", session: "session:s2", seq: 1, ts: T("2026-05-10T00:02:00.000Z"),
+                role: "user", message_kind: "task", intent_kind: "organic_task",
+                text: "subagent note", text_excerpt: "subagent note",
+                has_tool_use: false, has_error: false,
+            },
+        ]);
+
+        yield* w.put("tool_call", {
+            id: "tool_call:tc1", session: "session:s1", turn: "turn:t2",
+            name: "Read", ts: T("2026-05-10T00:01:05.000Z"), command_norm: null, has_error: false,
+        });
+        yield* w.put("read_file", {
+            id: "read_file:r1", in_id: "tool_call:tc1", out_id: "file:a",
+            evidence: "tool_name", path_seen: "src/ingest/codex.ts", ts: T("2026-05-10T00:01:05.000Z"),
+        });
+
+        yield* w.putMany("edited", [
+            { id: "edited:e1", in_id: "turn:t1", out_id: "file:a", tool: "Edit", ts: T("2026-05-10T00:00:15.000Z") },
+            { id: "edited:e2", in_id: "turn:t2", out_id: "file:a", tool: "Edit", ts: T("2026-05-10T00:01:10.000Z") },
+            // Decoy: subagent edit of the same file - must not count toward weight.
+            { id: "edited:e3", in_id: "turn:t4", out_id: "file:a", tool: "Edit", ts: T("2026-05-10T00:02:05.000Z") },
+        ]);
+
+        yield* w.put("mentioned_file", {
+            id: "mentioned_file:mf1", in_id: "turn:t2", out_id: "file:a",
+            source: "text", ts: T("2026-05-10T00:01:00.000Z"),
+        });
+
+        yield* w.put("commit", {
+            id: "commit:c1", sha: "abc1234567890", repo: "ax", message: "fix codex ingest",
+            author: "neco", ts: T("2026-05-10T00:03:00.000Z"),
+        });
+        yield* w.putMany("touched", [
+            { id: "touched:t1", in_id: "commit:c1", out_id: "file:a", additions: 5, deletions: 1, ts: T("2026-05-10T00:03:00.000Z") },
+            // Same commit, a different file - the neighbor loadNeighborFiles should surface.
+            { id: "touched:t2", in_id: "commit:c1", out_id: "file:b", additions: 1, deletions: 0, ts: T("2026-05-10T00:03:00.000Z") },
+        ]);
+        yield* w.put("produced", { id: "produced:p1", in_id: "session:s1", out_id: "commit:c1", ts: T("2026-05-10T00:03:00.000Z") });
+
+        yield* w.put("pull_request", {
+            id: "pull_request:pr1", repository: "repository:ax", provider: "github", number: 42,
+            title: "Fix codex ingest bug", state: "merged",
+        });
+        yield* w.put("delivery_outcome", {
+            id: "delivery_outcome:d1", session: "session:s1", status: "merged_to_main",
+            promotion_path: "direct", review_pain: "low", pr_size: "small",
+            pull_request: "pull_request:pr1", confidence: "medium",
+        });
+        yield* w.put("session_health", {
+            id: "session_health:sh1", session: "session:s1", source: "codex", interruptions: 1,
+        });
+    });
+
+describe("file context pack (DuckDB)", () => {
+    dtest("builds a compact pack with ranked user context and deduped evidence", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-file-context-pack-"), dylibPath, CORPUS));
+
+        const pack = await readThroughFixture(
+            fixture,
+            dylibPath,
             buildFileContextPack({
-                q: "fix ingest intent bug in src/ingest/codex.ts",
-                files: ["schema/schema.surql"],
-            }).pipe(Effect.provide(fakeContextLayer())),
+                q: "fix the codex ingest bug in src/ingest/codex.ts",
+                files: ["src/ingest/codex.ts"],
+            }),
         );
 
-        expect(pack.files.map((file) => file.path)).toEqual(["src/ingest/codex.ts", "schema/schema.surql"]);
-        expect(pack.evidence.tool_file).toHaveLength(2);
-        expect(pack.evidence.mention_turns.map((turn) => turn.id)).toEqual(["turn:user"]);
-        expect(pack.ai_context).toContain("can we fix ingest intent bug in codex transcript");
-        expect(pack.ai_context).toContain("Prior sessions that edited these files:");
-        expect(pack.ai_context).toContain("9 edits, 2 files, 1 commits, 3u/8a, 1 corrections, main, merged_to_main, moderate review");
-        // Regression: top_files must be PATHS, not file record ids (the lean
-        // loader projects out.path; selecting <string>out would leak `file:...`).
-        expect(pack.evidence.prior_file_sessions[0]?.top_files).toEqual(["src/ingest/codex.ts", "schema/schema.surql"]);
-        expect(pack.ai_context).toContain("Files: src/ingest/codex.ts, schema/schema.surql");
-        expect(pack.ai_context.match(/abc1234567/g)?.length).toBe(1);
+        // Only the file actually named resolves - schema/schema.surql was
+        // never mentioned in q or files.
+        expect(pack.files.map((file) => file.path)).toEqual(["src/ingest/codex.ts"]);
+
+        // Tool evidence: one read_file row, path taken from the JOIN (not a
+        // leaked file:a record id) - the exact regression the old test named.
+        expect(pack.evidence.tool_file).toHaveLength(1);
+        expect(pack.evidence.tool_file[0]).toMatchObject({
+            kind: "read_file",
+            path: "src/ingest/codex.ts",
+            tool_name: "Read",
+        });
+
+        // Mentions: turn:t2 (preference, mentioned_file) is scored and kept;
+        // the subagent turn never entered a mentioned_file edge at all.
+        expect(pack.evidence.mention_turns.map((t) => t.id)).toEqual(["turn:t2"]);
+        expect(pack.evidence.mention_turns[0]?.why).toEqual(["codex: src/ingest/codex.ts"]);
+
+        // Prior file sessions: weight = 2 (turn:t1 + turn:t2 edits), NOT 3 -
+        // the subagent decoy edit (turn:t4) must be filtered by the join.
+        expect(pack.evidence.prior_file_sessions).toHaveLength(1);
         expect(pack.evidence.prior_file_sessions[0]).toMatchObject({
             session: "session:s1",
-            weight: 9,
-            files_touched: 2,
+            title: "Fix codex ingest bug",
+            weight: 2,
+            files_touched: 1,
+            top_files: ["src/ingest/codex.ts"],
             produced_commits: 1,
+            delivery_status: "merged_to_main",
+            review_pain: "low",
+            pr_size: "small",
+            pr_title: "Fix codex ingest bug",
             merged_to_main: true,
-            corrections: 1,
-            review_pain: "moderate",
-            // Lean loader drops the unread `hands_free_ms` (was 600_000 under the
-            // retired slow loader; no consumer reads it).
-            hands_free_ms: null,
+            user_turns: 2,
+            assistant_turns: 1,
+            corrections: 0,
+            interruptions: 1,
         });
-        expect(pack.evidence.neighbor_files).toEqual([{ path: "package.json", count: 2 }]);
-    });
+
+        // Produced-session turns: both real user turns from session:s1,
+        // ordered earliest first.
+        expect(pack.evidence.produced_session_turns.map((t) => t.id)).toEqual(["turn:t1", "turn:t2"]);
+
+        // Neighbor files: touched:t2 (schema.surql) rode the same commit as
+        // the target file and is not itself a target - surfaces as a neighbor.
+        expect(pack.evidence.neighbor_files).toEqual([{ path: "schema/schema.surql", count: 1 }]);
+
+        expect(pack.ai_context).toContain("Prior sessions that edited these files:");
+        expect(pack.ai_context).toContain("2 edits, 1 files, 1 commits, 2u/1a");
+        expect(pack.ai_context).toContain("Neighbor files often changed with these files:");
+        expect(pack.ai_context).toContain("schema/schema.surql (1)");
+        expect(pack.ai_context.match(/abc1234567/g)?.length).toBe(1);
+
+        expect(pack.graph_inspection_query).toContain("FROM file WHERE id IN ('file:a')");
+    }, 60_000);
 });

--- a/apps/axctl/src/context/file-context-pack.ts
+++ b/apps/axctl/src/context/file-context-pack.ts
@@ -1,6 +1,5 @@
 import { Effect } from "effect";
-import type { DbError } from "@ax/lib/errors";
-import { SurrealClient } from "@ax/lib/db";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
 import {
     type BuildFileContextInput,
     type FileRow,
@@ -54,17 +53,41 @@ export interface FileContextPack {
     };
 }
 
+/**
+ * DuckDB SQL a human can paste into `ax duckdb sql` (or any DuckDB client
+ * against the published snapshot) to dig deeper than the rendered context.
+ * Was hand-rolled SurrealQL; SurrealDB is write-frozen (no ingest writes it
+ * any more), so that text pointed at a store this evidence no longer flows
+ * through - rewritten against the same tables/joins `context/file-evidence.ts`
+ * itself queries. `commit.sessions` (the reverse `<-produced.in` traversal) has
+ * no single-statement DuckDB equivalent; add a `JOIN produced p ON p.out_id =
+ * c.id JOIN session s ON s.id = p.in_id` to the last query for that.
+ */
 function renderInspectionQuery(files: readonly FileRow[]): string {
     if (files.length === 0) return "-- No matched file records to inspect.";
-    const fileRefs = files.map((file) => file.id).join(", ");
+    const fileRefs = files.map((file) => `'${file.id.replace(/'/g, "''")}'`).join(", ");
     return [
-        `LET $files = [${fileRefs}];`,
-        "SELECT id, path, repo, repository FROM file WHERE id IN $files;",
-        "SELECT id, evidence, path_seen, ts, out.{ id, path } AS file, in.{ id, name, command_norm, turn, session } AS tool_call FROM read_file WHERE out IN $files ORDER BY ts DESC LIMIT 40;",
-        "SELECT id, evidence, path_seen, ts, out.{ id, path } AS file, in.{ id, name, command_norm, turn, session } AS tool_call FROM searched_file WHERE out IN $files ORDER BY ts DESC LIMIT 40;",
-        "SELECT id, source, confidence, ts, out.{ id, path } AS file, in.{ id, session, seq, intent_kind, text_excerpt } AS turn FROM mentioned_file WHERE out IN $files ORDER BY ts DESC LIMIT 40;",
-        "SELECT in.session AS session, out.path AS file, count() AS edit_count, time::max(ts) AS last_seen FROM edited WHERE out IN $files GROUP BY session, file ORDER BY edit_count DESC, last_seen DESC LIMIT 40;",
-        "SELECT id, additions, deletions, ts, out.{ id, path } AS file, in.{ sha, message, author, ts, sessions: <-produced.in.{ id, source, cwd } } AS commit FROM touched WHERE out IN $files ORDER BY ts DESC LIMIT 40;",
+        `SELECT id, path, repo, repository FROM file WHERE id IN (${fileRefs});`,
+        `SELECT e.id, e.evidence, e.path_seen, e.ts, f.id AS file_id, f.path AS file_path,
+       tc.id AS tool_call_id, tc.name AS tool_name, tc.command_norm, tc.turn, tc.session
+FROM read_file e JOIN file f ON f.id = e.out_id JOIN tool_call tc ON tc.id = e.in_id
+WHERE e.out_id IN (${fileRefs}) ORDER BY e.ts DESC LIMIT 40;`,
+        `SELECT e.id, e.evidence, e.path_seen, e.ts, f.id AS file_id, f.path AS file_path,
+       tc.id AS tool_call_id, tc.name AS tool_name, tc.command_norm, tc.turn, tc.session
+FROM searched_file e JOIN file f ON f.id = e.out_id JOIN tool_call tc ON tc.id = e.in_id
+WHERE e.out_id IN (${fileRefs}) ORDER BY e.ts DESC LIMIT 40;`,
+        `SELECT mf.id, mf.source, mf.confidence, mf.ts, f.id AS file_id, f.path AS file_path,
+       t.id AS turn_id, t.session, t.seq, t.intent_kind, t.text_excerpt
+FROM mentioned_file mf JOIN file f ON f.id = mf.out_id JOIN turn t ON t.id = mf.in_id
+WHERE mf.out_id IN (${fileRefs}) ORDER BY mf.ts DESC LIMIT 40;`,
+        `SELECT t.session AS session, f.path AS file, count(*) AS edit_count, max(e.ts) AS last_seen
+FROM edited e JOIN turn t ON t.id = e.in_id JOIN file f ON f.id = e.out_id
+WHERE e.out_id IN (${fileRefs}) GROUP BY t.session, f.path
+ORDER BY edit_count DESC, last_seen DESC LIMIT 40;`,
+        `SELECT tt.id, tt.additions, tt.deletions, tt.ts, f.id AS file_id, f.path AS file_path,
+       c.sha, c.message, c.author, c.ts AS commit_ts
+FROM touched tt JOIN file f ON f.id = tt.out_id JOIN "commit" c ON c.id = tt.in_id
+WHERE tt.out_id IN (${fileRefs}) ORDER BY tt.ts DESC LIMIT 40;`,
     ].join("\n\n");
 }
 
@@ -157,7 +180,7 @@ function renderAiContext(
     return lines.join("\n");
 }
 
-export const buildFileContextPack = (input: BuildFileContextInput): Effect.Effect<FileContextPack, DbError, SurrealClient> =>
+export const buildFileContextPack = (input: BuildFileContextInput): Effect.Effect<FileContextPack, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
         const signals = extractFileContextSignals(input.q, input.files);
         const files = yield* resolveFiles(signals.paths, { fuzzyFallback: true });

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -1,5 +1,4 @@
 import { Effect, Schema } from "effect";
-import { SurrealClient } from "@ax/lib/db";
 import { CacheRead } from "@ax/lib/duckdb/seam";
 import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import { errorSignatureRecordKey, symbolRecordKey } from "../ingest/record-keys.ts";
@@ -820,33 +819,38 @@ export const loadRecentCommitsForFile = (fileIds: readonly string[], limit: numb
  *  hidden coupling that single-commit `git log` can't see. */
 export const loadCoTouchedFiles = (fileIds: readonly string[], limit: number) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as FileMemoryCoTouch[];
         const cap = Math.max(1, Math.min(limit, 20));
         const targetSet = new Set(fileIds);
 
-        // Stage 1: top sessions that edited the target file. `count()` must
-        // appear in SELECT to be sortable in ORDER BY under SurrealDB v3.
-        const [sessionsRows] = yield* db.query<[Array<{ session: string; n: number }>]>(`
-            SELECT <string>in.session AS session, count() AS n
-            FROM edited
-            WHERE out IN [${fileIds.join(", ")}]
-              AND in.session.source != "claude-subagent"
-            GROUP BY session
+        // Stage 1: top sessions that edited the target file.
+        const sessionsRows = yield* read.rows(Schema.Struct({ session: Schema.String, n: NumberFromBigIntColumn }), `
+            SELECT t.session AS session, count(*) AS n
+            FROM edited e
+            JOIN turn t ON t.id = e.in_id
+            JOIN session s ON s.id = t.session
+            WHERE e.out_id IN (${fileIds.map(() => "?").join(", ")})
+              AND s.source <> 'claude-subagent'
+            GROUP BY t.session
             ORDER BY n DESC
-            LIMIT 15;
-        `);
+            LIMIT 15
+        `, fileIds);
         const sessionIds = sessionsRows.map((r) => r.session).filter(Boolean);
         if (sessionIds.length === 0) return [] as FileMemoryCoTouch[];
 
         // Stage 2: all files those sessions touched. Aggregate per file in JS.
-        const [editedRows] = yield* db.query<[
-            Array<{ session: string; file: string; path: string | null }>
-        ]>(`
-            SELECT <string>in.session AS session, <string>out AS file, out.path AS path
-            FROM edited
-            WHERE in.session IN [${sessionIds.join(", ")}];
-        `);
+        const editedRows = yield* read.rows(Schema.Struct({
+            session: Schema.String,
+            file: Schema.String,
+            path: Schema.NullOr(Schema.String),
+        }), `
+            SELECT t.session AS session, e.out_id AS file, f.path AS path
+            FROM edited e
+            JOIN turn t ON t.id = e.in_id
+            JOIN file f ON f.id = e.out_id
+            WHERE t.session IN (${sessionIds.map(() => "?").join(", ")})
+        `, sessionIds);
 
         // Count distinct sessions per co-touched file (not total edits, to
         // weight files that show up across MANY sessions over heavy churn in

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -668,15 +668,16 @@ export const loadPriorFileSessions = (fileIds: readonly string[], limit: number)
 
 export const loadNeighborFiles = (touches: readonly TouchRow[], targetPaths: readonly string[]) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         const commitIds = Array.from(new Set(touches.map((touch) => touch.commit?.id).filter((id): id is string => !!id))).slice(0, 12);
         if (commitIds.length === 0) return [] as NeighborFile[];
-        const [rows] = yield* db.query<Array<Array<{ path: string }>>>(`
-            SELECT out.path AS path
-            FROM touched
-            WHERE in IN [${commitIds.join(", ")}]
-            LIMIT 200;
-        `);
+        const rows = yield* read.rows(Schema.Struct({ path: Schema.String }), `
+            SELECT f.path AS path
+            FROM touched t
+            JOIN file f ON f.id = t.out_id
+            WHERE t.in_id IN (${commitIds.map(() => "?").join(", ")})
+            LIMIT 200
+        `, commitIds);
         const target = new Set(targetPaths);
         const counts = new Map<string, number>();
         for (const row of rows) {

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -1,8 +1,8 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { CacheRead } from "@ax/lib/duckdb/seam";
 import { errorSignatureRecordKey, symbolRecordKey } from "../ingest/record-keys.ts";
 import { refListSource } from "@ax/lib/shared/record-select";
-import { surrealString } from "@ax/lib/shared/surql";
 import { normalizeErrorSignature } from "../ingest/turn-references.ts";
 import { classifyTurnIntent } from "../ingest/intent-kind.ts";
 import { numeric, durationMs, rankToolEvidence } from "./file-evidence-rank.ts";
@@ -81,36 +81,45 @@ const GENERIC_BASENAMES = new Set(["index.ts", "index.tsx", "index.js", "README.
  * repos. `fuzzyFallback: true` (the CLI pack) widens to suffix matching only
  * when the exact lookup finds nothing.
  */
+const FileRowSchema = Schema.Struct({
+    id: Schema.String,
+    path: Schema.String,
+    repo: Schema.NullOr(Schema.String),
+    repository: Schema.NullOr(Schema.String),
+});
+
 export const resolveFiles = (paths: readonly string[], opts: { readonly fuzzyFallback: boolean }) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         const clean = Array.from(new Set(paths.map((path) => path.trim()).filter(Boolean)));
         if (clean.length === 0) return [] as FileRow[];
-        const exactList = clean.map(surrealString).join(", ");
-        const [exactRows] = yield* db.query<[FileRow[]]>(`
-            SELECT <string>id AS id, path, repo, <string>repository AS repository
+        const exactRows = yield* read.rows(FileRowSchema, `
+            SELECT id, path, repo, repository
             FROM file
-            WHERE path IN [${exactList}]
-            LIMIT 20;
-        `);
-        if (!opts.fuzzyFallback) return exactRows.slice(0, 8);
-        if (exactRows.length > 0) return exactRows.slice(0, 8);
+            WHERE path IN (${clean.map(() => "?").join(", ")})
+            LIMIT 20
+        `, clean);
+        if (!opts.fuzzyFallback) return exactRows.slice(0, 8) as FileRow[];
+        if (exactRows.length > 0) return exactRows.slice(0, 8) as FileRow[];
 
-        const clauses = clean.flatMap((path) => {
+        const clauses: string[] = [];
+        const params: string[] = [];
+        for (const path of clean) {
             const base = path.split("/").at(-1) ?? path;
-            const pathClauses = [`string::ends_with(path, ${surrealString(path)})`];
+            clauses.push("ends_with(path, ?)");
+            params.push(path);
             if (path.includes("/") && !GENERIC_BASENAMES.has(base)) {
-                pathClauses.push(`string::ends_with(path, ${surrealString(base)})`);
+                clauses.push("ends_with(path, ?)");
+                params.push(base);
             }
-            return pathClauses;
-        });
-        const [rows] = yield* db.query<[FileRow[]]>(`
-            SELECT <string>id AS id, path, repo, <string>repository AS repository
+        }
+        const rows = yield* read.rows(FileRowSchema, `
+            SELECT id, path, repo, repository
             FROM file
             WHERE ${clauses.join(" OR ")}
-            LIMIT 20;
-        `);
-        return rows.slice(0, 8);
+            LIMIT 20
+        `, params);
+        return rows.slice(0, 8) as FileRow[];
     });
 
 export const loadToolEvidenceTable = (table: "read_file" | "searched_file", fileIds: readonly string[]) =>

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -3,7 +3,6 @@ import { SurrealClient } from "@ax/lib/db";
 import { CacheRead } from "@ax/lib/duckdb/seam";
 import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import { errorSignatureRecordKey, symbolRecordKey } from "../ingest/record-keys.ts";
-import { refListSource } from "@ax/lib/shared/record-select";
 import { normalizeErrorSignature } from "../ingest/turn-references.ts";
 import { classifyTurnIntent } from "../ingest/intent-kind.ts";
 import { numeric, durationMs, rankToolEvidence } from "./file-evidence-rank.ts";
@@ -467,85 +466,91 @@ export const loadProducedSessionTurns = (touches: readonly TouchRow[]) =>
  * Prior sessions that edited the target files, with per-session summary stats.
  *
  * Two-stage aggregation: run the cheap inner aggregation first (one indexed
- * query), then issue batched `IN [sessions]` reads in parallel plus per-session
- * INDEXED turn reads, aggregating client-side. `turn WHERE session IN [<sids>]`
- * is a membership scan over the 560k-row turn table (~3s for 50 sessions);
- * `session = <lit>` hits `turn_session_seq` (~1ms), so the turn reads fan out.
- * The other reads stay batched (session/produced/delivery_outcome/
- * session_health are tiny). This is the single loader both adapters share;
- * the old per-row-subquery variant cost ~3.5s per high-signal session and its
- * only extra output (`hands_free_ms`) had no consumer.
+ * query), then issue batched `session IN (...)` reads through CacheRead,
+ * aggregating client-side. Ported off the SurrealDB-specific "N per-session
+ * queries beat one IN-list scan" tuning (Surreal's `session = <lit>` hit a
+ * point index the `IN [...]` form didn't); DuckDB's turn_session_seq index
+ * serves an IN-list scan directly, so this is one batched query per shape
+ * instead of a fanned-out per-session loop.
  */
-const CONTEXT_TURN_FANOUT = 16;
-
 export const loadPriorFileSessions = (fileIds: readonly string[], limit: number) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as PriorFileSession[];
         const cappedLimit = Math.max(1, Math.min(limit, 50));
-        const [aggRows] = yield* db.query<[
-            Array<{
-                session: string;
-                file: string;
-                weight: number;
-                last_seen: string;
-            }>
-        ]>(`
-            SELECT <string>in.session AS session, out.path AS file, count() AS weight, time::max(ts) AS last_seen
-            FROM edited
-            WHERE out IN [${fileIds.join(", ")}]
-              AND in.session.source != "claude-subagent"
-            GROUP BY session, file
+        const aggRows = yield* read.rows(Schema.Struct({
+            session: Schema.String,
+            file: Schema.String,
+            weight: NumberFromBigIntColumn,
+            last_seen: TimestampColumn,
+        }), `
+            SELECT t.session AS session, f.path AS file, count(*) AS weight, max(e.ts) AS last_seen
+            FROM edited e
+            JOIN turn t ON t.id = e.in_id
+            JOIN session s ON s.id = t.session
+            JOIN file f ON f.id = e.out_id
+            WHERE e.out_id IN (${fileIds.map(() => "?").join(", ")})
+              AND s.source <> 'claude-subagent'
+            GROUP BY t.session, f.path
             ORDER BY weight DESC, last_seen DESC
-            LIMIT ${cappedLimit};
-        `);
+            LIMIT ?
+        `, [...fileIds, cappedLimit]);
         if (aggRows.length === 0) return [] as PriorFileSession[];
 
         const sessionIds = Array.from(new Set(aggRows.map((r) => r.session)));
-        const sidLiteral = sessionIds.join(", ");
+        const sidPlaceholders = sessionIds.map(() => "?").join(", ");
 
-        const perSessionTurns = <Row>(sqlFor: (sid: string) => string) =>
-            Effect.forEach(
-                sessionIds,
-                (sid) => db.query<[Row[]]>(sqlFor(sid)).pipe(Effect.map(([rows]) => rows ?? [])),
-                { concurrency: CONTEXT_TURN_FANOUT },
-            ).pipe(Effect.map((chunks) => chunks.flat()));
-
-        const [sessionsResult, producedResult, deliveryResult, healthResult] =
+        const [sessionsRows, producedRows, deliveryRows, healthRows, turnsRows, titleRows] =
             yield* Effect.all([
-                // Record-list selection for the by-id fetch - `FROM session
-                // WHERE id IN [...]` happens to work on `session` today, but
-                // the id IN-list form silently matches nothing on other tables
-                // (see @ax/lib/shared/record-select); don't rely on it. The
-                // non-id field IN-lists below are fine.
-                db.query<[Array<{ id: string; project: string | null; source: string | null; started_at: string | null; ended_at: string | null }>]>(
-                    `SELECT <string>id AS id, project, source, started_at, ended_at FROM ${refListSource(sessionIds)};`,
-                ),
-                db.query<[Array<{ in: string }>]>(
-                    `SELECT <string>in AS in FROM produced WHERE in IN [${sidLiteral}];`,
-                ),
-                db.query<[Array<{ session: string; status: string | null; review_pain: string | null; pr_size: string | null; pr_title: string | null }>]>(
-                    `SELECT <string>session AS session, status, review_pain, pr_size, pull_request.title AS pr_title FROM delivery_outcome WHERE session IN [${sidLiteral}];`,
-                ),
-                db.query<[Array<{ session: string; interruptions: number }>]>(
-                    `SELECT <string>session AS session, interruptions FROM session_health WHERE session IN [${sidLiteral}];`,
-                ),
+                read.rows(Schema.Struct({
+                    id: Schema.String,
+                    project: Schema.NullOr(Schema.String),
+                    source: Schema.NullOr(Schema.String),
+                    started_at: Schema.NullOr(TimestampColumn),
+                    ended_at: Schema.NullOr(TimestampColumn),
+                }), `SELECT id, project, source, started_at, ended_at FROM session WHERE id IN (${sidPlaceholders})`, sessionIds),
+                read.rows(Schema.Struct({ session_id: Schema.String }),
+                    `SELECT in_id AS session_id FROM produced WHERE in_id IN (${sidPlaceholders})`, sessionIds),
+                read.rows(Schema.Struct({
+                    session: Schema.NullOr(Schema.String),
+                    status: Schema.NullOr(Schema.String),
+                    review_pain: Schema.NullOr(Schema.String),
+                    pr_size: Schema.NullOr(Schema.String),
+                    pr_title: Schema.NullOr(Schema.String),
+                }), `
+                    SELECT d.session AS session, d.status AS status, d.review_pain AS review_pain,
+                           d.pr_size AS pr_size, pr.title AS pr_title
+                    FROM delivery_outcome d
+                    LEFT JOIN pull_request pr ON pr.id = d.pull_request
+                    WHERE d.session IN (${sidPlaceholders})
+                `, sessionIds),
+                read.rows(Schema.Struct({ session: Schema.String, interruptions: NumberFromBigIntColumn }),
+                    `SELECT session, interruptions FROM session_health WHERE session IN (${sidPlaceholders})`, sessionIds),
+                read.rows(Schema.Struct({ session: Schema.String, role: Schema.String, intent_kind: Schema.NullOr(Schema.String) }),
+                    `SELECT session, role, intent_kind FROM turn WHERE session IN (${sidPlaceholders}) AND role IN ('user', 'assistant')`, sessionIds),
+                read.rows(Schema.Struct({
+                    session: Schema.String,
+                    text_excerpt: Schema.String,
+                    seq: NumberFromBigIntColumn,
+                    intent_kind: Schema.NullOr(Schema.String),
+                }), `
+                    SELECT session, text_excerpt, seq, intent_kind FROM turn
+                    WHERE session IN (${sidPlaceholders}) AND role = 'user' AND message_kind = 'task'
+                      AND intent_kind IN ('organic_task', 'preference', 'correction')
+                      AND text_excerpt IS NOT NULL
+                    ORDER BY seq ASC
+                `, sessionIds),
             ], { concurrency: "unbounded" });
 
-        const turnsRows = yield* perSessionTurns<{ session: string; role: string; intent_kind: string | null }>(
-            (sid) => `SELECT <string>session AS session, role, intent_kind FROM turn WHERE session = ${sid} AND role IN ['user','assistant'];`,
-        );
-        const titleRows = yield* perSessionTurns<{ session: string; text_excerpt: string; seq: number; intent_kind: string | null }>(
-            (sid) => `SELECT <string>session AS session, text_excerpt, seq, intent_kind FROM turn WHERE session = ${sid} AND role = 'user' AND message_kind = 'task' AND intent_kind IN ['organic_task','preference','correction'] AND text_excerpt IS NOT NONE ORDER BY seq ASC;`,
-        );
-
-        const [sessionsRows] = sessionsResult;
-        const [producedRows] = producedResult;
-        const [deliveryRows] = deliveryResult;
-        const [healthRows] = healthResult;
-
         const sessionMeta = new Map<string, { project: string | null; source: string | null; started_at: string | null; ended_at: string | null }>();
-        for (const row of sessionsRows) sessionMeta.set(row.id, row);
+        for (const row of sessionsRows) {
+            sessionMeta.set(row.id, {
+                project: row.project,
+                source: row.source,
+                started_at: row.started_at?.toISOString() ?? null,
+                ended_at: row.ended_at?.toISOString() ?? null,
+            });
+        }
 
         const turnCounts = new Map<string, { user: number; assistant: number; corrections: number }>();
         for (const row of turnsRows) {
@@ -560,11 +565,11 @@ export const loadPriorFileSessions = (fileIds: readonly string[], limit: number)
         }
 
         const producedCounts = new Map<string, number>();
-        for (const row of producedRows) producedCounts.set(row.in, (producedCounts.get(row.in) ?? 0) + 1);
+        for (const row of producedRows) producedCounts.set(row.session_id, (producedCounts.get(row.session_id) ?? 0) + 1);
 
         const deliveryBySession = new Map<string, { status: string | null; review_pain: string | null; pr_size: string | null; pr_title: string | null }>();
         for (const row of deliveryRows) {
-            if (!deliveryBySession.has(row.session)) deliveryBySession.set(row.session, row);
+            if (row.session && !deliveryBySession.has(row.session)) deliveryBySession.set(row.session, row);
         }
 
         const interruptionsBySession = new Map<string, number>();
@@ -623,7 +628,7 @@ export const loadPriorFileSessions = (fileIds: readonly string[], limit: number)
                 interruptions: interruptionsBySession.get(row.session) ?? 0,
                 duration_ms: durationMs(meta?.started_at, meta?.ended_at),
                 hands_free_ms: null,
-                last_seen: row.last_seen ?? null,
+                last_seen: row.last_seen.toISOString(),
                 fileWeights: new Map(),
             };
             base.weight += weight;

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -696,43 +696,48 @@ export const loadNeighborFiles = (touches: readonly TouchRow[], targetPaths: rea
  *  not "any correction in a session that happened to edit this file." */
 export const loadFileTargetedCorrections = (fileIds: readonly string[], limit: number) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as FileMemoryCorrection[];
         const cap = Math.max(1, Math.min(limit, 20));
         // Defense-in-depth: existing turn rows still carry the old (loose)
         // intent_kind classification. Filter slash-command bodies and long
         // text at query time so the hook doesn't surface non-corrections
         // until a re-derivation pass cleans them up.
-        const [rows] = yield* db.query<[
-            Array<{
-                turn_id: string;
-                session_id: string;
-                ts: string | null;
-                text: string | null;
-            }>
-        ]>(`
+        const rows = yield* read.rows(Schema.Struct({
+            turn_id: Schema.String,
+            session_id: Schema.String,
+            ts: Schema.NullOr(TimestampColumn),
+            text: Schema.NullOr(Schema.String),
+        }), `
             SELECT
-                <string>in.id AS turn_id,
-                <string>in.session AS session_id,
-                <string>in.ts AS ts,
-                in.text_excerpt AS text
-            FROM mentioned_file
-            WHERE out IN [${fileIds.join(", ")}]
-              AND in.role = "user"
-              AND in.intent_kind = "correction"
-              AND in.session.source != "claude-subagent"
-              AND in.text_excerpt IS NOT NONE
-              AND string::len(in.text_excerpt) < 500
-            ORDER BY ts DESC
-            LIMIT ${cap * 2};
-        `);
+                t.id AS turn_id,
+                t.session AS session_id,
+                t.ts AS ts,
+                t.text_excerpt AS text
+            FROM mentioned_file mf
+            JOIN turn t ON t.id = mf.in_id
+            JOIN session s ON s.id = t.session
+            WHERE mf.out_id IN (${fileIds.map(() => "?").join(", ")})
+              AND t.role = 'user'
+              AND t.intent_kind = 'correction'
+              AND s.source <> 'claude-subagent'
+              AND t.text_excerpt IS NOT NULL
+              AND length(t.text_excerpt) < 500
+            ORDER BY t.ts DESC
+            LIMIT ?
+        `, [...fileIds, cap * 2]);
         if (rows.length === 0) return [] as FileMemoryCorrection[];
 
         // Defense-in-depth filter (TS side): existing rows still carry old
         // loose intent classification. Drop wrapper-instruction-shaped text
         // that slipped through. Once intent-kind.ts is re-derived this becomes
         // a no-op.
-        const filtered = rows.filter((r) => {
+        const filtered = rows.map((row) => ({
+            turn_id: row.turn_id,
+            session_id: row.session_id,
+            ts: row.ts?.toISOString() ?? null,
+            text: row.text,
+        })).filter((r) => {
             const t = (r.text ?? "").trimStart();
             if (t.startsWith("## Your task")) return false;
             if (t.startsWith("# /")) return false;
@@ -744,14 +749,18 @@ export const loadFileTargetedCorrections = (fileIds: readonly string[], limit: n
         // Batch-fetch delivery_outcome for the unique sessions to surface
         // `merged_to_main` and PR titles next to each correction quote.
         const sessionIds = Array.from(new Set(filtered.map((r) => r.session_id)));
-        const sidLiteral = sessionIds.join(", ");
-        const [deliveryRows] = yield* db.query<[
-            Array<{ session: string; status: string | null; pr_title: string | null }>
-        ]>(
-            `SELECT <string>session AS session, status, pull_request.title AS pr_title FROM delivery_outcome WHERE session IN [${sidLiteral}];`,
-        );
+        const deliveryRows = yield* read.rows(Schema.Struct({
+            session: Schema.NullOr(Schema.String),
+            status: Schema.NullOr(Schema.String),
+            pr_title: Schema.NullOr(Schema.String),
+        }), `
+            SELECT d.session AS session, d.status AS status, pr.title AS pr_title
+            FROM delivery_outcome d
+            LEFT JOIN pull_request pr ON pr.id = d.pull_request
+            WHERE d.session IN (${sessionIds.map(() => "?").join(", ")})
+        `, sessionIds);
         const deliveryBySession = new Map<string, { status: string | null; pr_title: string | null }>();
-        for (const row of deliveryRows) deliveryBySession.set(row.session, row);
+        for (const row of deliveryRows) if (row.session) deliveryBySession.set(row.session, row);
 
         return filtered.map((row): FileMemoryCorrection => {
             const delivery = deliveryBySession.get(row.session_id);

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -401,9 +401,20 @@ export const loadMentions = (signals: MentionSignals, files: readonly FileRow[])
             .slice(0, 12);
     });
 
+const SessionTurnQueryRow = Schema.Struct({
+    id: Schema.String,
+    session: Schema.String,
+    source: Schema.NullOr(Schema.String),
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: TimestampColumn,
+    message_kind: Schema.NullOr(Schema.String),
+    intent_kind: Schema.NullOr(Schema.String),
+    text_excerpt: Schema.NullOr(Schema.String),
+});
+
 export const loadProducedSessionTurns = (touches: readonly TouchRow[]) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         const sessionIds = Array.from(
             new Set(
                 touches.flatMap((touch) =>
@@ -414,33 +425,40 @@ export const loadProducedSessionTurns = (touches: readonly TouchRow[]) =>
             ),
         ).slice(0, 8);
         if (sessionIds.length === 0) return [] as SessionTurn[];
-        const [rows] = yield* db.query<[SessionTurn[]]>(`
+        const rows = yield* read.rows(SessionTurnQueryRow, `
             SELECT
-                <string>id AS id,
-                <string>session AS session,
-                session.source AS source,
-                seq,
-                <string>ts AS ts,
-                message_kind,
-                intent_kind,
-                text_excerpt
-            FROM turn
-            WHERE session IN [${sessionIds.join(", ")}]
-              AND text_excerpt IS NOT NONE
-              AND message_kind = "task"
-              AND session.source != "claude-subagent"
-            ORDER BY ts ASC
-            LIMIT 40;
-        `);
+                t.id AS id,
+                t.session AS session,
+                s.source AS source,
+                t.seq AS seq,
+                t.ts AS ts,
+                t.message_kind AS message_kind,
+                t.intent_kind AS intent_kind,
+                t.text_excerpt AS text_excerpt
+            FROM turn t
+            JOIN session s ON s.id = t.session
+            WHERE t.session IN (${sessionIds.map(() => "?").join(", ")})
+              AND t.text_excerpt IS NOT NULL
+              AND t.message_kind = 'task'
+              AND s.source <> 'claude-subagent'
+            ORDER BY t.ts ASC
+            LIMIT 40
+        `, sessionIds);
         return rows
-            .map((row) => ({
-                ...row,
+            .map((row): SessionTurn => ({
+                id: row.id,
+                session: row.session,
+                source: row.source,
+                seq: row.seq,
+                ts: row.ts.toISOString(),
+                message_kind: row.message_kind,
                 intent_kind: row.intent_kind ?? classifyTurnIntent({
                     role: "user",
                     messageKind: row.message_kind ?? "task",
                     source: row.source ?? null,
                     text: row.text_excerpt ?? null,
                 }),
+                text_excerpt: row.text_excerpt,
             }))
             .filter((row) => ["organic_task", "correction", "preference"].includes(row.intent_kind ?? ""));
     });

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -198,24 +198,100 @@ export const loadToolEvidenceTable = (table: "read_file" | "searched_file", file
         return mapped.sort((a, b) => rankToolEvidence(b) - rankToolEvidence(a));
     });
 
+const TouchQueryRow = Schema.Struct({
+    id: Schema.String,
+    additions: Schema.NullOr(NumberFromBigIntColumn),
+    deletions: Schema.NullOr(NumberFromBigIntColumn),
+    ts: TimestampColumn,
+    file_id: Schema.NullOr(Schema.String),
+    file_path: Schema.NullOr(Schema.String),
+    file_repo: Schema.NullOr(Schema.String),
+    file_repository: Schema.NullOr(Schema.String),
+    commit_id: Schema.NullOr(Schema.String),
+    commit_sha: Schema.NullOr(Schema.String),
+    commit_message: Schema.NullOr(Schema.String),
+    commit_author: Schema.NullOr(Schema.String),
+    commit_ts: Schema.NullOr(TimestampColumn),
+});
+
+const ProducedSessionRow = Schema.Struct({
+    commit_id: Schema.String,
+    session_id: Schema.String,
+    source: Schema.NullOr(Schema.String),
+    cwd: Schema.NullOr(Schema.String),
+});
+
+/**
+ * `touched` is a `(commit) -in-> edge -out-> (file)` edge; `commit.sessions`
+ * (the sessions that produced the commit) was a reverse graph traversal
+ * (`<-produced.in`) in SurrealQL. DuckDB has no record-graph traversal, so
+ * this is a second batched query over `produced` (session -in-> commit -out->)
+ * for the commit ids the first query returned, grouped back onto each commit
+ * in JS - same batching shape as `prevTurnQuery` in label-mining-service.ts.
+ */
 export const loadTouches = (fileIds: readonly string[]) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as TouchRow[];
-        const [rows] = yield* db.query<[TouchRow[]]>(`
+        const rows = yield* read.rows(TouchQueryRow, `
             SELECT
-                <string>id AS id,
-                additions,
-                deletions,
-                <string>ts AS ts,
-                out.{ id, path, repo, repository } AS file,
-                in.{ id, sha, message, author, ts, sessions: <-produced.in.{ id, source, cwd } } AS commit
-            FROM touched
-            WHERE out IN [${fileIds.join(", ")}]
-            ORDER BY ts DESC
-            LIMIT 40;
-        `);
-        return rows;
+                t.id AS id,
+                t.additions AS additions,
+                t.deletions AS deletions,
+                t.ts AS ts,
+                f.id AS file_id,
+                f.path AS file_path,
+                f.repo AS file_repo,
+                f.repository AS file_repository,
+                c.id AS commit_id,
+                c.sha AS commit_sha,
+                c.message AS commit_message,
+                c.author AS commit_author,
+                c.ts AS commit_ts
+            FROM touched t
+            JOIN file f ON f.id = t.out_id
+            JOIN "commit" c ON c.id = t.in_id
+            WHERE t.out_id IN (${fileIds.map(() => "?").join(", ")})
+            ORDER BY t.ts DESC
+            LIMIT 40
+        `, fileIds);
+
+        const commitIds = Array.from(new Set(rows.map((row) => row.commit_id).filter((id): id is string => id !== null)));
+        const sessionsByCommit = new Map<string, Array<{ id: string; source: string | null; cwd: string | null }>>();
+        if (commitIds.length > 0) {
+            const producedRows = yield* read.rows(ProducedSessionRow, `
+                SELECT p.out_id AS commit_id, s.id AS session_id, s.source AS source, s.cwd AS cwd
+                FROM produced p
+                JOIN session s ON s.id = p.in_id
+                WHERE p.out_id IN (${commitIds.map(() => "?").join(", ")})
+            `, commitIds);
+            for (const row of producedRows) {
+                const list = sessionsByCommit.get(row.commit_id) ?? [];
+                list.push({ id: row.session_id, source: row.source, cwd: row.cwd });
+                sessionsByCommit.set(row.commit_id, list);
+            }
+        }
+
+        return rows.map((row): TouchRow => ({
+            id: row.id,
+            additions: row.additions,
+            deletions: row.deletions,
+            ts: row.ts.toISOString(),
+            file: row.file_id === null ? null : {
+                id: row.file_id,
+                path: row.file_path ?? "",
+                repo: row.file_repo,
+                repository: row.file_repository,
+            },
+            commit: row.commit_id === null ? null : {
+                id: row.commit_id,
+                sha: row.commit_sha,
+                message: row.commit_message,
+                author: row.commit_author,
+                ts: row.commit_ts?.toISOString() ?? null,
+                sessions: sessionsByCommit.get(row.commit_id) ?? [],
+            },
+        }));
     });
 
 export const loadMentions = (signals: MentionSignals, files: readonly FileRow[]) =>

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -778,22 +778,26 @@ export const loadFileTargetedCorrections = (fileIds: readonly string[], limit: n
 /** Recent commits whose `touched` relation points to any of these files. */
 export const loadRecentCommitsForFile = (fileIds: readonly string[], limit: number) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as FileMemoryCommit[];
         const cap = Math.max(1, Math.min(limit, 20));
-        const [rows] = yield* db.query<[
-            Array<{ commit_id: string; sha: string | null; message: string | null; ts: string | null }>
-        ]>(`
+        const rows = yield* read.rows(Schema.Struct({
+            commit_id: Schema.String,
+            sha: Schema.NullOr(Schema.String),
+            message: Schema.NullOr(Schema.String),
+            ts: Schema.NullOr(TimestampColumn),
+        }), `
             SELECT
-                <string>in.id AS commit_id,
-                in.sha AS sha,
-                in.message AS message,
-                <string>in.ts AS ts
-            FROM touched
-            WHERE out IN [${fileIds.join(", ")}]
-            ORDER BY ts DESC
-            LIMIT ${cap};
-        `);
+                c.id AS commit_id,
+                c.sha AS sha,
+                c.message AS message,
+                c.ts AS ts
+            FROM touched t
+            JOIN "commit" c ON c.id = t.in_id
+            WHERE t.out_id IN (${fileIds.map(() => "?").join(", ")})
+            ORDER BY c.ts DESC
+            LIMIT ?
+        `, [...fileIds, cap]);
         // De-dupe by commit_id (multiple touched rows can share a commit when
         // we feed in several file-id variants for the same canonical file).
         const seen = new Set<string>();
@@ -805,7 +809,7 @@ export const loadRecentCommitsForFile = (fileIds: readonly string[], limit: numb
                 commit_id: row.commit_id,
                 sha: row.sha,
                 message: row.message?.split("\n")[0]?.trim() ?? null,
-                ts: row.ts,
+                ts: row.ts?.toISOString() ?? null,
             });
             if (out.length >= cap) break;
         }

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { CacheRead } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import { errorSignatureRecordKey, symbolRecordKey } from "../ingest/record-keys.ts";
 import { refListSource } from "@ax/lib/shared/record-select";
 import { normalizeErrorSignature } from "../ingest/turn-references.ts";
@@ -122,27 +123,79 @@ export const resolveFiles = (paths: readonly string[], opts: { readonly fuzzyFal
         return rows.slice(0, 8) as FileRow[];
     });
 
+const ToolEvidenceQueryRow = Schema.Struct({
+    evidence: Schema.NullOr(Schema.String),
+    path_seen: Schema.NullOr(Schema.String),
+    excerpt: Schema.NullOr(Schema.String),
+    ts: TimestampColumn,
+    path: Schema.NullOr(Schema.String),
+    tool_name: Schema.NullOr(Schema.String),
+    command_norm: Schema.NullOr(Schema.String),
+    turn_id: Schema.NullOr(Schema.String),
+    turn_seq: Schema.NullOr(NumberFromBigIntColumn),
+    turn_intent_kind: Schema.NullOr(Schema.String),
+    turn_text_excerpt: Schema.NullOr(Schema.String),
+    turn_session_id: Schema.NullOr(Schema.String),
+    turn_session_source: Schema.NullOr(Schema.String),
+});
+
+/**
+ * `read_file`/`searched_file` are `(tool_call) -in-> edge -out-> (file)` edges.
+ * The `claude-subagent` filter is against the TOOL CALL's own session (`tc`),
+ * matching the original `in.session.source` - not the (possibly different)
+ * turn's session.
+ */
 export const loadToolEvidenceTable = (table: "read_file" | "searched_file", fileIds: readonly string[]) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         if (fileIds.length === 0) return [] as ToolEvidenceRow[];
-        const [rows] = yield* db.query<[Array<Omit<ToolEvidenceRow, "kind">>]>(`
+        const rows = yield* read.rows(ToolEvidenceQueryRow, `
             SELECT
-                evidence,
-                path_seen,
-                excerpt,
-                <string>ts AS ts,
-                out.path AS path,
-                in.name AS tool_name,
-                in.command_norm AS command_norm,
-                in.turn.{ id, seq, intent_kind, text_excerpt, session: session.{ id, source } } AS turn
-            FROM ${table}
-            WHERE out IN [${fileIds.join(", ")}]
-              AND in.session.source != "claude-subagent"
-            ORDER BY ts DESC
-            LIMIT 30;
-        `);
-        return rows.map((row) => ({ ...row, kind: table })).sort((a, b) => rankToolEvidence(b) - rankToolEvidence(a));
+                e.evidence AS evidence,
+                e.path_seen AS path_seen,
+                e.excerpt AS excerpt,
+                e.ts AS ts,
+                f.path AS path,
+                tc.name AS tool_name,
+                tc.command_norm AS command_norm,
+                t.id AS turn_id,
+                t.seq AS turn_seq,
+                t.intent_kind AS turn_intent_kind,
+                t.text_excerpt AS turn_text_excerpt,
+                tsess.id AS turn_session_id,
+                tsess.source AS turn_session_source
+            FROM ${table} e
+            JOIN file f ON f.id = e.out_id
+            JOIN tool_call tc ON tc.id = e.in_id
+            JOIN session s ON s.id = tc.session
+            LEFT JOIN turn t ON t.id = tc.turn
+            LEFT JOIN session tsess ON tsess.id = t.session
+            WHERE e.out_id IN (${fileIds.map(() => "?").join(", ")})
+              AND s.source <> 'claude-subagent'
+            ORDER BY e.ts DESC
+            LIMIT 30
+        `, fileIds);
+        const mapped: ToolEvidenceRow[] = rows.map((row) => ({
+            kind: table,
+            evidence: row.evidence,
+            path_seen: row.path_seen,
+            excerpt: row.excerpt,
+            ts: row.ts.toISOString(),
+            path: row.path,
+            tool_name: row.tool_name,
+            command_norm: row.command_norm,
+            turn: row.turn_id === null ? null : {
+                id: row.turn_id,
+                seq: row.turn_seq,
+                intent_kind: row.turn_intent_kind,
+                text_excerpt: row.turn_text_excerpt,
+                session: row.turn_session_id === null ? null : {
+                    id: row.turn_session_id,
+                    source: row.turn_session_source,
+                },
+            },
+        }));
+        return mapped.sort((a, b) => rankToolEvidence(b) - rankToolEvidence(a));
     });
 
 export const loadTouches = (fileIds: readonly string[]) =>

--- a/apps/axctl/src/context/file-evidence.ts
+++ b/apps/axctl/src/context/file-evidence.ts
@@ -294,11 +294,42 @@ export const loadTouches = (fileIds: readonly string[]) =>
         }));
     });
 
+const MentionQueryRow = Schema.Struct({
+    id: Schema.String,
+    session: Schema.String,
+    source: Schema.NullOr(Schema.String),
+    seq: Schema.NullOr(NumberFromBigIntColumn),
+    ts: TimestampColumn,
+    intent_kind: Schema.NullOr(Schema.String),
+    text_excerpt: Schema.NullOr(Schema.String),
+    score: NumberFromBigIntColumn,
+    why: Schema.String,
+});
+type MentionQueryRowType = typeof MentionQueryRow.Type;
+
+const mentionRowToTurn = (row: MentionQueryRowType): Omit<MentionTurn, "score" | "why"> & { score: number; why: string } => ({
+    id: row.id,
+    session: row.session,
+    source: row.source,
+    seq: row.seq,
+    ts: row.ts.toISOString(),
+    intent_kind: row.intent_kind,
+    text_excerpt: row.text_excerpt,
+    score: row.score,
+    why: row.why,
+});
+
+/**
+ * `mentioned_file`/`mentioned_symbol`/`mentioned_error` are `(turn) -in->
+ * edge -out-> (target)` edges. `why` was `string::concat(source, ": ", ...)`
+ * self-referencing the `source` alias defined earlier in the same SELECT -
+ * DuckDB (standard SQL) cannot do that, so the expression is repeated.
+ */
 export const loadMentions = (signals: MentionSignals, files: readonly FileRow[]) =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         const scored = new Map<string, MentionTurn>();
-        const addRows = (rows: Array<Omit<MentionTurn, "score" | "why"> & { readonly score: number; readonly why: string }>) => {
+        const addRows = (rows: readonly (Omit<MentionTurn, "score" | "why"> & { readonly score: number; readonly why: string })[]) => {
             for (const row of rows) {
                 if (row.source === "claude-subagent") continue;
                 if (!["organic_task", "correction", "preference"].includes(row.intent_kind ?? "")) continue;
@@ -313,47 +344,56 @@ export const loadMentions = (signals: MentionSignals, files: readonly FileRow[])
 
         const fileIds = files.map((file) => file.id);
         if (fileIds.length > 0) {
-            const [rows] = yield* db.query<[Array<Omit<MentionTurn, "score" | "why"> & { score: number; why: string }>]>(`
-                SELECT <string>in.id AS id, <string>in.session AS session, in.session.source AS source, in.seq AS seq,
-                       <string>in.ts AS ts, in.intent_kind AS intent_kind, in.text_excerpt AS text_excerpt,
-                       8 AS score, string::concat(source, ": ", out.path) AS why
-                FROM mentioned_file
-                WHERE out IN [${fileIds.join(", ")}]
-                  AND in.session.source != "claude-subagent"
-                ORDER BY ts DESC
-                LIMIT 40;
-            `);
-            addRows(rows);
+            const rows = yield* read.rows(MentionQueryRow, `
+                SELECT t.id AS id, t.session AS session, s.source AS source, t.seq AS seq,
+                       t.ts AS ts, t.intent_kind AS intent_kind, t.text_excerpt AS text_excerpt,
+                       8 AS score, (s.source || ': ' || f.path) AS why
+                FROM mentioned_file mf
+                JOIN turn t ON t.id = mf.in_id
+                JOIN session s ON s.id = t.session
+                JOIN file f ON f.id = mf.out_id
+                WHERE mf.out_id IN (${fileIds.map(() => "?").join(", ")})
+                  AND s.source <> 'claude-subagent'
+                ORDER BY t.ts DESC
+                LIMIT 40
+            `, fileIds);
+            addRows(rows.map(mentionRowToTurn));
         }
 
-        const symbolIds = signals.symbols.map((symbol) => `symbol:\`${symbolRecordKey(symbol)}\``);
+        const symbolIds = signals.symbols.map((symbol) => `symbol:${symbolRecordKey(symbol)}`);
         if (symbolIds.length > 0) {
-            const [rows] = yield* db.query<[Array<Omit<MentionTurn, "score" | "why"> & { score: number; why: string }>]>(`
-                SELECT <string>in.id AS id, <string>in.session AS session, in.session.source AS source, in.seq AS seq,
-                       <string>in.ts AS ts, in.intent_kind AS intent_kind, in.text_excerpt AS text_excerpt,
-                       5 AS score, string::concat(source, ": ", out.name) AS why
-                FROM mentioned_symbol
-                WHERE out IN [${symbolIds.join(", ")}]
-                  AND in.session.source != "claude-subagent"
-                ORDER BY ts DESC
-                LIMIT 40;
-            `);
-            addRows(rows);
+            const rows = yield* read.rows(MentionQueryRow, `
+                SELECT t.id AS id, t.session AS session, s.source AS source, t.seq AS seq,
+                       t.ts AS ts, t.intent_kind AS intent_kind, t.text_excerpt AS text_excerpt,
+                       5 AS score, (s.source || ': ' || sym.name) AS why
+                FROM mentioned_symbol ms
+                JOIN turn t ON t.id = ms.in_id
+                JOIN session s ON s.id = t.session
+                JOIN symbol sym ON sym.id = ms.out_id
+                WHERE ms.out_id IN (${symbolIds.map(() => "?").join(", ")})
+                  AND s.source <> 'claude-subagent'
+                ORDER BY t.ts DESC
+                LIMIT 40
+            `, symbolIds);
+            addRows(rows.map(mentionRowToTurn));
         }
 
-        const errorIds = signals.errors.map((error) => `error_signature:\`${errorSignatureRecordKey(normalizeErrorSignature(error))}\``);
+        const errorIds = signals.errors.map((error) => `error_signature:${errorSignatureRecordKey(normalizeErrorSignature(error))}`);
         if (errorIds.length > 0) {
-            const [rows] = yield* db.query<[Array<Omit<MentionTurn, "score" | "why"> & { score: number; why: string }>]>(`
-                SELECT <string>in.id AS id, <string>in.session AS session, in.session.source AS source, in.seq AS seq,
-                       <string>in.ts AS ts, in.intent_kind AS intent_kind, in.text_excerpt AS text_excerpt,
-                       10 AS score, string::concat(source, ": ", out.text) AS why
-                FROM mentioned_error
-                WHERE out IN [${errorIds.join(", ")}]
-                  AND in.session.source != "claude-subagent"
-                ORDER BY ts DESC
-                LIMIT 40;
-            `);
-            addRows(rows);
+            const rows = yield* read.rows(MentionQueryRow, `
+                SELECT t.id AS id, t.session AS session, s.source AS source, t.seq AS seq,
+                       t.ts AS ts, t.intent_kind AS intent_kind, t.text_excerpt AS text_excerpt,
+                       10 AS score, (s.source || ': ' || es.text) AS why
+                FROM mentioned_error me
+                JOIN turn t ON t.id = me.in_id
+                JOIN session s ON s.id = t.session
+                JOIN error_signature es ON es.id = me.out_id
+                WHERE me.out_id IN (${errorIds.map(() => "?").join(", ")})
+                  AND s.source <> 'claude-subagent'
+                ORDER BY t.ts DESC
+                LIMIT 40
+            `, errorIds);
+            addRows(rows.map(mentionRowToTurn));
         }
 
         return Array.from(scored.values())

--- a/apps/axctl/src/hooks/file-context-hook.test.ts
+++ b/apps/axctl/src/hooks/file-context-hook.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { publishCacheFixture, readThroughFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import {
     adaptClaudePayload,
+    buildFileContextHookResponse,
     filterSuppressed,
     finalizeInjection,
     generateLookupCandidates,
@@ -13,6 +16,8 @@ import {
     shouldInjectFileMemory,
     type FileContextHookDecision,
 } from "./file-context-hook.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("file-context-hook (duckdb)", { requireFts: true });
 
 interface PriorSessionInit {
     readonly session?: string;
@@ -643,4 +648,51 @@ describe("finalizeInjection", () => {
         expect(result.inject).toBe(false);
         expect(result.reason).toBe("no_prior_sessions");
     });
+});
+
+describe("buildFileContextHookResponse (DuckDB, no SurrealDB reachable)", () => {
+    // Before this port, a file-context hook fire built `AppLayer` and opened a
+    // live SurrealDB WebSocket, waiting up to the 5s `CONNECT_TIMEOUT_MS` if
+    // nothing was listening. `buildFileContextHookResponse`'s type signature is
+    // now `Effect<FileContextHookResponse, CacheReadError, CacheRead>` - no
+    // `SurrealClient` in the R channel, so it is a COMPILE-TIME impossibility
+    // for this Effect to construct a SurrealDB connection; Effect.provide below
+    // only has a `CacheRead` layer to give it, and the code still typechecks.
+    // `AX_DB_URL` pointed at a dead port is set anyway, to demonstrate at
+    // runtime that nothing in this path so much as reads that variable.
+    dtest("resolves fast with AX_DB_URL pointed at a port nothing listens on", async () => {
+        const priorDbUrl = process.env.AX_DB_URL;
+        process.env.AX_DB_URL = "ws://127.0.0.1:1/rpc";
+        try {
+            const fixture = await runWithPlatform(
+                publishCacheFixture(
+                    tempDir("ax-file-context-hook-nodb-"),
+                    dylibPath,
+                    (w) => w.put("file", { id: "file:a", path: "src/ingest/codex.ts" }),
+                ),
+            );
+
+            const startMs = performance.now();
+            const response = await readThroughFixture(
+                fixture,
+                dylibPath,
+                buildFileContextHookResponse({
+                    event: "pre-edit",
+                    task: "fix the ingest bug",
+                    files: ["src/ingest/codex.ts"],
+                    format: "plain",
+                }),
+            );
+            const elapsedMs = performance.now() - startMs;
+
+            // Well under the 5s CONNECT_TIMEOUT_MS a stalled SurrealDB dial
+            // would have cost - this is milliseconds, not seconds.
+            expect(elapsedMs).toBeLessThan(2000);
+            expect(response.inject).toBe(false); // no prior sessions in this tiny fixture
+            expect(response.reason).toBe("no_prior_sessions");
+        } finally {
+            if (priorDbUrl === undefined) delete process.env.AX_DB_URL;
+            else process.env.AX_DB_URL = priorDbUrl;
+        }
+    }, 60_000);
 });

--- a/apps/axctl/src/hooks/file-context-hook.ts
+++ b/apps/axctl/src/hooks/file-context-hook.ts
@@ -1,7 +1,5 @@
 import { Effect } from "effect";
-import type { DbError } from "@ax/lib/errors";
-import { SurrealClient } from "@ax/lib/db";
-import type { CacheRead } from "@ax/lib/duckdb/seam";
+import type { CacheRead, CacheReadError } from "@ax/lib/duckdb/seam";
 import { decodeJsonRecordOrNull } from "@ax/lib/decode";
 import {
     type BuildFileContextInput,
@@ -32,7 +30,7 @@ export interface FileContextHookEvidence {
 
 export const buildFileContextHookEvidence = (
     input: BuildFileContextInput,
-): Effect.Effect<FileContextHookEvidence, DbError, SurrealClient> =>
+): Effect.Effect<FileContextHookEvidence, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
         const signals = extractFileContextSignals(input.q, input.files);
         const files = yield* resolveFiles(signals.paths, { fuzzyFallback: false });
@@ -49,7 +47,7 @@ export const buildFileContextHookEvidence = (
         // Each evidence query is isolated: a SQL failure in one (schema drift,
         // bad cast, missing table) must not block the hook output. Degrade to
         // empty and log to stderr; the agent still gets whatever did succeed.
-        const guard = <T,>(eff: Effect.Effect<T, DbError, SurrealClient>, label: string, fallback: T) =>
+        const guard = <T,>(eff: Effect.Effect<T, CacheReadError, CacheRead>, label: string, fallback: T) =>
             eff.pipe(Effect.catch((err) =>
                 Effect.sync(() => {
                     console.error(`axctl hook ${label} query failed:`, err.message);
@@ -443,7 +441,7 @@ const DEDUP_WINDOW_MINUTES = 30;
 
 export const buildFileContextHookResponse = (
     input: FileContextHookInput,
-): Effect.Effect<FileContextHookResponse, DbError, SurrealClient | CacheRead> =>
+): Effect.Effect<FileContextHookResponse, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
         const emptyEvidence = {
             prior_file_sessions: [] as readonly PriorFileSession[],

--- a/apps/axctl/src/judgment-cutover-sidecar.test.ts
+++ b/apps/axctl/src/judgment-cutover-sidecar.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SurrealClient } from "@ax/lib/db";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 import { Judgment, JudgmentLayer, NumberColumn, TextColumn } from "@ax/lib/sqlite";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { upsertRetro } from "./ingest/retro.ts";
@@ -66,7 +67,11 @@ describe("judgment cutover sidecar", () => {
         const graph = Layer.succeed(SurrealClient, {
             query: () => Effect.succeed([[]]),
         } as never);
-        const deps = Layer.mergeAll(sidecar, graph, BunFileSystem.layer, BunPath.layer);
+        // `selfImproveQuery` reads reviewed classifier_graph_fact rows through
+        // CacheRead now (see label-mining-service.ts); no facts exist in this
+        // fixture, matching the SurrealQL stub's empty result above.
+        const cacheRead = makeTestCacheRead({ fallback: [] }).layer;
+        const deps = Layer.mergeAll(sidecar, graph, cacheRead, BunFileSystem.layer, BunPath.layer);
         const result = await Effect.runPromise(Effect.gen(function* () {
             const judgment = yield* Judgment;
             yield* judgment.put("transcript_label_review", {


### PR DESCRIPTION
Wave 3, chunk `c-read-context`: the file-evidence / file-context hot path and the classifier services move onto the DuckDB `CacheRead` seam.

## The hot path is the point

`hooks/file-context-hook.ts` is the Claude Code `file-context` hook, routed runtime `"db"`. **Every fire opened a live SurrealDB WebSocket through the full `AppLayer`**, waiting up to the 5s `CONNECT_TIMEOUT_MS` - while `CacheRead` sat in its signature and was never yielded, dead in the Requires channel.

`context/file-evidence.ts` is 665 lines with 10 separate `SurrealClient` blocks. Ported one block per commit (`7dcc45d8..3e9d233d`), with the caller landing alongside the last one - caller and callee in the same chunk on purpose, because splitting them across two concurrent chunks is how a boundary break reaches the branch with neither side able to see it.

Proof, not assertion: a dead-port test (`AX_DB_URL` on a port nothing listens on) that fails before and passes after.

## Also ported

- `classifiers/label-mining-service.ts` + `classifiers/package-service.ts`
- `context/file-context-pack.ts`
- `context/file-evidence-rank.ts` - already pure, dead import removed

Test files moved off the banned `packages/lib/src/testing/surreal.ts` route-table fake onto real DuckDB fixtures. That fake answers SurrealQL no engine serves, which is the structural reason dead-engine readers ship green.

## Cross-chunk repair included

`cli/classifiers-package-operations.ts` is the caller of the ported `package-service.ts` but lives in another chunk's territory, so neither implementer could touch both sides and the branch typechecked red at the boundary. Repaired here, and the two call sites are deliberately **not** given the same shape:

- `runClassifiersPackageOperations` **gains** `CacheRead` beside `SurrealClient` - its read half moved, but `applyExecutionSurrealWritePlan` still emits SurrealQL, so it genuinely needs both.
- the quality-status report path **drops** `SurrealClient` for `CacheRead` - it reads through the seam only.

Collapsing both to one signature would hide exactly the distinction wave 3 exists to make visible.

## Known remaining gap

`projectReviewed` and `applyExecutionSurrealWritePlanReport` keep `SurrealClient` for their **write** statements. Reads are fully ported; the write plan is a `CacheWrite`/ingest-seam concern and belongs to that chunk.

## Verification

Scoped suites green: 346 pass / 4 skip / 0 fail across `classifiers/`, `context/`, `hooks/`. Canary `scripts/build-duckdb.test.ts` 4 pass / 0 fail, confirming the ICU-less static build is actually in use. Gates clean: `typecheck`, `tsc -p`, `check:no-node-fs`, `check:timestamp-cast`.

Base is `v2/duckdb`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
