### PR TITLE
feat(v2): c-read-dojo-profile - the silent-blend spar metric, and ax profile's data layer onto the seam

### DIFF
--- a/apps/axctl/src/cli/commands/profile-no-surreal.test.ts
+++ b/apps/axctl/src/cli/commands/profile-no-surreal.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `ax profile`, END TO END, with NO SurrealDB reachable.
+ *
+ * Mirrors `apps/axctl/src/cli/recall-no-surreal.test.ts`: spawns the ACTUAL
+ * CLI entrypoint as a child, with `AX_DB_URL` pointing at a port nothing is
+ * listening on, so any SurrealDB connect attempt can only fail or hang to its
+ * timeout - a real crash mode, not something an in-process test with a stub
+ * layer could observe.
+ *
+ * HONEST STATE (2026-08-17, wave-3 profile/queries.ts port): only
+ * `ax profile interview submit` is actually SurrealDB-free today, and this
+ * file proves exactly that - it does NOT claim `show`/`publish`/`widget`/bare
+ * `interview` are ported, because they are not:
+ *
+ *   - `fetchWindowedInvocations` (profile/queries.ts) is the one remaining
+ *     unported statement in this file's ownership. Porting it was tried and
+ *     reverted this session (see queries.ts's port history) because
+ *     `apps/axctl/src/team/team-profile.ts` imports it directly and that
+ *     file's own tests only provide a SurrealClient mock, not CacheRead -
+ *     porting it makes 9 unrelated tests fail with "Service not found:
+ *     ax/CacheRead". Needs a coordinated port of team-profile.ts by its
+ *     owner, out of scope here.
+ *   - `fetchCostModels` (queries/cost-analytics.ts, a DIFFERENT wave-3
+ *     chunk's file, not touched by this session) still resolves
+ *     SurrealClient for its main query; only its optional pricing-catalog
+ *     lookup reads CacheRead.
+ *
+ * Both are reached unconditionally on every `buildProfile` call (`ax profile
+ * show`'s and therefore `publish`/`widget`/bare `interview`'s common path),
+ * so those four commands genuinely still need a live SurrealDB today.
+ * Live-verified: `AX_DB_URL="ws://127.0.0.1:1/rpc" ax profile show --json`
+ * exits 1 after a 5s connect timeout with a `DbError`
+ * ("daemon not reachable..."), not a clean CacheRead-only run. `ax
+ * profile.ts`'s own runtime manifest (`resolveRuntime`/`axProfileRuntime`,
+ * see profile-interview.test.ts) already tracks this split: `interview
+ * submit` resolves to runtime "none"; `show`/`publish`/`interview` (bare)
+ * resolve to "db".
+ */
+import { describe, expect, test } from "bun:test";
+
+/** The CLI entrypoint, run the way `bin/axctl` runs it. */
+const CLI = new URL("../index.ts", import.meta.url).pathname;
+
+/** A port nothing listens on, so a SurrealDB connect can only FAIL. */
+const DEAD_DB_URL = "ws://127.0.0.1:1/rpc";
+
+/** A path nothing publishes to, so a CacheRead open can only FAIL too. */
+const DEAD_SNAPSHOT = "/tmp/does-not-exist-ax-profile-nodb.duckdb";
+
+interface CliRun {
+    readonly exitCode: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+const runCli = (args: ReadonlyArray<string>, extraEnv: Record<string, string> = {}): CliRun => {
+    const child = Bun.spawnSync(["bun", CLI, ...args], {
+        env: {
+            ...process.env,
+            AX_DB_URL: DEAD_DB_URL,
+            AX_DUCKDB_SNAPSHOT: DEAD_SNAPSHOT,
+            AX_PROGRESS: "off",
+            NO_COLOR: "1",
+            ...extraEnv,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    return {
+        exitCode: child.exitCode,
+        stdout: child.stdout.toString(),
+        stderr: child.stderr.toString(),
+    };
+};
+
+const tmpHome = () => `/tmp/ax-profile-nodb-home-${process.pid}-${Math.random().toString(36).slice(2)}`;
+
+describe("ax profile interview submit on the cache runtime", () => {
+    test("validates + writes highlights with no SurrealDB and no DuckDB snapshot reachable", async () => {
+        const home = tmpHome();
+        const inputPath = `${home}/highlights-input.json`;
+        await Bun.write(
+            inputPath,
+            JSON.stringify({ v: 1, authored_at: "2026-06-17T00:00:00Z", taste: "ship clean" }),
+        );
+
+        const run = runCli(["profile", "interview", "submit", "--file", inputPath], { HOME: home });
+
+        expect(run.stderr).not.toContain("SurrealClient");
+        expect(run.stderr).not.toContain("daemon not reachable");
+        expect(run.exitCode).toBe(0);
+        const written = await Bun.file(`${home}/.ax/profile-highlights.json`).json() as { taste?: string };
+        expect(written.taste).toBe("ship clean");
+
+        Bun.spawnSync(["rm", "-rf", home]);
+    }, 60_000);
+
+    test("rejects a bad shape without ever needing a DB, and writes nothing", async () => {
+        const home = tmpHome();
+        const inputPath = `${home}/highlights-input.json`;
+        await Bun.write(inputPath, JSON.stringify({ taste: 5 })); // taste must be a string
+
+        const run = runCli(["profile", "interview", "submit", "--file", inputPath], { HOME: home });
+
+        // /dev/null decodes to nothing usable - the CLI should fail on shape,
+        // not on a DB connect (which would show up as a DbError/timeout).
+        expect(run.stderr).not.toContain("SurrealClient");
+        expect(run.stderr).not.toContain("daemon not reachable");
+        expect(run.exitCode).not.toBe(0);
+        expect(await Bun.file(`${home}/.ax/profile-highlights.json`).exists()).toBe(false);
+
+        Bun.spawnSync(["rm", "-rf", home]);
+    }, 60_000);
+});
+
+describe("ax profile show/publish/widget/interview are NOT yet SurrealDB-free", () => {
+    // These pin the CURRENT, honest state (see file header) rather than
+    // asserting a success this session did not earn. Once
+    // fetchWindowedInvocations (this file's queries.ts) and fetchCostModels
+    // (queries/cost-analytics.ts) are both ported, this whole describe block
+    // should be deleted and `show`/`publish`/`widget`/`interview` folded into
+    // real no-surreal coverage above.
+    test("`ax profile show` still fails when SurrealDB is unreachable", () => {
+        const run = runCli(["profile", "show", "--json"]);
+        expect(run.exitCode).not.toBe(0);
+        expect(run.stderr).toContain("DbError");
+    }, 60_000);
+});

--- a/apps/axctl/src/dojo/skill-spar.test.ts
+++ b/apps/axctl/src/dojo/skill-spar.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { EmptyJudgmentTestLayer } from "../testing/judgment-test-layer.ts";
-import type { Judgment } from "@ax/lib/sqlite";
 import { Effect, Layer } from "effect";
-import { BunFileSystem } from "@effect/platform-bun";
-import { SurrealClient } from "@ax/lib/db";
-import { AxConfig, AxConfigTest } from "@ax/lib/config";
-import { makeTestSurrealClient, type TestSurrealClientOptions } from "@ax/lib/testing/surreal";
-import { makeTestCacheRead } from "@ax/lib/testing/cache";
+import { makeTestCacheRead, type TestCacheOptions } from "@ax/lib/testing/cache";
 import type { CacheRead } from "@ax/lib/duckdb/seam";
+import type { Judgment } from "@ax/lib/sqlite";
 import { ProcessServiceTest } from "@ax/lib/process";
 import { layerTestFileSystem } from "@ax/lib/testing/test-filesystem";
 import {
@@ -430,18 +426,22 @@ const defaultProcMock = ProcessServiceTest({
 
 const defaultFs = layerTestFileSystem({ [`${SKILL_DIR}/SKILL.md`]: SKILL_MD_CONTENT });
 
+/** A real-decode CacheRead fake (@ax/lib/testing/cache). */
+const resolveCache = (routes: TestCacheOptions["routes"]) =>
+    makeTestCacheRead(routes !== undefined ? { routes } : {});
+
 /** Run resolveSkillSparTask and unwrap the result. */
 const runResolve = (
     skillName: string,
     opts: ResolveSkillSparOpts | undefined,
-    tc: ReturnType<typeof makeTestSurrealClient>,
+    cache: ReturnType<typeof resolveCache>,
     proc: Layer.Layer<import("@ax/lib/process").ProcessService> = defaultProcMock,
     fs: Layer.Layer<import("effect").FileSystem.FileSystem> = defaultFs,
     repositoryKey: string | null = null,
 ) =>
     Effect.runPromise(
         resolveSkillSparTask(skillName, "/repo", repositoryKey, opts).pipe(
-            Effect.provide(Layer.mergeAll(tc.layer, proc, fs)),
+            Effect.provide(Layer.mergeAll(cache.layer, proc, fs)),
         ),
     );
 
@@ -449,7 +449,7 @@ const runResolve = (
 const runExpectCaptureFail = async (
     skillName: string,
     opts: ResolveSkillSparOpts | undefined,
-    tc: ReturnType<typeof makeTestSurrealClient>,
+    cache: ReturnType<typeof resolveCache>,
     msgSubstring: string,
     proc: Layer.Layer<import("@ax/lib/process").ProcessService> = defaultProcMock,
     fs: Layer.Layer<import("effect").FileSystem.FileSystem> = defaultFs,
@@ -457,7 +457,7 @@ const runExpectCaptureFail = async (
 ) => {
     const exit = await Effect.runPromiseExit(
         resolveSkillSparTask(skillName, "/repo", repositoryKey, opts).pipe(
-            Effect.provide(Layer.mergeAll(tc.layer, proc, fs)),
+            Effect.provide(Layer.mergeAll(cache.layer, proc, fs)),
         ),
     );
     expect(exit._tag).toBe("Failure");
@@ -473,27 +473,18 @@ describe("resolveSkillSparTask", () => {
     // Test 1: invoked-only history → resolves to the invoking session
     // -----------------------------------------------------------------------
     test("invoked-only: resolves to the most-recent invoking session", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                // invoked + loaded multi-statement: invoked has one row, loaded is empty
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                // session bulk fetch: source only (first_user_message derived from turn)
-                "source FROM": [
-                    [{ id: "session:s1", source: "claude" }],
-                ],
-                // turn text_excerpt for the picked session
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Fix the bug" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            // invoked has one row, loaded is empty (two separate bound queries)
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            // session bulk fetch: id + source (first_user_message derived from turn)
+            "id, source FROM session": [{ id: "session:s1", source: "claude" }],
+            // turn text_excerpt for the picked session
+            "FROM turn WHERE session": [{ text_excerpt: "Fix the bug" }],
         });
 
-        const result = await runResolve("my-skill", undefined, tc);
+        const result = await runResolve("my-skill", undefined, cache);
         expect(result.baselineSession).toBe("session:s1");
         expect(result.task).toBe("Fix the bug");
         expect(result.skill).toBe("my-skill");
@@ -507,25 +498,16 @@ describe("resolveSkillSparTask", () => {
     // Test 2: loaded-only history → resolves to the loading session
     // -----------------------------------------------------------------------
     test("loaded-only: resolves to the most-recent loading session", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                // invoked empty, loaded has one row
-                "FROM invoked WHERE out": [
-                    [],
-                    [{ sid: "session:s2", ts: "2026-02-05T00:00:00.000Z" }],
-                ],
-                "source FROM": [
-                    [{ id: "session:s2", source: "claude" }],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Do the loaded task" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            // invoked empty, loaded has one row
+            "FROM invoked WHERE out_id": [],
+            "FROM loaded WHERE out_id": [{ sid: "session:s2", ts: "2026-02-05T00:00:00.000Z" }],
+            "id, source FROM session": [{ id: "session:s2", source: "claude" }],
+            "FROM turn WHERE session": [{ text_excerpt: "Do the loaded task" }],
         });
 
-        const result = await runResolve("my-skill", undefined, tc);
+        const result = await runResolve("my-skill", undefined, cache);
         expect(result.baselineSession).toBe("session:s2");
         expect(result.task).toBe("Do the loaded task");
     });
@@ -534,28 +516,19 @@ describe("resolveSkillSparTask", () => {
     // Test 3: both invoked + loaded → max ts wins
     // -----------------------------------------------------------------------
     test("both invoked + loaded: most-recent edge-ts wins", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                // s1 invoked on Jan 10, s2 loaded on Jan 15 → s2 should win
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [{ sid: "session:s2", ts: "2026-01-15T00:00:00.000Z" }],
-                ],
-                "source FROM": [
-                    [
-                        { id: "session:s1", source: "claude" },
-                        { id: "session:s2", source: "claude" },
-                    ],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Newer task" }]],
-            },
+        // s1 invoked on Jan 10, s2 loaded on Jan 15 → s2 should win
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [{ sid: "session:s2", ts: "2026-01-15T00:00:00.000Z" }],
+            "id, source FROM session": [
+                { id: "session:s1", source: "claude" },
+                { id: "session:s2", source: "claude" },
+            ],
+            "FROM turn WHERE session": [{ text_excerpt: "Newer task" }],
         });
 
-        const result = await runResolve("my-skill", undefined, tc);
+        const result = await runResolve("my-skill", undefined, cache);
         expect(result.baselineSession).toBe("session:s2");
         expect(result.task).toBe("Newer task");
     });
@@ -564,95 +537,67 @@ describe("resolveSkillSparTask", () => {
     // Test 4: no history → SparCaptureError
     // -----------------------------------------------------------------------
     test("no invoked/loaded history → SparCaptureError", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [[], []],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [],
+            "FROM loaded WHERE out_id": [],
         });
 
-        await runExpectCaptureFail("my-skill", undefined, tc, "no sessions found");
+        await runExpectCaptureFail("my-skill", undefined, cache, "no sessions found");
     });
 
     // -----------------------------------------------------------------------
     // Test 5: unknown skill → SparCaptureError
     // -----------------------------------------------------------------------
     test("unknown skill → SparCaptureError", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [[]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [],
         });
 
-        await runExpectCaptureFail("ghost-skill", undefined, tc, "unknown skill ghost-skill");
+        await runExpectCaptureFail("ghost-skill", undefined, cache, "unknown skill ghost-skill");
     });
 
     // -----------------------------------------------------------------------
     // Test 6: synthetic skill → SparCaptureError
     // -----------------------------------------------------------------------
     test("synthetic skill → SparCaptureError", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:bash", name: "Bash", dir_path: "(synthetic)" }],
-                ],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:bash", dir_path: "(synthetic)" }],
         });
 
-        await runExpectCaptureFail("Bash", undefined, tc, "synthetic/tool skill");
+        await runExpectCaptureFail("Bash", undefined, cache, "synthetic/tool skill");
     });
 
     // -----------------------------------------------------------------------
     // Test 7: explicit opts.sessionId → uses it directly (no invoked/loaded)
     // -----------------------------------------------------------------------
     test("opts.sessionId: uses specified session directly, skips edge history", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                // Session existence check (no first_user_message - derived from turn)
-                "FROM session:": [
-                    [{ id: "session:s42" }],
-                ],
-                // Turn text_excerpt for the explicit session
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Custom task" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            // Session existence check (no first_user_message - derived from turn)
+            "session WHERE id = ?": [{ id: "session:s42" }],
+            // Turn text_excerpt for the explicit session
+            "FROM turn WHERE session": [{ text_excerpt: "Custom task" }],
         });
 
-        const result = await runResolve("my-skill", { sessionId: "session:s42" }, tc);
+        const result = await runResolve("my-skill", { sessionId: "session:s42" }, cache);
         expect(result.baselineSession).toBe("session:s42");
         expect(result.task).toBe("Custom task");
 
         // The invoked/loaded queries must NOT have been issued
-        expect(tc.captured.some((sql) => sql.includes("FROM invoked"))).toBe(false);
+        expect(cache.captured.some((sql) => sql.includes("FROM invoked"))).toBe(false);
     });
 
     // -----------------------------------------------------------------------
     // Test 8: opts.sha → parentSha is <sha>^
     // -----------------------------------------------------------------------
     test("opts.sha: parentSha resolved as sha^", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                "source FROM": [
-                    [{ id: "session:s1", source: "claude" }],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Task text" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            "id, source FROM session": [{ id: "session:s1", source: "claude" }],
+            "FROM turn WHERE session": [{ text_excerpt: "Task text" }],
         });
 
         // proc mock that verifies the sha^ call
@@ -666,7 +611,7 @@ describe("resolveSkillSparTask", () => {
             },
         });
 
-        const result = await runResolve("my-skill", { sha: "abc1234" }, tc, shaProcMock);
+        const result = await runResolve("my-skill", { sha: "abc1234" }, cache, shaProcMock);
         expect(result.parentSha).toBe("parentsha456");
         // Must have called git rev-parse ... abc1234^
         expect(capturedArgs.some((a) => a.includes("abc1234^"))).toBe(true);
@@ -676,21 +621,12 @@ describe("resolveSkillSparTask", () => {
     // Test 9: no opts → parentSha is HEAD
     // -----------------------------------------------------------------------
     test("no opts: parentSha resolved from HEAD", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                "source FROM": [
-                    [{ id: "session:s1", source: "claude" }],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "HEAD task" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            "id, source FROM session": [{ id: "session:s1", source: "claude" }],
+            "FROM turn WHERE session": [{ text_excerpt: "HEAD task" }],
         });
 
         const capturedArgs: string[][] = [];
@@ -703,7 +639,7 @@ describe("resolveSkillSparTask", () => {
             },
         });
 
-        const result = await runResolve("my-skill", undefined, tc, headProcMock);
+        const result = await runResolve("my-skill", undefined, cache, headProcMock);
         expect(result.parentSha).toBe("headsha999");
         expect(capturedArgs.some((a) => a.includes("HEAD"))).toBe(true);
         // Must NOT have been called with ^
@@ -714,18 +650,13 @@ describe("resolveSkillSparTask", () => {
     // Test 10: missing SKILL.md → SparCaptureError
     // -----------------------------------------------------------------------
     test("no SKILL.md → SparCaptureError", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
         });
 
         // Empty FS: no SKILL.md
         const emptyFs = layerTestFileSystem({});
-        await runExpectCaptureFail("my-skill", undefined, tc, "no SKILL.md", defaultProcMock, emptyFs);
+        await runExpectCaptureFail("my-skill", undefined, cache, "no SKILL.md", defaultProcMock, emptyFs);
     });
 
     // -----------------------------------------------------------------------
@@ -736,30 +667,21 @@ describe("resolveSkillSparTask", () => {
         // s2 appears once (invoked Jan 10). If the cross-table merge keeps the
         // MAX ts for s1 (Jan 20), s1 beats s2; if it wrongly kept s1's invoked
         // ts (Jan 1), s2 (Jan 10) would win. Asserting s1 locks the max merge.
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [
-                        { sid: "session:s1", ts: "2026-01-01T00:00:00.000Z" },
-                        { sid: "session:s2", ts: "2026-01-10T00:00:00.000Z" },
-                    ],
-                    [{ sid: "session:s1", ts: "2026-01-20T00:00:00.000Z" }],
-                ],
-                "source FROM": [
-                    [
-                        { id: "session:s1", source: "claude" },
-                        { id: "session:s2", source: "claude" },
-                    ],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Winner via loaded ts" }]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [
+                { sid: "session:s1", ts: "2026-01-01T00:00:00.000Z" },
+                { sid: "session:s2", ts: "2026-01-10T00:00:00.000Z" },
+            ],
+            "FROM loaded WHERE out_id": [{ sid: "session:s1", ts: "2026-01-20T00:00:00.000Z" }],
+            "id, source FROM session": [
+                { id: "session:s1", source: "claude" },
+                { id: "session:s2", source: "claude" },
+            ],
+            "FROM turn WHERE session": [{ text_excerpt: "Winner via loaded ts" }],
         });
 
-        const result = await runResolve("my-skill", undefined, tc);
+        const result = await runResolve("my-skill", undefined, cache);
         expect(result.baselineSession).toBe("session:s1");
         expect(result.task).toBe("Winner via loaded ts");
     });
@@ -767,103 +689,75 @@ describe("resolveSkillSparTask", () => {
     // -----------------------------------------------------------------------
     // Test: repositoryKey scopes the candidate fetch (record-literal WHERE)
     // -----------------------------------------------------------------------
-    test("repositoryKey emits a repository = repository:<key> filter on the session fetch", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                "source FROM": [
-                    [{ id: "session:s1", source: "claude" }],
-                ],
-                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Repo task" }]],
+    test("repositoryKey binds a repository = ? filter on the session fetch", async () => {
+        let repoParams: readonly unknown[] | undefined;
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            "id, source FROM session": (_sql, params) => {
+                repoParams = params;
+                return [{ id: "session:s1", source: "claude" }];
             },
+            "FROM turn WHERE session": [{ text_excerpt: "Repo task" }],
         });
 
-        // repositoryKey provided → scoping WHERE clause must be emitted on the bulk-fetch.
+        // repositoryKey provided → scoping WHERE clause must be emitted (bound
+        // param, not string-interpolated) on the bulk-fetch.
         await Effect.runPromise(
             resolveSkillSparTask("my-skill", "/repo", "local__abc").pipe(
-                Effect.provide(Layer.mergeAll(tc.layer, defaultProcMock, defaultFs)),
+                Effect.provide(Layer.mergeAll(cache.layer, defaultProcMock, defaultFs)),
             ),
         );
-        const fetchSql = tc.captured.find((s) => s.includes("source FROM"));
+        const fetchSql = cache.captured.find((s) => s.includes("id, source FROM session"));
         expect(fetchSql).toBeDefined();
-        expect(fetchSql).toContain("WHERE repository = repository:`local__abc`");
+        expect(fetchSql).toContain("AND repository = ?");
+        expect(repoParams).toContain("local__abc");
     });
 
     // -----------------------------------------------------------------------
     // Test 11: non-claude sessions filtered, remaining none → SparCaptureError
     // -----------------------------------------------------------------------
     test("only non-claude sessions in history → SparCaptureError", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                // source = codex, not claude
-                "source FROM": [
-                    [{ id: "session:s1", source: "codex" }],
-                ],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            // source = codex, not claude
+            "id, source FROM session": [{ id: "session:s1", source: "codex" }],
         });
 
-        await runExpectCaptureFail("my-skill", undefined, tc, "no main (source=claude) sessions");
+        await runExpectCaptureFail("my-skill", undefined, cache, "no main (source=claude) sessions");
     });
 
     // -----------------------------------------------------------------------
     // Task 12: auto-pick session has no first user turn → SparCaptureError
     // -----------------------------------------------------------------------
     test("auto-pick session with no first user turn → SparCaptureError (empty-task guard)", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM invoked WHERE out": [
-                    [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
-                    [],
-                ],
-                "source FROM": [
-                    [{ id: "session:s1", source: "claude" }],
-                ],
-                // turn query returns empty: no user turns in this session
-                "text_excerpt, seq FROM turn WHERE session": [[]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "FROM invoked WHERE out_id": [{ sid: "session:s1", ts: "2026-01-10T00:00:00.000Z" }],
+            "FROM loaded WHERE out_id": [],
+            "id, source FROM session": [{ id: "session:s1", source: "claude" }],
+            // turn query returns empty: no user turns in this session
+            "FROM turn WHERE session": [],
         });
 
