### PR TITLE
feat(v2): ax insights and ax report read the snapshot, not SurrealDB

### DIFF
--- a/apps/axctl/src/cli/commands/report.ts
+++ b/apps/axctl/src/cli/commands/report.ts
@@ -6,7 +6,8 @@
 import { Effect } from "effect";
 import { Argument, Command } from "effect/unstable/cli";
 import { Flag } from "effect/unstable/cli";
-import { SurrealClient } from "@ax/lib/db";
+import { LooseRowSchema } from "@ax/lib/duckdb/columns";
+import { cacheRows } from "@ax/lib/duckdb/query";
 import { prettyPrint } from "@ax/lib/json";
 import { INSIGHT_VIEWS, insightSqlForView } from "../../queries/insights.ts";
 import { enrichInsightRows } from "../../queries/insights-enrich.ts";
@@ -24,13 +25,18 @@ const cmdInsights = (input: { readonly view: InsightView; readonly limit: number
         // at parse time - the old isInsightView/exit(2) guard was dead code
         // through the CLI and is intentionally gone.
         const limit = requirePositiveInt("insights", "limit", input.limit);
-        const db = yield* SurrealClient;
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(
-            insightSqlForView(input.view, limit),
+        // The view is chosen at runtime out of 30 differently-shaped queries,
+        // so the column set is not known here and rows decode as
+        // `LooseRowSchema` - which is also what turns each view's `COUNT(*)`
+        // BIGINT cells into numbers before they reach the formatter.
+        const result = yield* cacheRows(
+            LooseRowSchema,
+            { sql: insightSqlForView(input.view, limit), params: [] },
+            `insights.${input.view}`,
         );
         // Classifier views resolve their per-row context here via indexed
         // lookups (the correlated $parent.session form scanned ~1s/row).
-        const rows = yield* enrichInsightRows(input.view, result?.[0] ?? []);
+        const rows = yield* enrichInsightRows(input.view, [...result] as Array<Record<string, unknown>>);
         console.log(formatInsightRows(input.view, [...rows], { json: input.json }));
     });
 
@@ -101,19 +107,16 @@ export const timelineCommand = Command.make(
 ));
 
 /**
- * `timeline` flips; `report` and `insights` do NOT, and the throwing proxy is
- * what settled it - both were flipped, run, and reverted on the failure:
- *
- * - `insights` reads through `insightSqlForView` (queries/insights.ts), ~1100
- *   lines of SurrealQL across 31 views. That is its own port, not a flip.
- * - `report` calls `writeDashboard` (dashboard/report.ts), which is still on
- *   the old engine.
- *
- * Both must be ported (or dropped) before the SurrealDB deletion chunk can
- * land - flipping them now would only trade a working command for a throw.
+ * All three are on the v2 cache runtime. c8 left `report` and `insights` on
+ * `"db"` and recorded them as blocked on "~1100 lines of SurrealQL across 31
+ * views" - **that reading was wrong**. `queries/insights.ts` was already DuckDB
+ * dialect (chunk 2b, #819); what still reached SurrealDB was the two HANDLERS,
+ * `cmdInsights` above and the five statements in `dashboard/report.ts`. The
+ * throwing proxy reports only that SOME path touched `SurrealClient` - it does
+ * not name the layer, and the SQL was not opened before the size was asserted.
  */
 export const reportRuntime: RuntimeManifest = {
-    report: { runtime: "db", hidden: true },
-    insights: { runtime: "db", hidden: true },
+    report: { runtime: "cache", hidden: true },
+    insights: { runtime: "cache", hidden: true },
     timeline: { runtime: "cache", hidden: true },
 };

--- a/apps/axctl/src/dashboard/report.ts
+++ b/apps/axctl/src/dashboard/report.ts
@@ -2,9 +2,8 @@ import { homedir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { jsonRecordField } from "@ax/lib/decode";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
-import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { LooseRowSchema, NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
 import { cacheRows } from "@ax/lib/duckdb/query";
 import { CacheRead } from "@ax/lib/duckdb/seam";
 import { posixPath } from "@ax/lib/shared/path";
@@ -17,15 +16,10 @@ import {
 } from "../queries/insights.ts";
 import { fetchWorktreesOverview } from "./worktrees-overview.ts";
 
-// PARTIALLY PORTED, blocked on chunk 2b: `repositoryOverviewSql`,
-// `recentFrictionSql`, `toolFailuresSql`, `sessionEvidenceSql` and
-// `schemaCoverageSql` (all from `../queries/insights.ts`, owned by chunk 2b)
-// still build SurrealQL and run through `SurrealClient` below - a surviving
-// reader that answers `[]` against write-frozen SurrealDB, not an error (see
-// wave3-band2-common.md). `COUNT_SQL` and `fetchWorktreesOverview` are this
-// file's own SQL and are fully on `CacheRead`. Once 2b ports `insights.ts`,
-// the five `queryRows(client, ...Sql(...))` calls below should move to
-// `CacheRead` too and the `SurrealClient` requirement drops out entirely.
+// FULLY PORTED. The five `../queries/insights.ts` statements this file runs
+// moved onto `CacheRead` once chunk 2b (#819) ported that module to DuckDB
+// dialect, and the `SurrealClient` requirement dropped out with them - which
+// is exactly what the note here previously said would happen.
 
 type Row = Record<string, unknown>;
 
@@ -99,32 +93,37 @@ const fetchCounts = (): Effect.Effect<DashboardCounts, never, CacheRead> =>
         return out;
     });
 
