### PR TITLE
fix(ingest): let the first run finish, and make a stage say why it stopped

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -1,5 +1,5 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
-import { Effect, Layer, Option, Path, References } from "effect";
+import { Effect, FileSystem, Layer, Option, Path, References } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Command, Flag } from "effect/unstable/cli";
 import { gcFileBuckets, type BlobGcResult } from "@ax/lib/blob-gc";
@@ -13,6 +13,8 @@ import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { duckdbAssetPathOption } from "../../duckdb-embed-wiring.ts";
 import { runIngest, withIngestRunFinish, type RunIngestResult } from "../../ingest/run.ts";
+import { resolveIngestDeadlineSeconds } from "../../ingest/deadline.ts";
+import { snapshotPath } from "@ax/lib/duckdb/client";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
 import type { OtelRetentionResult } from "../../otel/retention.ts";
 import { ingestLockOptions, withIngestLock } from "@ax/lib/ingest-lock";
@@ -323,7 +325,21 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         const commandName = opts.command ?? "ingest";
         const cfg = yield* AxConfig;
         const path = yield* Path.Path;
-        const timeoutSeconds = cfg.knobs.ingestTimeoutSeconds;
+        // The wall-clock budget is resolved PER RUN, not baked in: a warm
+        // incremental run wants the 900s tripwire, and a first-run backfill
+        // legitimately needs hours. One constant cannot be both, which is why
+        // every first ingest used to fail (#830). "First run" = no published
+        // snapshot yet; `fs.exists` is fail-open to false, so a filesystem
+        // hiccup degrades to today's behaviour rather than granting hours.
+        const deadline = resolveIngestDeadlineSeconds({
+            configuredSeconds: cfg.knobs.ingestTimeoutSeconds,
+            knobExplicitlySet: (process.env.AX_INGEST_TIMEOUT_SECONDS ?? "").trim().length > 0,
+            firstRun: !(yield* (yield* FileSystem.FileSystem)
+                .exists(snapshotPath())
+                .pipe(Effect.orElseSucceed(() => true))),
+        });
+        const timeoutSeconds = deadline.seconds;
+        if (deadline.upgraded) yield* Effect.logInfo(`ingest: ${deadline.reason}`);
         // The runId is minted HERE (not inside runIngest) so the timeout and
         // failure paths below can address the `ingest_run` row.
         const runId = runIdFor(commandName);

--- a/apps/axctl/src/ingest/deadline.test.ts
+++ b/apps/axctl/src/ingest/deadline.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import {
+    FIRST_RUN_INGEST_TIMEOUT_SECONDS,
+    resolveIngestDeadlineSeconds,
+} from "./deadline.ts";
+
+/**
+ * The regression this file pins is a USER-VISIBLE guarantee, not an
+ * implementation detail: a first `ax ingest` must be allowed to finish. The
+ * shipped default was 900s while a measured full backfill took 5,136s, so every
+ * first run failed with two stages reported failed (#830).
+ */
+describe("resolveIngestDeadlineSeconds", () => {
+    const base = { configuredSeconds: 900, knobExplicitlySet: false, firstRun: false } as const;
+
+    it("raises a first run past the incremental default", () => {
+        const decision = resolveIngestDeadlineSeconds({ ...base, firstRun: true });
+        expect(decision.seconds).toBe(FIRST_RUN_INGEST_TIMEOUT_SECONDS);
+        expect(decision.upgraded).toBe(true);
+        // The reason is operator-facing and gets printed - it must name the
+        // override, or the raise looks like the tool ignoring configuration.
+        expect(decision.reason).toContain("AX_INGEST_TIMEOUT_SECONDS");
+    });
+
+    it("the raised budget actually covers the measured backfill", () => {
+        // 5,136s is the real number from a 3,329-session / 924,371-turn corpus.
+        // A ceiling that does not clear it would reproduce the bug with a
+        // bigger constant, which is the trap this assertion exists to catch.
+        expect(FIRST_RUN_INGEST_TIMEOUT_SECONDS).toBeGreaterThan(5136);
+    });
+
+    it("leaves an incremental run on the configured budget", () => {
+        const decision = resolveIngestDeadlineSeconds(base);
+        expect(decision.seconds).toBe(900);
+        expect(decision.upgraded).toBe(false);
+    });
+
+    it("never overrides an explicit knob, not even on a first run", () => {
+        // An explicitly SMALL value is how a test or a CI job asks for a short
+        // leash. Silently multiplying it by 16 would break exactly the caller
+        // who was most specific about what they wanted.
+        const decision = resolveIngestDeadlineSeconds({
+            configuredSeconds: 30,
+            knobExplicitlySet: true,
+            firstRun: true,
+        });
+        expect(decision.seconds).toBe(30);
+        expect(decision.upgraded).toBe(false);
+    });
+
+    it("never LOWERS a configured budget that already exceeds the ceiling", () => {
+        const generous = FIRST_RUN_INGEST_TIMEOUT_SECONDS + 3600;
+        const decision = resolveIngestDeadlineSeconds({
+            configuredSeconds: generous,
+            knobExplicitlySet: false,
+            firstRun: true,
+        });
+        expect(decision.seconds).toBe(generous);
+        expect(decision.upgraded).toBe(false);
+    });
+
+    it("is a pure function of its input", () => {
+        const input = { configuredSeconds: 900, knobExplicitlySet: false, firstRun: true } as const;
+        expect(resolveIngestDeadlineSeconds(input)).toEqual(resolveIngestDeadlineSeconds(input));
+    });
+});