-        await runExpectCaptureFail("my-skill", undefined, tc, "has no first user message");
+        await runExpectCaptureFail("my-skill", undefined, cache, "has no first user message");
     });
 
     // -----------------------------------------------------------------------
     // Task 13: explicit sessionId with no first user turn → SparCaptureError
     // -----------------------------------------------------------------------
     test("explicit sessionId with no first user turn → SparCaptureError (empty-task guard)", async () => {
-        const tc = makeTestSurrealClient({
-            denyWrites: true,
-            routes: {
-                "FROM skill WHERE name": [
-                    [{ id: "skill:myskill", name: "my-skill", dir_path: SKILL_DIR }],
-                ],
-                "FROM session:": [
-                    [{ id: "session:s42" }],
-                ],
-                // turn query returns empty
-                "text_excerpt, seq FROM turn WHERE session": [[]],
-            },
+        const cache = resolveCache({
+            "FROM skill WHERE name": [{ id: "skill:myskill", dir_path: SKILL_DIR }],
+            "session WHERE id = ?": [{ id: "session:s42" }],
+            // turn query returns empty
+            "FROM turn WHERE session": [],
         });
 
-        await runExpectCaptureFail("my-skill", { sessionId: "session:s42" }, tc, "has no first user message");
+        await runExpectCaptureFail("my-skill", { sessionId: "session:s42" }, cache, "has no first user message");
     });
 });
 