-const queryRows = (
-    client: SurrealClientShape,
-    sql: string,
-): Effect.Effect<readonly Row[], DbError> =>
-    Effect.gen(function* () {
-        const result = yield* client.query<[Row[]]>(sql);
-        return result?.[0] ?? [];
-    });
+/**
+ * One insight view, read through `CacheRead`.
+ *
+ * The column set differs per view and is not known here, so rows decode as
+ * `LooseRowSchema` - which is also what turns a `COUNT(*)` BIGINT cell into a
+ * number. Without it `renderDashboardHtml`'s `JSON.stringify` throws on the
+ * first aggregate column (see `LooseCellColumn`).
+ *
+ * `cacheRows` degrades a failed read to `[]` and logs `context`, matching what
+ * the SurrealDB path did when a view's table was empty - one broken view must
+ * not take the whole report down.
+ */
+const insightRows = (sql: string, context: string): Effect.Effect<readonly Row[], never, CacheRead> =>
+    cacheRows(LooseRowSchema, { sql, params: [] }, context) as Effect.Effect<readonly Row[], never, CacheRead>;
 
 export const fetchDashboardData = (
     limit: number,
-): Effect.Effect<DashboardData, DbError, SurrealClient | CacheRead> =>
+): Effect.Effect<DashboardData, DbError, CacheRead> =>
     Effect.gen(function* () {
-        const client = yield* SurrealClient;
         const [counts, tableCounts, worktrees, repositories, friction, tools, sessions] =
             yield* Effect.all(
                 [
                     fetchCounts(),
-                    queryRows(client, schemaCoverageSql()),
+                    insightRows(schemaCoverageSql(), "report.schema_coverage"),
                     // Deref-free aggregates + JS join; the legacy correlated
                     // SQL full-scanned turn/tool_call once per checkout.
                     fetchWorktreesOverview(limit),
-                    queryRows(client, repositoryOverviewSql(limit)),
-                    queryRows(client, recentFrictionSql(limit)),
-                    queryRows(client, toolFailuresSql(limit)),
-                    queryRows(client, sessionEvidenceSql(limit)),
+                    insightRows(repositoryOverviewSql(limit), "report.repository_overview"),
+                    insightRows(recentFrictionSql(limit), "report.recent_friction"),
+                    insightRows(toolFailuresSql(limit), "report.tool_failures"),
+                    insightRows(sessionEvidenceSql(limit), "report.session_evidence"),
                 ],
                 { concurrency: 6 },
             );
@@ -146,7 +145,7 @@ export const fetchDashboardData = (
 
 export const writeDashboard = (
     opts: DashboardOpts,
-): Effect.Effect<DashboardWriteResult, DbError, SurrealClient | CacheRead | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<DashboardWriteResult, DbError, CacheRead | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;

--- a/apps/axctl/src/queries/graph-health.test.ts
+++ b/apps/axctl/src/queries/graph-health.test.ts
@@ -1,52 +1,196 @@
+/**
+ * `graph-health` is a DEFECT LIST: a healthy graph returns zero rows. That
+ * makes it the one view a text assertion cannot honestly cover - "the SQL
+ * contains GROUP BY repository, path" was true of the SurrealQL version right
+ * up until it stopped running at all, and an empty result reads identically
+ * whether the scan found nothing or the statement never executed.
+ *
+ * So this seeds a fixture snapshot with ONE of each defect the six scans look
+ * for and asserts each is found. The port from SurrealQL to DuckDB is what
+ * these cover; the remaining text assertions pin only the two facts a query
+ * result cannot show (the composed statement's shape, and the tables the
+ * provider-integrity scan reads - which `ingest/provider-parity.ts` also
+ * asserts against this file by name).
+ */
 import { describe, expect, test } from "bun:test";
-import {
-    duplicateRelationEdgesSql,
-    duplicateFileIdentitySql,
-    graphHealthSql,
-    legacySkillCollisionSql,
-    missingProducedScopeSql,
-    providerEventIntegritySql,
-    repositorySiblingSql,
-} from "./graph-health.ts";
+import { Effect, Schema } from "effect";
+import { publishCacheFixture, readFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { graphHealthSql, providerEventIntegritySql } from "./graph-health.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("graph health", {
+    requireFts: true,
+});
+
+const HealthRow = Schema.Struct({
+    check: Schema.String,
+    subject: Schema.String,
+    row_count: Schema.Number,
+    ids: Schema.String,
+});
+
+const ts = (iso: string) => new Date(iso);
+const AT = ts("2026-08-16T00:00:00.000Z");
 
 describe("graph health SQL", () => {
-    test("duplicateFileIdentitySql groups by repository path", () => {
-        expect(duplicateFileIdentitySql(10)).toContain("GROUP BY repository, path");
-        expect(duplicateFileIdentitySql(10)).not.toContain("HAVING");
+    dtest("every scan finds the defect it looks for", async () => {
+        const dir = tempDir("graph-health");
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    // 1. duplicate_file_identity - two `file` rows, one identity.
+                    yield* write.put("file", { id: "file:a", repository: "repo:ax", path: "src/x.ts" });
+                    yield* write.put("file", { id: "file:b", repository: "repo:ax", path: "src/x.ts" });
+
+                    // 2. repository_sibling - two repos sharing an identity key.
+                    yield* write.put("repository", {
+                        id: "repo:ax",
+                        name: "ax",
+                        remote_url: "git@github.com:Necmttn/ax.git",
+                        initial_commit: "abc123",
+                    });
+                    yield* write.put("repository", {
+                        id: "repo:ax-clone",
+                        name: "ax-clone",
+                        remote_url: "git@github.com:Necmttn/ax.git",
+                        initial_commit: "abc123",
+                    });
+
+                    // 3. missing_produced_scope - a `produced` edge with no checkout.
+                    yield* write.put("produced", {
+                        id: "produced:scopeless",
+                        in_id: "session:1",
+                        out_id: "commit:1",
+                        repository: "repo:ax",
+                        ts: AT,
+                    });
+
+                    // 4. legacy_skill_collision - two names that collapse onto one
+                    //    legacy record key once `:` is encoded as `__`.
+                    yield* write.put("skill", {
+                        id: "skill:one",
+                        name: "plugin:tdd",
+                        scope: "user",
+                        dir_path: "/skills/one",
+                        content_hash: "h1",
+                    });
+                    yield* write.put("skill", {
+                        id: "skill:two",
+                        name: "plugin__tdd",
+                        scope: "user",
+                        dir_path: "/skills/two",
+                        content_hash: "h2",
+                    });
+
+                    // 5. duplicate_relation_edges - two `invoked` edges, same key.
+                    yield* write.put("invoked", {
+                        id: "invoked:1",
+                        in_id: "turn:1",
+                        out_id: "skill:one",
+                        args: "{}",
+                        ts: AT,
+                    });
+                    yield* write.put("invoked", {
+                        id: "invoked:2",
+                        in_id: "turn:1",
+                        out_id: "skill:one",
+                        args: "{}",
+                        ts: AT,
+                    });
+
+                    // 6. provider_event_integrity - a provider nothing links to.
+                    yield* write.put("agent_provider", {
+                        id: "agent_provider:orphan",
+                        name: "orphan",
+                        display_name: "Orphan",
+                    });
+                }),
+            ),
+        );
+
+        const rows = await Effect.runPromise(
+            Effect.gen(function* () {
+                const read = yield* CacheRead;
+                return yield* read.rows(HealthRow, graphHealthSql(10), []);
+            }).pipe(Effect.provide(readFixture(fixture.snapshotPath, dylibPath))) as Effect.Effect<
+                ReadonlyArray<typeof HealthRow.Type>
+            >,
+        );
+
+        const byCheck = (name: string) => rows.filter((r) => r.check === name);
+
+        expect(byCheck("duplicate_file_identity")).toHaveLength(1);
+        expect(byCheck("duplicate_file_identity")[0]).toMatchObject({
+            subject: "repo:ax :: src/x.ts",
+            row_count: 2,
+        });
+        // `ids` is JSON-in-VARCHAR, not a native LIST - the bun:ffi client
+        // cannot decode a LIST column, so callers parse it.
+        expect(JSON.parse(byCheck("duplicate_file_identity")[0]!.ids).sort()).toEqual(["file:a", "file:b"]);
+
+        expect(byCheck("repository_sibling")).toHaveLength(1);
+        expect(byCheck("repository_sibling")[0]!.row_count).toBe(2);
+
+        expect(byCheck("missing_produced_scope")).toHaveLength(1);
+        expect(byCheck("missing_produced_scope")[0]!.subject).toBe("session:1 -> commit:1");
+
+        expect(byCheck("legacy_skill_collision")).toHaveLength(1);
+        expect(byCheck("legacy_skill_collision")[0]!.subject).toBe("plugin__tdd");
+
+        const relations = byCheck("duplicate_relation_edges");
+        expect(relations).toHaveLength(1);
+        expect(relations[0]!.subject.startsWith("invoked: ")).toBe(true);
+        expect(relations[0]!.row_count).toBe(2);
+
+        const provider = byCheck("provider_event_integrity");
+        expect(provider.map((r) => r.subject)).toContain("providers_without_sessions: orphan");
     });
 
-    test("repositorySiblingSql checks canonical identity drift", () => {
-        expect(repositorySiblingSql(10)).toContain("initial_commit");
-        expect(repositorySiblingSql(10)).toContain("remote_url");
-        expect(repositorySiblingSql(10)).not.toContain("HAVING");
+    dtest("a clean graph is an EMPTY result, not a zero-count report card", async () => {
+        const dir = tempDir("graph-health-clean");
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* write.put("file", { id: "file:only", repository: "repo:ax", path: "src/x.ts" });
+                    yield* write.put("repository", { id: "repo:ax", name: "ax" });
+                }),
+            ),
+        );
+        const rows = await Effect.runPromise(
+            Effect.gen(function* () {
+                const read = yield* CacheRead;
+                return yield* read.rows(HealthRow, graphHealthSql(10), []);
+            }).pipe(Effect.provide(readFixture(fixture.snapshotPath, dylibPath))) as Effect.Effect<
+                ReadonlyArray<typeof HealthRow.Type>
+            >,
+        );
+        expect(rows).toEqual([]);
     });
 