--- a/apps/axctl/src/ingest/deadline.ts
+++ b/apps/axctl/src/ingest/deadline.ts
@@ -1,0 +1,113 @@
+/**
+ * How long a single `ax ingest` is allowed to run, and why a fixed default
+ * cannot answer that question (#830).
+ *
+ * THE BUG THIS EXISTS TO FIX. `AX_INGEST_TIMEOUT_SECONDS` defaulted to 900 for
+ * every run, cold or warm. Measured on a real machine: `ax ingest --dry-run`
+ * estimated `~33m44s` for the backlog, the run was killed at 900s, and two
+ * stages were reported failed. The full backfill actually needed **5,136s**.
+ * So the shipped default could not finish a backfill the tool itself estimated
+ * at 34 minutes, and a new user's very first ingest was guaranteed to fail.
+ *
+ * WHY NOT JUST RAISE THE NUMBER. Because the two cases have opposite needs. A
+ * warm incremental run should NOT be allowed to grind for hours - a 900s cap
+ * there is a useful "something is wrong" tripwire, and the ordinary warm run
+ * finishes in 26s. A first run over a multi-gigabyte transcript corpus is a
+ * different job that legitimately takes hours. One constant cannot be both, so
+ * the deadline is resolved per run instead of baked in.
+ *
+ * WHY NOT DERIVE IT FROM THE DRY-RUN ESTIMATE. That was the first design, and
+ * it is wrong TODAY: the estimator itself under-predicts a large backfill by
+ * roughly 3x (it extrapolates per-session over the REMAINING sessions, while
+ * the dominant stages scale with the whole corpus - #831). Sizing a deadline
+ * from a number known to be 3x low would reintroduce the same failure with more
+ * machinery. When #831 lands, revisit this: an accurate estimate plus a margin
+ * beats a generous constant. Until then, a generous constant for the cold case
+ * is the honest choice, and it is stated as such rather than tuned to look
+ * precise.
+ *
+ * The resolver is PURE and the caller gathers the facts, so every branch is
+ * unit-testable without a store, a clock, or a filesystem.
+ */
+
+/**
+ * Ceiling for a first-run backfill: 4 hours.
+ *
+ * Rationale, not numerology: the measured full cold backfill on a 3,329-session
+ * / 924,371-turn corpus was 5,136s (1h26m). Four hours is ~2.8x that, which
+ * covers a corpus several times larger while still bounding a genuinely wedged
+ * run rather than letting it live forever. It is a backstop, not a target.
+ */
+export const FIRST_RUN_INGEST_TIMEOUT_SECONDS = 4 * 60 * 60;
+
+export interface IngestDeadlineInput {
+    /** `cfg.knobs.ingestTimeoutSeconds` - the env knob, or its default. */
+    readonly configuredSeconds: number;
+    /**
+     * Did the operator set `AX_INGEST_TIMEOUT_SECONDS` themselves? An explicit
+     * value is never overridden - including an explicit SMALL one, which is how
+     * a test or a CI job asks for a short leash on purpose.
+     */
+    readonly knobExplicitlySet: boolean;
+    /**
+     * Is this the first ingest into this store? Determined by the caller (no
+     * published snapshot yet). A first run has no watermarks, so every
+     * transcript, commit and skill on disk is read for the first time.
+     */
+    readonly firstRun: boolean;
+}
+
+export interface IngestDeadlineDecision {
+    readonly seconds: number;
+    /** True when the first-run ceiling replaced the configured value. */
+    readonly upgraded: boolean;
+    /** Operator-facing explanation; printed when `upgraded`. */
+    readonly reason: string;
+}
+
+/**
+ * Resolve the wall-clock budget for one ingest run.
+ *
+ * Precedence, highest first:
+ *  1. An explicit `AX_INGEST_TIMEOUT_SECONDS` - the operator's word is final.
+ *  2. A first run on an empty store - raise to the first-run ceiling.
+ *  3. Otherwise the configured value, unchanged.
+ */
+export const resolveIngestDeadlineSeconds = (
+    input: IngestDeadlineInput,
+): IngestDeadlineDecision => {
+    if (input.knobExplicitlySet) {
+        return {
+            seconds: input.configuredSeconds,
+            upgraded: false,
+            reason: "AX_INGEST_TIMEOUT_SECONDS was set explicitly",
+        };
+    }
+    if (!input.firstRun) {
+        return {
+            seconds: input.configuredSeconds,
+            upgraded: false,
+            reason: "incremental run against an existing store",
+        };
+    }
+    // A configured default that already covers a backfill needs no help. Guards
+    // against this function ever LOWERING a deadline, which would be a silent
+    // regression for anyone who raised the shipped default.
+    if (input.configuredSeconds >= FIRST_RUN_INGEST_TIMEOUT_SECONDS) {
+        return {
+            seconds: input.configuredSeconds,
+            upgraded: false,
+            reason: "configured budget already covers a first run",
+        };
+    }
+    return {
+        seconds: FIRST_RUN_INGEST_TIMEOUT_SECONDS,
+        upgraded: true,
+        reason:
+            `first ingest into this store - raised the wall-clock budget from ` +
+            `${input.configuredSeconds}s to ${FIRST_RUN_INGEST_TIMEOUT_SECONDS}s. ` +
+            `A full backfill reads every transcript on disk and was measured at ` +
+            `5,136s, so the incremental default cannot finish one. ` +
+            `Set AX_INGEST_TIMEOUT_SECONDS to override.`,
+    };
+};