@@ -872,19 +766,28 @@ describe("resolveSkillSparTask", () => {
 // ---------------------------------------------------------------------------
 
 describe("scoreSkillSpar", () => {
-    // AxConfig is required by fetchSessionMetrics (churn scan reads AxConfig.knobs).
-    const configLayer = AxConfigTest({}).pipe(Layer.provide(BunFileSystem.layer));
-    const paired = (options: TestSurrealClientOptions) => {
-        const tc = makeTestSurrealClient(options);
-        const cache = makeTestCacheRead({ routes: options.routes as never });
-        return { tc, layer: Layer.merge(tc.layer, cache.layer) };
-    };
+    const paired = (routes: TestCacheOptions["routes"]) =>
+        makeTestCacheRead(routes !== undefined ? { routes } : {});
 
     const runScore = <A>(
-        eff: Effect.Effect<A, unknown, SurrealClient | CacheRead | Judgment | AxConfig>,
-        tcLayer: Layer.Layer<SurrealClient | CacheRead>,
+        eff: Effect.Effect<A, unknown, CacheRead | Judgment>,
+        layer: Layer.Layer<CacheRead>,
     ): Promise<A> =>
-        Effect.runPromise(eff.pipe(Effect.provide(Layer.mergeAll(tcLayer, configLayer, EmptyJudgmentTestLayer))));
+        Effect.runPromise(eff.pipe(Effect.provide(Layer.merge(layer, EmptyJudgmentTestLayer))));
+
+    /**
+     * findVariantSession binds `cwd` as a positional `?` parameter (never
+     * string-interpolated), so route selection can no longer key off the cwd
+     * appearing in the SQL text - both arms issue the identical statement.
+     * Dispatch on the bound cwd instead.
+     */
+    const armRoute = (armA: ReadonlyArray<unknown> | null, armB: ReadonlyArray<unknown> | null) =>
+        (_sql: string, params?: ReadonlyArray<unknown>) => {
+            const cwd = String(params?.[0] ?? "");
+            if (cwd.includes("spar-arm-a")) return armA ? [...armA] : [];
+            if (cwd.includes("spar-arm-b")) return armB ? [...armB] : [];
+            return [];
+        };
 
     const MAIN_ROOT = "/main/repo";
 
@@ -899,16 +802,11 @@ describe("scoreSkillSpar", () => {
     // Test 1: both arm sessions found → known verdict
     // -----------------------------------------------------------------------
     test("both arms present → score returned with known verdict (regression on empty metrics)", async () => {
-        // Route by cwd substring: findVariantSession SQL includes the absolute cwd.
-        // spar-arm-a / spar-arm-b appear only in those two queries; all other
-        // queries fall through to the default [[]] → null/0/false metrics.
+        // spar-arm-a / spar-arm-b are dispatched by bound cwd param; all other
+        // queries fall through to the default [] → null/0/false metrics.
         // With empty metrics: variant.landed = false → verdict = "regression".
         const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "spar-arm-a": [[{ id: "session:arm-a" }]],
-                "spar-arm-b": [[{ id: "session:arm-b" }]],
-            },
+            "cwd = ?": armRoute([{ id: "session:arm-a" }], [{ id: "session:arm-b" }]),
         });
 
         const result = await runScore(
@@ -930,17 +828,14 @@ describe("scoreSkillSpar", () => {
     // Test 2: arm A session missing → SparCaptureError mentioning "arm A"
     // -----------------------------------------------------------------------
     test("arm A session missing → SparCaptureError mentioning 'arm A'", async () => {
-        // No route for spar-arm-a → default [[]] → findVariantSession → null
+        // No rows for arm A's cwd → findVariantSession → null
         const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "spar-arm-b": [[{ id: "session:arm-b" }]],
-            },
+            "cwd = ?": armRoute(null, [{ id: "session:arm-b" }]),
         });
 
         const exit = await Effect.runPromiseExit(
             scoreSkillSpar(SCORE_BRIEF, MAIN_ROOT, new Date()).pipe(
-                Effect.provide(Layer.mergeAll(layer, configLayer, EmptyJudgmentTestLayer)),
+                Effect.provide(Layer.merge(layer, EmptyJudgmentTestLayer)),
             ),
         );
         expect(exit._tag).toBe("Failure");
@@ -953,17 +848,14 @@ describe("scoreSkillSpar", () => {
     // Test 3: arm B session missing → SparCaptureError mentioning "arm B"
     // -----------------------------------------------------------------------
     test("arm B session missing → SparCaptureError mentioning 'arm B'", async () => {
-        // Arm A is found; arm B has no route → findVariantSession returns null.
+        // Arm A is found; arm B has no rows → findVariantSession returns null.
         const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "spar-arm-a": [[{ id: "session:arm-a" }]],
-            },
+            "cwd = ?": armRoute([{ id: "session:arm-a" }], null),
         });
 
         const exit = await Effect.runPromiseExit(
             scoreSkillSpar(SCORE_BRIEF, MAIN_ROOT, new Date()).pipe(
-                Effect.provide(Layer.mergeAll(layer, configLayer, EmptyJudgmentTestLayer)),
+                Effect.provide(Layer.merge(layer, EmptyJudgmentTestLayer)),
             ),
         );
         expect(exit._tag).toBe("Failure");
@@ -981,34 +873,31 @@ describe("scoreSkillSpar", () => {
         // -COST_TOL), no extra repair → "win". A SWAPPED wiring (B baseline /
         // A variant) would give +1.2 → "regression", so this asserts the seam.
         //
-        // findVariantSession routes by cwd substring (spar-arm-a / spar-arm-b).
-        // The cost + produced queries are shared across both metric fetches;
-        // each carries BOTH sessions' rows and the per-call clean-id lookup
-        // picks the right one (mirrors spar.test.ts's metric-row idiom).
+        // findVariantSession dispatches on the bound cwd param (spar-arm-a /
+        // spar-arm-b). The cost + produced queries are shared across both
+        // metric fetches; each carries BOTH sessions' rows and the per-call
+        // clean-id lookup picks the right one (mirrors spar.test.ts's
+        // metric-row idiom).
         const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "spar-arm-a": [[{ id: "session:arm-a" }]],
-                "spar-arm-b": [[{ id: "session:arm-b" }]],
-                // cost: arm-a = $2.00 (baseline), arm-b = $0.80 (variant, cheaper)
-                "FROM session_token_usage": [[
-                    { session: "session:arm-a", model: "claude", estimated_tokens: 2_000, estimated_cost_usd: 2.0 },
-                    { session: "session:arm-b", model: "claude", estimated_tokens: 800, estimated_cost_usd: 0.8 },
-                ]],
-                // both arms produced a commit → landed = true for both
-                "FROM produced": [[
-                    { session: "session:arm-a", commit: "commit:ca" },
-                    { session: "session:arm-b", commit: "commit:cb" },
-                ]],
-                "FROM touched": [[
-                    { commit: "commit:ca", file: "file:f1", path: "src/a.ts", additions: 10, deletions: 2 },
-                    { commit: "commit:cb", file: "file:f2", path: "src/b.ts", additions: 10, deletions: 2 },
-                ]],
-                // turns/wall: shared bare object (symmetric, not the asymmetry axis)
-                "AS turn_count": [
-                    { turn_count: 15, s: "2026-06-01T00:00:00.000Z", e: "2026-06-01T00:05:00.000Z" },
-                ],
-            },
+            "cwd = ?": armRoute([{ id: "session:arm-a" }], [{ id: "session:arm-b" }]),
+            // cost: arm-a = $2.00 (baseline), arm-b = $0.80 (variant, cheaper)
+            "FROM session_token_usage": [
+                { session: "session:arm-a", model: "claude", estimated_tokens: 2_000, estimated_cost_usd: 2.0 },
+                { session: "session:arm-b", model: "claude", estimated_tokens: 800, estimated_cost_usd: 0.8 },
+            ],
+            // both arms produced a commit → landed = true for both
+            "FROM produced": [
+                { session: "session:arm-a", commit: "commit:ca" },
+                { session: "session:arm-b", commit: "commit:cb" },
+            ],
+            "FROM touched": [
+                { commit: "commit:ca", file: "file:f1", path: "src/a.ts", additions: 10, deletions: 2 },
+                { commit: "commit:cb", file: "file:f2", path: "src/b.ts", additions: 10, deletions: 2 },
+            ],
+            // turns/wall: shared row (symmetric, not the asymmetry axis)
+            "AS turn_count": [
+                { turn_count: 15, started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T00:05:00.000Z" },
+            ],
         });
 
         const result = await runScore(
@@ -1034,12 +923,12 @@ describe("scoreSkillSpar", () => {
     // Test 5: malformed created_at → SparCaptureError (no RangeError escape)
     // -----------------------------------------------------------------------
     test("malformed created_at → SparCaptureError before any session lookup", async () => {
-        const { tc, layer } = paired({ denyWrites: true });
+        const { layer, captured } = paired({});
         const badBrief: SkillSparBrief = { ...SCORE_BRIEF, createdAt: "not-a-date" };
 
         const exit = await Effect.runPromiseExit(
             scoreSkillSpar(badBrief, MAIN_ROOT, new Date()).pipe(
-                Effect.provide(Layer.mergeAll(layer, configLayer, EmptyJudgmentTestLayer)),
+                Effect.provide(Layer.merge(layer, EmptyJudgmentTestLayer)),
             ),
         );
         expect(exit._tag).toBe("Failure");
@@ -1047,7 +936,7 @@ describe("scoreSkillSpar", () => {
             expect(JSON.stringify(exit.cause)).toContain("malformed created_at");
         }
         // Failed before issuing any query (no findVariantSession call).
-        expect(tc.captured.length).toBe(0);
+        expect(captured.length).toBe(0);
     });
 });
 

--- a/apps/axctl/src/dojo/skill-spar.ts
+++ b/apps/axctl/src/dojo/skill-spar.ts
@@ -6,16 +6,14 @@
  * with the original skill, Arm B runs with the edited skill active (global
  * swap during Arm B only, restored immediately after).
  */
-import { Effect, FileSystem } from "effect";
-import { SurrealClient } from "@ax/lib/db";
+import { Effect, FileSystem, Schema } from "effect";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
-import { AxConfig } from "@ax/lib/config";
-import type { DbError } from "@ax/lib/errors";
-import type { CacheRead, CacheReadError } from "@ax/lib/duckdb/seam";
-import { recordLiteral } from "@ax/lib/ids";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { TimestampColumn } from "@ax/lib/duckdb/columns";
+import { andAll, eqClause, inClause } from "@ax/lib/duckdb/clause";
 import { posixPath } from "@ax/lib/shared/path";
-import { surrealString, refListSource, recordKeyPart } from "@ax/lib/shared/surreal";
 import { ProcessService, type ProcessError } from "@ax/lib/process";
+import { cleanSessionId } from "../metrics/util.ts";
 import {
     scoreSpar,
     fetchSessionMetrics,
@@ -330,6 +328,15 @@ export const buildSkillSparBrief = (
  *      session in JS, filter to source=claude, pick most-recent.
  * 4. Resolve parentSha from `opts.sha^` or git HEAD.
  */
+const SkillLookupRow = Schema.Struct({
+    id: Schema.String,
+    dir_path: Schema.NullOr(Schema.String),
+});
+const SessionIdRow = Schema.Struct({ id: Schema.String });
+const TextExcerptRow = Schema.Struct({ text_excerpt: Schema.NullOr(Schema.String) });
+const SkillEdgeRow = Schema.Struct({ sid: Schema.String, ts: TimestampColumn });
+const SessionSourceRow = Schema.Struct({ id: Schema.String, source: Schema.NullOr(Schema.String) });
+
 export const resolveSkillSparTask = (
     skillName: string,
     repoRoot: string,
@@ -337,21 +344,20 @@ export const resolveSkillSparTask = (
     opts?: ResolveSkillSparOpts,
 ): Effect.Effect<
     SkillSparTask,
-    DbError | ProcessError | SparCaptureError,
-    SurrealClient | ProcessService | FileSystem.FileSystem
+    CacheReadError | ProcessError | SparCaptureError,
+    CacheRead | ProcessService | FileSystem.FileSystem
 > =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         const fs = yield* FileSystem.FileSystem;
         const proc = yield* ProcessService;
 
         // 1. Skill row lookup ---------------------------------------------------
-        const skillQueryRows = yield* db.query<[
-            Array<{ id: string; name: string; dir_path: string | null }>,
-        ]>(
-            `SELECT type::string(id) AS id, name, dir_path FROM skill WHERE name = ${surrealString(skillName)} LIMIT 1;`,
-        );
-        const skillRow = skillQueryRows?.[0]?.[0] ?? null;
+        const skillRow = (yield* read.rows(
+            SkillLookupRow,
+            `SELECT id, dir_path FROM skill WHERE name = ? LIMIT 1`,
+            [skillName],
+        ))[0] ?? null;
         if (!skillRow) {
             return yield* Effect.fail(new SparCaptureError(`unknown skill ${skillName}`));
         }
@@ -361,7 +367,7 @@ export const resolveSkillSparTask = (
             );
         }
         const skillDir = skillRow.dir_path ?? "";
-        const skillId = skillRow.id; // "skill:`abc`" - already type::string
+        const skillId = skillRow.id; // bare skill id (VARCHAR PK)
 
         // 2. SKILL.md snapshot --------------------------------------------------
         const skillMdPath = `${skillDir}/SKILL.md`;
@@ -379,13 +385,12 @@ export const resolveSkillSparTask = (
             // first user turn (first_user_message is not stored on session rows;
             // it is derived via the turn table - see enrichSessions in
             // apps/axctl/src/dashboard/sessions-query.ts).
-            const key = recordKeyPart(opts.sessionId, "session") ?? opts.sessionId;
-            const sessRows = yield* db.query<[
-                Array<{ id: string }>,
-            ]>(
-                `SELECT type::string(id) AS id FROM ${recordLiteral("session", key)};`,
-            );
-            const sess = sessRows?.[0]?.[0] ?? null;
+            const key = cleanSessionId(opts.sessionId);
+            const sess = (yield* read.rows(
+                SessionIdRow,
+                `SELECT id FROM session WHERE id = ?`,
+                [key],
+            ))[0] ?? null;
             if (!sess) {
                 return yield* Effect.fail(
                     new SparCaptureError(`session ${opts.sessionId} not found`),
@@ -394,10 +399,12 @@ export const resolveSkillSparTask = (
             baselineSession = sess.id;
 
             // Derive first user turn text_excerpt (the canonical first-message field).
-            const promptRows = yield* db.query<[Array<{ text_excerpt: string | null }>]>(
-                `SELECT text_excerpt, seq FROM turn WHERE session = ${recordLiteral("session", key)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
-            );
-            const promptText = promptRows?.[0]?.[0]?.text_excerpt ?? null;
+            const promptRow = (yield* read.rows(
+                TextExcerptRow,
+                `SELECT text_excerpt FROM turn WHERE session = ? AND role = 'user' ORDER BY seq ASC LIMIT 1`,
+                [key],
+            ))[0] ?? null;
+            const promptText = promptRow?.text_excerpt ?? null;
             if (!promptText) {
                 return yield* Effect.fail(
                     new SparCaptureError(
@@ -407,22 +414,30 @@ export const resolveSkillSparTask = (
             }
             task = promptText;
         } else {
-            // Infer from invoked + loaded edge history (deref-free, two flat queries).
-            const edgeRows = yield* db.query<[
-                Array<{ sid: string; ts: string }>,
-                Array<{ sid: string; ts: string }>,
-            ]>(
-                `SELECT type::string(session) AS sid, type::string(ts) AS ts FROM invoked WHERE out = ${skillId} AND session IS NOT NONE;\n` +
-                `SELECT type::string(in) AS sid, type::string(ts) AS ts FROM loaded WHERE out = ${skillId};`,
-            );
-            const [invokedRows, loadedRows] = edgeRows;
+            // Infer from invoked + loaded edge history (deref-free, two flat
+            // queries fanned out together; UNION ALL would also work but the
+            // two tables have distinct session-ref columns, so two bound
+            // queries stay simpler than aliasing both into one statement).
+            const [invokedRows, loadedRows] = yield* Effect.all([
+                read.rows(
+                    SkillEdgeRow,
+                    `SELECT session AS sid, ts FROM invoked WHERE out_id = ? AND session IS NOT NULL`,
+                    [skillId],
+                ),
+                read.rows(
+                    SkillEdgeRow,
+                    `SELECT in_id AS sid, ts FROM loaded WHERE out_id = ?`,
+                    [skillId],
+                ),
+            ]);
 
-            // Merge: keep max edge-ts per session across both tables.
-            const maxBySid = new Map<string, string>();
-            for (const row of [...(invokedRows ?? []), ...(loadedRows ?? [])]) {
-                if (!row.sid || !row.ts) continue;
+            // Merge: keep max edge-ts (epoch ms) per session across both tables.
+            const maxBySid = new Map<string, number>();
+            for (const row of [...invokedRows, ...loadedRows]) {
+                if (!row.sid) continue;
+                const ts = row.ts.getTime();
                 const prev = maxBySid.get(row.sid);
-                if (!prev || row.ts > prev) maxBySid.set(row.sid, row.ts);
+                if (prev === undefined || ts > prev) maxBySid.set(row.sid, ts);
             }
 
             if (maxBySid.size === 0) {
@@ -433,31 +448,24 @@ export const resolveSkillSparTask = (
                 );
             }
 
-            // Bulk-fetch session rows (source filter + task text). When a
-            // `repositoryKey` is known (run inside a git repo), scope candidates
-            // to THIS repo so the chosen task is re-runnable in the parentSha
-            // worktree - a global pick could hand back a task from an unrelated
-            // repo. `repository` is a record-typed field, so it filters via a
-            // record literal (same shape as listSessionsNear). Absent key (not in
-            // a git tree) → global selection (v1 limitation, task may be cross-repo).
+            // Bulk-fetch session rows (source filter). When a `repositoryKey`
+            // is known (run inside a git repo), scope candidates to THIS repo
+            // so the chosen task is re-runnable in the parentSha worktree - a
+            // global pick could hand back a task from an unrelated repo.
+            // Absent key (not in a git tree) → global selection (v1
+            // limitation, task may be cross-repo).
             const candidateSids = [...maxBySid.keys()];
-            // first_user_message is NOT stored on the session row - it must be
-            // derived from the first user turn (see enrichSessions in
-            // apps/axctl/src/dashboard/sessions-query.ts). Exclude it from the
-            // bulk fetch and derive it separately after picking the best session.
-            const pick = repositoryKey
-                ? ["id", "source", "repository"]
-                : ["id", "source"];
-            const repoClause = repositoryKey
-                ? ` WHERE repository = ${recordLiteral("repository", repositoryKey)}`
-                : "";
-            const sessionRows = yield* db.query<[
-                Array<{ id: string; source: string | null }>,
-            ]>(
-                `SELECT type::string(id) AS id, source FROM ${refListSource(candidateSids, pick)}${repoClause};`,
+            const clause = andAll([
+                inClause("id", candidateSids),
+                eqClause("repository", repositoryKey),
+            ]);
+            const sessionRows = yield* read.rows(
+                SessionSourceRow,
+                `SELECT id, source FROM session WHERE TRUE ${clause.sql}`,
+                clause.params,
             );
 
-            const mainSessions = (sessionRows?.[0] ?? []).filter((s) => s.source === "claude");
+            const mainSessions = sessionRows.filter((s) => s.source === "claude");
             if (mainSessions.length === 0) {
                 return yield* Effect.fail(
                     new SparCaptureError(
@@ -467,9 +475,9 @@ export const resolveSkillSparTask = (
             }
 
             // Pick the session whose most-recent edge-ts is highest.
-            let best: { id: string; ts: string } | null = null;
+            let best: { id: string; ts: number } | null = null;
             for (const sess of mainSessions) {
-                const ts = maxBySid.get(sess.id) ?? "";
+                const ts = maxBySid.get(sess.id) ?? -Infinity;
                 if (!best || ts > best.ts) {
                     best = { id: sess.id, ts };
                 }
@@ -477,11 +485,12 @@ export const resolveSkillSparTask = (
             baselineSession = best!.id;
 
             // Derive the task text from the first user turn in the chosen session.
-            const bestKey = recordKeyPart(best!.id, "session") ?? best!.id;
-            const promptRows = yield* db.query<[Array<{ text_excerpt: string | null }>]>(
-                `SELECT text_excerpt, seq FROM turn WHERE session = ${recordLiteral("session", bestKey)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
-            );
-            const promptText = promptRows?.[0]?.[0]?.text_excerpt ?? null;
+            const promptRow = (yield* read.rows(
+                TextExcerptRow,
+                `SELECT text_excerpt FROM turn WHERE session = ? AND role = 'user' ORDER BY seq ASC LIMIT 1`,
+                [best!.id],
+            ))[0] ?? null;
+            const promptText = promptRow?.text_excerpt ?? null;
             if (!promptText) {
                 return yield* Effect.fail(
                     new SparCaptureError(
@@ -545,8 +554,8 @@ export const scoreSkillSpar = (
     sinceForChurn: Date,
 ): Effect.Effect<
     { sessionA: string; sessionB: string; a: SparMetrics; b: SparMetrics; score: SparScore },
-    DbError | CacheReadError | JudgmentError | SparCaptureError,
-    SurrealClient | CacheRead | Judgment | AxConfig
+    CacheReadError | JudgmentError | SparCaptureError,
+    CacheRead | Judgment
 > =>
     Effect.gen(function* () {
         const cwdA = posixPath.join(mainRepoRoot, brief.worktreeA);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
-import { BunFileSystem } from "@effect/platform-bun";
-import { SurrealClient } from "@ax/lib/db";
-import { AxConfig, AxConfigTest } from "@ax/lib/config";
-import { makeTestSurrealClient, type TestSurrealClientOptions } from "@ax/lib/testing/surreal";
-import { makeTestCacheRead } from "@ax/lib/testing/cache";
-import type { CacheRead } from "@ax/lib/duckdb/seam";
+import { makeTestCacheRead, type TestCacheOptions } from "@ax/lib/testing/cache";
+import type { CacheRead, CacheReadError } from "@ax/lib/duckdb/seam";
 import {
     COST_TOL,
     fetchSessionMetrics,
@@ -18,8 +14,7 @@ import {
     stampSparSession,
 } from "./spar.ts";
 import type { SparBrief, SparMetrics } from "./spar.ts";
-import { EmptyJudgmentTestLayer, judgmentTestLayer } from "../testing/judgment-test-layer.ts";
-import type { Judgment } from "@ax/lib/sqlite";
+import { judgmentTestLayer } from "../testing/judgment-test-layer.ts";
 
 const baseMetrics = (o: Partial<SparMetrics> = {}): SparMetrics => ({
     costUsd: 1.20,
@@ -130,70 +125,55 @@ describe("renderSparReport", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Effect glue (fake SurrealClient)
+// Effect glue (real-decode CacheRead fake - @ax/lib/testing/cache)
 // ---------------------------------------------------------------------------
 
-// enrichSessions/churn read fan-out width from AxConfig.knobs.
-const configLayer = AxConfigTest({}).pipe(Layer.provide(BunFileSystem.layer));
+const cacheRead = (routes: TestCacheOptions["routes"]) =>
+    makeTestCacheRead(routes !== undefined ? { routes } : {});
 
-const paired = (options: TestSurrealClientOptions) => {
-    const tc = makeTestSurrealClient(options);
-    const cache = makeTestCacheRead({ routes: options.routes as never });
-    return { tc, layer: Layer.merge(tc.layer, cache.layer) };
-};
-
-const runDb = <A>(
-    eff: Effect.Effect<A, unknown, SurrealClient | CacheRead | Judgment | AxConfig>,
-    layer: Layer.Layer<SurrealClient | CacheRead>,
-): Promise<A> =>
-    Effect.runPromise(eff.pipe(Effect.provide(Layer.mergeAll(layer, configLayer, EmptyJudgmentTestLayer))));
-
-const runDbOnly = <A>(
-    eff: Effect.Effect<A, unknown, SurrealClient | CacheRead | Judgment>,
-    layer: Layer.Layer<SurrealClient | CacheRead>,
-): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(Layer.merge(layer, EmptyJudgmentTestLayer))));
+const runCache = <A>(
+    eff: Effect.Effect<A, CacheReadError, CacheRead>,
+    layer: Layer.Layer<CacheRead>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(layer)));
 
 describe("fetchSessionMetrics", () => {
     test("composes cost + churn + turn/wall for a session", async () => {
         const since = new Date("2026-06-11T00:00:00.000Z");
         // routes: cost usage, churn base scan, churn fan-out, and the focused
         // turn/wall lookup. Unmatched -> [[]] (pricing falls back to built-in).
-        const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "FROM session_token_usage": [[
-                    { session: "session:`s1`", model: "claude", estimated_tokens: 1_000, estimated_cost_usd: 1.5 },
-                ]],
-                // churn base session scan (selects id AS session, source)
-                "AS session, source\nFROM session": [[
-                    { session: "session:`s1`", source: "codex" },
-                ]],
-                "FROM produced": [[{ session: "session:`s1`", commit: "commit:`c1`" }]],
-                "FROM touched": [[
-                    { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 13, deletions: 3 },
-                ]],
-                // churn edit events: an initial edit (enables episode opening),
-                // then the repair edit between the failure and its pass.
-                "FROM tool_call": [[
-                    { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
-                    { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb\nc" }) },
-                ]],
-                // failure opens an episode; the later pass closes it so the
-                // edit between them is classified as repair.
-                "FROM command_outcome": [[
-                    { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "check", status: "error", command_norm: "tsc" },
-                    { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "check", status: "ok", command_norm: "tsc" },
-                ]],
-                // focused turn/wall lookup: `FROM ONLY` returns the bare object,
-                // so the statement result is `[ {turn_count, s, e} ]` (NOT
-                // doubly-nested - that mismatch hid the rows[0][0] indexing bug).
-                "AS turn_count": [
-                    { turn_count: 21, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:10:00.000Z" },
-                ],
-            },
+        const { layer } = cacheRead({
+            "FROM session_token_usage": [[
+                { session: "session:`s1`", model: "claude", estimated_tokens: 1_000, estimated_cost_usd: 1.5 },
+            ]],
+            // churn base session scan (selects id AS session, source)
+            "AS session, source\nFROM session": [[
+                { session: "session:`s1`", source: "codex" },
+            ]],
+            "FROM produced": [[{ session: "session:`s1`", commit: "commit:`c1`" }]],
+            "FROM touched": [[
+                { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 13, deletions: 3 },
+            ]],
+            // churn edit events: an initial edit (enables episode opening),
+            // then the repair edit between the failure and its pass.
+            "FROM tool_call": [[
+                { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb\nc" }) },
+            ]],
+            // failure opens an episode; the later pass closes it so the
+            // edit between them is classified as repair.
+            "FROM command_outcome": [[
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "check", status: "error", command_norm: "tsc" },
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "check", status: "ok", command_norm: "tsc" },
+            ]],
+            // focused turn/wall lookup (real DuckDB SELECT against `session`,
+            // count(*) subquery against `turn`): row carries turn_count +
+            // started_at/ended_at (Date, decoded via TimestampColumn).
+            "AS turn_count": [
+                { turn_count: 21, started_at: "2026-06-11T00:00:00.000Z", ended_at: "2026-06-11T00:10:00.000Z" },
+            ],
         });
 
-        const m = await runDb(fetchSessionMetrics("session:`s1`", since), layer);
+        const m = await runCache(fetchSessionMetrics("session:`s1`", since), layer);
         expect(m.costUsd).toBe(1.5);
         expect(m.turns).toBe(21);
         expect(m.wallMs).toBe(600_000);
@@ -207,27 +187,24 @@ describe("fetchSessionMetrics", () => {
         // zero verification failures) is FILTERED OUT of churn.hotSessions by
         // hasVerificationSignal. landed must come from the produced edge, not
         // hotSessions - otherwise the best outcome scores as a regression.
-        const { layer } = paired({
-            denyWrites: true,
-            routes: {
-                "FROM session_token_usage": [[
-                    { session: "session:`clean`", model: "claude", estimated_tokens: 500, estimated_cost_usd: 0.7 },
-                ]],
-                // churn base scan: clean session has NO verification signal, so
-                // it never appears here (and thus never in hotSessions).
-                "AS session, source\nFROM session": [[]],
-                // produced edge + touched LOC DO carry the clean session.
-                "FROM produced": [[{ session: "session:`clean`", commit: "commit:`cc`" }]],
-                "FROM touched": [[
-                    { commit: "commit:`cc`", file: "file:`f1`", path: "src/a.ts", additions: 9, deletions: 1 },
-                ]],
-                "AS turn_count": [
-                    { turn_count: 12, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:05:00.000Z" },
-                ],
-            },
+        const { layer } = cacheRead({
+            "FROM session_token_usage": [[
+                { session: "session:`clean`", model: "claude", estimated_tokens: 500, estimated_cost_usd: 0.7 },
+            ]],
+            // churn base scan: clean session has NO verification signal, so
+            // it never appears here (and thus never in hotSessions).
+            "AS session, source\nFROM session": [[]],
+            // produced edge + touched LOC DO carry the clean session.
+            "FROM produced": [[{ session: "session:`clean`", commit: "commit:`cc`" }]],
+            "FROM touched": [[
+                { commit: "commit:`cc`", file: "file:`f1`", path: "src/a.ts", additions: 9, deletions: 1 },
+            ]],
+            "AS turn_count": [
+                { turn_count: 12, started_at: "2026-06-11T00:00:00.000Z", ended_at: "2026-06-11T00:05:00.000Z" },
+            ],
         });
 
-        const m = await runDb(
+        const m = await runCache(
             fetchSessionMetrics("session:`clean`", new Date("2026-06-11T00:00:00.000Z")),
             layer,
         );
@@ -239,8 +216,8 @@ describe("fetchSessionMetrics", () => {
     });
 
     test("null cost + null turn/wall when nothing matches", async () => {
-        const { layer } = paired({ denyWrites: true });
-        const m = await runDb(
+        const { layer } = cacheRead({});
+        const m = await runCache(
             fetchSessionMetrics("session:`ghost`", new Date("2026-06-11T00:00:00.000Z")),
             layer,
         );
@@ -254,25 +231,41 @@ describe("fetchSessionMetrics", () => {
 });
 
 describe("findVariantSession", () => {
-    test("returns the most recent bare id; embeds cwd + since literals", async () => {
-        const { tc, layer } = paired({
-            denyWrites: true,
-            routes: { "FROM session": [[{ id: "session:variant" }]] },
+    test("returns the most recent bare id; binds cwd + since as parameters", async () => {
+        const { layer, captured } = cacheRead({
+            "FROM session": [{ id: "variant" }],
         });
-        const id = await runDbOnly(
+        const id = await runCache(
             findVariantSession("/abs/cwd", Date.parse("2026-06-13T10:00:00.000Z")),
             layer,
         );
-        expect(id).toBe("session:variant");
-        const sql = tc.captured[0]!;
-        expect(sql).toContain(`cwd = "/abs/cwd"`);
-        expect(sql).toContain("started_at >=");
+        expect(id).toBe("variant");
+        const sql = captured[0]!;
+        // DuckDB binds are positional `?` placeholders, not interpolated
+        // literals - the cwd/since values are proven by the fixture's
+        // param-inspecting variants below, not by string content here.
+        expect(sql).toContain("cwd = ?");
+        expect(sql).toContain("started_at >= ?");
         expect(sql).toContain("ORDER BY started_at DESC LIMIT 1");
     });
 
+    test("binds the given cwd and since as positional parameters", async () => {
+        let seenParams: readonly unknown[] | undefined;
+        const { layer } = cacheRead({
+            "FROM session": (_sql, params) => {
+                seenParams = params;
+                return [{ id: "variant" }];
+            },
+        });
+        const sinceMs = Date.parse("2026-06-13T10:00:00.000Z");
+        await runCache(findVariantSession("/abs/cwd", sinceMs), layer);
+        expect(seenParams?.[0]).toBe("/abs/cwd");
+        expect((seenParams?.[1] as Date).getTime()).toBe(sinceMs);
+    });
+
     test("returns null when no variant session exists", async () => {
-        const { layer } = paired({ denyWrites: true });
-        const id = await runDbOnly(
+        const { layer } = cacheRead({});
+        const id = await runCache(
             findVariantSession("/abs/cwd", Date.now()),
             layer,
         );

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -2,21 +2,22 @@
  * ax dojo spar - replay benchmark.
  *
  * Pure cores (scoreSpar, renderSparBrief/parseSparBrief, renderSparReport) are
- * fully unit-tested. The Effect glue (captureBaseline, findVariantSession,
- * fetchSessionMetrics) composes existing query functions and is tested with a
- * fake SurrealClient + a live spar-plan smoke.
+ * fully unit-tested. `fetchSessionMetrics` and `findVariantSession` read
+ * entirely off the DuckDB `CacheRead` snapshot and are tested with a real-
+ * decode fake (`@ax/lib/testing/cache`); `captureBaseline` still resolves
+ * `SurrealClient` transitively (`listSessionsNear`, owned by another wave-3
+ * chunk) and is covered only by the live spar-plan smoke.
  *
  * Spec: docs/superpowers/specs/2026-06-13-dojo-spar-design.md
  */
-import { Effect } from "effect";
+import { Effect, Option, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { AxConfig } from "@ax/lib/config";
 import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import type { DbError } from "@ax/lib/errors";
 import { Judgment, type JudgmentError } from "@ax/lib/sqlite";
 import { stableId } from "@ax/lib/stable-id";
-import { recordLiteral } from "@ax/lib/ids";
-import { surrealDate, surrealString } from "@ax/lib/shared/surql";
 import { ProcessService, type ProcessError } from "@ax/lib/process";
 import { findCommitWindow } from "@ax/lib/git-window";
 import { fetchSessionCostMap } from "../metrics/cost-estimate.ts";
@@ -290,11 +291,16 @@ export const renderSparReport = (score: SparScore, brief: SparBrief): string => 
 // Effect glue: metrics, baseline capture, variant lookup
 // ---------------------------------------------------------------------------
 
-interface TurnWallRow {
-    readonly turn_count: number | null;
-    readonly s: string | null;
-    readonly e: string | null;
-}
+/**
+ * The focused turn/wall lookup, entirely against the DuckDB snapshot:
+ * `count(*)` decodes as BIGINT (never `Schema.Number` - see
+ * `@ax/lib/duckdb/columns`), and `started_at`/`ended_at` decode as `Date`.
+ */
+const TurnWallRow = Schema.Struct({
+    turn_count: NumberFromBigIntColumn,
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
+});
 
 /**
  * Resolve one session's spar metrics: cost (from the shared cost map), repair
@@ -314,9 +320,8 @@ interface TurnWallRow {
 export const fetchSessionMetrics = (
     sessionId: string,
     sinceForChurn: Date,
-): Effect.Effect<SparMetrics, DbError | CacheReadError, SurrealClient | CacheRead | AxConfig> =>
+): Effect.Effect<SparMetrics, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
         const read = yield* CacheRead;
         const cleanId = cleanSessionId(sessionId);
 
@@ -342,25 +347,25 @@ export const fetchSessionMetrics = (
         const repairLines = churnRow?.repairLinesAdded ?? 0;
         const episodes = churnRow?.episodes ?? 0;
 
-        // turns + wall: count() over the turn_session_seq index + the session's
-        // own start/end timestamps (mirrors enrichSessions' indexed lookup).
-        const lit = recordLiteral("session", cleanId);
-        // `FROM ONLY <lit>` returns the bare object (not an array of rows), so
-        // the query result is `[ {turn_count, s, e} ]` - read rows[0] directly.
-        // (Indexing rows[0][0] would step INTO the object and yield undefined,
-        // which previously left turns/wall always null.)
-        const rows = yield* db.query<[TurnWallRow | null]>(
+        // turns + wall: an indexed count over turn(session, seq) plus the
+        // session's own start/end timestamps (mirrors enrichSessions' indexed
+        // lookup). `read.first` returns `none` when the session id itself has
+        // no row - the correlated subquery still returns 0 (never null) for a
+        // session with zero turns, so `turns` is null ONLY on a missing session.
+        const rowOpt = yield* read.first(
+            TurnWallRow,
             `SELECT
-                (SELECT count() FROM turn WHERE session = ${lit} GROUP ALL)[0].count AS turn_count,
-                type::string(started_at) AS s,
-                type::string(ended_at) AS e
-             FROM ONLY ${lit};`,
+                (SELECT count(*) FROM turn WHERE session = ?) AS turn_count,
+                started_at,
+                ended_at
+             FROM session WHERE id = ?`,
+            [cleanId, cleanId],
         );
-        const row = rows?.[0] ?? null;
-        const turns = row?.turn_count != null ? Number(row.turn_count) || 0 : null;
-        const startMs = row?.s ? Date.parse(row.s) : NaN;
-        const endMs = row?.e ? Date.parse(row.e) : NaN;
-        const wallMs = Number.isFinite(startMs) && Number.isFinite(endMs) ? endMs - startMs : null;
+        const row = Option.getOrNull(rowOpt);
+        const turns = row?.turn_count ?? null;
+        const wallMs = row?.started_at != null && row?.ended_at != null
+            ? row.ended_at.getTime() - row.started_at.getTime()
+            : null;
 
         return { costUsd, turns, wallMs, repairLines, episodes, landed };
     });
@@ -486,6 +491,9 @@ export const stampSparSession = (
         });
     });
 
+/** `session.id` is a bare VARCHAR in DuckDB (no `session:` record prefix). */
+const VariantSessionRow = Schema.Struct({ id: Schema.String });
+
 /**
  * Find the most recent variant session run in `cwd` at/after `sinceMs` (the
  * brief's createdAt). Returns the bare session id, or null when the agent
@@ -494,18 +502,13 @@ export const stampSparSession = (
 export const findVariantSession = (
     cwd: string,
     sinceMs: number,
-): Effect.Effect<string | null, DbError, SurrealClient> =>
+): Effect.Effect<string | null, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        // `started_at` must stay in the projection: SurrealDB v3 resolves the
-        // ORDER BY idiom against the SELECT shape, so ordering by a field that
-        // was projected away ("AS id" only) fails to parse.
-        const rows = yield* db.query<[Array<{ id: string }>]>(
-            `SELECT type::string(id) AS id, started_at FROM session`
-            + ` WHERE cwd = ${surrealString(cwd)}`
-            + ` AND started_at >= ${surrealDate(new Date(sinceMs))}`
-            + ` ORDER BY started_at DESC LIMIT 1;`,
+        const read = yield* CacheRead;
+        const rowOpt = yield* read.first(
+            VariantSessionRow,
+            `SELECT id FROM session WHERE cwd = ? AND started_at >= ? ORDER BY started_at DESC LIMIT 1`,
+            [cwd, new Date(sinceMs)],
         );
-        const id = rows?.[0]?.[0]?.id;
-        return id ? String(id) : null;
+        return Option.match(rowOpt, { onNone: () => null, onSome: (r) => r.id });
     });

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { buildRepresentativePayload, composeChain, dedupeChainCosts, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
 import type { BenchLedger, ChainHookRow } from "./bench.ts";
-import { SurrealClient } from "@ax/lib/db";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
 
-// fake-client harness (mirrors apps/axctl/src/improve/show.test.ts)
-const fakeClient = (...fixtures: unknown[][]) => {
-    let i = 0;
-    return {
-        layer: Layer.succeed(SurrealClient, {
-            query: <T>(_: string) => Effect.succeed([(fixtures[i++] ?? [])] as unknown as T),
-        } as never),
-    };
-};
+/** A real-decode CacheRead fake (@ax/lib/testing/cache) - `total` decodes as
+ *  BIGINT via NumberFromBigIntColumn, so the fixture's job is just to hand
+ *  back the row; the decode contract is exercised for real. */
+const fakeCache = (total: number | null) =>
+    makeTestCacheRead({ routes: { "FROM tool_call": total === null ? [] : [{ total }] } });
 
 describe("percentiles", () => {
     test("p50/p95/min/max/mean over samples", () => {
@@ -151,22 +147,21 @@ describe("dedupeChainCosts", () => {
 
 describe("estFiresPerDay", () => {
     test("counts matched tool_calls / days", async () => {
-        const client = fakeClient([{ total: 420 }]); // 420 matched over 30d
         const r = await Effect.runPromise(
-            estFiresPerDay(["Bash", "Edit"], 30).pipe(Effect.provide(client.layer)),
+            estFiresPerDay(["Bash", "Edit"], 30).pipe(Effect.provide(fakeCache(420).layer)), // 420 matched over 30d
         );
         expect(r.perDay).toBe(14);
         expect(r.matched).toEqual(["Bash", "Edit"]);
     });
     test("no tools (non-tool hook) -> perDay null, basis n/a", async () => {
         const r = await Effect.runPromise(
-            estFiresPerDay([], 30).pipe(Effect.provide(fakeClient([]).layer)),
+            estFiresPerDay([], 30).pipe(Effect.provide(fakeCache(null).layer)),
         );
         expect(r.perDay).toBeNull();
     });
     test("total=0 -> perDay 0", async () => {
         const r = await Effect.runPromise(
-            estFiresPerDay(["Bash"], 30).pipe(Effect.provide(fakeClient([{ total: 0 }]).layer)),
+            estFiresPerDay(["Bash"], 30).pipe(Effect.provide(fakeCache(0).layer)),
         );
         expect(r.perDay).toBe(0);
     });

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -6,11 +6,10 @@
  * live CLI smoke. Built incrementally across the hooks-bench plan tasks.
  */
 
-import { Effect, FileSystem, Path } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import type { CacheRead } from "@ax/lib/duckdb/seam";
-import type { DbError } from "@ax/lib/errors";
-import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { Effect, FileSystem, Path, Schema } from "effect";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { andAll, inClause, withinDaysClause } from "@ax/lib/duckdb/clause";
 import { HOME } from "@ax/lib/paths";
 import { readAllHooks } from "./config.ts";
 import type { ConfiguredHookWithEvidence } from "./config.ts";
@@ -106,31 +105,34 @@ export interface FireFrequency {
     readonly basis: string;
 }
 
+const ToolCallTotalRow = Schema.Struct({ total: NumberFromBigIntColumn });
+
 /**
  * Estimate fires/day for a tool-matching hook: COUNT tool_call rows whose
  * `name` is in the hook's matched tools over the last `days`, divided by days.
  * Non-tool hooks (no matched tools) have no tool_call basis -> perDay null.
  *
- * Datetime cutoff inlined via `surrealDate` (SurrealClient.query takes no
- * bindings; same pattern as report-queries.ts). Count idiom: top-level
- * `count() AS total ... GROUP ALL` (mirrors wrapped.ts / recall.ts; the repo
- * memory note that count needs GROUP ALL).
+ * Reads the DuckDB snapshot via `CacheRead`: the `name IN (...)` + date-window
+ * filters are bound parameters (`inClause` / `withinDaysClause`, never string-
+ * interpolated), and `count(*)` decodes through `NumberFromBigIntColumn` (a
+ * BIGINT column, not `Schema.Number`).
  */
 export const estFiresPerDay = (
     tools: readonly string[],
     days: number,
-): Effect.Effect<FireFrequency, DbError, SurrealClient> =>
+): Effect.Effect<FireFrequency, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
         if (tools.length === 0) return { perDay: null, matched: [], basis: "n/a" };
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
         // Guard days so days=0 can't divide to Infinity.
         const window = Math.max(1, days);
-        const since = new Date(Date.now() - window * 86_400_000);
-        const list = tools.map((t) => surrealString(t)).join(", ");
-        const r = yield* db.query<[Array<{ total: number }>]>(
-            `SELECT count() AS total FROM tool_call WHERE name IN [${list}] AND ts > ${surrealDate(since)} GROUP ALL;`,
+        const clause = andAll([inClause("name", tools), withinDaysClause("ts", window)]);
+        const rows = yield* read.rows(
+            ToolCallTotalRow,
+            `SELECT count(*) AS total FROM tool_call WHERE TRUE ${clause.sql}`,
+            clause.params,
         );
-        const total = r?.[0]?.[0]?.total ?? 0;
+        const total = rows[0]?.total ?? 0;
         return { perDay: Math.round(total / window), matched: [...tools], basis: `tool_call/${window}d` };
     });
 
@@ -290,8 +292,8 @@ const CHAIN_PROVIDER = "claude";
  * Best-effort + soft-fail: a failed config read or summary query degrades to
  * the default-estimate path and writes a notice to STDERR (so `--json` stdout
  * stays clean) - never a silent approximation. Deps: HookProviderRegistry |
- * FileSystem | Path | SurrealClient | CacheRead (`readAllHooks` reads the
- * snapshot).
+ * FileSystem | Path | CacheRead (`readAllHooks` + `queryHookSummary` both read
+ * the DuckDB snapshot).
  */
 export const gatherChain = (
     meta: InstallableHookMeta,
@@ -300,7 +302,7 @@ export const gatherChain = (
 ): Effect.Effect<
     ChainSummary | null,
     never,
-    HookProviderRegistry | FileSystem.FileSystem | Path.Path | SurrealClient | CacheRead
+    HookProviderRegistry | FileSystem.FileSystem | Path.Path | CacheRead
 > =>
     Effect.gen(function* () {
         const event = meta.events[0];
@@ -349,18 +351,22 @@ export const gatherChain = (
         return composeChain(event, costs, candidateP50, budgetMs, chainNames);
     });
 
+const ToolCallInputJsonRow = Schema.Struct({ input_json: Schema.NullOr(Schema.String) });
+
 /** Fetch one recent `tool_call.input_json` for `tool`, parsed to an object, or
  *  null when none / unparseable. Soft-fails (a DB error -> null) so the bench
  *  always proceeds with an empty payload body. */
 const sampleToolInput = (
     tool: string,
-): Effect.Effect<Record<string, unknown> | null, never, SurrealClient> =>
+): Effect.Effect<Record<string, unknown> | null, never, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const rows = yield* db.query<[Array<{ input_json: string | null }>]>(
-            `SELECT input_json FROM tool_call WHERE name = ${surrealString(tool)} AND input_json != NONE ORDER BY ts DESC LIMIT 1;`,
-        ).pipe(Effect.catch(() => Effect.succeed([[]] as [Array<{ input_json: string | null }>])));
-        const raw = rows?.[0]?.[0]?.input_json;
+        const read = yield* CacheRead;
+        const rows = yield* read.rows(
+            ToolCallInputJsonRow,
+            `SELECT input_json FROM tool_call WHERE name = ? AND input_json IS NOT NULL ORDER BY ts DESC LIMIT 1`,
+            [tool],
+        ).pipe(Effect.catch(() => Effect.succeed([])));
+        const raw = rows[0]?.input_json;
         if (typeof raw !== "string") return null;
         try {
             const parsed = JSON.parse(raw);
@@ -393,7 +399,7 @@ export const benchHook = (
 ): Effect.Effect<
     BenchLedger,
     never,
-    SurrealClient | CacheRead | FileSystem.FileSystem | Path.Path | HookProviderRegistry
+    CacheRead | FileSystem.FileSystem | Path.Path | HookProviderRegistry
 > =>
     Effect.gen(function* () {
         const path = yield* Path.Path;

--- a/apps/axctl/src/hooks/cli.ts
+++ b/apps/axctl/src/hooks/cli.ts
@@ -36,8 +36,9 @@ import { fetchHookLatencyRegression, renderHookLatency } from "../queries/hook-l
 /**
  * `ax hooks` config CRUD subcommands (provider-agnostic: claude/cursor/codex/
  * opencode). Spliced into the existing `hooksCommand` group in cli/index.ts.
- * Every handler provides `HookProviderRegistryDefault`; SurrealClient +
- * FileSystem + Path come from AppLayer.
+ * Every handler provides `HookProviderRegistryDefault`; CacheRead + FileSystem
+ * + Path come from AppLayer (readAllHooks reads the DuckDB snapshot, not
+ * SurrealDB - see hooks/config.ts).
  */
 
 const json = Flag.boolean("json").pipe(Flag.withDefault(false));

--- a/apps/axctl/src/improve/impact.test.ts
+++ b/apps/axctl/src/improve/impact.test.ts
@@ -123,7 +123,7 @@ describe("estimateImpact", () => {
 describe("estimateImpactCached", () => {
     test("second call within TTL skips recompute", async () => {
         const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
-        const layer = makeDb([[[]]]);
+        const layer = cacheRead().layer;
         const cache = createImpactEstimateCache();
         const a = await run(estimateImpactCached(p, 1_000, cache), layer);
         const b = await run(estimateImpactCached(p, 2_000, cache), layer);
@@ -132,7 +132,7 @@ describe("estimateImpactCached", () => {
 
     test("expired entry recomputes", async () => {
         const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
-        const layer = makeDb([[[]]]);
+        const layer = cacheRead().layer;
         const cache = createImpactEstimateCache();
         const a = await run(estimateImpactCached(p, 1_000, cache), layer);
         const b = await run(estimateImpactCached(p, 1_000 + 11 * 60_000, cache), layer);
@@ -142,7 +142,7 @@ describe("estimateImpactCached", () => {
 
     test("independent cache adapters isolate same-sig estimates", async () => {
         const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
-        const layer = makeDb([[[]]]);
+        const layer = cacheRead().layer;
         const a = await run(estimateImpactCached(p, 1_000, createImpactEstimateCache()), layer);
         const b = await run(estimateImpactCached(p, 2_000, createImpactEstimateCache()), layer);
         expect(b).not.toBe(a);

--- a/apps/axctl/src/improve/impact.test.ts
+++ b/apps/axctl/src/improve/impact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer, Option } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { CacheRead, type CacheReadService } from "@ax/lib/duckdb/seam";
+import { Effect, type Layer } from "effect";
+import { makeTestCacheRead, type TestCacheOptions } from "@ax/lib/testing/cache";
+import type { CacheRead } from "@ax/lib/duckdb/seam";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
 import {
     createImpactEstimateCache,
@@ -26,28 +26,14 @@ const proposal = (over: Partial<ProposalDto>): ProposalDto =>
         ...over,
     }) as ProposalDto;
 
-type QueryResult = Array<Record<string, unknown>>;
-const makeDb = (resultsPerCall: QueryResult[][]) => {
-    let call = 0;
-    const stub: SurrealClientShape = {
-        query: (_sql: string) => {
-            const r = resultsPerCall[Math.min(call, resultsPerCall.length - 1)];
-            call += 1;
-            return Effect.succeed(r);
-        },
-    } as unknown as SurrealClientShape;
-    return Layer.succeed(SurrealClient, stub);
-};
+/** A real-decode CacheRead fake (@ax/lib/testing/cache) - empty routes ->
+ *  every query returns zero rows, which is enough for the estimators that
+ *  never touch CacheRead (guidance/skill/fallback) and a valid zero baseline
+ *  for the ones that do (hook, routing). */
+const cacheRead = (routes: TestCacheOptions["routes"] = {}) => makeTestCacheRead({ routes });
 
-const emptyCache: CacheReadService = {
-    rows: () => Effect.succeed([]) as never,
-    first: () => Effect.succeed(Option.none()) as never,
-    raw: () => Effect.succeed({ columns: [], rows: [] }) as never,
-    snapshotPath: "(test)",
-};
-
-const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient | CacheRead>, layer: Layer.Layer<SurrealClient>) =>
-    Effect.runPromise(eff.pipe(Effect.provide(Layer.merge(layer, Layer.succeed(CacheRead, emptyCache)))));
+const run = <A>(eff: Effect.Effect<A, unknown, CacheRead>, layer: Layer.Layer<CacheRead>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)));
 
 describe("parseBaseline", () => {
     test("tolerates missing/corrupt baseline", () => {
@@ -64,7 +50,7 @@ describe("estimateImpact", () => {
                 form: "guidance",
                 baseline: '{"frequency":9,"evidence":"9 corrections across 4 sessions"}',
             })),
-            makeDb([[[]]]),
+            cacheRead().layer,
         );
         expect(est.kind).toBe("correction_pressure");
         // headline = LIVE frequency (matches the card chip); frozen baseline (9) becomes a growth note
@@ -77,7 +63,7 @@ describe("estimateImpact", () => {
     test("skill: frequency + tool from baseline", async () => {
         const est = await run(
             estimateImpact(proposal({ form: "skill", baseline: '{"tool":"Bash","frequency":12}' })),
-            makeDb([[[]]]),
+            cacheRead().layer,
         );
         // live frequency (7 on the fixture), not the frozen baseline 12
         expect(est.headline).toContain("7×");
@@ -86,6 +72,9 @@ describe("estimateImpact", () => {
     });
 
     test("hook with target_tool: addressable failures from tool_call stats", async () => {
+        // Two `tool_call` count(*) queries hit the same table: the total and
+        // the `status = ?` failure count. Distinguish by SQL shape, exactly
+        // as the real DuckDB statements differ.
         const est = await run(
             estimateImpact(proposal({
                 form: "hook",
@@ -99,7 +88,9 @@ describe("estimateImpact", () => {
                     failure_mode: null,
                 },
             } as Partial<ProposalDto>)),
-            makeDb([[[{ n: 200 }], [{ n: 14 }]]]),
+            cacheRead({
+                "FROM tool_call": (sql) => sql.includes("status = ?") ? [{ n: 14 }] : [{ n: 200 }],
+            }).layer,
         );
         expect(est.kind).toBe("addressable_failures");
         expect(est.headline).toContain("14 failures");
@@ -108,11 +99,11 @@ describe("estimateImpact", () => {
     });
 
     test("routing proposal: recomputes savings via dispatch candidates", async () => {
-        // fetchDispatchCandidates issues one multi-statement query; an
-        // oversized empty tuple satisfies its destructuring with zero rows.
+        // fetchDispatchCandidates is CacheRead-native; empty routes -> zero
+        // rows everywhere, which is a valid (empty) baseline.
         const est = await run(
             estimateImpact(proposal({ form: "hook", title: ROUTING_PROPOSAL_TITLE })),
-            makeDb([[Array.from({ length: 8 }, () => []) as unknown as QueryResult]]),
+            cacheRead().layer,
         );
         expect(est.kind).toBe("savings_usd");
         expect(est.confidence).toBe("estimated");
@@ -122,7 +113,7 @@ describe("estimateImpact", () => {
     test("fallback: frequency", async () => {
         const est = await run(
             estimateImpact(proposal({ form: "automation" })),
-            makeDb([[[]]]),
+            cacheRead().layer,
         );
         expect(est.kind).toBe("frequency");
         expect(est.headline).toContain("7×");

--- a/apps/axctl/src/improve/impact.ts
+++ b/apps/axctl/src/improve/impact.ts
@@ -1,6 +1,7 @@
-import { Effect } from "effect";
-import { SurrealClient } from "@ax/lib/db";
+import { Effect, Schema } from "effect";
 import { CacheRead } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
 import type { ImpactEstimate, ProposalDto } from "@ax/lib/shared/dashboard-types";
 import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { interventionFormSpec } from "./intervention-forms.ts";
@@ -54,18 +55,25 @@ const routingImpact = Effect.fn("improve.routingImpact")(function* () {
     } satisfies ImpactEstimate;
 });
 
-const TOOL_STATS_SQL = (
-    tool: string,
-) => `SELECT count() AS n FROM tool_call WHERE name = ${JSON.stringify(tool)} AND ts > time::now() - ${HOOK_WINDOW_DAYS}d GROUP ALL;
-SELECT count() AS n FROM tool_call WHERE name = ${JSON.stringify(tool)} AND status = "error" AND ts > time::now() - ${HOOK_WINDOW_DAYS}d GROUP ALL;`;
+const ToolCallCountRow = Schema.Struct({ n: NumberFromBigIntColumn });
 
 const hookImpact = Effect.fn("improve.hookImpact")(function* (tool: string) {
-    const db = yield* SurrealClient;
-    const [totalRows, failRows] = yield* db.query<
-        [Array<{ n: number }>, Array<{ n: number }>]
-    >(TOOL_STATS_SQL(tool));
-    const total = Number(totalRows?.[0]?.n ?? 0);
-    const failures = Number(failRows?.[0]?.n ?? 0);
+    const read = yield* CacheRead;
+    const within = withinDaysClause("ts", HOOK_WINDOW_DAYS);
+    const [totalRows, failRows] = yield* Effect.all([
+        read.rows(
+            ToolCallCountRow,
+            `SELECT count(*) AS n FROM tool_call WHERE name = ? ${within.sql}`,
+            [tool, ...within.params],
+        ),
+        read.rows(
+            ToolCallCountRow,
+            `SELECT count(*) AS n FROM tool_call WHERE name = ? AND status = ? ${within.sql}`,
+            [tool, "error", ...within.params],
+        ),
+    ]);
+    const total = totalRows[0]?.n ?? 0;
+    const failures = failRows[0]?.n ?? 0;
     return {
         kind: "addressable_failures",
         headline: `intersects ${failures.toLocaleString("en")} failures (of ${total.toLocaleString("en")} ${tool} calls) in ${HOOK_WINDOW_DAYS}d`,

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -10,6 +10,7 @@ import {
     fetchDailyActivity,
     fetchDailyActivityFull,
     fetchDailyModels,
+    fetchDailyToolCalls,
     fetchDeepSessionCount,
     fetchGuardrailHookEvidence,
     fetchGuardrailVerdicts,
@@ -384,6 +385,30 @@ describe("fetchDailyModels", () => {
     test("empty -> empty array", async () => {
         const cache = cacheRead({});
         const r = await runCache(fetchDailyModels({ windowDays: 30 }), cache.layer);
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchDailyToolCalls", () => {
+    test("returns per-day tool_call counts", async () => {
+        const cache = cacheRead({
+            "FROM tool_call": [
+                { date: "2026-06-11", tool_calls: 120 },
+                { date: "2026-06-12", tool_calls: 80 },
+            ],
+        });
+        const r = await runCache(fetchDailyToolCalls({ windowDays: 30 }), cache.layer);
+        expect(r).toEqual([
+            { date: "2026-06-11", tool_calls: 120 },
+            { date: "2026-06-12", tool_calls: 80 },
+        ]);
+        expect(cache.captured[0]).toContain("strftime(ts, '%Y-%m-%d')");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+    });
+
+    test("empty -> empty array", async () => {
+        const cache = cacheRead({});
+        const r = await runCache(fetchDailyToolCalls({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -9,6 +9,7 @@ import {
     fetchCommitCount,
     fetchDailyActivity,
     fetchDailyActivityFull,
+    fetchDailyModels,
     fetchDeepSessionCount,
     fetchGuardrailHookEvidence,
     fetchGuardrailVerdicts,
@@ -362,6 +363,28 @@ describe("fetchWrappedCounts", () => {
         expect(r.verification_calls).toBe(500);
         expect(r.context_calls).toBe(300);
         expect(r.tool_calls).toBe(1000);
+    });
+});
+
+describe("fetchDailyModels", () => {
+    test("returns per-day per-model token totals, null model -> (unattributed)", async () => {
+        const cache = cacheRead({
+            "FROM session_token_usage": [
+                { date: "2026-06-11", model: "claude-opus-5", tokens: 40000 },
+                { date: "2026-06-11", model: null, tokens: 500 },
+            ],
+        });
+        const r = await runCache(fetchDailyModels({ windowDays: 30 }), cache.layer);
+        expect(r[0]).toEqual({ date: "2026-06-11", model: "claude-opus-5", tokens: 40000 });
+        expect(r[1]).toEqual({ date: "2026-06-11", model: "(unattributed)", tokens: 500 });
+        expect(cache.captured[0]).toContain("strftime(ts, '%Y-%m-%d')");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+    });
+
+    test("empty -> empty array", async () => {
+        const cache = cacheRead({});
+        const r = await runCache(fetchDailyModels({ windowDays: 30 }), cache.layer);
+        expect(r).toHaveLength(0);
     });
 });
 

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -287,27 +287,26 @@ describe("fetchTopTools", () => {
 
 describe("fetchWrappedCounts", () => {
     test("aggregates tool_calls, failures, distinct_tools and pattern-matches in JS", async () => {
-        const db = makeMockDb([
-            // 1: toolAgg rows
-            [[
-                { tool: "bun test", count: 900, failures: 10 },
-                { tool: "Read", count: 2000, failures: 5 },
-                { tool: "Bash", count: 3000, failures: 50 },
-            ]],
-            // 2: turnCount
-            [[{ count: 41200 }]],
-            // 3: distinctSkills
-            [[{ count: 56 }]],
-            // 4: reposCount
-            [[{ count: 12 }]],
-            // 5: verifyAgg (full command_text labels)
-            [[
-                { cmd: "bun test", count: 900 },
-                { cmd: "Read", count: 2000 },
-                { cmd: "Bash", count: 3000 },
-            ]],
-        ]);
-        const r = await runWithMock(db, fetchWrappedCounts({ windowDays: 30 }));
+        const cache = makeTestCacheRead({
+            // Positional, mirroring fetchWrappedCounts' fixed query order:
+            // toolAgg, turnCount, distinctSkills, reposCount, verifyAgg.
+            responses: [
+                [
+                    { tool: "bun test", count: 900, failures: 10 },
+                    { tool: "Read", count: 2000, failures: 5 },
+                    { tool: "Bash", count: 3000, failures: 50 },
+                ],
+                [{ count: 41200 }],
+                [{ count: 56 }],
+                [{ count: 12 }],
+                [
+                    { cmd: "bun test", count: 900 },
+                    { cmd: "Read", count: 2000 },
+                    { cmd: "Bash", count: 3000 },
+                ],
+            ],
+        });
+        const r = await runCache(fetchWrappedCounts({ windowDays: 30 }), cache.layer);
         expect(r.turns).toBe(41200);
         expect(r.tool_calls).toBe(5900); // 900+2000+3000
         expect(r.tool_failures).toBe(65); // 10+5+50
@@ -319,18 +318,18 @@ describe("fetchWrappedCounts", () => {
         // "Read" -> context via tool-taxonomy isContextTool (verifyAgg)
         expect(r.context_calls).toBe(2000);
         // SQL contains window clause
-        expect(db.captured[0]).toContain("time::now() - 30d");
-        expect(db.captured[0]).toContain("FROM tool_call");
-        expect(db.captured[1]).toContain("FROM turn");
-        expect(db.captured[2]).toContain("FROM invoked");
-        expect(db.captured[3]).toContain("FROM session");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+        expect(cache.captured[0]).toContain("FROM tool_call");
+        expect(cache.captured[1]).toContain("FROM turn");
+        expect(cache.captured[2]).toContain("FROM invoked");
+        expect(cache.captured[3]).toContain("FROM session");
         // 5th query classifies the full command text
-        expect(db.captured[4]).toContain("command_text");
+        expect(cache.captured[4]).toContain("command_text");
     });
 
     test("empty tables -> all zeros", async () => {
-        const db = makeMockDb([[[]], [[]], [[]], [[]], [[]]]);
-        const r = await runWithMock(db, fetchWrappedCounts({ windowDays: 30 }));
+        const cache = makeTestCacheRead({ responses: [[], [], [], [], []] });
+        const r = await runCache(fetchWrappedCounts({ windowDays: 30 }), cache.layer);
         expect(r.turns).toBe(0);
         expect(r.tool_calls).toBe(0);
         expect(r.tool_failures).toBe(0);
@@ -342,23 +341,24 @@ describe("fetchWrappedCounts", () => {
     });
 
     test("verification + context patterns are exclusive of non-matching tools", async () => {
-        const db = makeMockDb([
-            [[
-                { tool: "lint", count: 500, failures: 0 },   // verification
-                { tool: "grep", count: 300, failures: 2 },   // context
-                { tool: "Agent", count: 200, failures: 0 },  // neither
-            ]],
-            [[{ count: 1000 }]],
-            [[{ count: 10 }]],
-            [[{ count: 5 }]],
-            // verifyAgg (full command_text labels)
-            [[
-                { cmd: "lint", count: 500 },   // verification
-                { cmd: "grep", count: 300 },   // context
-                { cmd: "Agent", count: 200 },  // neither
-            ]],
-        ]);
-        const r = await runWithMock(db, fetchWrappedCounts({ windowDays: 30 }));
+        const cache = makeTestCacheRead({
+            responses: [
+                [
+                    { tool: "lint", count: 500, failures: 0 }, // verification
+                    { tool: "grep", count: 300, failures: 2 }, // context
+                    { tool: "Agent", count: 200, failures: 0 }, // neither
+                ],
+                [{ count: 1000 }],
+                [{ count: 10 }],
+                [{ count: 5 }],
+                [
+                    { cmd: "lint", count: 500 }, // verification
+                    { cmd: "grep", count: 300 }, // context
+                    { cmd: "Agent", count: 200 }, // neither
+                ],
+            ],
+        });
+        const r = await runCache(fetchWrappedCounts({ windowDays: 30 }), cache.layer);
         expect(r.verification_calls).toBe(500);
         expect(r.context_calls).toBe(300);
         expect(r.tool_calls).toBe(1000);

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -9,6 +9,7 @@ import {
     fetchCommitCount,
     fetchDailyActivity,
     fetchDailyActivityFull,
+    fetchDailyCommits,
     fetchDailyModels,
     fetchDailyToolCalls,
     fetchDeepSessionCount,
@@ -409,6 +410,31 @@ describe("fetchDailyToolCalls", () => {
     test("empty -> empty array", async () => {
         const cache = cacheRead({});
         const r = await runCache(fetchDailyToolCalls({ windowDays: 30 }), cache.layer);
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchDailyCommits", () => {
+    test("returns per-day commit counts", async () => {
+        const cache = cacheRead({
+            'FROM "commit"': [
+                { date: "2026-06-11", commits: 3 },
+                { date: "2026-06-12", commits: 1 },
+            ],
+        });
+        const r = await runCache(fetchDailyCommits({ windowDays: 30 }), cache.layer);
+        expect(r).toEqual([
+            { date: "2026-06-11", commits: 3 },
+            { date: "2026-06-12", commits: 1 },
+        ]);
+        expect(cache.captured[0]).toContain("strftime(ts, '%Y-%m-%d')");
+        expect(cache.captured[0]).toContain('FROM "commit"');
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+    });
+
+    test("empty -> empty array", async () => {
+        const cache = cacheRead({});
+        const r = await runCache(fetchDailyCommits({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { Effect } from "effect";
+import { Effect, type Layer } from "effect";
 import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
+import { makeTestCacheRead, type TestCacheOptions } from "@ax/lib/testing/cache";
+import type { CacheRead, CacheReadError } from "@ax/lib/duckdb/seam";
 import { judgmentTestLayer } from "../testing/judgment-test-layer.ts";
 import {
     fetchAcceptedProposals,
@@ -21,40 +23,49 @@ import {
     fetchWrappedCounts,
 } from "./queries.ts";
 
+/** A real-decode CacheRead fake (@ax/lib/testing/cache). */
+const cacheRead = (routes: TestCacheOptions["routes"] = {}) => makeTestCacheRead({ routes });
+const runCache = <A>(
+    eff: Effect.Effect<A, CacheReadError, CacheRead>,
+    layer: Layer.Layer<CacheRead>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
 describe("fetchTokenTotals", () => {
     test("sums tokens and sessions over the window", async () => {
-        const db = makeMockDb([[[{ prompt_tokens: 100, completion_tokens: 40, sessions: 3 }]]]);
-        const r = await runWithMock(db, fetchTokenTotals({ windowDays: 30 }));
+        const cache = cacheRead({
+            "FROM session_token_usage": [{ prompt_tokens: 100, completion_tokens: 40, sessions: 3 }],
+        });
+        const r = await runCache(fetchTokenTotals({ windowDays: 30 }), cache.layer);
         expect(r).toEqual({ prompt_tokens: 100, completion_tokens: 40, sessions: 3 });
-        expect(db.captured[0]).toContain("time::now() - 30d");
-        expect(db.captured[0]).toContain("session_token_usage");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+        expect(cache.captured[0]).toContain("session_token_usage");
     });
 
     test("empty window -> zeros", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchTokenTotals({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchTokenTotals({ windowDays: 30 }), cache.layer);
         expect(r).toEqual({ prompt_tokens: 0, completion_tokens: 0, sessions: 0 });
     });
 });
 
 describe("fetchDailyActivity", () => {
     test("returns day keys from session table (not turn)", async () => {
-        const db = makeMockDb([[[{ date: "2026-06-11" }, { date: "2026-06-12" }]]]);
-        const r = await runWithMock(db, fetchDailyActivity({ windowDays: 30 }));
+        const cache = cacheRead({ "FROM session": [{ date: "2026-06-11" }, { date: "2026-06-12" }] });
+        const r = await runCache(fetchDailyActivity({ windowDays: 30 }), cache.layer);
         expect(r).toEqual(["2026-06-11", "2026-06-12"]);
         // Fix 1a: must use session.started_at (fast) not turn.ts (full-scan)
-        expect(db.captured[0]).toContain('time::format(started_at, "%Y-%m-%d")');
-        expect(db.captured[0]).toContain("FROM session");
-        expect(db.captured[0]).not.toContain("FROM turn");
+        expect(cache.captured[0]).toContain("strftime(started_at, '%Y-%m-%d')");
+        expect(cache.captured[0]).toContain("FROM session");
+        expect(cache.captured[0]).not.toContain("FROM turn");
     });
 });
 
 describe("fetchHarnesses", () => {
     test("returns distinct sources", async () => {
-        const db = makeMockDb([[[{ source: "claude" }, { source: "codex" }]]]);
-        const r = await runWithMock(db, fetchHarnesses({ windowDays: 30 }));
+        const cache = cacheRead({ "FROM session": [{ source: "claude" }, { source: "codex" }] });
+        const r = await runCache(fetchHarnesses({ windowDays: 30 }), cache.layer);
         expect(r).toEqual(["claude", "codex"]);
-        expect(db.captured[0]).toContain("GROUP BY source");
+        expect(cache.captured[0]).toContain("GROUP BY source");
     });
 });
 

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -214,16 +214,16 @@ describe("fetchDeepSessionCount", () => {
 
 describe("fetchPeakHour", () => {
     test("returns the peak hour as a number", async () => {
-        const db = makeMockDb([[[{ hour: "13", count: 42 }]]]);
-        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        const cache = cacheRead({ "strftime(started_at, '%H')": [{ hour: "13", count: 42 }] });
+        const r = await runCache(fetchPeakHour({ windowDays: 30 }), cache.layer);
         expect(r).toBe(13);
-        expect(db.captured[0]).toContain("time::format(started_at");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain("strftime(started_at");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 
     test("empty window -> null", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchPeakHour({ windowDays: 30 }), cache.layer);
         expect(r).toBeNull();
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -24,6 +24,7 @@ import {
     fetchTokenTotals,
     fetchTopTools,
     fetchWindowedInvocations,
+    fetchWindowedSessions,
     fetchWrappedCounts,
 } from "./queries.ts";
 
@@ -460,6 +461,36 @@ describe("fetchWindowedInvocations", () => {
     test("empty invocations -> empty array", async () => {
         const db = makeMockDb([[[]]]);
         const r = await runWithMock(db, fetchWindowedInvocations({ windowDays: 7 }));
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchWindowedSessions", () => {
+    test("returns id+s+e as ISO strings, ended_at required", async () => {
+        // "s"/"e" aren't `_at`-suffixed, so the fixture helper's auto Date
+        // conversion doesn't apply here - pass real Dates directly.
+        const cache = cacheRead({
+            "id, started_at AS s, ended_at AS e": [
+                {
+                    id: "sess-1",
+                    s: new Date("2026-06-12T10:00:00.000Z"),
+                    e: new Date("2026-06-12T12:30:00.000Z"),
+                },
+                { id: "sess-2", s: new Date("2026-06-12T09:00:00.000Z"), e: null },
+            ],
+        });
+        const r = await runCache(fetchWindowedSessions({ windowDays: 30 }), cache.layer);
+        // sess-2 has no ended_at -> filtered out
+        expect(r).toEqual([
+            { id: "sess-1", s: "2026-06-12T10:00:00.000Z", e: "2026-06-12T12:30:00.000Z" },
+        ]);
+        expect(cache.captured[0]).toContain("AND ended_at IS NOT NULL");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+    });
+
+    test("empty -> empty array", async () => {
+        const cache = cacheRead({});
+        const r = await runCache(fetchWindowedSessions({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -246,17 +246,17 @@ describe("fetchSpawnedCount", () => {
 
 describe("fetchCommitCount", () => {
     test("returns commit count using ts field", async () => {
-        const db = makeMockDb([[[{ count: 1000 }]]]);
-        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        const cache = cacheRead({ 'FROM "commit"': [{ count: 1000 }] });
+        const r = await runCache(fetchCommitCount({ windowDays: 30 }), cache.layer);
         expect(r).toBe(1000);
-        expect(db.captured[0]).toContain("FROM commit");
-        expect(db.captured[0]).toContain("ts >");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain('FROM "commit"');
+        expect(cache.captured[0]).toContain("ts >=");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 
     test("empty -> 0", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchCommitCount({ windowDays: 30 }), cache.layer);
         expect(r).toBe(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -497,20 +497,22 @@ describe("fetchWindowedSessions", () => {
 
 describe("fetchGuardrailHookEvidence", () => {
     test("returns per-hook fire/block/warn counts from hook evidence", async () => {
-        const db = makeMockDb([[[
-            { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
-            { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
-        ]]]);
-        const rows = await runWithMock(db, fetchGuardrailHookEvidence({ windowDays: 14 }));
+        const cache = cacheRead({
+            "FROM hook_command_invocation": [
+                { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
+                { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
+            ],
+        });
+        const rows = await runCache(fetchGuardrailHookEvidence({ windowDays: 14 }), cache.layer);
         expect(rows).toEqual([
             { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
             { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
         ]);
-        expect(db.captured[0]).toContain("FROM hook_command_invocation");
-        expect(db.captured[0]).toContain("time::now() - 14d");
-        expect(db.captured[0]).toContain("GROUP BY hook_name");
-        expect(db.captured[0]).toContain('effect = "blocked"');
-        expect(db.captured[0]).toContain('"injected_context"');
+        expect(cache.captured[0]).toContain("FROM hook_command_invocation");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
+        expect(cache.captured[0]).toContain("GROUP BY hook_name");
+        expect(cache.captured[0]).toContain("effect = 'blocked'");
+        expect(cache.captured[0]).toContain("'injected_context'");
     });
 });
 

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -127,54 +127,56 @@ describe("fetchAcceptedProposals", () => {
 
 describe("fetchDailyActivityFull", () => {
     test("returns date+sessions+tokens rows, window applied", async () => {
-        const db = makeMockDb([
-            [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 3 }]],
-            [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 80_000 }]],
-        ]);
-        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        const cache = cacheRead({
+            "FROM session\nWHERE": [{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 3 }],
+            "FROM session_token_usage": [{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 80_000 }],
+        });
+        const r = await runCache(fetchDailyActivityFull({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(2);
         expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
         expect(r[1]).toEqual({ date: "2026-06-12", sessions: 3, tokens: 80_000 });
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
         // Fix 1b: must use session table (fast) not turn table full-scan
-        expect(db.captured[0]).toContain("FROM session");
-        expect(db.captured[0]).toContain("count() AS sessions");
-        expect(db.captured[0]).not.toContain("array::len(array::distinct(session))");
+        expect(cache.captured[0]).toContain("FROM session");
+        expect(cache.captured[0]).toContain("count(*) AS sessions");
+        expect(cache.captured[0]).not.toContain("array::len(array::distinct(session))");
     });
 
     test("day with no tokens entry gets tokens=0", async () => {
-        const db = makeMockDb([
-            [[{ date: "2026-06-11", sessions: 5 }]],
-            [[]],
-        ]);
-        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        const cache = cacheRead({
+            "FROM session\nWHERE": [{ date: "2026-06-11", sessions: 5 }],
+            "FROM session_token_usage": [],
+        });
+        const r = await runCache(fetchDailyActivityFull({ windowDays: 30 }), cache.layer);
         expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 0 });
     });
 
     test("empty window -> empty array", async () => {
-        const db = makeMockDb([[[]], [[]]]);
-        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchDailyActivityFull({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });
 
 describe("fetchSessionDurations", () => {
     test("returns started_at+ended_at as ISO strings, window applied", async () => {
-        const db = makeMockDb([[[
-            { started_at: "2026-06-11T10:00:00Z", ended_at: "2026-06-11T12:30:00Z" },
-            { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:00:00Z" },
-        ]]]);
-        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
-        expect(r[0]!.started_at).toBe("2026-06-11T10:00:00Z");
-        expect(r[0]!.ended_at).toBe("2026-06-11T12:30:00Z");
-        expect(db.captured[0]).toContain("ended_at IS NOT NONE");
-        expect(db.captured[0]).toContain("started_at IS NOT NONE");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        const cache = cacheRead({
+            "FROM session": [
+                { started_at: "2026-06-11T10:00:00.000Z", ended_at: "2026-06-11T12:30:00.000Z" },
+                { started_at: "2026-06-12T09:00:00.000Z", ended_at: "2026-06-12T10:00:00.000Z" },
+            ],
+        });
+        const r = await runCache(fetchSessionDurations({ windowDays: 30 }), cache.layer);
+        expect(r[0]!.started_at).toBe("2026-06-11T10:00:00.000Z");
+        expect(r[0]!.ended_at).toBe("2026-06-11T12:30:00.000Z");
+        expect(cache.captured[0]).toContain("ended_at IS NOT NULL");
+        expect(cache.captured[0]).toContain("started_at IS NOT NULL");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 
     test("empty window -> empty array", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchSessionDurations({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -71,23 +71,25 @@ describe("fetchHarnesses", () => {
 
 describe("fetchSkillInvocations", () => {
     test("returns name+count rows, window applied", async () => {
-        const db = makeMockDb([[[{ skill: "tdd", count: 88 }]]]);
-        const r = await runWithMock(db, fetchSkillInvocations({ windowDays: 30 }));
+        const cache = cacheRead({ "FROM invoked": [{ skill: "tdd", count: 88 }] });
+        const r = await runCache(fetchSkillInvocations({ windowDays: 30 }), cache.layer);
         expect(r).toEqual([{ skill: "tdd", count: 88 }]);
-        expect(db.captured[0]).toContain("FROM invoked");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain("FROM invoked");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 });
 
 describe("fetchSkillScopes", () => {
     test("maps name -> scope, tombstones filtered in SQL", async () => {
-        const db = makeMockDb([[ [
-            { name: "tdd", scope: "plugin:superpowers" },
-            { name: "my-local", scope: "user" },
-        ]]]);
-        const r = await runWithMock(db, fetchSkillScopes());
+        const cache = cacheRead({
+            "FROM skill": [
+                { name: "tdd", scope: "plugin:superpowers" },
+                { name: "my-local", scope: "user" },
+            ],
+        });
+        const r = await runCache(fetchSkillScopes(), cache.layer);
         expect(r.get("tdd")).toBe("plugin:superpowers");
-        expect(db.captured[0]).toContain("deleted_at IS NONE");
+        expect(cache.captured[0]).toContain("deleted_at IS NULL");
     });
 });
 

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -230,16 +230,16 @@ describe("fetchPeakHour", () => {
 
 describe("fetchSpawnedCount", () => {
     test("returns spawned count in window", async () => {
-        const db = makeMockDb([[[{ count: 420 }]]]);
-        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        const cache = cacheRead({ "FROM spawned": [{ count: 420 }] });
+        const r = await runCache(fetchSpawnedCount({ windowDays: 30 }), cache.layer);
         expect(r).toBe(420);
-        expect(db.captured[0]).toContain("FROM spawned");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain("FROM spawned");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 
     test("empty -> 0", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchSpawnedCount({ windowDays: 30 }), cache.layer);
         expect(r).toBe(0);
     });
 });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -9,6 +9,7 @@ import {
     fetchCommitCount,
     fetchDailyActivity,
     fetchDailyActivityFull,
+    fetchDeepSessionCount,
     fetchGuardrailHookEvidence,
     fetchGuardrailVerdicts,
     fetchHarnesses,
@@ -178,6 +179,36 @@ describe("fetchSessionDurations", () => {
         const cache = cacheRead({});
         const r = await runCache(fetchSessionDurations({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchDeepSessionCount", () => {
+    test("counts sessions with >=1 real (non-reverted, LOC>0) commit", async () => {
+        const cache = cacheRead({
+            "count(*) AS total FROM session": [{ total: 42 }],
+            "FROM produced p": [
+                { session: "sess-a", commit: "commit-1" },
+                { session: "sess-b", commit: "commit-2" },
+            ],
+            "FROM touched t": [
+                { commit: "commit-1", loc: 12 },
+                { commit: "commit-2", loc: 0 },
+            ],
+        });
+        const r = await runCache(fetchDeepSessionCount({ windowDays: 30 }), cache.layer);
+        expect(r).toEqual({ deep: 1, total: 42 });
+        expect(cache.captured.some((sql) => sql.includes("c.reverted IS DISTINCT FROM TRUE"))).toBe(true);
+        expect(cache.captured.some((sql) => sql.includes("s.source != 'claude-subagent'"))).toBe(true);
+        expect(cache.captured.some((sql) => sql.includes("t.in_id IN (?, ?)"))).toBe(true);
+    });
+
+    test("no produced rows -> deep 0, total preserved", async () => {
+        const cache = cacheRead({
+            "count(*) AS total FROM session": [{ total: 7 }],
+            "FROM produced p": [],
+        });
+        const r = await runCache(fetchDeepSessionCount({ windowDays: 30 }), cache.layer);
+        expect(r).toEqual({ deep: 0, total: 7 });
     });
 });
 

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -263,22 +263,24 @@ describe("fetchCommitCount", () => {
 
 describe("fetchTopTools", () => {
     test("returns top 10 tools by run count, window applied", async () => {
-        const db = makeMockDb([[[
-            { tool: "Bash", count: 5000 },
-            { tool: "Read", count: 3200 },
-        ]]]);
-        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        const cache = cacheRead({
+            "FROM tool_call": [
+                { tool: "Bash", count: 5000 },
+                { tool: "Read", count: 3200 },
+            ],
+        });
+        const r = await runCache(fetchTopTools({ windowDays: 30 }), cache.layer);
         expect(r[0]).toEqual({ name: "Bash", runs: 5000 });
         expect(r[1]).toEqual({ name: "Read", runs: 3200 });
-        expect(db.captured[0]).toContain("FROM tool_call");
-        expect(db.captured[0]).toContain("command_norm ?? name");
-        expect(db.captured[0]).toContain("LIMIT 10");
-        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(cache.captured[0]).toContain("FROM tool_call");
+        expect(cache.captured[0]).toContain("COALESCE(command_norm, name)");
+        expect(cache.captured[0]).toContain("LIMIT 10");
+        expect(cache.captured[0]).toContain("INTERVAL '1 day'");
     });
 
     test("empty -> empty array", async () => {
-        const db = makeMockDb([[[]]]);
-        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        const cache = cacheRead({});
+        const r = await runCache(fetchTopTools({ windowDays: 30 }), cache.layer);
         expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -470,19 +470,17 @@ export const fetchSpawnedCount = Effect.fn("profile.fetchSpawnedCount")(
 // --- commit count ------------------------------------------------------------
 // commit table uses `ts` (datetime) - confirmed in packages/schema/src/schema.surql.
 
-const COMMIT_COUNT_SQL = (d: number) => `
-SELECT count() AS count
-FROM commit
-WHERE ts > time::now() - ${win(d)}
-GROUP ALL;`;
+const COMMIT_COUNT_SQL = `
+SELECT count(*) AS count
+FROM "commit"
+WHERE TRUE`;
 
 export const fetchCommitCount = Effect.fn("profile.fetchCommitCount")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(COMMIT_COUNT_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        return Number(rows[0]?.count ?? 0);
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(CountRow, `${COMMIT_COUNT_SQL} ${within.sql}`, within.params);
+        return rows[0]?.count ?? 0;
     },
 );
 

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -9,11 +9,9 @@
  */
 import { Effect, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
-import { recordLiteral } from "@ax/lib/ids";
-import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { CacheRead, type CacheReadError, type CacheReadService } from "@ax/lib/duckdb/seam";
-import { TimestampColumn } from "@ax/lib/duckdb/columns";
-import { withinDaysClause } from "@ax/lib/duckdb/clause";
+import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
+import { inClause, withinDaysClause } from "@ax/lib/duckdb/clause";
 import type { DuckDbParam } from "@ax/lib/duckdb/types";
 import { isContextTool, isVerificationTool } from "./tool-taxonomy.ts";
 import type { GuardrailHookEvidenceRow, GuardrailVerdictRow } from "./guardrails.ts";
@@ -326,27 +324,33 @@ export const fetchSessionDurations = Effect.fn("profile.fetchSessionDurations")(
  * LOC floor beyond >0 - a surgical fix that ships clean is a deep outcome; size
  * lives on the SCALE axis, not here.
  */
-const DEEP_PRODUCED_SQL = (d: number) => `
-SELECT type::string(in) AS session, type::string(out) AS commit
-FROM produced
-WHERE in.started_at > time::now() - ${win(d)}
-  AND in.source != "claude-subagent"
-  AND out.reverted != true;`;
+// DuckDB is bare-ref (no `session:`/`commit:` record prefixes and no `in`/`out`
+// graph deref), so the old SurrealQL `in.started_at`/`in.source`/`out.reverted`
+// path through the `produced` edge becomes explicit JOINs against `session` and
+// `commit`, and `touched.in`/`commit` become `touched.in_id`/`"commit".id`.
+// `out.reverted != true` needs `IS DISTINCT FROM TRUE` (not `!= TRUE`) because
+// `reverted` is a nullable BOOLEAN (schema.duckdb.sql: NONE means "not known
+// reverted") and plain `!=` against NULL evaluates to NULL, which WHERE treats
+// as false and would wrongly drop every commit that has never been checked.
+const DEEP_PRODUCED_SQL = `
+SELECT p.in_id AS session, p.out_id AS commit
+FROM produced p
+JOIN session s ON s.id = p.in_id
+JOIN "commit" c ON c.id = p.out_id
+WHERE TRUE`;
 
-const COMMIT_LANDED_LOC_SQL = (refs: string) => `
-SELECT type::string(in) AS commit, math::sum((additions ?? 0) + (deletions ?? 0)) AS loc
-FROM touched WHERE in IN [${refs}] GROUP BY commit;`;
+const COMMIT_LANDED_LOC_SQL = `
+SELECT t.in_id AS commit, SUM(COALESCE(t.additions, 0) + COALESCE(t.deletions, 0)) AS loc
+FROM touched t
+WHERE TRUE`;
 
 // DEPTH denominator: own (non-subagent) session count, so the numerator's
 // subagent filter is mirrored. fetchSessionDurations (which feeds hours/longest)
 // keeps counting every session, so the two denominators differ on purpose -
 // subagent sessions roughly DOUBLE the raw count and would halve this share.
-const DEEP_SESSION_TOTAL_SQL = (d: number) => `
-SELECT count() AS total FROM session
-WHERE started_at > time::now() - ${win(d)}
-  AND started_at IS NOT NONE
-  AND source != "claude-subagent"
-GROUP ALL;`;
+const DEEP_SESSION_TOTAL_SQL = `
+SELECT count(*) AS total FROM session
+WHERE TRUE`;
 
 const LOC_CHUNK = 500;
 
@@ -357,26 +361,33 @@ export interface DeepSessionCount {
     readonly total: number;
 }
 
+const DeepSessionTotalRow = Schema.Struct({ total: NumberFromBigIntColumn });
+const DeepProducedRow = Schema.Struct({ session: Schema.String, commit: Schema.String });
+const CommitLandedLocRow = Schema.Struct({ commit: Schema.String, loc: NumberFromBigIntColumn });
+
 export const fetchDeepSessionCount = Effect.fn("profile.fetchDeepSessionCount")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const totalRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DEEP_SESSION_TOTAL_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const total = Number(totalRows[0]?.total ?? 0);
+        const read = yield* CacheRead;
 
-        const produced = yield* db
-            .query<[Array<Record<string, unknown>>]>(DEEP_PRODUCED_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const totalWithin = withinDaysClause("started_at", opts.windowDays);
+        const totalRows = yield* read.rows(
+            DeepSessionTotalRow,
+            `${DEEP_SESSION_TOTAL_SQL} ${totalWithin.sql} AND started_at IS NOT NULL AND source != 'claude-subagent'`,
+            totalWithin.params,
+        );
+        const total = totalRows[0]?.total ?? 0;
 
-        // (session, commit-key) pairs for landed, non-reverted commits.
-        const pairs = produced
-            .map((r) => ({
-                session: String(r.session ?? ""),
-                commit: recordKeyPart(String(r.commit ?? ""), "commit"),
-            }))
-            .filter((p): p is { session: string; commit: string } =>
-                p.session.length > 0 && p.commit !== null && p.commit.length > 0);
+        const producedWithin = withinDaysClause("s.started_at", opts.windowDays);
+        const produced = yield* read.rows(
+            DeepProducedRow,
+            `${DEEP_PRODUCED_SQL} ${producedWithin.sql} `
+                + "AND s.source != 'claude-subagent' AND c.reverted IS DISTINCT FROM TRUE",
+            producedWithin.params,
+        );
+
+        // (session, commit) pairs for landed, non-reverted commits. Ids are
+        // already bare strings in DuckDB, so no key-extraction step is needed.
+        const pairs = produced.filter((p) => p.session.length > 0 && p.commit.length > 0);
         if (pairs.length === 0) return { deep: 0, total } satisfies DeepSessionCount;
 
         const commitKeys = [...new Set(pairs.map((p) => p.commit))];
@@ -385,21 +396,21 @@ export const fetchDeepSessionCount = Effect.fn("profile.fetchDeepSessionCount")(
             chunks.push(commitKeys.slice(i, i + LOC_CHUNK));
         }
         const locRows = (yield* Effect.all(
-            chunks.map((keys) =>
-                db.query<[Array<Record<string, unknown>>]>(
-                    COMMIT_LANDED_LOC_SQL(keys.map((k) => recordLiteral("commit", k)).join(", ")),
-                ).pipe(Effect.map((r) => r?.[0] ?? [])),
-            ),
+            chunks.map((keys) => {
+                const inKeys = inClause("t.in_id", keys);
+                return read.rows(
+                    CommitLandedLocRow,
+                    `${COMMIT_LANDED_LOC_SQL} ${inKeys.sql} GROUP BY t.in_id`,
+                    inKeys.params,
+                );
+            }),
             { concurrency: 4 },
         )).flat();
 
-        // Commit keys whose landed diff actually touched code.
+        // Commits whose landed diff actually touched code.
         const realCommits = new Set<string>();
         for (const row of locRows) {
-            if (Number(row.loc ?? 0) > 0) {
-                const key = recordKeyPart(String(row.commit ?? ""), "commit");
-                if (key !== null && key.length > 0) realCommits.add(key);
-            }
+            if (row.loc > 0) realCommits.add(row.commit);
         }
 
         // Distinct sessions that produced >=1 real commit.

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -698,26 +698,26 @@ export interface DailyToolCallRow {
     readonly tool_calls: number;
 }
 
-const DAILY_TOOL_CALLS_SQL = (d: number) => `
+const DAILY_TOOL_CALLS_SQL = `
 SELECT
-    time::format(ts, "%Y-%m-%d") AS date,
-    count() AS tool_calls
+    strftime(ts, '%Y-%m-%d') AS date,
+    count(*) AS tool_calls
 FROM tool_call
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date
-ORDER BY date ASC;`;
+WHERE TRUE`;
+
+const DailyToolCallDbRow = Schema.Struct({ date: Schema.String, tool_calls: NumberFromBigIntColumn });
 
 export const fetchDailyToolCalls = Effect.fn("profile.fetchDailyToolCalls")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_TOOL_CALLS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(
+            DailyToolCallDbRow,
+            `${DAILY_TOOL_CALLS_SQL} ${within.sql} AND ts IS NOT NULL GROUP BY date ORDER BY date ASC`,
+            within.params,
+        );
         return rows
-            .map((r) => ({
-                date: String(r.date),
-                tool_calls: Number(r.tool_calls ?? 0),
-            }))
+            .map((r) => ({ date: r.date, tool_calls: r.tool_calls }))
             .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyToolCallRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -835,32 +835,40 @@ export const fetchWindowedSessions = Effect.fn("profile.fetchWindowedSessions")(
 
 // --- guardrail receipts -----------------------------------------------------
 
-const GUARDRAIL_HOOK_EVIDENCE_SQL = (d: number) => `
+const GUARDRAIL_HOOK_EVIDENCE_SQL = `
 SELECT
     hook_name,
-    count() AS fires,
-    math::sum(IF effect = "blocked" OR provider_status = "blocking_error" THEN 1 ELSE 0 END) AS blocked,
-    math::sum(IF effect IN ["notified", "injected_context", "modified_input"] THEN 1 ELSE 0 END) AS warned
+    count(*) AS fires,
+    SUM(CASE WHEN effect = 'blocked' OR provider_status = 'blocking_error' THEN 1 ELSE 0 END) AS blocked,
+    SUM(CASE WHEN effect IN ('notified', 'injected_context', 'modified_input') THEN 1 ELSE 0 END) AS warned
 FROM hook_command_invocation
-WHERE ts > time::now() - ${win(d)}
-  AND hook_name IS NOT NONE
-GROUP BY hook_name
-ORDER BY fires DESC
-LIMIT 1000;`;
+WHERE TRUE`;
+
+const GuardrailHookDbRow = Schema.Struct({
+    hook_name: Schema.String,
+    fires: NumberFromBigIntColumn,
+    blocked: NumberFromBigIntColumn,
+    warned: NumberFromBigIntColumn,
+});
 
 export const fetchGuardrailHookEvidence = Effect.fn("profile.fetchGuardrailHookEvidence")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
         const rows = yield* timedQuery(
             "guardrailHookEvidence",
-            db.query<[Array<Record<string, unknown>>]>(GUARDRAIL_HOOK_EVIDENCE_SQL(opts.windowDays))
-                .pipe(Effect.map((r) => r?.[0] ?? [])),
+            read.rows(
+                GuardrailHookDbRow,
+                `${GUARDRAIL_HOOK_EVIDENCE_SQL} ${within.sql} AND hook_name IS NOT NULL `
+                    + "GROUP BY hook_name ORDER BY fires DESC LIMIT 1000",
+                within.params,
+            ),
         );
         return rows.map((r) => ({
-            hook_name: String(r.hook_name ?? ""),
-            fires: Number(r.fires ?? 0),
-            blocked: Number(r.blocked ?? 0),
-            warned: Number(r.warned ?? 0),
+            hook_name: r.hook_name,
+            fires: r.fires,
+            blocked: r.blocked,
+            warned: r.warned,
         })).filter((r) => r.hook_name.length > 0) satisfies GuardrailHookEvidenceRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -729,26 +729,26 @@ export interface DailyCommitRow {
     readonly commits: number;
 }
 
-const DAILY_COMMITS_SQL = (d: number) => `
+const DAILY_COMMITS_SQL = `
 SELECT
-    time::format(ts, "%Y-%m-%d") AS date,
-    count() AS commits
-FROM commit
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date
-ORDER BY date ASC;`;
+    strftime(ts, '%Y-%m-%d') AS date,
+    count(*) AS commits
+FROM "commit"
+WHERE TRUE`;
+
+const DailyCommitDbRow = Schema.Struct({ date: Schema.String, commits: NumberFromBigIntColumn });
 
 export const fetchDailyCommits = Effect.fn("profile.fetchDailyCommits")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_COMMITS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(
+            DailyCommitDbRow,
+            `${DAILY_COMMITS_SQL} ${within.sql} AND ts IS NOT NULL GROUP BY date ORDER BY date ASC`,
+            within.params,
+        );
         return rows
-            .map((r) => ({
-                date: String(r.date),
-                commits: Number(r.commits ?? 0),
-            }))
+            .map((r) => ({ date: r.date, commits: r.commits }))
             .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyCommitRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -803,26 +803,32 @@ export interface WindowedSessionRow {
     readonly e: string;
 }
 
-const WINDOWED_SESSIONS_SQL = (d: number) => `
-SELECT
-    type::string(id) AS id,
-    type::string(started_at) AS s,
-    type::string(ended_at) AS e
+const WINDOWED_SESSIONS_SQL = `
+SELECT id, started_at AS s, ended_at AS e
 FROM session
-WHERE started_at > time::now() - ${win(d)} AND ended_at IS NOT NONE;`;
+WHERE TRUE`;
+
+const WindowedSessionDbRow = Schema.Struct({
+    id: Schema.String,
+    s: Schema.NullOr(TimestampColumn),
+    e: Schema.NullOr(TimestampColumn),
+});
 
 export const fetchWindowedSessions = Effect.fn("profile.fetchWindowedSessions")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(WINDOWED_SESSIONS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", opts.windowDays);
+        const rows = yield* read.rows(
+            WindowedSessionDbRow,
+            `${WINDOWED_SESSIONS_SQL} ${within.sql} AND ended_at IS NOT NULL`,
+            within.params,
+        );
         return rows
-            .filter((r) => r.id != null && r.s != null && r.e != null)
+            .filter((r): r is { id: string; s: Date; e: Date } => r.s !== null && r.e !== null)
             .map((r) => ({
-                id: String(r.id),
-                s: String(r.s),
-                e: String(r.e),
+                id: r.id,
+                s: r.s.toISOString(),
+                e: r.e.toISOString(),
             })) satisfies WindowedSessionRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -424,26 +424,28 @@ export const fetchDeepSessionCount = Effect.fn("profile.fetchDeepSessionCount")(
 
 // --- peak hour ---------------------------------------------------------------
 
-const PEAK_HOUR_SQL = (d: number) => `
-SELECT
-    time::format(started_at, "%H") AS hour,
-    count() AS count
+// time::format(started_at, "%H") -> DuckDB strftime; both return a
+// zero-padded 24h hour string ("00".."23").
+const PEAK_HOUR_SQL = `
+SELECT strftime(started_at, '%H') AS hour, count(*) AS count
 FROM session
-WHERE started_at > time::now() - ${win(d)}
-  AND started_at IS NOT NONE
-GROUP BY hour
-ORDER BY count DESC
-LIMIT 1;`;
+WHERE TRUE`;
+
+const PeakHourRow = Schema.Struct({ hour: Schema.String, count: NumberFromBigIntColumn });
 
 export const fetchPeakHour = Effect.fn("profile.fetchPeakHour")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(PEAK_HOUR_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", opts.windowDays);
+        const rows = yield* read.rows(
+            PeakHourRow,
+            `${PEAK_HOUR_SQL} ${within.sql} AND started_at IS NOT NULL `
+                + "GROUP BY hour ORDER BY count DESC LIMIT 1",
+            within.params,
+        );
         const row = rows[0];
         if (row == null) return null;
-        return Number(row.hour ?? 0);
+        return Number(row.hour);
     },
 );
 

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -11,11 +11,30 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { recordLiteral } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
+import { CacheRead, type CacheReadError, type CacheReadService } from "@ax/lib/duckdb/seam";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
+import type { DuckDbParam } from "@ax/lib/duckdb/types";
 import { isContextTool, isVerificationTool } from "./tool-taxonomy.ts";
 import type { GuardrailHookEvidenceRow, GuardrailVerdictRow } from "./guardrails.ts";
 import { listStoredProposals } from "../improve/judgment-proposals.ts";
 
 const win = (d: number) => `${Math.max(1, Math.trunc(d))}d`;
+
+/**
+ * Unwrap `CacheReadService.raw`'s `{ columns, rows }` to just the rows - the
+ * DuckDB-side equivalent of the old `db.query(...).pipe(Effect.map(r => r?.[0]
+ * ?? []))` SurrealDB multi-statement-result unwrap. Schema-free on purpose:
+ * every function here already coerces each field with `Number(...)`/
+ * `String(...)` at the call site (its pre-existing style), and `Number(...)`
+ * on a native BIGINT is a safe widening (unlike `JSON.stringify`, which is
+ * never called on these raw rows before that coercion happens).
+ */
+const rawRows = (
+    read: CacheReadService,
+    sql: string,
+    params?: ReadonlyArray<DuckDbParam>,
+): Effect.Effect<ReadonlyArray<Record<string, unknown>>, CacheReadError> =>
+    read.raw(sql, params).pipe(Effect.map((r) => r.rows));
 
 // ---------------------------------------------------------------------------
 // Per-query slow-query diagnostics
@@ -51,22 +70,21 @@ export interface TokenTotals {
     readonly sessions: number;
 }
 
-const TOKEN_TOTALS_SQL = (d: number) => `
+const TOKEN_TOTALS_SQL = `
 SELECT
-    math::sum(prompt_tokens ?? 0) AS prompt_tokens,
-    math::sum(completion_tokens ?? 0) AS completion_tokens,
-    count() AS sessions
+    SUM(COALESCE(prompt_tokens, 0)) AS prompt_tokens,
+    SUM(COALESCE(completion_tokens, 0)) AS completion_tokens,
+    count(*) AS sessions
 FROM session_token_usage
-WHERE ts > time::now() - ${win(d)}
-GROUP ALL;`;
+WHERE TRUE`;
 
 export const fetchTokenTotals = Effect.fn("profile.fetchTokenTotals")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
         const rows = yield* timedQuery(
             "tokenTotals",
-            db.query<[Array<Record<string, unknown>>]>(TOKEN_TOTALS_SQL(opts.windowDays))
-                .pipe(Effect.map((r) => r?.[0] ?? [])),
+            rawRows(read, `${TOKEN_TOTALS_SQL} ${within.sql}`, within.params),
         );
         const row = rows[0] ?? {};
         return {
@@ -82,19 +100,22 @@ export const fetchTokenTotals = Effect.fn("profile.fetchTokenTotals")(
 // users who accumulate millions of turn rows). The streak only needs distinct
 // active days, and session.started_at is indexed.
 
-const DAILY_ACTIVITY_SQL = (d: number) => `
-SELECT time::format(started_at, "%Y-%m-%d") AS date
+const DAILY_ACTIVITY_SQL = `
+SELECT strftime(started_at, '%Y-%m-%d') AS date
 FROM session
-WHERE started_at > time::now() - ${win(d)} AND started_at IS NOT NONE
-GROUP BY date ORDER BY date ASC;`;
+WHERE started_at IS NOT NULL`;
 
 export const fetchDailyActivity = Effect.fn("profile.fetchDailyActivity")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", opts.windowDays);
         const rows = yield* timedQuery(
             "dailyActivity",
-            db.query<[Array<Record<string, unknown>>]>(DAILY_ACTIVITY_SQL(opts.windowDays))
-                .pipe(Effect.map((r) => r?.[0] ?? [])),
+            rawRows(
+                read,
+                `${DAILY_ACTIVITY_SQL} ${within.sql} GROUP BY date ORDER BY date ASC`,
+                within.params,
+            ),
         );
         return rows
             .map((r) => String(r.date))
@@ -104,19 +125,20 @@ export const fetchDailyActivity = Effect.fn("profile.fetchDailyActivity")(
 
 // --- harnesses --------------------------------------------------------------
 
-const HARNESSES_SQL = (d: number) => `
-SELECT source, count() AS count
+const HARNESSES_SQL = `
+SELECT source, count(*) AS count
 FROM session
-WHERE started_at > time::now() - ${win(d)} AND source IS NOT NONE
-GROUP BY source
-ORDER BY count DESC;`;
+WHERE source IS NOT NULL`;
 
 export const fetchHarnesses = Effect.fn("profile.fetchHarnesses")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(HARNESSES_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", opts.windowDays);
+        const rows = yield* rawRows(
+            read,
+            `${HARNESSES_SQL} ${within.sql} GROUP BY source ORDER BY count DESC`,
+            within.params,
+        );
         return rows.map((r) => String(r.source));
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -659,26 +659,34 @@ export interface DailyModelRow {
     readonly tokens: number;
 }
 
-const DAILY_MODEL_TOKENS_SQL = (d: number) => `
+const DAILY_MODEL_TOKENS_SQL = `
 SELECT
-    time::format(ts, "%Y-%m-%d") AS date,
+    strftime(ts, '%Y-%m-%d') AS date,
     model,
-    math::sum(prompt_tokens ?? 0) + math::sum(completion_tokens ?? 0) AS tokens
+    SUM(COALESCE(prompt_tokens, 0)) + SUM(COALESCE(completion_tokens, 0)) AS tokens
 FROM session_token_usage
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date, model
-ORDER BY date ASC, tokens DESC;`;
+WHERE TRUE`;
+
+const DailyModelDbRow = Schema.Struct({
+    date: Schema.String,
+    model: Schema.NullOr(Schema.String),
+    tokens: NumberFromBigIntColumn,
+});
 
 export const fetchDailyModels = Effect.fn("profile.fetchDailyModels")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_MODEL_TOKENS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(
+            DailyModelDbRow,
+            `${DAILY_MODEL_TOKENS_SQL} ${within.sql} AND ts IS NOT NULL `
+                + "GROUP BY date, model ORDER BY date ASC, tokens DESC",
+            within.params,
+        );
         return rows.map((r) => ({
-            date: String(r.date),
-            model: r.model == null ? "(unattributed)" : String(r.model),
-            tokens: Number(r.tokens ?? 0),
+            date: r.date,
+            model: r.model ?? "(unattributed)",
+            tokens: r.tokens,
         })) satisfies DailyModelRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -7,11 +7,12 @@
  * Read-only tables: session_token_usage, turn, session, invoked, skill,
  * proposal.
  */
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { recordLiteral } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { CacheRead, type CacheReadError, type CacheReadService } from "@ax/lib/duckdb/seam";
+import { TimestampColumn } from "@ax/lib/duckdb/columns";
 import { withinDaysClause } from "@ax/lib/duckdb/clause";
 import type { DuckDbParam } from "@ax/lib/duckdb/types";
 import { isContextTool, isVerificationTool } from "./tool-taxonomy.ts";
@@ -225,38 +226,43 @@ export interface DailyActivityRow {
 
 // Session-based: count() per day from the session table - avoids the full
 // turn-table scan (array::distinct(session) over millions of Codex turns = 3s+).
-const DAILY_SESSIONS_SQL = (d: number) => `
+const DAILY_SESSIONS_SQL = `
 SELECT
-    time::format(started_at, "%Y-%m-%d") AS date,
-    count() AS sessions
+    strftime(started_at, '%Y-%m-%d') AS date,
+    count(*) AS sessions
 FROM session
-WHERE started_at > time::now() - ${win(d)} AND started_at IS NOT NONE
-GROUP BY date ORDER BY date ASC;`;
+WHERE started_at IS NOT NULL`;
 
-const DAILY_TOKENS_SQL = (d: number) => `
+const DAILY_TOKENS_SQL = `
 SELECT
-    time::format(ts, "%Y-%m-%d") AS date,
-    math::sum(prompt_tokens ?? 0) + math::sum(completion_tokens ?? 0) AS tokens
+    strftime(ts, '%Y-%m-%d') AS date,
+    SUM(COALESCE(prompt_tokens, 0)) + SUM(COALESCE(completion_tokens, 0)) AS tokens
 FROM session_token_usage
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date
-ORDER BY date ASC;`;
+WHERE ts IS NOT NULL`;
 
 export const fetchDailyActivityFull = Effect.fn("profile.fetchDailyActivityFull")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
+        const read = yield* CacheRead;
+        const withinStarted = withinDaysClause("started_at", opts.windowDays);
+        const withinTs = withinDaysClause("ts", opts.windowDays);
         const sessionRows = yield* timedQuery(
             "dailySessions",
-            db.query<[Array<Record<string, unknown>>]>(DAILY_SESSIONS_SQL(opts.windowDays))
-                .pipe(Effect.map((r) => r?.[0] ?? [])),
+            rawRows(
+                read,
+                `${DAILY_SESSIONS_SQL} ${withinStarted.sql} GROUP BY date ORDER BY date ASC`,
+                withinStarted.params,
+            ),
         );
         const tokenRows = yield* timedQuery(
             "dailyTokens",
-            db.query<[Array<Record<string, unknown>>]>(DAILY_TOKENS_SQL(opts.windowDays))
-                .pipe(Effect.map((r) => r?.[0] ?? [])),
+            rawRows(
+                read,
+                `${DAILY_TOKENS_SQL} ${withinTs.sql} GROUP BY date ORDER BY date ASC`,
+                withinTs.params,
+            ),
         );
-        // Join tokens onto session rows in JS (two grouped queries; SurrealDB
-        // 3.x grouped aggregates stay deref-free per the hang rule).
+        // Join tokens onto session rows in JS (two grouped queries; mirrors
+        // the deref-free-aggregate discipline the SurrealDB era established).
         const tokenMap = new Map(
             tokenRows
                 .map((r) => [String(r.date), Number(r.tokens ?? 0)] as const)
@@ -278,27 +284,34 @@ export interface SessionDurationRow {
     readonly ended_at: string;
 }
 
-const SESSION_DURATIONS_SQL = (d: number) => `
-SELECT
-    type::string(started_at) AS started_at,
-    type::string(ended_at) AS ended_at
+const SESSION_DURATIONS_SQL = `
+SELECT started_at, ended_at
 FROM session
-WHERE started_at > time::now() - ${win(d)}
-  AND started_at IS NOT NONE
-  AND ended_at IS NOT NONE;`;
+WHERE started_at IS NOT NULL
+  AND ended_at IS NOT NULL`;
+
+// `started_at`/`ended_at` are TIMESTAMP columns - `raw()` would hand back
+// native `Date`s, and `String(date)` is NOT an ISO string (it's the JS
+// default toString() format). Decode through Schema + toISOString() so the
+// string contract this row type promises actually holds.
+const SessionDurationDbRow = Schema.Struct({
+    started_at: TimestampColumn,
+    ended_at: TimestampColumn,
+});
 
 export const fetchSessionDurations = Effect.fn("profile.fetchSessionDurations")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(SESSION_DURATIONS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        return rows
-            .filter((r) => r.started_at != null && r.ended_at != null)
-            .map((r) => ({
-                started_at: String(r.started_at),
-                ended_at: String(r.ended_at),
-            })) satisfies SessionDurationRow[];
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", opts.windowDays);
+        const rows = yield* read.rows(
+            SessionDurationDbRow,
+            `${SESSION_DURATIONS_SQL} ${within.sql}`,
+            within.params,
+        );
+        return rows.map((r) => ({
+            started_at: r.started_at.toISOString(),
+            ended_at: r.ended_at.toISOString(),
+        })) satisfies SessionDurationRow[];
     },
 );
 

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -451,19 +451,19 @@ export const fetchPeakHour = Effect.fn("profile.fetchPeakHour")(
 
 // --- spawned count -----------------------------------------------------------
 
-const SPAWNED_COUNT_SQL = (d: number) => `
-SELECT count() AS count
+const SPAWNED_COUNT_SQL = `
+SELECT count(*) AS count
 FROM spawned
-WHERE ts > time::now() - ${win(d)}
-GROUP ALL;`;
+WHERE TRUE`;
+
+const CountRow = Schema.Struct({ count: NumberFromBigIntColumn });
 
 export const fetchSpawnedCount = Effect.fn("profile.fetchSpawnedCount")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(SPAWNED_COUNT_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        return Number(rows[0]?.count ?? 0);
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(CountRow, `${SPAWNED_COUNT_SQL} ${within.sql}`, within.params);
+        return rows[0]?.count ?? 0;
     },
 );
 

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -491,26 +491,26 @@ export interface TopToolRow {
     readonly runs: number;
 }
 
-const TOP_TOOLS_SQL = (d: number) => `
-SELECT
-    (command_norm ?? name) AS tool,
-    count() AS count
+const TOP_TOOLS_SQL = `
+SELECT COALESCE(command_norm, name) AS tool, count(*) AS count
 FROM tool_call
-WHERE ts > time::now() - ${win(d)}
-  AND (command_norm ?? name) IS NOT NONE
-GROUP BY tool
-ORDER BY count DESC
-LIMIT 10;`;
+WHERE TRUE`;
+
+const TopToolDbRow = Schema.Struct({ tool: Schema.String, count: NumberFromBigIntColumn });
 
 export const fetchTopTools = Effect.fn("profile.fetchTopTools")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(TOP_TOOLS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("ts", opts.windowDays);
+        const rows = yield* read.rows(
+            TopToolDbRow,
+            `${TOP_TOOLS_SQL} ${within.sql} AND COALESCE(command_norm, name) IS NOT NULL `
+                + "GROUP BY tool ORDER BY count DESC LIMIT 10",
+            within.params,
+        );
         return rows.map((r) => ({
-            name: String(r.tool),
-            runs: Number(r.count ?? 0),
+            name: r.tool,
+            runs: r.count,
         })) satisfies TopToolRow[];
     },
 );

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -539,17 +539,19 @@ export interface WrappedCounts {
 // via tool-taxonomy.ts (ecosystem-aware program matching; see issue #471).
 
 // Per-tool rows (name, count, failures) - same shape as WRAPPED_TOOLS_SQL but windowed.
-const TOOL_AGG_SQL = (d: number) => `
+const TOOL_AGG_SQL = `
 SELECT
-    (command_norm ?? name) AS tool,
-    count() AS count,
-    math::sum(IF has_error = true THEN 1 ELSE 0 END) AS failures
+    COALESCE(command_norm, name) AS tool,
+    count(*) AS count,
+    SUM(CASE WHEN has_error THEN 1 ELSE 0 END) AS failures
 FROM tool_call
-WHERE ts > time::now() - ${win(d)}
-  AND (command_norm ?? name) IS NOT NONE
-GROUP BY tool
-ORDER BY count DESC
-LIMIT 200;`;
+WHERE TRUE`;
+
+const ToolAggRow = Schema.Struct({
+    tool: Schema.String,
+    count: NumberFromBigIntColumn,
+    failures: NumberFromBigIntColumn,
+});
 
 // Verification / context counts classify on the FULL command (`command_text`),
 // not the collapsed `command_norm` - `normalizeCommand` strips the subcommand
@@ -557,79 +559,92 @@ LIMIT 200;`;
 // `npm run`, `bundle exec rspec` -> `bundle`), so the normalized label alone
 // can't see the verifier. Grouped to keep cardinality sane; the command text
 // is classified in-process and never returned (counts-only privacy invariant).
-const VERIFY_AGG_SQL = (d: number) => `
-SELECT
-    (command_text ?? command_norm ?? name) AS cmd,
-    count() AS count
+const VERIFY_AGG_SQL = `
+SELECT COALESCE(command_text, command_norm, name) AS cmd, count(*) AS count
 FROM tool_call
-WHERE ts > time::now() - ${win(d)}
-  AND (command_text ?? command_norm ?? name) IS NOT NONE
-GROUP BY cmd;`;
+WHERE TRUE`;
+
+const VerifyAggRow = Schema.Struct({ cmd: Schema.String, count: NumberFromBigIntColumn });
 
 // Total turn count in window.
-const TURN_COUNT_SQL = (d: number) => `
-SELECT count() AS count
+const TURN_COUNT_SQL = `
+SELECT count(*) AS count
 FROM turn
-WHERE ts > time::now() - ${win(d)}
-GROUP ALL;`;
+WHERE TRUE`;
 
-// Distinct invoked skill names in window.
-const DISTINCT_SKILLS_SQL = (d: number) => `
-SELECT count() AS count
+// Distinct invoked skill names in window. DuckDB is bare-ref, so the old
+// `out.name` deref through `invoked` becomes an explicit JOIN against `skill`.
+const DISTINCT_SKILLS_SQL = `
+SELECT count(*) AS count
 FROM (
-    SELECT out.name AS skill
-    FROM invoked
-    WHERE ts > time::now() - ${win(d)} AND out.name IS NOT NONE
-    GROUP BY skill
-) GROUP ALL;`;
+    SELECT sk.name AS skill
+    FROM invoked i
+    JOIN skill sk ON sk.id = i.out_id
+    WHERE TRUE`;
 
 // Count of distinct non-null repositories in window (count only, never names).
-const REPOS_COUNT_SQL = (d: number) => `
-SELECT count() AS count
+const REPOS_COUNT_SQL = `
+SELECT count(*) AS count
 FROM (
     SELECT repository
     FROM session
-    WHERE started_at > time::now() - ${win(d)} AND repository IS NOT NONE
-    GROUP BY repository
-) GROUP ALL;`;
+    WHERE TRUE`;
 
 export const fetchWrappedCounts = Effect.fn("profile.fetchWrappedCounts")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const toolRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(TOOL_AGG_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const turnRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(TURN_COUNT_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const skillRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DISTINCT_SKILLS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const repoRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(REPOS_COUNT_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const verifyRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(VERIFY_AGG_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const toolWithin = withinDaysClause("ts", opts.windowDays);
+        const verifyWithin = withinDaysClause("ts", opts.windowDays);
+        const turnWithin = withinDaysClause("ts", opts.windowDays);
+        const skillWithin = withinDaysClause("i.ts", opts.windowDays);
+        const repoWithin = withinDaysClause("started_at", opts.windowDays);
 
-        const tool_calls = toolRows.reduce((s, r) => s + Number(r.count ?? 0), 0);
-        const tool_failures = toolRows.reduce((s, r) => s + Number(r.failures ?? 0), 0);
+        const toolRows = yield* read.rows(
+            ToolAggRow,
+            `${TOOL_AGG_SQL} ${toolWithin.sql} AND COALESCE(command_norm, name) IS NOT NULL `
+                + "GROUP BY tool ORDER BY count DESC LIMIT 200",
+            toolWithin.params,
+        );
+        const turnRows = yield* read.rows(
+            CountRow,
+            `${TURN_COUNT_SQL} ${turnWithin.sql}`,
+            turnWithin.params,
+        );
+        const skillRows = yield* read.rows(
+            CountRow,
+            `${DISTINCT_SKILLS_SQL} ${skillWithin.sql} AND sk.name IS NOT NULL GROUP BY skill) t`,
+            skillWithin.params,
+        );
+        const repoRows = yield* read.rows(
+            CountRow,
+            `${REPOS_COUNT_SQL} ${repoWithin.sql} AND repository IS NOT NULL GROUP BY repository) t`,
+            repoWithin.params,
+        );
+        const verifyRows = yield* read.rows(
+            VerifyAggRow,
+            `${VERIFY_AGG_SQL} ${verifyWithin.sql} AND COALESCE(command_text, command_norm, name) IS NOT NULL `
+                + "GROUP BY cmd",
+            verifyWithin.params,
+        );
+
+        const tool_calls = toolRows.reduce((s, r) => s + r.count, 0);
+        const tool_failures = toolRows.reduce((s, r) => s + r.failures, 0);
         const distinct_tools = toolRows.length;
 
         // Verification/context classify on the full command text (verifyRows),
         // not the collapsed command_norm tool label (toolRows).
         const cmdCount = (pred: (label: string) => boolean): number =>
             verifyRows
-                .filter((r) => pred(String(r.cmd ?? "")))
-                .reduce((s, r) => s + Number(r.count ?? 0), 0);
+                .filter((r) => pred(r.cmd))
+                .reduce((s, r) => s + r.count, 0);
 
         return {
-            turns: Number(turnRows[0]?.count ?? 0),
+            turns: turnRows[0]?.count ?? 0,
             tool_calls,
             tool_failures,
             distinct_tools,
-            distinct_skills: Number(skillRows[0]?.count ?? 0),
-            repos_count: Number(repoRows[0]?.count ?? 0),
+            distinct_skills: skillRows[0]?.count ?? 0,
+            repos_count: repoRows[0]?.count ?? 0,
             verification_calls: cmdCount(isVerificationTool),
             context_calls: cmdCount(isContextTool),
         } satisfies WrappedCounts;

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -150,20 +150,23 @@ export interface SkillInvocationRow {
     readonly count: number;
 }
 
-const SKILL_INVOCATIONS_SQL = (d: number) => `
-SELECT out.name AS skill, count() AS count
-FROM invoked
-WHERE ts > time::now() - ${win(d)} AND out.name IS NOT NONE
-GROUP BY skill
-ORDER BY count DESC
-LIMIT 100;`;
+// `invoked.out_id` is a bare ref -> skill (no graph deref in DuckDB), so the
+// skill name comes from a join, not a dotted path.
+const SKILL_INVOCATIONS_SQL = `
+SELECT sk.name AS skill, count(*) AS count
+FROM invoked i
+JOIN skill sk ON sk.id = i.out_id
+WHERE TRUE`;
 
 export const fetchSkillInvocations = Effect.fn("profile.fetchSkillInvocations")(
     function* (opts: { readonly windowDays: number }) {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(SKILL_INVOCATIONS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("i.ts", opts.windowDays);
+        const rows = yield* rawRows(
+            read,
+            `${SKILL_INVOCATIONS_SQL} ${within.sql} GROUP BY sk.name ORDER BY count DESC LIMIT 100`,
+            within.params,
+        );
         return rows.map((r) => ({
             skill: String(r.skill),
             count: Number(r.count ?? 0),
@@ -172,14 +175,12 @@ export const fetchSkillInvocations = Effect.fn("profile.fetchSkillInvocations")(
 );
 
 const SKILL_SCOPES_SQL = `
-SELECT name, scope FROM skill WHERE deleted_at IS NONE;`;
+SELECT name, scope FROM skill WHERE deleted_at IS NULL`;
 
 export const fetchSkillScopes = Effect.fn("profile.fetchSkillScopes")(
     function* () {
-        const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(SKILL_SCOPES_SQL)
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const read = yield* CacheRead;
+        const rows = yield* rawRows(read, SKILL_SCOPES_SQL);
         return new Map(rows.map((r) => [String(r.name), String(r.scope)]));
     },
 );

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -5,15 +5,14 @@ import { cacheReadTestLayer, judgmentTestLayer } from "../testing/judgment-test-
 import { buildProfile } from "./render.ts";
 
 // buildProfile's own queries.ts fetch* calls are now served by CacheRead (see
-// the wave-3 queries.ts port history). Only 4 statements still resolve
+// the wave-3 queries.ts port history). Only 3 statements still resolve
 // SurrealClient: fetchCostModels' main query (queries/cost-analytics.ts - a
 // different wave-3 chunk's file, only its OPTIONAL pricing-catalog lookup
 // reads CacheRead, skipped here since no fixture row needs repricing) and
-// three queries.ts functions not yet ported (fetchWindowedInvocations -
-// deliberately left, porting it breaks apps/axctl/src/team/team-profile.ts
-// which is out of this chunk's ownership; fetchWindowedSessions,
-// fetchGuardrailHookEvidence - not yet reached). `surrealResults` replays
-// ONLY those four, in call order (see buildProfile's own ordering comment).
+// fetchWindowedInvocations (deliberately left unported - porting it breaks
+// apps/axctl/src/team/team-profile.ts, out of this chunk's ownership) and
+// fetchGuardrailHookEvidence (not yet reached). `surrealResults` replays
+// ONLY those three, in call order (see buildProfile's own ordering comment).
 const surrealResults = [
     // fetchCostModels (queries/cost-analytics.ts COST_MODELS_SQL)
     [[{
@@ -28,11 +27,6 @@ const surrealResults = [
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:01:00Z" },
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:30:00Z" },
         { session: "session:2", skill: "tdd", ts: "2026-06-12T11:01:00Z" },
-    ]],
-    // fetchWindowedSessions (WINDOWED_SESSIONS_SQL)
-    [[
-        { id: "session:1", s: "2026-06-12T10:00:00Z", e: "2026-06-12T12:30:00Z" },
-        { id: "session:2", s: "2026-06-12T09:00:00Z", e: "2026-06-12T10:30:00Z" },
     ]],
     // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL)
     [[
@@ -137,6 +131,19 @@ const CACHE_ROUTES: Readonly<Record<string, ReadonlyArray<Record<string, unknown
     // fetchDeepSessionCount landed LOC per commit (COMMIT_LANDED_LOC_SQL) -
     // commit:def landed nothing -> not deep
     "FROM touched t": [{ commit: "commit:abc", loc: 120 }, { commit: "commit:def", loc: 0 }],
+    // fetchWindowedSessions (WINDOWED_SESSIONS_SQL) - real Dates, see header note.
+    "id, started_at AS s, ended_at AS e": [
+        {
+            id: "session:1",
+            s: new Date("2026-06-12T10:00:00Z"),
+            e: new Date("2026-06-12T12:30:00Z"),
+        },
+        {
+            id: "session:2",
+            s: new Date("2026-06-12T09:00:00Z"),
+            e: new Date("2026-06-12T10:30:00Z"),
+        },
+    ],
 };
 
 const proposalRows = [{

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -4,24 +4,18 @@ import { makeMockDb, type TestSurrealClient } from "@ax/lib/testing/surreal";
 import { cacheReadTestLayer, judgmentTestLayer } from "../testing/judgment-test-layer.ts";
 import { buildProfile } from "./render.ts";
 
-// Mock result order MUST match the query order in buildProfile:
-// 1 tokenTotals  2 dailyActivity  3 harnesses  4 skillInvocations
-// 5 skillScopes  6 acceptedProposals  7 costModels
-// 8 dailyActivityFull(sessions)  9 dailyActivityFull(tokens)
-// 10 sessionDurations  11 peakHour  12 spawnedCount  13 commitCount  14 topTools
-// 15 wrappedCounts(toolAgg)  16 wrappedCounts(turnCount)
-// 17 wrappedCounts(distinctSkills)  18 wrappedCounts(reposCount)
-// 18b wrappedCounts(verifyAgg)
-// 19 dailyModels  20 dailyToolCalls  21 dailyCommits
-// 22 windowedInvocations  23 windowedSessions
-// 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
-// 27 contentTypeBreakdown  28 guardrailHookEvidence  29 guardrailVerdicts
-const mockResults = [
-    [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
-    [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
-    [[{ source: "claude" }, { source: "codex" }]],
-    [[{ skill: "tdd", count: 88 }]],
-    [[{ name: "tdd", scope: "plugin:superpowers" }]],
+// buildProfile's own queries.ts fetch* calls are now served by CacheRead (see
+// the wave-3 queries.ts port history). Only 4 statements still resolve
+// SurrealClient: fetchCostModels' main query (queries/cost-analytics.ts - a
+// different wave-3 chunk's file, only its OPTIONAL pricing-catalog lookup
+// reads CacheRead, skipped here since no fixture row needs repricing) and
+// three queries.ts functions not yet ported (fetchWindowedInvocations -
+// deliberately left, porting it breaks apps/axctl/src/team/team-profile.ts
+// which is out of this chunk's ownership; fetchWindowedSessions,
+// fetchGuardrailHookEvidence - not yet reached). `surrealResults` replays
+// ONLY those four, in call order (see buildProfile's own ordering comment).
+const surrealResults = [
+    // fetchCostModels (queries/cost-analytics.ts COST_MODELS_SQL)
     [[{
         model: "fable", sessions: 100, prompt_tokens: 1, completion_tokens: 1,
         cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 150,
@@ -29,68 +23,18 @@ const mockResults = [
         model: "haiku", sessions: 42, prompt_tokens: 1, completion_tokens: 1,
         cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50,
     }]],
-    [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 12 }]],
-    [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 120_000_000 }]],
-    [[
-        { started_at: "2026-06-12T10:00:00Z", ended_at: "2026-06-12T12:30:00Z" },
-        { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:30:00Z" },
-    ]],
-    [[{ hour: "13", count: 42 }]],
-    [[{ count: 420 }]],
-    [[{ count: 1000 }]],
-    [[{ tool: "Bash", count: 5000 }, { tool: "Read", count: 3200 }]],
-    // 15: wrappedCounts toolAgg (Bash=verification, Read=context)
-    [[
-        { tool: "bun test", count: 900, failures: 10 },
-        { tool: "Read", count: 2000, failures: 5 },
-        { tool: "Bash", count: 3000, failures: 50 },
-    ]],
-    // 16: wrappedCounts turnCount
-    [[{ count: 41200 }]],
-    // 17: wrappedCounts distinctSkills
-    [[{ count: 56 }]],
-    // 18: wrappedCounts reposCount
-    [[{ count: 12 }]],
-    // 18b: wrappedCounts verifyAgg (full command_text: bun test=verification, Read=context)
-    [[
-        { cmd: "bun test", count: 900 },
-        { cmd: "Read", count: 2000 },
-        { cmd: "Bash", count: 3000 },
-    ]],
-    // 19: dailyModels
-    [[
-        { date: "2026-06-11", model: "fable", tokens: 80_000 },
-        { date: "2026-06-12", model: "fable", tokens: 100_000_000 },
-        { date: "2026-06-12", model: "haiku", tokens: 20_000_000 },
-    ]],
-    // 20: dailyToolCalls
-    [[{ date: "2026-06-11", tool_calls: 200 }, { date: "2026-06-12", tool_calls: 3900 }]],
-    // 21: dailyCommits
-    [[{ date: "2026-06-11", commits: 7 }, { date: "2026-06-12", commits: 50 }]],
-    // 22: windowedInvocations
+    // fetchWindowedInvocations (WINDOWED_INVOCATIONS_SQL)
     [[
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:01:00Z" },
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:30:00Z" },
         { session: "session:2", skill: "tdd", ts: "2026-06-12T11:01:00Z" },
     ]],
-    // 23: windowedSessions
+    // fetchWindowedSessions (WINDOWED_SESSIONS_SQL)
     [[
         { id: "session:1", s: "2026-06-12T10:00:00Z", e: "2026-06-12T12:30:00Z" },
         { id: "session:2", s: "2026-06-12T09:00:00Z", e: "2026-06-12T10:30:00Z" },
     ]],
-    // 24: deepSessions total (non-subagent session count = DEPTH denominator)
-    [[{ total: 2 }]],
-    // 25: deepSessions produced edges (session -> non-reverted commit)
-    [[
-        { session: "session:1", commit: "commit:abc" },
-        { session: "session:2", commit: "commit:def" },
-    ]],
-    // 26: deepSessions landed LOC per commit (commit:def landed nothing -> not deep)
-    [[
-        { commit: "commit:abc", loc: 120 },
-        { commit: "commit:def", loc: 0 },
-    ]],
-    // 28: guardrailHookEvidence
+    // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL)
     [[
         { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 412, blocked: 9, warned: 0 },
         { hook_name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
@@ -98,13 +42,102 @@ const mockResults = [
     ]],
 ];
 
-// 27 in the old positional list - `fetchContentTypeBreakdown` reads the
-// published snapshot now, so it is no longer a SurrealQL statement and gets its
-// own fixture. Everything after it in `mockResults` shifts up by one.
+// `fetchContentTypeBreakdown` (queries/content-types.ts) reads the published
+// CacheRead snapshot, matched below by its own "has_content" fragment (a
+// different wave-3 chunk's convention, unchanged here).
 const contentTypeRows = [
     { ct: "content_type:code", calls: 10, bytes: 800 },
     { ct: "content_type:text", calls: 5, bytes: 200 },
 ];
+
+// One entry per queries.ts CacheRead statement, keyed by a fragment of that
+// statement's own SQL text unique enough not to collide with any other
+// statement in this file (verified by hand against queries.ts; every key
+// names the _SQL constant it targets). `cacheReadTestLayer` does NOT run
+// Schema decode (see judgment-test-layer.ts), so a field a ported function
+// calls a Date method on (fetchSessionDurations' .toISOString()) must be a
+// real `Date` here, not a string - everything else here is read via
+// Number(...)/String(...) at the call site, so plain values are safe.
+const CACHE_ROUTES: Readonly<Record<string, ReadonlyArray<Record<string, unknown>>>> = {
+    // fetchTokenTotals (TOKEN_TOTALS_SQL)
+    "count(*) AS sessions\nFROM session_token_usage": [
+        { prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 },
+    ],
+    // fetchDailyActivity (DAILY_ACTIVITY_SQL)
+    "AS date\nFROM session\nWHERE started_at IS NOT NULL": [
+        { date: "2026-06-11" }, { date: "2026-06-12" },
+    ],
+    // fetchHarnesses (HARNESSES_SQL)
+    "source, count(*) AS count": [{ source: "claude" }, { source: "codex" }],
+    // fetchSkillInvocations (SKILL_INVOCATIONS_SQL)
+    "sk.name AS skill, count(*) AS count": [{ skill: "tdd", count: 88 }],
+    // fetchSkillScopes (SKILL_SCOPES_SQL)
+    "FROM skill WHERE deleted_at IS NULL": [{ name: "tdd", scope: "plugin:superpowers" }],
+    // fetchDailyActivityFull sessions half (DAILY_SESSIONS_SQL)
+    "count(*) AS sessions\nFROM session\nWHERE started_at IS NOT NULL": [
+        { date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 12 },
+    ],
+    // fetchDailyActivityFull tokens half (DAILY_TOKENS_SQL)
+    "FROM session_token_usage\nWHERE ts IS NOT NULL": [
+        { date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 120_000_000 },
+    ],
+    // fetchSessionDurations (SESSION_DURATIONS_SQL) - real Dates, see header note.
+    "SELECT started_at, ended_at\nFROM session": [
+        { started_at: new Date("2026-06-12T10:00:00Z"), ended_at: new Date("2026-06-12T12:30:00Z") },
+        { started_at: new Date("2026-06-12T09:00:00Z"), ended_at: new Date("2026-06-12T10:30:00Z") },
+    ],
+    // fetchPeakHour (PEAK_HOUR_SQL)
+    "strftime(started_at, '%H') AS hour": [{ hour: "13", count: 42 }],
+    // fetchSpawnedCount (SPAWNED_COUNT_SQL)
+    "FROM spawned": [{ count: 420 }],
+    // fetchCommitCount (COMMIT_COUNT_SQL)
+    "AS count\nFROM \"commit\"": [{ count: 1000 }],
+    // fetchTopTools (TOP_TOOLS_SQL)
+    "COALESCE(command_norm, name) AS tool, count(*) AS count": [
+        { tool: "Bash", count: 5000 }, { tool: "Read", count: 3200 },
+    ],
+    // fetchWrappedCounts toolAgg (TOOL_AGG_SQL) - Bash=verification, Read=context
+    "SUM(CASE WHEN has_error THEN 1 ELSE 0 END) AS failures": [
+        { tool: "bun test", count: 900, failures: 10 },
+        { tool: "Read", count: 2000, failures: 5 },
+        { tool: "Bash", count: 3000, failures: 50 },
+    ],
+    // fetchWrappedCounts turnCount (TURN_COUNT_SQL)
+    "count(*) AS count\nFROM turn": [{ count: 41200 }],
+    // fetchWrappedCounts distinctSkills (DISTINCT_SKILLS_SQL)
+    "    JOIN skill sk ON sk.id = i.out_id\n    WHERE TRUE": [{ count: 56 }],
+    // fetchWrappedCounts reposCount (REPOS_COUNT_SQL)
+    "    SELECT repository\n    FROM session": [{ count: 12 }],
+    // fetchWrappedCounts verifyAgg (VERIFY_AGG_SQL) - full command_text labels
+    "COALESCE(command_text, command_norm, name) AS cmd": [
+        { cmd: "bun test", count: 900 }, { cmd: "Read", count: 2000 }, { cmd: "Bash", count: 3000 },
+    ],
+    // fetchDailyModels (DAILY_MODEL_TOKENS_SQL)
+    "    model,\n    SUM(COALESCE(prompt_tokens, 0))": [
+        { date: "2026-06-11", model: "fable", tokens: 80_000 },
+        { date: "2026-06-12", model: "fable", tokens: 100_000_000 },
+        { date: "2026-06-12", model: "haiku", tokens: 20_000_000 },
+    ],
+    // fetchDailyToolCalls (DAILY_TOOL_CALLS_SQL)
+    "AS tool_calls\nFROM tool_call": [
+        { date: "2026-06-11", tool_calls: 200 }, { date: "2026-06-12", tool_calls: 3900 },
+    ],
+    // fetchDailyCommits (DAILY_COMMITS_SQL)
+    "AS commits\nFROM \"commit\"": [
+        { date: "2026-06-11", commits: 7 }, { date: "2026-06-12", commits: 50 },
+    ],
+    // fetchDeepSessionCount total (DEEP_SESSION_TOTAL_SQL) - non-subagent
+    // session count = DEPTH denominator
+    "count(*) AS total FROM session": [{ total: 2 }],
+    // fetchDeepSessionCount produced edges (DEEP_PRODUCED_SQL) - session -> non-reverted commit
+    "FROM produced p": [
+        { session: "session:1", commit: "commit:abc" },
+        { session: "session:2", commit: "commit:def" },
+    ],
+    // fetchDeepSessionCount landed LOC per commit (COMMIT_LANDED_LOC_SQL) -
+    // commit:def landed nothing -> not deep
+    "FROM touched t": [{ commit: "commit:abc", loc: 120 }, { commit: "commit:def", loc: 0 }],
+};
 
 const proposalRows = [{
     id: "p1", form: "guidance", title: "Stop edit loops early",
@@ -126,15 +159,25 @@ const runProfile = <A, E>(
     effect: Effect.Effect<A, E, unknown>,
     proposals: ReadonlyArray<Record<string, unknown>> = proposalRows,
     contentTypes: ReadonlyArray<Record<string, unknown>> = contentTypeRows,
+    cacheOverrides: Readonly<Record<string, ReadonlyArray<Record<string, unknown>>>> = {},
 ) => Effect.runPromise(effect.pipe(Effect.provide(Layer.mergeAll(
     db.layer,
-    // Two cache reads on this path, dispatched by SQL text: the content-type
-    // breakdown this chunk ported (`has_content`), and the pricing catalog
-    // `fetchCostModels` resolves when a row stores zero cost against real
-    // tokens - none of these fixtures do, so empty is the right answer there.
-    cacheReadTestLayer((sql) =>
-        sql.includes("has_content") ? contentTypes : []
-    ),
+    // Dispatched by SQL text: content-type breakdown (`has_content`, a
+    // different wave-3 chunk's convention) first, then per-test overrides,
+    // then the default CACHE_ROUTES table built above. The pricing-catalog
+    // lookup inside fetchCostModels resolves when a row stores zero cost
+    // against real tokens - none of these fixtures do, so falling through to
+    // empty is the right answer for it.
+    cacheReadTestLayer((sql) => {
+        if (sql.includes("has_content")) return contentTypes;
+        for (const [key, rows] of Object.entries(cacheOverrides)) {
+            if (sql.includes(key)) return rows;
+        }
+        for (const [key, rows] of Object.entries(CACHE_ROUTES)) {
+            if (sql.includes(key)) return rows;
+        }
+        return [];
+    }),
     judgmentTestLayer((sql) => {
         const now = new Date();
         if (sql.includes("FROM proposal")) return proposals;
@@ -166,7 +209,7 @@ const env = {
 
 describe("buildProfile", () => {
     test("assembles a valid ProfileV1", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const p = await runProfile(db, buildProfile({ windowDays: 30, includeCost: true, env }));
 
         expect(p.v).toBe(1);
@@ -249,36 +292,46 @@ describe("buildProfile", () => {
     });
 
     test("includeCost=false strips cost everywhere; share falls back to sessions", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const p = await runProfile(db, buildProfile({ windowDays: 30, includeCost: false, env }));
         expect(p.stats.cost_usd).toBeUndefined();
         expect(p.stats.models[0]).toEqual({ name: "fable", share: 100 / 142 });
     });
 
     test("no proposals -> taste has only the mix pattern from content types", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const p = await runProfile(db, buildProfile({ windowDays: 30, includeCost: true, env }), []);
         expect(p.taste?.patterns).toHaveLength(1);
         expect(p.taste?.patterns[0]?.category).toBe("tool-output-mix");
     });
 
     test("no proposals + no content types -> taste omitted", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const p = await runProfile(db, buildProfile({ windowDays: 30, includeCost: true, env }), [], []);
         expect(p.taste).toBeUndefined();
     });
 
     test("empty daily + durations -> activity and insights omitted", async () => {
-        // Blank out dailyFull(sessions+tokens) and sessionDurations (indices 6, 7, 8).
-        const empty = mockResults.map((r, i) => (i >= 6 && i <= 8 ? [[]] : r));
-        const db = makeMockDb(empty);
-        const p = await runProfile(db, buildProfile({ windowDays: 30, includeCost: true, env }));
+        // Blank out dailyFull(sessions+tokens) and sessionDurations via a
+        // CACHE_ROUTES override - all three are now CacheRead statements.
+        const db = makeMockDb(surrealResults);
+        const p = await runProfile(
+            db,
+            buildProfile({ windowDays: 30, includeCost: true, env }),
+            proposalRows,
+            contentTypeRows,
+            {
+                "count(*) AS sessions\nFROM session\nWHERE started_at IS NOT NULL": [],
+                "FROM session_token_usage\nWHERE ts IS NOT NULL": [],
+                "SELECT started_at, ended_at\nFROM session": [],
+            },
+        );
         expect(p.activity).toBeUndefined();
         expect(p.insights).toBeUndefined();
     });
 
     test("buildProfile attaches highlights from env", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const profile = await runProfile(db, buildProfile({
             windowDays: 30,
             includeCost: true,
@@ -292,7 +345,7 @@ describe("buildProfile", () => {
     });
 
     test("buildProfile omits highlights when env.highlights is null", async () => {
-        const db = makeMockDb(mockResults);
+        const db = makeMockDb(surrealResults);
         const profile = await runProfile(db, buildProfile({
             windowDays: 30,
             includeCost: true,

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -5,14 +5,14 @@ import { cacheReadTestLayer, judgmentTestLayer } from "../testing/judgment-test-
 import { buildProfile } from "./render.ts";
 
 // buildProfile's own queries.ts fetch* calls are now served by CacheRead (see
-// the wave-3 queries.ts port history). Only 3 statements still resolve
+// the wave-3 queries.ts port history). Only 2 statements still resolve
 // SurrealClient: fetchCostModels' main query (queries/cost-analytics.ts - a
 // different wave-3 chunk's file, only its OPTIONAL pricing-catalog lookup
 // reads CacheRead, skipped here since no fixture row needs repricing) and
 // fetchWindowedInvocations (deliberately left unported - porting it breaks
-// apps/axctl/src/team/team-profile.ts, out of this chunk's ownership) and
-// fetchGuardrailHookEvidence (not yet reached). `surrealResults` replays
-// ONLY those three, in call order (see buildProfile's own ordering comment).
+// apps/axctl/src/team/team-profile.ts, out of this chunk's ownership).
+// `surrealResults` replays ONLY those two, in call order (see buildProfile's
+// own ordering comment).
 const surrealResults = [
     // fetchCostModels (queries/cost-analytics.ts COST_MODELS_SQL)
     [[{
@@ -27,12 +27,6 @@ const surrealResults = [
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:01:00Z" },
         { session: "session:1", skill: "tdd", ts: "2026-06-12T10:30:00Z" },
         { session: "session:2", skill: "tdd", ts: "2026-06-12T11:01:00Z" },
-    ]],
-    // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL)
-    [[
-        { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 412, blocked: 9, warned: 0 },
-        { hook_name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
-        { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 0 },
     ]],
 ];
 
@@ -143,6 +137,12 @@ const CACHE_ROUTES: Readonly<Record<string, ReadonlyArray<Record<string, unknown
             s: new Date("2026-06-12T09:00:00Z"),
             e: new Date("2026-06-12T10:30:00Z"),
         },
+    ],
+    // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL)
+    "FROM hook_command_invocation": [
+        { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 412, blocked: 9, warned: 0 },
+        { hook_name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
+        { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 0 },
     ],
 };
 

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -3,7 +3,14 @@
  * ProfileV1. Privacy invariants live HERE, not at the edge: cost only when
  * includeCost; aggregates only (nothing in this module touches transcript
  * content, project names, or paths). Environment (github login, today,
- * hook files, rules text) is injected so the Effect needs only SurrealClient.
+ * hook files, rules text) is injected so the Effect needs no ambient env
+ * reads.
+ *
+ * NOT SurrealClient-free yet: `./queries.ts` (this package) still resolves
+ * SurrealClient for every fetch* it exports, and `../queries/cost-analytics.ts`
+ * (owned by a different wave-3 chunk) resolves BOTH SurrealClient and
+ * CacheRead per query - so buildProfile keeps SurrealClient in its R channel
+ * even once queries.ts is ported.
  */
 import { Effect } from "effect";
 import { fetchContentTypeBreakdown } from "../queries/content-types.ts";

--- a/apps/axctl/src/self-improve/commands.test.ts
+++ b/apps/axctl/src/self-improve/commands.test.ts
@@ -29,7 +29,7 @@ test("guidanceNextSql selects fields used for ordering", () => {
 
 test("sessionSummarySql orders by a selected alias", () => {
     const sql = sessionSummarySql();
-    expect(sql).toContain("(ended_at ?? started_at) AS last_seen_at");
+    expect(sql).toContain("COALESCE(s.ended_at, s.started_at) AS last_seen_at");
     expect(sql).toContain("ORDER BY last_seen_at DESC");
-    expect(sql).not.toContain("ORDER BY (ended_at ?? started_at)");
+    expect(sql).not.toContain("ORDER BY COALESCE(s.ended_at, s.started_at)");
 });

--- a/apps/axctl/src/self-improve/commands.ts
+++ b/apps/axctl/src/self-improve/commands.ts
@@ -1,7 +1,8 @@
-import { Effect } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import type { DbError } from "@ax/lib/errors";
-import { buildGuidanceWriteStatements, guidanceFromSignal } from "./guidance.ts";
+import { Effect, Schema } from "effect";
+import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
+import { withinDaysClause } from "@ax/lib/duckdb/clause";
+import { guidanceFromSignal, type GuidanceDraft } from "./guidance.ts";
 import { deriveSignalsForSelfImprove, type SignalInput } from "./signals.ts";
 
 export type SelfImproveCommand =
@@ -22,58 +23,166 @@ export function guidanceNextSql(): string {
 SELECT id, guidance, version, text, status, scope, risk, evidence, metrics_before
     , created_at
 FROM guidance_version
-WHERE status = "proposed"
+WHERE status = 'proposed'
 ORDER BY created_at DESC
-LIMIT 5;`;
+LIMIT 5`;
 }
 
-export const guidanceNext = (): Effect.Effect<unknown, DbError, SurrealClient> =>
+const GuidanceNextRow = Schema.Struct({
+    id: Schema.String,
+    guidance: Schema.String,
+    version: Schema.String,
+    text: Schema.String,
+    status: Schema.String,
+    scope: Schema.NullOr(Schema.String),
+    risk: Schema.NullOr(Schema.String),
+    evidence: Schema.NullOr(Schema.String),
+    metrics_before: Schema.NullOr(Schema.String),
+    created_at: TimestampColumn,
+});
+
+export const guidanceNext = (): Effect.Effect<unknown, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const result = yield* db.query(guidanceNextSql());
-        return result?.[0] ?? [];
+        const read = yield* CacheRead;
+        return yield* read.rows(GuidanceNextRow, guidanceNextSql());
     });
 
 export function sessionSummarySql(): string {
     return `
-SELECT id, project, cwd, started_at, ended_at,
-    (ended_at ?? started_at) AS last_seen_at,
-    array::len((SELECT id FROM tool_call WHERE session = $parent.id)) AS tool_calls,
-    array::len((SELECT id FROM tool_call WHERE session = $parent.id AND has_error = true)) AS failures
-FROM session
+SELECT s.id AS id, s.project AS project, s.cwd AS cwd, s.started_at AS started_at, s.ended_at AS ended_at,
+    COALESCE(s.ended_at, s.started_at) AS last_seen_at,
+    (SELECT count(*) FROM tool_call t WHERE t.session = s.id) AS tool_calls,
+    (SELECT count(*) FROM tool_call t WHERE t.session = s.id AND t.has_error = TRUE) AS failures
+FROM session s
 ORDER BY last_seen_at DESC
-LIMIT 5;`;
+LIMIT 5`;
 }
 
-export const sessionSummary = (): Effect.Effect<unknown, DbError, SurrealClient> =>
+const SessionSummaryRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    cwd: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
+    last_seen_at: Schema.NullOr(TimestampColumn),
+    // count(*) decodes as BIGINT, never Schema.Number - see @ax/lib/duckdb/columns.
+    tool_calls: NumberFromBigIntColumn,
+    failures: NumberFromBigIntColumn,
+});
+
+export const sessionSummary = (): Effect.Effect<unknown, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const result = yield* db.query(sessionSummarySql());
-        return result?.[0] ?? [];
+        const read = yield* CacheRead;
+        return yield* read.rows(SessionSummaryRow, sessionSummarySql());
     });
 
+/**
+ * Documentation/test text only - NOT what `deriveWeeklyGuidance` executes.
+ * The real reads are three separate bound-parameter DuckDB statements (see
+ * below); this stays as a readable summary of what they select, using the
+ * same guarded `CURRENT_TIMESTAMP` cast (@ax/lib/duckdb/clause daysAgoExpr)
+ * the real queries use, so it also passes check:timestamp-cast.
+ */
 export function weeklyEvidenceSql(days: number): string {
+    const cutoff = `CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(${days} AS INTEGER) * INTERVAL '1 day')`;
     return `
-SELECT id, project, started_at AS startedAt FROM session WHERE started_at > time::now() - ${days}d;
-SELECT session AS sessionId, command_norm AS commandNorm, has_error AS hasError, ts FROM tool_call WHERE ts > time::now() - ${days}d;
-SELECT session AS sessionId, status, ts FROM plan_snapshot WHERE ts > time::now() - ${days}d;`;
+SELECT id, project, started_at AS startedAt FROM session WHERE started_at > ${cutoff};
+SELECT session AS sessionId, command_norm AS commandNorm, has_error AS hasError, ts FROM tool_call WHERE ts > ${cutoff};
+SELECT session AS sessionId, ts FROM plan_snapshot WHERE ts > ${cutoff};`;
 }
 
-export const deriveWeeklyGuidance = (days = 7): Effect.Effect<unknown, DbError, SurrealClient> =>
+const SessionEvidenceRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(TimestampColumn),
+});
+const ToolCallEvidenceRow = Schema.Struct({
+    session: Schema.String,
+    command_norm: Schema.NullOr(Schema.String),
+    has_error: Schema.Boolean,
+    ts: TimestampColumn,
+});
+// plan_snapshot has no `status` column in the DuckDB schema (never made the
+// SurrealDB -> DuckDB migration; SignalInput.planSnapshots.status is optional
+// and unused by every current signal deriver - see signals.ts), so it is
+// mapped to `null` below rather than selected.
+const PlanSnapshotEvidenceRow = Schema.Struct({
+    session: Schema.String,
+    ts: TimestampColumn,
+});
+
+export interface DeriveWeeklyGuidanceResult {
+    readonly guidanceCount: number;
+    readonly guidance: readonly GuidanceDraft[];
+    /**
+     * Reads are ported to CacheRead (the published DuckDB snapshot); the
+     * write side is NOT. `guidance`/`guidance_version` writes only happen
+     * inside ingest, under the ingest lock (`withCacheWrite` in
+     * @ax/lib/duckdb/seam) - this command is a standalone CLI invocation,
+     * never an ingest stage, so it holds no lock. Persisting SurrealDB
+     * instead would be a silent data-loss trap: SurrealDB is write-frozen
+     * from ingest's perspective, `guidanceNext` now reads the DuckDB
+     * snapshot, and nothing would ever read a Surreal-side write back. So
+     * this returns the derived drafts as DATA ONLY, un-persisted, until a
+     * follow-up (an ingest derive-stage, or a dedicated locked write path)
+     * gives this command a legal write target.
+     */
+    readonly persisted: false;
+}
+
+export const deriveWeeklyGuidance = (
+    days = 7,
+): Effect.Effect<DeriveWeeklyGuidanceResult, CacheReadError, CacheRead> =>
     Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const result = yield* db.query(weeklyEvidenceSql(days));
+        const read = yield* CacheRead;
+        const within = withinDaysClause("started_at", days);
+        const withinTs = withinDaysClause("ts", days);
+        const [sessionRows, toolCallRows, planSnapshotRows] = yield* Effect.all([
+            read.rows(
+                SessionEvidenceRow,
+                `SELECT id, project, started_at FROM session WHERE TRUE ${within.sql}`,
+                within.params,
+            ),
+            read.rows(
+                ToolCallEvidenceRow,
+                `SELECT session, command_norm, has_error, ts FROM tool_call WHERE TRUE ${withinTs.sql}`,
+                withinTs.params,
+            ),
+            read.rows(
+                PlanSnapshotEvidenceRow,
+                `SELECT session, ts FROM plan_snapshot WHERE TRUE ${withinTs.sql}`,
+                withinTs.params,
+            ),
+        ]);
+
         const input: SignalInput = {
-            sessions: (result?.[0] ?? []) as SignalInput["sessions"],
-            toolCalls: (result?.[1] ?? []) as SignalInput["toolCalls"],
-            planSnapshots: (result?.[2] ?? []) as SignalInput["planSnapshots"],
+            sessions: sessionRows.map((r) => ({
+                id: r.id,
+                project: r.project,
+                startedAt: r.started_at?.toISOString() ?? null,
+            })),
+            toolCalls: toolCallRows.map((r) => ({
+                sessionId: r.session,
+                commandNorm: r.command_norm,
+                hasError: r.has_error,
+                ts: r.ts.toISOString(),
+            })),
+            planSnapshots: planSnapshotRows.map((r) => ({
+                sessionId: r.session,
+                status: null,
+                ts: r.ts.toISOString(),
+            })),
         };
         const guidance = deriveSignalsForSelfImprove(input).map(guidanceFromSignal);
-        for (const draft of guidance) {
-            yield* db.query(buildGuidanceWriteStatements(draft).join("\n"));
+        if (guidance.length > 0) {
+            console.error(
+                `ax self-improve weekly: derived ${guidance.length} guidance draft(s) but did NOT persist them - `
+                + "writes only happen inside ingest, under the ingest lock; this command is not an ingest stage. "
+                + "See DeriveWeeklyGuidanceResult.persisted in self-improve/commands.ts.",
+            );
         }
-        return { guidanceCount: guidance.length, guidance };
+        return { guidanceCount: guidance.length, guidance, persisted: false };
     });
 
-export const selfImproveWeekly = (): Effect.Effect<unknown, DbError, SurrealClient> =>
+export const selfImproveWeekly = (): Effect.Effect<DeriveWeeklyGuidanceResult, CacheReadError, CacheRead> =>
     deriveWeeklyGuidance(7);


### PR DESCRIPTION
Wave 3, chunk `c-read-dojo-profile`: `dojo/`, `improve/`, `profile/`, `self-improve/` and two `hooks/` files move onto the DuckDB `CacheRead` seam. 22 commits, one per file or per query block.

## The silent-blend metric

`dojo/spar.ts`'s `fetchSessionMetrics` resolved **both** `SurrealClient` and `CacheRead`, then folded cost and landed-LOC (DuckDB, real) together with turn and wall counts (SurrealQL, empty) into a single `SparMetrics`.

That is the harder variant of the dead-engine defect: it does not return an empty object, it returns a **populated-looking** one with a few fields quietly zeroed. Every spar receipt scored on those fields was wrong and looked fine.

Also ported: `improve/impact.ts`'s `hookImpact()` branch (its sibling `routingImpact()` was already on `CacheRead` - two branches of one dispatcher on two engines), `dojo/skill-spar.ts`, `hooks/bench.ts`, `self-improve/commands.ts`, and the `hooks/cli.ts` + `profile/render.ts` vestigial imports.

`profile/queries.ts` - the data layer for all of `ax profile` - ported one `SurrealClient` block per commit.

## A real silent regression, found and fixed

`profile/render.test.ts` was feeding everything through the old positional `SurrealClient` mock after earlier commits had already moved those functions to `CacheRead`. **Two of seven tests were failing outright; the other five passed only because their assertions never touched the now-blank fields.**

Rewritten to key a `CacheRead` fake off unique SQL-text fragments per statement, which then exposed a follow-on off-by-one in the positional array.

This is the failure mode the whole wave is about: a test suite that is green because it is not looking.

## `fetchWindowedInvocations` deliberately NOT ported

Porting it broke `team/team-profile.ts` - 9 runtime failures, `Service not found: ax/CacheRead` - because that file is another chunk's and provides only a `SurrealClient` mock. Reverted rather than reaching across the boundary.

**Consequence, stated plainly:** `ax profile show/publish/widget/interview` are **not** SurrealDB-free yet. They are also blocked by `fetchCostModels` in `queries/cost-analytics.ts`, another chunk's file. Live-verified against a dead `AX_DB_URL`: `ax profile show` exits 1 after a 5s timeout with a `DbError`.

## Tests that can actually tell

`cli/commands/profile-no-surreal.test.ts` spawns the real CLI against a dead port. It covers `ax profile interview submit` (genuinely SurrealDB-free) **and pins `ax profile show`'s current honest failure mode** rather than asserting a success the code does not yet deliver.

An in-process test cannot prove any of this - it is handed the layers either way.

## Verification

Scoped: 2241 pass / 0 fail across `dojo`, `improve`, `hooks`, `self-improve`, `profile`, `team`, `packages`, `scripts`. Gates clean: `typecheck`, `tsc -p`, `check:no-node-fs`, `check:timestamp-cast`.

Base is `v2/duckdb`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
