### PR TITLE
refactor(v2): flip eleven ported command families off the SurrealDB runtime

### DIFF
--- a/apps/axctl/src/cli/commands/ax-thinking.ts
+++ b/apps/axctl/src/cli/commands/ax-thinking.ts
@@ -124,7 +124,7 @@ export const thinkingCommand = Command.make(
 
 export const axThinkingRuntime: RuntimeManifest = {
     thinking: {
-        runtime: "db",
+        runtime: "cache",
         hidden: false,
     },
 };

--- a/apps/axctl/src/cli/commands/context.ts
+++ b/apps/axctl/src/cli/commands/context.ts
@@ -36,5 +36,5 @@ export const contextCommand = Command.make("context").pipe(
 );
 
 export const contextRuntime: RuntimeManifest = {
-    context: { runtime: "db", hidden: true },
+    context: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/costs.ts
+++ b/apps/axctl/src/cli/commands/costs.ts
@@ -314,7 +314,7 @@ export const pricingCommand = Command.make(
 ).pipe(Command.withDescription("Inspect imported model pricing rows"));
 
 export const costsRuntime: RuntimeManifest = {
-    costs: { runtime: "db", hidden: true },
-    loc: { runtime: "db", hidden: true },
-    pricing: { runtime: "db", hidden: true },
+    costs: { runtime: "cache", hidden: true },
+    loc: { runtime: "cache", hidden: true },
+    pricing: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/digest.ts
+++ b/apps/axctl/src/cli/commands/digest.ts
@@ -59,7 +59,7 @@ export const digestCommand = Command.make(
 
 export const digestRuntime: RuntimeManifest = {
     digest: {
-        runtime: "db",
+        runtime: "cache",
         hidden: false,
     },
 };

--- a/apps/axctl/src/cli/commands/evidence.ts
+++ b/apps/axctl/src/cli/commands/evidence.ts
@@ -46,5 +46,5 @@ export const evidenceCommand = Command.make("evidence").pipe(
 );
 
 export const evidenceRuntime: RuntimeManifest = {
-    evidence: { runtime: "db", hidden: true },
+    evidence: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/project.ts
+++ b/apps/axctl/src/cli/commands/project.ts
@@ -28,5 +28,5 @@ export const projectCommand = Command.make("project").pipe(
 );
 
 export const projectRuntime: RuntimeManifest = {
-    project: { runtime: "db", hidden: true },
+    project: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/report.ts
+++ b/apps/axctl/src/cli/commands/report.ts
@@ -100,8 +100,20 @@ export const timelineCommand = Command.make(
     "Highlight/event timeline for a session (segments + ranked events, LLM-free). --json for the full structure.",
 ));
 
+/**
+ * `timeline` flips; `report` and `insights` do NOT, and the throwing proxy is
+ * what settled it - both were flipped, run, and reverted on the failure:
+ *
+ * - `insights` reads through `insightSqlForView` (queries/insights.ts), ~1100
+ *   lines of SurrealQL across 31 views. That is its own port, not a flip.
+ * - `report` calls `writeDashboard` (dashboard/report.ts), which is still on
+ *   the old engine.
+ *
+ * Both must be ported (or dropped) before the SurrealDB deletion chunk can
+ * land - flipping them now would only trade a working command for a throw.
+ */
 export const reportRuntime: RuntimeManifest = {
     report: { runtime: "db", hidden: true },
     insights: { runtime: "db", hidden: true },
-    timeline: { runtime: "db", hidden: true },
+    timeline: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/usage.ts
+++ b/apps/axctl/src/cli/commands/usage.ts
@@ -58,5 +58,5 @@ export const usageCommand = Command.make(
 );
 
 export const usageRuntime: RuntimeManifest = {
-    usage: { runtime: "db", hidden: false },
+    usage: { runtime: "cache", hidden: false },
 };

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -289,7 +289,11 @@ describe("effect cli", () => {
         expect(context).toBeDefined();
         const subNames = context!.subcommands.flatMap((g) => g.commands.map((c) => c.name));
         expect(subNames).toEqual(expect.arrayContaining(["file"]));
-        expect(DB_COMMANDS.has("context")).toBe(true);
+        // Ported to the v2 cache runtime. `DB_COMMANDS` is what decides whether
+        // AppLayer (and its SurrealDB connect) is built, so a ported command
+        // MUST be absent from it - same acceptance shape as `recall` below.
+        expect(entryRuntime(RUNTIME_BY_COMMAND["context"]!)).toBe("cache");
+        expect(DB_COMMANDS.has("context")).toBe(false);
     });
 
     test("hook group exposes file-context and log, declared db-conditional and excluded from DB_COMMANDS (dispatch resolves per-invocation)", () => {
@@ -322,15 +326,17 @@ describe("effect cli", () => {
         expect(DB_COMMANDS.has("hooks")).toBe(false);
     });
 
-    test("cost and pricing commands are routed through DB", () => {
+    test("cost and pricing commands are routed on the v2 cache runtime", () => {
         const costs = rootCommand.subcommands
             .flatMap((g) => g.commands)
             .find((c) => c.name === "costs");
         expect(costs).toBeDefined();
         const subNames = costs!.subcommands.flatMap((g) => g.commands.map((c) => c.name));
         expect(subNames).toEqual(expect.arrayContaining(["summary", "for"]));
-        expect(DB_COMMANDS.has("costs")).toBe(true);
-        expect(DB_COMMANDS.has("pricing")).toBe(true);
+        expect(entryRuntime(RUNTIME_BY_COMMAND["costs"]!)).toBe("cache");
+        expect(entryRuntime(RUNTIME_BY_COMMAND["pricing"]!)).toBe("cache");
+        expect(DB_COMMANDS.has("costs")).toBe(false);
+        expect(DB_COMMANDS.has("pricing")).toBe(false);
     });
 
     test("recall is routed on the v2 cache runtime, and never opens SurrealDB", () => {


### PR DESCRIPTION
Wave 3 of the v2 SurrealDB → DuckDB migration. Bases on `v2/duckdb`; it does NOT go to `main`.

## Why a runtime declaration is not a label

`runtime: "db"` is what makes `main()` build `AppLayer` and open a SurrealDB
socket. Eleven command families had their readers ported onto the `CacheRead`
seam in the wave-3 read chunks (#814–#819) but were still declared `"db"`, so
every invocation still paid a connect for an engine it no longer queried.

`"cache"` provides `CacheRead` **plus the throwing SurrealClient proxy**. That
makes the flip an acceptance test rather than a relabelling: any surviving path
into the old engine fails loudly instead of quietly answering from it.

## Flipped

`costs` · `loc` · `pricing` · `usage` · `thinking` · `context` · `digest` ·
`project` · `evidence` · `timeline`

`tsc` cannot see this defect - the proxy satisfies the type - so each one was
**run** against the local snapshot after the flip, not just typechecked:

```
ax costs summary            ax costs for --query duckdb
ax loc --since 7            ax pricing
ax usage                    ax thinking
ax digest                   ax context file
ax project context|verify|harness
ax evidence guidance-next|session-summary|weekly
```

All exit 0 with no proxy throw.

## Not flipped, and why

Two were flipped, run, and reverted on the failure. The reason is recorded at
the declaration so the next reader does not retry it blind:

| Command | Blocker |
|---|---|
| `insights` | reads through `insightSqlForView` - ~1100 lines of SurrealQL across 31 views. Its own port, not a flip. |
| `report` | calls `writeDashboard`, still on the old engine. |

Both must be ported (or dropped) before the SurrealDB deletion chunk can land.

## Test assertions that pinned the old truth

`effect-cli.test.ts` asserted `DB_COMMANDS.has("context")`, `…("costs")`, and
`…("pricing")`. Those now pin the new truth in the shape the existing `recall`
test already used: runtime is `"cache"` **and** the command is absent from
`DB_COMMANDS` - the latter being what actually decides whether `AppLayer` is
built.

## Verification

`bun test apps/axctl/src/cli` - 696 pass, 0 fail. Full suite: 6156 pass, 4 fail,
all four `Electron failed to install correctly` in `studio-desktop` (an electron
binary missing from this worktree's `node_modules`, identical on `v2/duckdb`
before this change). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