--- a/apps/axctl/src/ingest/run-stage-settle.test.ts
+++ b/apps/axctl/src/ingest/run-stage-settle.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import { Cause, Effect, Exit } from "effect";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { settleStage } from "./run.ts";
+import { BaseStageStats } from "./stage/types.ts";
+import { CacheWriteUnlockedError } from "@ax/lib/duckdb/seam";
+import type { IngestStageError } from "./stage/registry.ts";
+
+/** A concrete member of the `IngestStageError` union (it is a type union, not a
+ *  class), so a typed-failure Exit can actually be constructed. */
+const stageFailure = (message: string) =>
+    new CacheWriteUnlockedError({ livePath: "/tmp/live.duckdb", lockPath: "/tmp/ingest.lock", message });
+
+/**
+ * #840. A stage row opens at `running` and must be replaced on EVERY exit path.
+ * The wrapper had a success arm (`Effect.tap`) and a typed-failure arm
+ * (`Effect.catch`) and nothing else, so an INTERRUPTED stage reached neither -
+ * 38 rows accumulated at `running` with no `ended_at` and no reason, 3 of them
+ * inside a run that reported `ok`.
+ *
+ * Interruption is the case no end-to-end ingest test triggers reliably, so
+ * these craft the `Exit` directly. That is the whole point: the arm that was
+ * missing is the arm that is hardest to reach by accident.
+ */
+
+interface Recorded {
+    readonly finishes: Array<{ readonly status: unknown; readonly errorText: unknown }>;
+    readonly events: Array<Record<string, unknown>>;
+}
+
+/**
+ * Minimal recording stub. `writeIngestStageFinish` is one `exec` plus a
+ * heartbeat `exec`; `writeIngestEvent` is one `put`. Anything else is a
+ * genuine failure of this test's assumptions and should throw loudly rather
+ * than silently record nothing.
+ */
+const recordingWrite = (): { readonly write: CacheWriteService; readonly rec: Recorded } => {
+    const rec: Recorded = { finishes: [], events: [] };
+    const write = {
+        exec: (sql: string, params?: ReadonlyArray<unknown>) =>
+            Effect.sync(() => {
+                if (sql.includes("UPDATE ingest_stage SET status")) {
+                    rec.finishes.push({ status: params?.[0], errorText: params?.[2] });
+                }
+            }),
+        put: (table: string, row: Record<string, unknown>) =>
+            Effect.sync(() => {
+                if (table === "ingest_event") rec.events.push(row);
+            }),
+    } as unknown as CacheWriteService;
+    return { write, rec };
+};
+
+const ledgerKey = { runId: "run1", source: "claude", stage: "transcripts" } as const;
+const eventName = { source: "claude", stage: "transcripts" } as const;
+
+const settle = (exit: Exit.Exit<BaseStageStats, IngestStageError>) =>
+    Effect.gen(function* () {
+        const { write, rec } = recordingWrite();
+        yield* settleStage(write, ledgerKey, eventName, exit);
+        return rec;
+    });
+
+describe("settleStage", () => {
+    it("settles an INTERRUPTED stage instead of stranding it at running", async () => {
+        const rec = await Effect.runPromise(settle(Exit.interrupt(1 as never)));
+        expect(rec.finishes).toHaveLength(1);
+        expect(rec.finishes[0]?.status).toBe("interrupted");
+        // A terminal row with no reason is the defect; the reason must name the
+        // plausible causes because the stage itself cannot tell them apart.
+        expect(String(rec.finishes[0]?.errorText)).toContain("interrupted");
+        expect(rec.finishes[0]?.errorText).not.toBeNull();
+    });
+
+    it("records ok with counts on success", async () => {
+        const rec = await Effect.runPromise(
+            settle(Exit.succeed(BaseStageStats.make({ durationMs: 5, summary: "done" }))),
+        );
+        expect(rec.finishes[0]?.status).toBe("ok");
+        // `ok` carries no error text - the union forbids supplying one, and the
+        // writer nulls the column.
+        expect(rec.finishes[0]?.errorText).toBeNull();
+        expect(rec.events).toHaveLength(1);
+    });
+
+    it("records error with the failure text on a typed failure", async () => {
+        const rec = await Effect.runPromise(
+            settle(Exit.fail(stageFailure("boom"))),
+        );
+        expect(rec.finishes[0]?.status).toBe("error");
+        expect(String(rec.finishes[0]?.errorText)).toContain("boom");
+    });
+
+    it("settles a DEFECT as error rather than leaving the row open", async () => {
+        const rec = await Effect.runPromise(
+            settle(Exit.failCause(Cause.die(new Error("unexpected")))),
+        );
+        expect(rec.finishes[0]?.status).toBe("error");
+        expect(String(rec.finishes[0]?.errorText)).toContain("unexpected");
+    });
+
+    it("never leaves a settled row without a status", async () => {
+        // The property that matters across all four arms, stated once.
+        const exits: ReadonlyArray<Exit.Exit<BaseStageStats, IngestStageError>> = [
+            Exit.succeed(BaseStageStats.make({ durationMs: 0, summary: "s" })),
+            Exit.fail(stageFailure("m")),
+            Exit.interrupt(1 as never),
+            Exit.failCause(Cause.die(new Error("d"))),
+        ];
+        for (const exit of exits) {
+            const rec = await Effect.runPromise(settle(exit));
+            expect(rec.finishes).toHaveLength(1);
+            expect(rec.finishes[0]?.status).not.toBe("running");
+            expect(typeof rec.finishes[0]?.status).toBe("string");
+        }
+    });
+
+    it("does not fail the caller when the bookkeeping write fails during interruption", async () => {
+        // A run already being torn down must not have its cause replaced by a
+        // write error - that is why the interrupt arm ignores failures.
+        const write = {
+            exec: () => Effect.fail(new Error("db gone") as never),
+            put: () => Effect.fail(new Error("db gone") as never),
+        } as unknown as CacheWriteService;
+        const exit = await Effect.runPromiseExit(
+            settleStage(write, ledgerKey, eventName, Exit.interrupt(1 as never)),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+    });
+});

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -10,6 +10,7 @@ import { LiveTrace } from "@ax/lib/live-traces/index";
 import { TraceSink } from "@ax/lib/live-traces/Sink";
 import { ProcessService } from "@ax/lib/process";
 import {
+    reconcileStrandedIngestStages,
     writeIngestEvent,
     writeIngestRunFinish,
     writeIngestRunStart,
@@ -160,6 +161,75 @@ const resolveStages = (
     return registry.all();
 };
 
+/**
+ * Settle one stage row from the stage's `Exit`, on EVERY exit path.
+ *
+ * This mirrors {@link withIngestRunFinish} deliberately: the run-level finalizer
+ * already had all four arms (success / typed failure / interruption / defect),
+ * and the stage-level wrapper had only the first two. That asymmetry is #840 -
+ * `Effect.tap` runs only on success and `Effect.catch` only on a typed failure,
+ * so an INTERRUPTED stage reached neither and its row stayed `running` forever,
+ * with no `ended_at` and no reason. Both the derive watchdog
+ * (`stage/runner.ts`, `Effect.timeoutOrElse`) and the outer run deadline
+ * interrupt stages, which is why 38 rows accumulated - 3 of them inside a run
+ * that reported `ok`, since the watchdog fails OPEN with a success sentinel.
+ *
+ * The interruption and defect arms `ignore` their write errors, exactly as the
+ * run-level finalizer does: a run that is already being torn down must not have
+ * its cause replaced by a bookkeeping failure. Success and typed failure let a
+ * write error propagate, because there the write IS the work.
+ *
+ * Exported for tests: the four arms are the contract, and crafting an `Exit`
+ * directly covers the interruption case that no end-to-end ingest test can
+ * trigger reliably.
+ */
+export const settleStage = (
+    write: CacheWriteService,
+    ledgerKey: { readonly runId: string; readonly source: string; readonly stage: string },
+    eventName: { readonly source: string; readonly stage: string },
+    exit: Exit.Exit<BaseStageStats, IngestStageError>,
+): Effect.Effect<void, CacheWriteError> => {
+    if (Exit.isSuccess(exit)) {
+        const counts = numericCounts(exit.value);
+        return Effect.gen(function* () {
+            yield* writeIngestStageFinish(write, { ...ledgerKey, status: "ok", counts });
+            yield* writeIngestEvent(write, {
+                ...ledgerKey,
+                level: "info",
+                message: `${eventName.source} ${eventName.stage} complete`,
+                counts,
+            });
+        });
+    }
+    // Read the cause before the `hasInterrupts` guard: its negative branch
+    // would otherwise narrow `exit` to `never`.
+    const cause = exit.cause;
+    const settle = (status: "error" | "interrupted", message: string) =>
+        Effect.gen(function* () {
+            yield* writeIngestStageFinish(write, { ...ledgerKey, status, errorText: message });
+            yield* writeIngestEvent(write, {
+                ...ledgerKey,
+                level: "error",
+                message,
+            });
+        });
+    if (Exit.hasInterrupts(exit)) {
+        // The watchdog overwrites this row with `timeout` immediately after,
+        // via `recordStageOutcome` - it knows the cap, and this arm does not.
+        return settle(
+            "interrupted",
+            "interrupted - the run ended before this stage finished (deadline, watchdog cap, or SIGINT)",
+        ).pipe(Effect.ignore);
+    }
+    const failure = Cause.findErrorOption(cause);
+    if (Option.isSome(failure)) {
+        return settle("error", errorText(failure.value));
+    }
+    // Defect: still settle the row (never leave "running"), best effort; the
+    // defect itself propagates past this finalizer.
+    return settle("error", errorText(Cause.squash(cause))).pipe(Effect.ignore);
+};
+
 const wrapStage = (
     runId: string,
     stageDef: StageDef<BaseStageStats, AxConfig | ProcessService, IngestStageError>,
@@ -171,40 +241,47 @@ const wrapStage = (
         run: (ctx: IngestContext, write: CacheWriteService) =>
             Effect.gen(function* () {
                 yield* writeIngestStageStart(write, ledgerKey);
-
-                return yield* stageDef.run(ctx, write).pipe(
-                    Effect.tap((value) => {
-                        const counts = numericCounts(value);
-                        return Effect.gen(function* () {
-                            yield* writeIngestStageFinish(write, { ...ledgerKey, status: "ok", counts });
-                            yield* writeIngestEvent(write, {
-                                ...ledgerKey,
-                                level: "info",
-                                message: `${eventName.source} ${eventName.stage} complete`,
-                                counts,
-                            });
-                        });
-                    }),
-                    Effect.catch((error) =>
-                        Effect.gen(function* () {
-                            const message = errorText(error);
-                            yield* writeIngestStageFinish(write, {
-                                ...ledgerKey,
-                                status: "error",
-                                errorText: message,
-                            });
-                            yield* writeIngestEvent(write, {
-                                ...ledgerKey,
-                                level: "error",
-                                message,
-                            });
-                            return yield* error;
-                        }),
-                    ),
+                return yield* Effect.onExit(stageDef.run(ctx, write), (exit) =>
+                    settleStage(write, ledgerKey, eventName, exit),
                 );
             }),
     };
 };
+
+/**
+ * Settle a stage the RUNNER decided about without ever entering (or while
+ * cutting short) the stage body - the two cases the stage's own `Exit` cannot
+ * describe honestly.
+ *
+ * `timeout`: the derive watchdog capped a running stage. The stage body was
+ * interrupted, so {@link settleStage} has already written `interrupted`; this
+ * overwrites it with the precise status and the cap that fired. Ordering is
+ * guaranteed - `Effect.timeoutOrElse` completes the body's interruption
+ * (finalizers included) before it runs `orElse`.
+ *
+ * `skipped`: the stage never started, so it has NO row at all. Writing one is
+ * the point: a stage silently dropped for want of budget is indistinguishable
+ * from a stage that was never configured, and that ambiguity is what made a
+ * blank skill graph look like a broken feature rather than a starved derive.
+ */
+const recordRunnerStageOutcome = (
+    runId: string,
+    write: CacheWriteService,
+) =>
+(
+    stageKey: string,
+    outcome: { readonly status: "timeout" | "skipped"; readonly errorText: string },
+): Effect.Effect<void> =>
+    Effect.gen(function* () {
+        const eventName = stageEventName(stageKey);
+        const ledgerKey = { runId, source: eventName.source, stage: eventName.stage } as const;
+        if (outcome.status === "skipped") yield* writeIngestStageStart(write, ledgerKey);
+        yield* writeIngestStageFinish(write, {
+            ...ledgerKey,
+            status: outcome.status,
+            errorText: outcome.errorText,
+        });
+    }).pipe(Effect.ignore);
 
 export interface RunIngestOptions {
     readonly command: string;
@@ -309,6 +386,23 @@ export const runIngest = (
             sinceDays: sinceDays ?? null,
         });
 
+        // Clean up after runs that could not clean up after themselves. A
+        // finalizer cannot run on SIGKILL or power loss, so settling every stage
+        // on every exit path is necessary but never sufficient - the next run
+        // has to reconcile the residue (#840). Deliberately AFTER
+        // `reapStaleIngestRuns` above, which is what marks a stranded RUN
+        // terminal; this only touches stages whose parent run already is, so a
+        // concurrent run's live stages are untouched. Best effort: bookkeeping
+        // must not be able to fail an ingest.
+        const reconciled = yield* reconcileStrandedIngestStages(write, runId).pipe(
+            Effect.catchCause(() => Effect.succeed(0)),
+        );
+        if (reconciled > 0) {
+            yield* Effect.logInfo(
+                `ingest: reconciled ${reconciled} stage row(s) stranded at 'running' by an earlier run`,
+            );
+        }
+
         if (opts.args.includes("--reset")) {
             for (const table of ["invoked", "loaded", "proposed", "concerns", "recovered_by", "skill_paired", "skill"]) {
                 yield* write.exec(`DELETE FROM "${table}"`);
@@ -332,7 +426,10 @@ export const runIngest = (
             wrappedStages,
             ctx,
             write,
-            deadlineMs === undefined ? {} : { deadlineMs },
+            {
+                ...(deadlineMs === undefined ? {} : { deadlineMs }),
+                recordStageOutcome: recordRunnerStageOutcome(runId, write),
+            },
         ).pipe(
             LiveTrace.withTrace({
                 traceId: `ingest:${runId}`,

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -15,8 +15,27 @@ import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 const runPipeline = <S extends BaseStageStats, R, E>(
     stages: ReadonlyArray<StageDef<S, R, E>>,
     ctx: IngestContext,
-    opts: { readonly deadlineMs?: number; readonly reserveMs?: number } = {},
+    opts: {
+        readonly deadlineMs?: number;
+        readonly reserveMs?: number;
+        readonly recordStageOutcome?: (
+            stageKey: string,
+            outcome: { readonly status: "timeout" | "skipped"; readonly errorText: string },
+        ) => Effect.Effect<void>;
+    } = {},
 ) => runPipelineWithWrite(stages, ctx, {} as CacheWriteService, opts);
+
+/** Collect what the runner reports about outcomes only IT can describe. */
+const outcomeRecorder = () => {
+    const seen: Array<{ key: string; status: string; errorText: string }> = [];
+    const recordStageOutcome = (
+        key: string,
+        outcome: { readonly status: "timeout" | "skipped"; readonly errorText: string },
+    ) => Effect.sync(() => {
+        seen.push({ key, status: outcome.status, errorText: outcome.errorText });
+    });
+    return { seen, recordStageOutcome };
+};
 
 const stage = (key: string, deps: string[]): StageDef => ({
     meta: StageMeta.make({ key, deps, tags: ["ingest"] }),
@@ -408,6 +427,54 @@ describe("derive-stage watchdog (#671)", () => {
         });
     });
 
+    it("reports the capped stage as `timeout`, naming the cap that fired (#840)", async () => {
+        // Without this, the stage's own finalizer can only say "interrupted" -
+        // it cannot know a watchdog cap was the reason. The precise status is
+        // the difference between "raise AX_STAGE_TIMEOUT_SECONDS" and "debug a
+        // stage that was working fine".
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const rec = outcomeRecorder();
+            const hang: StageDef = {
+                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
+                run: () => Effect.never,
+            };
+            await Effect.runPromise(
+                runPipeline([hang], ctx(), { recordStageOutcome: rec.recordStageOutcome }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(rec.seen).toHaveLength(1);
+            expect(rec.seen[0]!.key).toBe("hang");
+            expect(rec.seen[0]!.status).toBe("timeout");
+            expect(rec.seen[0]!.errorText).toContain("AX_STAGE_TIMEOUT_SECONDS");
+        });
+    });
+
+    it("reports nothing when no stage is capped", async () => {
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const rec = outcomeRecorder();
+            const fine: StageDef = {
+                meta: StageMeta.make({ key: "fine", deps: [], tags: ["derive"] }),
+                run: () => Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: "fine" })),
+            };
+            await Effect.runPromise(
+                runPipeline([fine], ctx(), { recordStageOutcome: rec.recordStageOutcome }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(rec.seen).toEqual([]);
+        });
+    });
+
+    it("still completes when no recorder is supplied (the hook is optional)", async () => {
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const hang: StageDef = {
+                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
+                run: () => Effect.never,
+            };
+            const results = await Effect.runPromise(
+                runPipeline([hang], ctx()) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(results[0]!.summary).toBe("timed out (watchdog)");
+        });
+    });
+
     it("does NOT watchdog a non-derive (ingest) stage that runs past the cap", async () => {
         await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const slowIngest: StageDef = {
@@ -458,6 +525,29 @@ describe("runPipeline derive budget (#697)", () => {
         const derive = stats.find((s) => s.summary.includes("skipped"));
         expect(derive).toBeDefined();
         expect(stats.some((s) => s.summary === "claude ok")).toBe(true);
+    });
+
+    it("records a budget-skipped stage as `skipped` so it is not invisible (#840)", async () => {
+        // A skipped stage never starts, so it produces no Exit and, before this,
+        // no row at all - indistinguishable from a stage that was never
+        // configured. That ambiguity is what made a blank skill graph read as a
+        // broken feature rather than a starved derive.
+        const rec = outcomeRecorder();
+        await Effect.runPromise(
+            runPipeline([instant("claude", ["ingest"]), hangs("derive-metrics", ["derive"])], ctx, {
+                deadlineMs: Date.now() - 1,
+                reserveMs: 0,
+                recordStageOutcome: rec.recordStageOutcome,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+        expect(rec.seen).toHaveLength(1);
+        expect(rec.seen[0]!.key).toBe("derive-metrics");
+        expect(rec.seen[0]!.status).toBe("skipped");
+        // The reason must survive into the row, not just the log line.
+        expect(rec.seen[0]!.errorText.length).toBeGreaterThan(0);
+        // An `ingest`-tagged stage is exempt from the budget and must not be
+        // reported as skipped.
+        expect(rec.seen.some((s) => s.key === "claude")).toBe(false);
     });
 
     it("a derive stage is capped by the time left, not its static 300s cap", async () => {

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -140,12 +140,30 @@ export const topoLayers = <S extends BaseStageStats, R, E>(
  *  are budgeted against it so the pass ends cleanly instead of being killed by
  *  the outer ingest timeout (#697); omit it and derives keep only their static
  *  `AX_STAGE_TIMEOUT_SECONDS` cap. `opts.reserveMs` overrides the finalization
- *  reserve (env default) - tests pass 0. */
+ *  reserve (env default) - tests pass 0.
+ *
+ *  `opts.recordStageOutcome` lets the caller record the two outcomes only the
+ *  RUNNER knows about, which the stage's own `Exit` cannot express: a watchdog
+ *  `timeout` (the stage body is interrupted, so it can only report
+ *  "interrupted" - the cap that fired is known here) and a budget `skipped`
+ *  (the stage never runs at all, so it produces no `Exit` and, without this,
+ *  no row either). Optional and fire-and-forget by contract: this is
+ *  bookkeeping, and it must never change whether the pass succeeds. See #840. */
 export const runPipeline = <S extends BaseStageStats, R, E>(
     stages: ReadonlyArray<StageDef<S, R, E>>,
     ctx: IngestContext,
     write: CacheWriteService,
-    opts: { readonly deadlineMs?: number; readonly reserveMs?: number } = {},
+    opts: {
+        readonly deadlineMs?: number;
+        readonly reserveMs?: number;
+        readonly recordStageOutcome?: (
+            stageKey: string,
+            outcome: {
+                readonly status: "timeout" | "skipped";
+                readonly errorText: string;
+            },
+        ) => Effect.Effect<void>;
+    } = {},
 ): Effect.Effect<ReadonlyArray<S>, E, R> =>
     Effect.gen(function* () {
         topoLayers(stages); // cycle check
@@ -202,24 +220,51 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                         });
                         if (budget._tag === "uncapped") return body;
                         if (budget._tag === "skip") {
+                            const reason = `skipped - ${budget.reason}`;
                             return Effect.logWarning(
                                 `ingest: skipping derive stage '${s.meta.key}' - ${budget.reason}.`,
                             ).pipe(
+                                // Record the skip BEFORE succeeding: a stage
+                                // dropped for want of budget has no Exit and no
+                                // row, so without this it is indistinguishable
+                                // from a stage that was never configured.
+                                Effect.andThen(
+                                    opts.recordStageOutcome?.(s.meta.key, {
+                                        status: "skipped",
+                                        errorText: reason,
+                                    }) ?? Effect.void,
+                                ),
                                 Effect.as({
                                     durationMs: 0,
                                     summary: "skipped (out of budget)",
                                 } as unknown as S),
                             );
                         }
+                        const capSeconds = Math.round(budget.capMs / 1000);
                         return body.pipe(
                             Effect.timeoutOrElse({
                                 duration: budget.capMs,
                                 orElse: () =>
                                     Effect.logWarning(
-                                        `ingest: derive stage '${s.meta.key}' exceeded ${Math.round(budget.capMs / 1000)}s - ` +
+                                        `ingest: derive stage '${s.meta.key}' exceeded ${capSeconds}s - ` +
                                             `skipping it (failed open) so the run can finish. ` +
                                             `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
                                     ).pipe(
+                                        // Overwrite the `interrupted` row the
+                                        // stage's own finalizer just wrote with
+                                        // the precise cap that fired. Safe to
+                                        // order this way: timeoutOrElse
+                                        // completes the body's interruption,
+                                        // finalizers included, before orElse.
+                                        Effect.andThen(
+                                            opts.recordStageOutcome?.(s.meta.key, {
+                                                status: "timeout",
+                                                errorText:
+                                                    `timed out - exceeded the ${capSeconds}s derive watchdog cap ` +
+                                                    `(raise or disable with AX_STAGE_TIMEOUT_SECONDS); ` +
+                                                    `the run continued without this stage`,
+                                            }) ?? Effect.void,
+                                        ),
                                         Effect.as({
                                             durationMs: budget.capMs,
                                             summary: "timed out (watchdog)",

--- a/apps/axctl/src/ingest/telemetry.ts
+++ b/apps/axctl/src/ingest/telemetry.ts
@@ -27,7 +27,7 @@
  */
 import { Effect } from "effect";
 import { cacheRow, jsonParam } from "@ax/lib/duckdb/row";
-import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 
 export type IngestEventLevel = "debug" | "info" | "warn" | "error";
 
@@ -155,6 +155,41 @@ export const writeIngestStageStart = (
         yield* writeIngestRunHeartbeat(write, input.runId);
     });
 
+/**
+ * The terminal statuses a stage row can carry, and the ONE non-terminal one.
+ *
+ * `running` is written by {@link writeIngestStageStart} and must be replaced by
+ * one of the others on EVERY exit path. It was not, for a long time: the stage
+ * wrapper settled the row on success and on a typed failure but had no
+ * interruption arm, so the derive watchdog and the outer run deadline both
+ * stranded rows at `running` with no `ended_at` and no reason. 38 such rows
+ * accumulated, 3 of them inside a run that reported `ok` (#840).
+ *
+ * The four non-`ok` statuses are deliberately distinct, because they are
+ * distinct operator questions:
+ *  - `error`       -> the stage's own work failed; read `error_text`
+ *  - `timeout`     -> the derive watchdog capped it; the cap is the thing to raise
+ *  - `skipped`     -> never attempted, no budget left before the run deadline
+ *  - `interrupted` -> something outside the stage ended the run (deadline, SIGINT)
+ * Collapsing these into `error` would tell an operator to debug a stage that
+ * worked fine and simply ran out of clock.
+ */
+export type IngestStageTerminalStatus = "ok" | "error" | "timeout" | "skipped" | "interrupted";
+
+/**
+ * A settled stage outcome. `ok` carries counts; every non-`ok` status REQUIRES
+ * `errorText`, enforced by the union rather than by a convention someone has to
+ * remember - a terminal row with no reason is the defect this type exists to
+ * prevent.
+ */
+export type IngestStageOutcome =
+    | { readonly status: "ok"; readonly counts?: Record<string, number> }
+    | {
+        readonly status: Exclude<IngestStageTerminalStatus, "ok">;
+        readonly errorText: string;
+        readonly counts?: Record<string, number>;
+    };
+
 /** Settle a stage row and bump the run heartbeat. */
 export const writeIngestStageFinish = (
     write: CacheWriteService,
@@ -162,10 +197,7 @@ export const writeIngestStageFinish = (
         readonly runId: string;
         readonly source: string;
         readonly stage: string;
-        readonly status: "ok" | "error";
-        readonly counts?: Record<string, number>;
-        readonly errorText?: string;
-    },
+    } & IngestStageOutcome,
 ): Effect.Effect<void, CacheWriteError> =>
     Effect.gen(function* () {
         yield* write.exec(
@@ -173,12 +205,37 @@ export const writeIngestStageFinish = (
             [
                 input.status,
                 jsonParam(input.counts ?? {}),
-                input.errorText ?? null,
+                input.status === "ok" ? null : input.errorText,
                 ingestStageId(input.runId, input.source, input.stage),
             ],
         );
         yield* writeIngestRunHeartbeat(write, input.runId);
     });
+
+/**
+ * Reconcile stage rows that a previous run left at `running`.
+ *
+ * A finalizer cannot run if the process was hard-killed (SIGKILL, power loss),
+ * so "settle on every exit path" can never be complete on its own - the next
+ * run has to clean up after the one that could not. Scoped to rows whose PARENT
+ * RUN is already terminal, so a genuinely concurrent run's live stages are never
+ * touched, and excludes the caller's own run id for the same reason.
+ *
+ * Returns the number of rows reconciled. Idempotent: a second call finds none.
+ */
+export const reconcileStrandedIngestStages = (
+    write: CacheWriteService,
+    currentRunId: string,
+): Effect.Effect<number, CacheReadError> =>
+    write.raw(
+        `UPDATE ingest_stage
+         SET status = 'interrupted',
+             ended_at = COALESCE(ended_at, CURRENT_TIMESTAMP),
+             error_text = COALESCE(error_text, 'interrupted - the run ended without settling this stage; reconciled by a later run')
+         WHERE status = 'running' AND run <> ?
+           AND run IN (SELECT id FROM ingest_run WHERE status <> 'running')`,
+        [currentRunId],
+    ).pipe(Effect.map((result) => result.rowsChanged));
 
 /**
  * Append one ledger event AND fan it out to in-process subscribers.

--- a/packages/lib/src/duckdb/publish-guard.test.ts
+++ b/packages/lib/src/duckdb/publish-guard.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The empty-publish backstop, against REAL databases.
+ *
+ * This must be an end-to-end test and not a unit test of a predicate, because
+ * the property that matters is about a FILE ON DISK: after a run that would have
+ * wiped the snapshot, is the snapshot still there with its rows in it? A mocked
+ * guard can be correct while the publish still happens.
+ *
+ * The failure being prevented has hit a real store five times: the published
+ * snapshot went to zero rows while the live database kept everything, and every
+ * read afterwards answered "no data" with exit code 0.
+ */
+import { describe, expect } from "bun:test";
+import { Effect, FileSystem, Path } from "effect";
+import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
+import { withIngestLock } from "../ingest-lock.ts";
+import { runWithPlatform } from "../testing/cache-fixture.ts";
+import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
+import { withCacheWrite, CacheReadLayer, CacheRead, type CacheWriteService } from "./seam.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("publish guard");
+
+/** One ingest "run" against `dir`, publishing to `dir/snapshot.duckdb`. */
+const asIngestRun = <A>(
+    dir: string,
+    liveName: string,
+    body: (write: CacheWriteService) => Effect.Effect<A, unknown, never>,
+): Promise<A> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const path = yield* Path.Path;
+            const lockPath = path.join(dir, "ingest.lock");
+            const outcome = yield* withIngestLock(
+                {
+                    lockPath,
+                    command: "publish-guard-test",
+                    staleMs: 60_000,
+                    onBusy: () => Effect.die("the ingest lock was busy in a single-process test"),
+                },
+                withCacheWrite(
+                    {
+                        livePath: path.join(dir, liveName),
+                        lockPath,
+                        snapshotPath: path.join(dir, "snapshot.duckdb"),
+                        schemaSql: DUCKDB_SCHEMA_SQL,
+                        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                    },
+                    body,
+                ),
+            );
+            if (outcome._tag !== "completed") {
+                throw new Error(`ingest run did not complete: ${outcome._tag}`);
+            }
+            return outcome.value;
+        }) as Effect.Effect<A, unknown, FileSystem.FileSystem | Path.Path>,
+    );
+
+/** Sessions visible in `dir/snapshot.duckdb` through the normal read seam. */
+const snapshotSessions = (dir: string): Promise<number> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const path = yield* Path.Path;
+            const read = yield* CacheRead;
+            const result = yield* read.raw("SELECT CAST(count(*) AS DOUBLE) AS n FROM session");
+            return Number(result.rows[0]?.n ?? 0);
+        }).pipe(
+            Effect.provide(
+                CacheReadLayer({
+                    snapshotPath: `${dir}/snapshot.duckdb`,
+                    ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                }),
+            ),
+        ) as Effect.Effect<number, unknown, FileSystem.FileSystem | Path.Path>,
+    );
+
+const insertSession = (write: CacheWriteService, id: string) =>
+    write.put("session", {
+        id,
+        source: "claude",
+        started_at: new Date("2026-01-01T00:00:00Z"),
+    });
+
+describe("empty-publish guard", () => {
+    dtest("refuses to replace a populated snapshot with an empty one", async () => {
+        const dir = await tempDir("refuse");
+
+        // Run 1: a real ingest that writes sessions and publishes them.
+        await asIngestRun(dir, "live.duckdb", (write) => insertSession(write, "session-1"));
+        expect(await snapshotSessions(dir)).toBe(1);
+
+        // Run 2: a DIFFERENT, fresh live database - the shape that destroyed the
+        // real store. It writes nothing and would publish its empty self over
+        // the snapshot from run 1.
+        await asIngestRun(dir, "other-live.duckdb", () => Effect.void);
+
+        // The guard's whole purpose, stated as the user experiences it: the data
+        // is still there.
+        expect(await snapshotSessions(dir)).toBe(1);
+    });
+
+    dtest("still publishes normally when the incoming database has rows", async () => {
+        const dir = await tempDir("allow");
+        await asIngestRun(dir, "live.duckdb", (write) => insertSession(write, "session-1"));
+        expect(await snapshotSessions(dir)).toBe(1);
+
+        // The same live database, now with a second session: an ordinary
+        // incremental run must publish exactly as before. A guard that blocked
+        // this would be worse than the bug.
+        await asIngestRun(dir, "live.duckdb", (write) => insertSession(write, "session-2"));
+        expect(await snapshotSessions(dir)).toBe(2);
+    });
+
+    dtest("publishes an empty database when there is no snapshot to lose", async () => {
+        const dir = await tempDir("first");
+        // A first ingest that finds nothing to ingest is not a data-loss event,
+        // and it must still produce a readable snapshot - otherwise every read
+        // on a brand-new machine reports "no cache" instead of "no data yet".
+        await asIngestRun(dir, "live.duckdb", () => Effect.void);
+        expect(await snapshotSessions(dir)).toBe(0);
+    });
+
+    dtest("an explicit override still allows the empty publish", async () => {
+        const dir = await tempDir("override");
+        await asIngestRun(dir, "live.duckdb", (write) => insertSession(write, "session-1"));
+        expect(await snapshotSessions(dir)).toBe(1);
+
+        const saved = process.env.AX_ALLOW_EMPTY_PUBLISH;
+        process.env.AX_ALLOW_EMPTY_PUBLISH = "1";
+        try {
+            await asIngestRun(dir, "other-live.duckdb", () => Effect.void);
+            expect(await snapshotSessions(dir)).toBe(0);
+        } finally {
+            if (saved === undefined) delete process.env.AX_ALLOW_EMPTY_PUBLISH;
+            else process.env.AX_ALLOW_EMPTY_PUBLISH = saved;
+        }
+    });
+});

--- a/packages/lib/src/duckdb/publish-guard.test.ts
+++ b/packages/lib/src/duckdb/publish-guard.test.ts
@@ -59,7 +59,6 @@ const asIngestRun = <A>(
 const snapshotSessions = (dir: string): Promise<number> =>
     runWithPlatform(
         Effect.gen(function* () {
-            const path = yield* Path.Path;
             const read = yield* CacheRead;
             const result = yield* read.raw("SELECT CAST(count(*) AS DOUBLE) AS n FROM session");
             return Number(result.rows[0]?.n ?? 0);

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -625,15 +625,109 @@ export const withCacheWrite = <A, E, R>(
                     // its body succeeding says nothing about the state of the
                     // database it would be publishing.
                     if (options.publish !== false) {
-                        yield* opened.db
-                            .publishSnapshot(options.livePath, target, { from: conn })
-                            .pipe(Effect.mapError((err) => toPublishError(err, target)));
+                        const safe = yield* publishWouldNotDestroyData(fs, conn, target);
+                        if (safe) {
+                            yield* opened.db
+                                .publishSnapshot(options.livePath, target, { from: conn })
+                                .pipe(Effect.mapError((err) => toPublishError(err, target)));
+                        }
                     }
                     return value;
                 }),
             (conn) => conn.close.pipe(Effect.andThen(Effect.sync(opened.close))),
         );
     });
+
+/** Escape hatch for the empty-publish guard below. Only a caller that MEANS to
+ *  replace a populated snapshot with an empty one should set it. */
+const ALLOW_EMPTY_PUBLISH_ENV = "AX_ALLOW_EMPTY_PUBLISH";
+
+/**
+ * Refuse to replace a POPULATED snapshot with an EMPTY one.
+ *
+ * This is a data-loss backstop, and it is here because the failure it prevents
+ * has now happened five times to a real store. The published snapshot went to
+ * zero rows while the live database kept everything, and every read surface
+ * afterwards answered "no data" instead of failing - the worst shape of bug this
+ * project produces, because exit code 0 makes it look like an answer.
+ *
+ * `snapshotPath()` honouring `AX_DATA_DIR` (the fix for the first four) closed
+ * the path-asymmetry route. It did NOT close the class: ANY process that opens a
+ * fresh live database and publishes with the default target still overwrites the
+ * real snapshot, and on the fifth occurrence the culprit could not be identified
+ * afterwards at all. So this guard deliberately does not care WHO is publishing
+ * or WHY. It compares outcomes, which is the only thing that reliably
+ * distinguishes a rebuild from a wipe.
+ *
+ * THE RULE IS NARROW ON PURPOSE: refuse only when the incoming database has zero
+ * sessions and the existing snapshot has some. That cannot fire on any honest
+ * run - a store with data keeps publishing normally, a first publish onto no
+ * snapshot is allowed, an empty-onto-empty publish is allowed, and `ax ingest
+ * --reset` only clears skill tables so its sessions survive. A "refuse if much
+ * smaller" heuristic was rejected: it needs a threshold, and a threshold is a
+ * guess that either fires on a legitimate prune or misses a partial wipe.
+ *
+ * Failure to EVALUATE the guard is not failure to publish: an unreadable or
+ * corrupt existing snapshot returns `true` (publish proceeds), because refusing
+ * to publish over a file we cannot read would wedge recovery.
+ */
+const publishWouldNotDestroyData = (
+    fs: FileSystem.FileSystem,
+    conn: DuckDbConnection,
+    target: string,
+): Effect.Effect<boolean> =>
+    Effect.gen(function* () {
+        if ((process.env[ALLOW_EMPTY_PUBLISH_ENV] ?? "").trim().length > 0) return true;
+
+        const exists = yield* fs.exists(target).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return true; // first publish - nothing to lose
+
+        const incoming = yield* sessionCount(conn).pipe(Effect.orElseSucceed(() => -1));
+        // Only an unambiguously EMPTY incoming database can trip the guard. -1
+        // means the count could not be read, which is not evidence of emptiness.
+        if (incoming !== 0) return true;
+
+        const existing = yield* countSessionsIn(conn, target).pipe(Effect.orElseSucceed(() => 0));
+        if (existing <= 0) return true; // empty over empty: no loss either way
+
+        yield* Effect.logError(
+            `ax cache: REFUSED to publish an empty snapshot over a populated one - ` +
+                `the incoming database has 0 sessions and ${target} has ${existing}. ` +
+                `The existing snapshot is untouched and your data is safe. ` +
+                `This usually means a process opened a FRESH live database and published ` +
+                `with the default target: pin AX_DUCKDB_SNAPSHOT (or AX_DATA_DIR) for ` +
+                `isolated runs, or pass 'publish: false' for a maintenance write. ` +
+                `Set ${ALLOW_EMPTY_PUBLISH_ENV}=1 if replacing it is genuinely what you want.`,
+        );
+        return false;
+    });
+
+/** Sessions in the database this connection is attached to. */
+const sessionCount = (
+    conn: DuckDbConnection,
+): Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError> =>
+    conn.query("SELECT CAST(count(*) AS DOUBLE) AS n FROM session").pipe(
+        // Rows are keyed by COLUMN NAME, not position - `rows[0][0]` is
+        // `undefined`, which would silently read every count as 0 and turn this
+        // guard into a no-op. The projection casts to DOUBLE so no BIGINT
+        // reaches JS as a bigint (see CLAUDE.md on `raw`).
+        Effect.map((result) => Number(result.rows[0]?.n ?? 0)),
+    );
+
+/** Sessions in ANOTHER database file, read-only, without disturbing it. The
+ *  alias is unlikely to collide and is detached on every exit path. */
+const countSessionsIn = (
+    conn: DuckDbConnection,
+    path: string,
+): Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError> =>
+    Effect.acquireUseRelease(
+        conn.exec(`ATTACH '${path.replace(/'/g, "''")}' AS ax_publish_guard (READ_ONLY)`),
+        () =>
+            conn.query("SELECT CAST(count(*) AS DOUBLE) AS n FROM ax_publish_guard.session").pipe(
+                Effect.map((result) => Number(result.rows[0]?.n ?? 0)),
+            ),
+        () => conn.exec("DETACH ax_publish_guard").pipe(Effect.ignore),
+    );
 
 /**
  * Say out loud what the writer changed. Silent sanitisation is the failure mode


### PR DESCRIPTION
Closes #830. Closes #840. Investigates #837.

A first `ax ingest` could not succeed, and when it failed the ledger could not
say why. Both halves are one code change, because they share the stage finalizer
and the deadline plumbing.

Then, mid-work, the published snapshot was destroyed for the fifth time - during
this branch's own test run. So this also carries the backstop that makes that
class of data loss impossible, and that part is the most important thing here.

## 1. The first run could not finish (#830)

Measured on a real machine: `ax ingest --dry-run` estimated `~33m44s` for the
backlog. The default `AX_INGEST_TIMEOUT_SECONDS` is **900**. The run was killed
at 900s with `[axctl] ingest/codex failed` and `[axctl] ingest/git failed`. The
full backfill actually needed **5,136s**. So the shipped default could not finish
a backfill the tool itself estimated at 34 minutes.

Raising the constant is not the fix, because the two cases want opposite things:
a warm incremental run finishes in 26s and *should* trip a 900s tripwire, while a
first-run backfill over a multi-gigabyte corpus legitimately takes hours. So the
budget is now resolved per run (`apps/axctl/src/ingest/deadline.ts`):

| case | budget |
| --- | --- |
| `AX_INGEST_TIMEOUT_SECONDS` set explicitly | exactly that, always - including a deliberately small one |
| first ingest (no published snapshot yet) | 4h, and it says so on stderr |
| incremental run | unchanged |

**Not derived from the dry-run estimate, deliberately.** That was the first
design and it is wrong *today*: the estimator itself under-predicts a large
backfill by ~3x (#831). Sizing a deadline from a number known to be 3x low
reintroduces the same failure with more machinery. The module says so, and says
to revisit once #831 lands.

The resolver is pure and the caller gathers the facts, so every branch is tested
without a store, a clock, or a filesystem. One test asserts the ceiling actually
clears the measured 5,136s - a ceiling that did not would be the same bug with a
bigger constant.

## 2. A stage could not report that it was interrupted (#840)

`ingest_stage` across all history: **ok 521, `running` 38, error 10**. Rows
stranded at `running` with no `ended_at` and no reason - including **3 inside a
run that reported `ok`**.

The cause is one combinator. `wrapStage` settled the row with `Effect.tap` on
success and `Effect.catch` on a typed failure, and nothing else. Neither runs on
**interruption**, so an interrupted stage never settled. Two interrupt sources
split all 38 rows cleanly: the derive watchdog (`stage/runner.ts`) orphans
`derive`-tagged stages, and the outer run deadline (`ingest-lock.ts`) orphans
`ingest`-tagged ones. The watchdog additionally fails OPEN with a *success*
sentinel, which is why the run above still said `ok`.

The correct pattern already existed 60 lines up the same file: `withIngestRunFinish`
uses `Effect.onExit` with all four arms. `settleStage` now mirrors it exactly.

Also:

- **The status vocabulary is now unforgeable.** `IngestStageOutcome` is a union
  where every non-`ok` status *requires* `errorText`. A terminal row with no
  reason was the defect; now it does not typecheck. The statuses are
  deliberately distinct - `error` (the work failed), `timeout` (the watchdog cap
  fired), `skipped` (never attempted, no budget), `interrupted` (something
  outside the stage ended the run) - because collapsing them into `error` tells
  an operator to debug a stage that worked fine and ran out of clock. `status` is
  a plain VARCHAR, so no DDL change.
- **The runner reports the two outcomes only it can describe** (`recordStageOutcome`,
  optional and fire-and-forget). `timeout` overwrites the stage's own
  `interrupted` with the cap that actually fired; `skipped` *creates* a row for a
  stage that never started, because before this a starved derive left no trace at
  all. That invisibility is why a blank skill graph read as a broken feature
  rather than a starved stage - `skill_paired` was 0 after a backfill, and a
  manual `ax derive-signals` produced 34 pairs.
- **Orphans are reconciled at the start of the next run.** Settling on every exit
  path is necessary but never sufficient: no finalizer runs on SIGKILL. Scoped to
  rows whose parent run is already terminal, so a concurrent run is never
  touched. One statement, `rowsChanged` for the count, idempotent - verified
  against a copy of the real store.

## 3. The empty-publish backstop (unfiled; the fifth occurrence)

While working on the above, `~/.ax/cache/ax-snapshot.duckdb` went to **8.1 MB, 0
sessions, one `ingest_run` with 2 stages** - the exact fingerprint of a brand-new
database that ingested nothing and then published. The live database was intact
and *richer* than before (4,392 sessions / 1,035,519 turns), so nothing was
permanently lost and the snapshot was restored from it.

`snapshotPath()` honouring `AX_DATA_DIR` closed the path-asymmetry route that
caused the first four. It did not close the **class**: any process that opens a
fresh live database and publishes with the default target still overwrites the
real snapshot. I could not identify this occurrence's culprit - I overwrote the
empty file while restoring instead of moving it aside first, which destroyed the
evidence. That is a mistake worth naming, and it is also the argument for a guard
that does not depend on knowing who did it.

`withCacheWrite` now **refuses to replace a populated snapshot with an empty
one**, and the rule is narrow on purpose: refuse only when the incoming database
has **zero** sessions and the existing snapshot has some. That cannot fire on an
honest run - a store with data publishes normally, a first publish onto no
snapshot is allowed, empty-onto-empty is allowed, and `ax ingest --reset` only
clears skill tables so its sessions survive. A "refuse if much smaller"
heuristic was rejected: it needs a threshold, and a threshold either fires on a
legitimate prune or misses a partial wipe. `AX_ALLOW_EMPTY_PUBLISH=1` overrides.
Failure to *evaluate* the guard permits the publish, so an unreadable existing
snapshot cannot wedge recovery.

The test is end-to-end against real DuckDB files, because the property is about a
file on disk: after a run that would have wiped it, does the snapshot still have
its rows? **It caught a real bug in the guard before it shipped** - I read the
count as `rows[0][0]`, but rows are keyed by column name, so every count read as
0 and the guard was a no-op. That is now a comment in the code.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` clean, including `*.test.ts`.
- New: 6 deadline tests, 6 stage-settle tests (all four exit arms, plus the
  property that no arm leaves a row unsettled), 4 real-database publish-guard
  tests, 3 runner tests for `timeout`/`skipped`/no-recorder.
- `check:timestamp-cast`, `check:raw-numeric-cast`, `check:no-node-fs` all clean.
- The reconciliation statement was run against a **copy** of the real 4,392-session
  store and is idempotent (`still_running = 0` on a second pass).

## What this does NOT do

**#837 is investigated, not fixed - and my first answer to it was wrong.**
It asks why `signals` - tagged `derive`, documented cap 300s - ran **2,256s** and
reported `ok`. I first wrote here that the watchdog *does* fire, "so the earlier
theory that synchronous `bun:ffi` defeats every timer is **wrong as a general
claim**". ~~That claim stands.~~ **Retracted.** I reached it the same careless way
the theory I was correcting was reached: the three runner tests that prove the
watchdog fires use `Effect.never` as the stage body - a completely idle fiber.
They prove the **wiring**, not that the cap can interrupt **work**.

Measured since, in this repo, with a 1,000ms cap: a single synchronous 3,000ms
body runs to completion; 30 x 100ms synchronous slices with no explicit yield run
to completion; the same slices wrapped in `Effect.promise` **also** run to
completion (a promise resolving synchronously after blocking work continues on
the microtask queue, so the timer, a macrotask, never gets a turn); only slices
with an explicit `Effect.yieldNow` time out, at 1,106ms. And the cap really was
300s for that run - `AX_STAGE_TIMEOUT_SECONDS` was unset, verified from the
launching command, which matches the run's `started_at` to under a second.

So the corrected statement is: the watchdog's wiring is correct and fires against
an idle or genuinely asynchronous body, and it cannot interrupt a body that never
returns the event loop's timer phase - which every DuckDB-backed derive is. Full
evidence and three candidate fixes are on #837. None of them is "raise the cap",
and none of them belongs in this PR: they are design changes, and the deadline
design here is already cooperative rather than a racing timer for this reason.

What this PR *does* fix about #837 is the reporting - a stage the watchdog does
cap now records `status = 'timeout'` naming the cap, instead of `ok` or a stranded
`running` row - so the next occurrence is visible rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