-    test("missingProducedScopeSql checks valued produced fields", () => {
-        expect(missingProducedScopeSql(10)).toContain("FROM produced");
-        expect(missingProducedScopeSql(10)).toContain("repository IS NONE");
+    test("the six scans compose into ONE statement with no inner terminators", () => {
+        const sql = graphHealthSql(10);
+        // A stray `;` inside a UNION arm would end the statement early and the
+        // rest would parse as a second, unrun statement.
+        expect(sql.slice(0, -1)).not.toContain(";");
+        expect(sql.endsWith(";")).toBe(true);
+        for (
+            const check of [
+                "duplicate_file_identity",
+                "repository_sibling",
+                "missing_produced_scope",
+                "legacy_skill_collision",
+                "duplicate_relation_edges",
+                "provider_event_integrity",
+            ]
+        ) {
+            expect(sql).toContain(`'${check}' AS check`);
+        }
     });
 
-    test("legacySkillCollisionSql finds lossy names", () => {
-        expect(legacySkillCollisionSql(10)).toContain("string::replace");
-        expect(legacySkillCollisionSql(10)).not.toContain("HAVING");
-    });
-
-    test("duplicateRelationEdgesSql checks semantic relation keys", () => {
-        const sql = duplicateRelationEdgesSql(10);
-        expect(sql).toContain("invoked");
-        expect(sql).toContain("GROUP BY in, out, args");
-        expect(sql).toContain("GROUP BY in, out, tool");
-        expect(sql).toContain("GROUP BY in, out, kind");
-        expect(sql).toContain("GROUP BY in, out, checkout");
-        expect(sql).not.toContain("HAVING");
-    });
-
-    test("graphHealthSql embeds subqueries without inner terminators", () => {
-        expect(graphHealthSql(10)).not.toContain(";),");
-        expect(graphHealthSql(10)).toContain("duplicate_relation_edges");
-    });
-
-    test("providerEventIntegritySql reads provider event graph tables", () => {
+    test("providerEventIntegritySql reads the three provider-native tables", () => {
+        // `ingest/provider-parity.ts` asserts these same two strings against
+        // this file by path - keep them literal.
         const sql = providerEventIntegritySql(10);
         expect(sql).toContain("FROM agent_event");
         expect(sql).toContain("FROM agent_session");

--- a/apps/axctl/src/queries/graph-health.ts
+++ b/apps/axctl/src/queries/graph-health.ts
@@ -1,3 +1,29 @@
+/**
+ * The `graph-health` insight view: six integrity scans over the published
+ * snapshot, in ONE statement.
+ *
+ * SHAPE CHANGE from the SurrealDB original. That version was a
+ * `RETURN { duplicate_file_identity: (...), ... }` object literal whose values
+ * were nested result sets - a shape DuckDB has no single-statement equivalent
+ * for, and `CacheRead.rows` returns flat rows regardless. So the six checks
+ * UNION ALL into one flat table with a discriminator, the same resolution
+ * `schemaCoverageSql` already uses for its own nested original:
+ *
+ *   check       which scan produced the row (e.g. `duplicate_file_identity`)
+ *   subject     what the scan groups by, rendered as text
+ *   row_count   how many rows share that subject (1 for the "missing" scans)
+ *   ids         the offending row ids, as a JSON array in a VARCHAR
+ *
+ * `ids` is VARCHAR-encoded JSON rather than a native LIST because the bun:ffi
+ * client cannot decode a LIST column (see the ARRAYS note in
+ * schema.duckdb.sql); `to_json(array_agg(...))` is what every other ported
+ * query in this repo uses for the same reason.
+ *
+ * EMPTY IS THE HEALTHY ANSWER. Each scan only emits rows for what is WRONG, so
+ * a healthy graph returns zero rows - the view is a defect list, not a report
+ * card, exactly as the original was.
+ */
+
 function checkedLimit(limit: number): number {
     if (!Number.isInteger(limit) || limit <= 0) {
         throw new RangeError(`limit must be a positive integer (got ${limit})`);
@@ -9,116 +35,162 @@ function withoutTerminator(sql: string): string {
     return sql.replace(/;\s*$/, "");
 }
 
+/** Two or more `file` rows claiming the same (repository, path) identity. */
 export function duplicateFileIdentitySql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
-SELECT * FROM (
-SELECT repository, path, count() AS row_count, array::group(id) AS ids
+SELECT
+    'duplicate_file_identity' AS check,
+    COALESCE(repository, '(none)') || ' :: ' || COALESCE(path, '(none)') AS subject,
+    CAST(count(*) AS DOUBLE) AS row_count,
+    to_json(array_agg(id)) AS ids
 FROM file
 GROUP BY repository, path
-)
-WHERE row_count > 1
+HAVING count(*) > 1
 ORDER BY row_count DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+/**
+ * Two or more `repository` rows sharing an identity key. The original's
+ * `IS NOT NONE` is SurrealDB's absent-vs-null distinction; DuckDB has only
+ * NULL, so both arms become `IS NOT NULL`.
+ */
 export function repositorySiblingSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
-SELECT * FROM (
-SELECT initial_commit, remote_url, count() AS row_count, array::group(id) AS ids
+SELECT
+    'repository_sibling' AS check,
+    COALESCE(initial_commit, '(none)') || ' :: ' || COALESCE(remote_url, '(none)') AS subject,
+    CAST(count(*) AS DOUBLE) AS row_count,
+    to_json(array_agg(id)) AS ids
 FROM repository
-WHERE initial_commit IS NOT NONE OR remote_url IS NOT NONE
+WHERE initial_commit IS NOT NULL OR remote_url IS NOT NULL
 GROUP BY initial_commit, remote_url
-)
-WHERE row_count > 1
+HAVING count(*) > 1
 ORDER BY row_count DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+/** `produced` edges that lost their repo/checkout/time scope. */
 export function missingProducedScopeSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
-SELECT id, in, out, repository, checkout, ts
+SELECT
+    'missing_produced_scope' AS check,
+    in_id || ' -> ' || out_id AS subject,
+    CAST(1 AS DOUBLE) AS row_count,
+    to_json([id]) AS ids
 FROM produced
-WHERE repository IS NONE OR checkout IS NONE OR ts IS NONE
+WHERE repository IS NULL OR checkout IS NULL OR ts IS NULL
 LIMIT ${safeLimit};`.trim();
 }
 
+/**
+ * Distinct skill names that collide once `:` is encoded as `__` - the legacy
+ * record-id encoding for plugin-namespaced skills (see skill-id.ts).
+ */
 export function legacySkillCollisionSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
-SELECT * FROM (
-SELECT string::replace(name, ":", "__") AS legacy_key, count() AS row_count, array::group(name) AS names
+SELECT
+    'legacy_skill_collision' AS check,
+    replace(name, ':', '__') AS subject,
+    CAST(count(*) AS DOUBLE) AS row_count,
+    to_json(array_agg(name)) AS ids
 FROM skill
-GROUP BY legacy_key
-)
-WHERE row_count > 1
+GROUP BY replace(name, ':', '__')
+HAVING count(*) > 1
 ORDER BY row_count DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+/**
+ * One relation table's duplicate edges. `in`/`out` are `in_id`/`out_id` in the
+ * DuckDB schema - `in` and `out` are reserved words there, and every ported
+ * query in this repo uses the `_id` form.
+ */
 function duplicateRelationTableSql(
     table: string,
     groupFields: readonly string[],
     limit: number,
 ): string {
     const group = groupFields.join(", ");
-    const fields = groupFields.join(", ");
-    return `(SELECT * FROM (
-SELECT ${fields}, count() AS row_count, array::group(id) AS ids
+    const subject = groupFields.map((f) => `COALESCE(CAST(${f} AS VARCHAR), '(none)')`).join(" || ' :: ' || ");
+    return `
+SELECT
+    'duplicate_relation_edges' AS check,
+    '${table}: ' || ${subject} AS subject,
+    CAST(count(*) AS DOUBLE) AS row_count,
+    to_json(array_agg(id)) AS ids
 FROM ${table}
 GROUP BY ${group}
-)
-WHERE row_count > 1
+HAVING count(*) > 1
 ORDER BY row_count DESC
-LIMIT ${limit})`;
+LIMIT ${limit}`;
 }
+
+const DUPLICATE_RELATION_TABLES: ReadonlyArray<{ readonly table: string; readonly fields: readonly string[] }> = [
+    { table: "invoked", fields: ["in_id", "out_id", "args"] },
+    { table: "edited", fields: ["in_id", "out_id", "tool"] },
+    { table: "concerns", fields: ["in_id", "out_id", "kind"] },
+    { table: "produced", fields: ["in_id", "out_id", "checkout"] },
+    { table: "touched", fields: ["in_id", "out_id", "checkout"] },
+    { table: "proposed", fields: ["in_id", "out_id"] },
+    { table: "corrected_by", fields: ["in_id", "out_id"] },
+];
 
 export function duplicateRelationEdgesSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
-    return `{
-    invoked: ${duplicateRelationTableSql("invoked", ["in", "out", "args"], safeLimit)},
-    edited: ${duplicateRelationTableSql("edited", ["in", "out", "tool"], safeLimit)},
-    concerns: ${duplicateRelationTableSql("concerns", ["in", "out", "kind"], safeLimit)},
-    produced: ${duplicateRelationTableSql("produced", ["in", "out", "checkout"], safeLimit)},
-    touched: ${duplicateRelationTableSql("touched", ["in", "out", "checkout"], safeLimit)},
-    proposed: ${duplicateRelationTableSql("proposed", ["in", "out"], safeLimit)},
-    corrected_by: ${duplicateRelationTableSql("corrected_by", ["in", "out"], safeLimit)}
-}`;
+    return DUPLICATE_RELATION_TABLES
+        .map(({ table, fields }) => `(${duplicateRelationTableSql(table, fields, safeLimit)})`)
+        .join("\nUNION ALL\n");
 }
 
+/**
+ * Provider-native rows that lost their links. The original's third arm used
+ * `count(<-agent_session.provider) = 0` - a SurrealDB reverse-edge traversal;
+ * the DuckDB form is a `NOT EXISTS` against `agent_session.provider`.
+ */
 export function providerEventIntegritySql(limit: number): string {
     const safeLimit = checkedLimit(limit);
-    return `{
-    events_missing_session: (
-        SELECT id, agent_session, provider, seq, type
-        FROM agent_event
-        WHERE agent_session IS NONE OR provider IS NONE
-        LIMIT ${safeLimit}
-    ),
-    sessions_missing_provider: (
-        SELECT id, provider, provider_session_id, ax_session
-        FROM agent_session
-        WHERE provider IS NONE OR provider_session_id IS NONE
-        LIMIT ${safeLimit}
-    ),
-    providers_without_sessions: (
-        SELECT id, name
-        FROM agent_provider
-        WHERE count(<-agent_session.provider) = 0
-        LIMIT ${safeLimit}
-    )
-}`;
+    return `
+(SELECT
+    'provider_event_integrity' AS check,
+    'events_missing_session: ' || id AS subject,
+    CAST(1 AS DOUBLE) AS row_count,
+    to_json([id]) AS ids
+FROM agent_event
+WHERE agent_session IS NULL OR provider IS NULL
+LIMIT ${safeLimit})
+UNION ALL
+(SELECT
+    'provider_event_integrity' AS check,
+    'sessions_missing_provider: ' || id AS subject,
+    CAST(1 AS DOUBLE) AS row_count,
+    to_json([id]) AS ids
+FROM agent_session
+WHERE provider IS NULL OR provider_session_id IS NULL
+LIMIT ${safeLimit})
+UNION ALL
+(SELECT
+    'provider_event_integrity' AS check,
+    'providers_without_sessions: ' || COALESCE(p.name, p.id) AS subject,
+    CAST(1 AS DOUBLE) AS row_count,
+    to_json([p.id]) AS ids
+FROM agent_provider p
+WHERE NOT EXISTS (SELECT 1 FROM agent_session s WHERE s.provider = p.id)
+LIMIT ${safeLimit})`.trim();
 }
 
 export function graphHealthSql(limit: number): string {
-    return `RETURN {
-    duplicate_file_identity: (${withoutTerminator(duplicateFileIdentitySql(limit))}),
-    repository_sibling: (${withoutTerminator(repositorySiblingSql(limit))}),
-    missing_produced_scope: (${withoutTerminator(missingProducedScopeSql(limit))}),
-    legacy_skill_collision: (${withoutTerminator(legacySkillCollisionSql(limit))}),
-    duplicate_relation_edges: ${duplicateRelationEdgesSql(limit)},
-    provider_event_integrity: ${providerEventIntegritySql(limit)}
-};`;
+    const safeLimit = checkedLimit(limit);
+    return [
+        `(${withoutTerminator(duplicateFileIdentitySql(safeLimit))})`,
+        `(${withoutTerminator(repositorySiblingSql(safeLimit))})`,
+        `(${withoutTerminator(missingProducedScopeSql(safeLimit))})`,
+        `(${withoutTerminator(legacySkillCollisionSql(safeLimit))})`,
+        duplicateRelationEdgesSql(safeLimit),
+        providerEventIntegritySql(safeLimit),
+    ].join("\nUNION ALL\n") + ";";
 }

--- a/packages/lib/src/duckdb/columns.test.ts
+++ b/packages/lib/src/duckdb/columns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Schema } from "effect";
-import { JsonArrayColumn, JsonObjectColumn, TimestampColumn } from "./columns.ts";
+import { JsonArrayColumn, JsonObjectColumn, LooseRowSchema, TimestampColumn } from "./columns.ts";
 import { UTC_CLOCK_TOLERANCE_MS, utcClockOk } from "./seam.ts";
 
 const decode = <S extends Schema.Top>(schema: S, value: unknown) =>
@@ -142,5 +142,50 @@ describe("utcClockOk", () => {
         for (const minutes of [15, -15, 30, -30, 45, 60, -60, 330, 840, -720]) {
             expect(utcClockOk(offset(minutes * 60_000), base)).toBe(false);
         }
+    });
+});
+
+describe("LooseRowSchema", () => {
+    test("a BIGINT cell in an untyped row becomes a number", async () => {
+        // The reason it exists: `ax insights` picks one of 30 differently-shaped
+        // views at runtime, so no schema names the COUNT columns, and an
+        // undecoded BIGINT reaches `JSON.stringify` - which throws on bigints.
+        const exit = await decode(LooseRowSchema, { table_name: "session", count: 42n });
+        expect(exit._tag).toBe("Success");
+        const row = (exit as { value: Record<string, unknown> }).value;
+        expect(row.count).toBe(42);
+        expect(typeof row.count).toBe("number");
+    });
+
+    test("non-bigint cells pass through untouched, null included", async () => {
+        const at = new Date("2026-08-16T00:00:00.000Z");
+        const exit = await decode(LooseRowSchema, {
+            name: "tdd",
+            ratio: 0.5,
+            ok: true,
+            ts: at,
+            missing: null,
+        });
+        expect(exit._tag).toBe("Success");
+        expect((exit as { value: Record<string, unknown> }).value).toEqual({
+            name: "tdd",
+            ratio: 0.5,
+            ok: true,
+            ts: at,
+            missing: null,
+        });
+    });
+
+    test("an out-of-range bigint becomes its decimal STRING, never a rounded number", async () => {
+        // `NumberFromBigIntColumn` fails here instead, which is right for a
+        // named column the caller can retype as `Schema.BigInt`. A whole report
+        // must not die because one cell exceeded 2^53, and silently rounding
+        // would be the wrong-answer failure this migration keeps hitting.
+        const huge = BigInt(Number.MAX_SAFE_INTEGER) + 10n;
+        const exit = await decode(LooseRowSchema, { total: huge });
+        expect(exit._tag).toBe("Success");
+        const row = (exit as { value: Record<string, unknown> }).value;
+        expect(row.total).toBe(huge.toString());
+        expect(JSON.stringify(row)).toBe(`{"total":"${huge}"}`);
     });
 });

--- a/packages/lib/src/duckdb/columns.ts
+++ b/packages/lib/src/duckdb/columns.ts
@@ -27,6 +27,11 @@ import { Effect, Option, Schema, SchemaGetter, SchemaIssue } from "effect";
 
 export { NumberFromBigIntColumn } from "./bigint-column.ts";
 
+/** JS safe-integer bounds as bigints - the range a BIGINT can cross into a
+ *  `number` without losing exactness. Used by {@link LooseCellColumn}. */
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
 /**
  * A `TIMESTAMP` column.
  *
@@ -132,3 +137,44 @@ export const JsonObjectColumn = <S extends Schema.Top>(shape: S) =>
             encode: SchemaGetter.transform((value: S["Encoded"]) => JSON.stringify(value)),
         }),
     );
+
+/**
+ * One cell of a row whose column set is not known at compile time.
+ *
+ * Most readers name their columns and type them, and a BIGINT column gets
+ * {@link NumberFromBigIntColumn}. Two surfaces cannot do that: `ax insights`
+ * runs one of 30 differently-shaped views chosen at runtime, and the evidence
+ * report renders whatever columns those views return. They decode rows as
+ * `Record<string, unknown>`, which means nothing declares the BIGINT columns -
+ * and a `COUNT(*)` cell arrives as a JS `bigint` (see `coerceValue` in
+ * row-decode.ts: 64-bit widths stay `bigint`).
+ *
+ * That is the undecoded-BIGINT trap, and its usual shape is a WRONG ANSWER
+ * rather than an error: the report serializes its rows with `JSON.stringify`,
+ * which THROWS on a bigint, while a `typeof x === "number"` guard elsewhere
+ * would simply read false and drop the value.
+ *
+ * So the conversion is declared here, at the read boundary, rather than hidden
+ * in a `JSON.stringify` replacer - a replacer would make the symptom go away
+ * while leaving every other consumer of the same row holding a bigint.
+ *
+ * An out-of-range bigint becomes its DECIMAL STRING, not a rounded number.
+ * `NumberFromBigIntColumn` fails instead, which is right for a named column a
+ * caller can retype as `Schema.BigInt`; here there is no such caller, and a
+ * whole report must not die because one cell exceeded 2^53.
+ */
+export const LooseCellColumn = Schema.Unknown.pipe(
+    Schema.decodeTo(Schema.Unknown, {
+        decode: SchemaGetter.transform((value: unknown): unknown => {
+            if (typeof value !== "bigint") return value;
+            return value >= MIN_SAFE_BIGINT && value <= MAX_SAFE_BIGINT
+                ? Number(value)
+                : value.toString();
+        }),
+        encode: SchemaGetter.transform((value: unknown): unknown => value),
+    }),
+);
+
+/** A row whose columns are not known at compile time. See {@link LooseCellColumn}. */
+export const LooseRowSchema = Schema.Record(Schema.String, LooseCellColumn);
+export type LooseRow = typeof LooseRowSchema.Type;


### PR DESCRIPTION
Wave 3 of the v2 SurrealDB → DuckDB migration. Bases on `v2/duckdb`; it does NOT go to `main`.

## Retraction first

The flip chunk (#823) left `report` and `insights` on `"db"` and recorded them
as blocked on **"~1100 lines of SurrealQL across 31 views"**. That was wrong.

`queries/insights.ts` was ported to DuckDB dialect by #819 - the only SurrealQL
left in it is prose inside comments. What still reached SurrealDB was two
**handlers**, and `dashboard/report.ts`'s own header comment already spelled out
the remaining move: *"Once 2b ports `insights.ts`, the five calls below should
move to `CacheRead` too."*

The inference failed because the throwing proxy's error was read as evidence
about the **queries**. The proxy says only that *some* path touched
`SurrealClient` - it does not name the layer, and the SQL was never opened
before the size was asserted.

## What moved

| File | Change |
|---|---|
| `dashboard/report.ts` | five `queryRows(client, …)` → `CacheRead`; `SurrealClient` drops out of `fetchDashboardData` and `writeDashboard` |
| `cli/commands/report.ts` | `cmdInsights` reads through `cacheRows` |
| both | `runtime: "db"` → `"cache"` |

## The undecoded-BIGINT trap, where no column has a name

Both surfaces decode rows whose column set is chosen at runtime, so nothing
declares the BIGINT columns and every `COUNT(*)` cell arrives as a JS `bigint`.
`renderDashboardHtml` serializes with `JSON.stringify`, which **throws** on a
bigint; elsewhere the same cell fails a `typeof x === "number"` guard and is
silently dropped - the wrong-answer shape this migration keeps hitting.

New `LooseCellColumn` / `LooseRowSchema` (`@ax/lib/duckdb/columns`) declares the
conversion **at the read boundary**, not in a `JSON.stringify` replacer - a
replacer fixes the symptom and leaves every other consumer of the same row
holding a bigint. An out-of-range bigint becomes its decimal **string**, never a
rounded number: `NumberFromBigIntColumn` fails instead, which is right for a
named column a caller can retype as `Schema.BigInt`, but here no such caller
exists and a whole report must not die over one cell above 2^53.

## graph-health was the one view still on SurrealQL

`queries/graph-health.ts` was untouched by #819: `count()`, `array::group()`,
`IS NOT NONE`, `string::replace`, a `<-agent_session.provider` reverse
traversal, and a `RETURN { … }` object literal of nested result sets.

Ported by UNION-ing the six scans into one flat table -
`(check, subject, row_count, ids)` - the same resolution `schemaCoverageSql`
already uses for its own nested original, with `in`/`out` corrected to the
schema's `in_id`/`out_id`.

Its tests were SQL-text assertions, which is the one thing that cannot verify a
defect list: **an empty result reads identically whether a scan found nothing or
the statement never ran.** They are now a real round trip - a fixture snapshot
seeded with one of each of the six defects, asserting each is found, plus a
clean-graph case asserting the empty result.

## Verified

- All **31/31** views run against the real snapshot (`ax insights <view> --limit 3`), exit 0, no proxy throw.
- `ax report --limit=3 --out …` writes its HTML and exits 0.
- Full suite 6156 pass / 4 fail - the four are `Electron failed to install correctly` in `studio-desktop`, identical on `v2/duckdb` before this change.
- Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
