### PR TITLE
fix(ingest): the dry-run estimate answered a narrower question than it was asked

### DIFF
--- a/apps/axctl/src/ingest/derive-cost.test.ts
+++ b/apps/axctl/src/ingest/derive-cost.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import {
+    estimateUncoveredSeconds,
+    UNCOVERED_COST_FALLBACK_FACTOR,
+} from "./derive-cost.ts";
+
+/**
+ * #831. The estimator answered a narrower question than it was asked: it timed
+ * one harness's transcript parsing and reported that as the whole run. Measured
+ * consequence - estimate `~33m44s`, actual 5,136s.
+ */
+describe("estimateUncoveredSeconds", () => {
+    it("prefers the machine's own last successful run over any shipped factor", () => {
+        const est = estimateUncoveredSeconds({
+            parseSeconds: 100,
+            prior: { wallSeconds: 5_136, totalStageSeconds: 8_371, uncoveredStageSeconds: 8_353 },
+        });
+        expect(est.basis).toBe("prior-run");
+        // wall x uncovered share = 5136 x (8353/8371) ~= 5125. NOT 8,353: summing
+        // stage-seconds and calling them wall time is the trap this converts away.
+        expect(est.seconds).toBe(5_125);
+        expect(est.seconds).toBeLessThan(8_353);
+    });
+
+    it("does NOT scale the prior measurement by the backlog", () => {
+        // This is the whole design decision, so it gets an assertion. The
+        // uncovered stages are sized by the corpus and the repo set, not the
+        // backlog: on the measured warm re-pass over the SAME corpus,
+        // `claude-config` went 203s -> 637s while the backlog went to nearly
+        // nothing. Scaling this term with the backlog would rebuild the original
+        // bug in the warm case.
+        const small = estimateUncoveredSeconds({
+            parseSeconds: 1,
+            prior: { wallSeconds: 5_136, totalStageSeconds: 8_371, uncoveredStageSeconds: 8_353 },
+        });
+        const large = estimateUncoveredSeconds({
+            parseSeconds: 10_000,
+            prior: { wallSeconds: 5_136, totalStageSeconds: 8_371, uncoveredStageSeconds: 8_353 },
+        });
+        expect(small.seconds).toBe(large.seconds);
+    });
+
+    it("falls back to the measured factor when there is no history", () => {
+        const est = estimateUncoveredSeconds({ parseSeconds: 1_000 });
+        expect(est.basis).toBe("fallback-factor");
+        // parse + uncovered must come to the factor, so the factor describes the
+        // WHOLE run rather than just the extra.
+        expect(1_000 + est.seconds).toBe(1_000 * UNCOVERED_COST_FALLBACK_FACTOR);
+    });
+
+    it("the fallback would have caught the real 3x miss", () => {
+        // The reported estimate was ~2,024s of projected parse work against
+        // 5,136s actual. The old model returned the parse figure as the total.
+        const est = estimateUncoveredSeconds({ parseSeconds: 2_024 });
+        const total = 2_024 + est.seconds;
+        // Not exact - it is one measurement - but it must land in the right
+        // order of magnitude instead of being 3x low.
+        expect(total).toBeGreaterThan(4_000);
+        expect(total).toBeLessThan(6_500);
+    });
+
+    it("ignores a useless prior rather than dividing by it", () => {
+        for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+            const est = estimateUncoveredSeconds({
+                parseSeconds: 100,
+                prior: { wallSeconds: 100, totalStageSeconds: 200, uncoveredStageSeconds: bad },
+            });
+            expect(est.basis).toBe("fallback-factor");
+        }
+    });
+
+    it("fabricates nothing when there is nothing to go on", () => {
+        // No sample and no history: the honest answer is zero here, and the
+        // caller already renders "couldn't time a sample" rather than an ETA.
+        const est = estimateUncoveredSeconds({ parseSeconds: 0 });
+        expect(est.seconds).toBe(0);
+    });
+
+    it("never returns a negative estimate", () => {
+        expect(estimateUncoveredSeconds({ parseSeconds: -100 }).seconds).toBe(0);
+    });
+});

--- a/apps/axctl/src/ingest/derive-cost.ts
+++ b/apps/axctl/src/ingest/derive-cost.ts
@@ -1,0 +1,143 @@
+/**
+ * The part of an ingest's cost the calibration sample cannot see (#831).
+ *
+ * THE BUG. `ax ingest --dry-run` estimated `~33m44s`; the run took **5,136s**,
+ * about 3x more. The estimator times a sample of sessions from ONE harness,
+ * derives a sessions/sec rate, and multiplies by the remaining session count.
+ * Measured per-stage durations from that very run show what that model covers:
+ *
+ *     claude-sidecars 2507s   signals 2256s   codex 1629s   git 945s
+ *     claude-config 203s      session-health 221s   proposals 218s
+ *     claude 18s   <- the sampled stage
+ *
+ * A FALSE START WORTH RECORDING. The first version of this module blamed
+ * "whole-corpus derive stages" and sized them per 1,000 turns. That model is
+ * wrong, and the warm re-pass proves it: `signals` went 2,256s cold to **21s**
+ * warm (107x) because derive stages ARE windowed by the since-window. A
+ * per-turn derive coefficient would have over-predicted a warm run by an order
+ * of magnitude - trading a 3x under-estimate for a worse over-estimate.
+ *
+ * WHAT IS ACTUALLY MISSING. Not "derives" as a category, but **every stage the
+ * sample never observed**. The sample times `claude` (18s) or `codex` transcript
+ * parsing. The run also does sidecar-artifact discovery, git history, config and
+ * skill scanning, and the derive chain - roughly 35 other stages. Those do not
+ * scale with the sampled harness's session rate, and assuming they cost ZERO is
+ * the entire error. The old estimate was not 3x low by bad arithmetic; it
+ * answered a narrower question than the one asked.
+ *
+ * THE MODEL, AND WHY IT LEANS ON HISTORY. Total = the sampled parse term
+ * (unchanged) PLUS an uncovered term. The uncovered term comes from THIS
+ * MACHINE's last successful run - its WALL time, times the share of its
+ * stage-seconds the sample cannot observe (see {@link PriorRunObservation} for
+ * why the conversion matters). That is preferred over any constant this repo
+ * could ship because
+ * the uncovered cost depends on corpus shape (a Codex-heavy corpus has ~10x the
+ * `turn` rows per session), repo count, and disk - none of which a shipped
+ * number knows. When there is no history, a measured ratio is used and the
+ * estimate says it is rough. The BASIS is always reported: an estimate that
+ * hides how it was reached invites the same false confidence that made a 900s
+ * default look reasonable against a 34-minute job.
+ */
+
+/**
+ * When there is no local history, how much bigger the whole run is than its
+ * sampled stage.
+ *
+ * Measured once, on the cold backfill above: 8,371 stage-seconds in total
+ * against 18s for the sampled `claude` stage. That literal ratio (465x) is
+ * useless as a multiplier - it says more about `claude` being cheap on a
+ * watermarked corpus than about anything general. What IS usable is the shape of
+ * the whole run against its wall clock: 5,136s wall for a job whose sampled rate
+ * projected 2,024s, i.e. **~2.5x**. Rounded to 2.5 and used only as a
+ * first-run fallback, flagged rough. One sample, one machine, one corpus - it
+ * exists to stop the answer being confidently 3x low, not to be precise.
+ */
+export const UNCOVERED_COST_FALLBACK_FACTOR = 2.5;
+
+/**
+ * What a previous successful run measured on THIS machine.
+ *
+ * STAGE-SECONDS ARE NOT WALL SECONDS, and conflating them is a real trap this
+ * shape exists to close. Stages run concurrently, so their durations sum to far
+ * more than the clock: measured, 8,371 stage-seconds over 5,136s wall on the
+ * cold run (1.63x) and 1,916 over 639s on the warm one (3.0x). An earlier
+ * version of this module summed the uncovered stages' durations and reported
+ * that as wall time - which would have replaced a 3x UNDER-estimate with a ~3x
+ * OVER-estimate. So the prior run is recorded as a wall time plus the SHARE of
+ * its stage-seconds that the sample cannot observe, and the conversion happens
+ * in one place below.
+ */
+export interface PriorRunObservation {
+    /** That run's actual wall-clock duration, in seconds. */
+    readonly wallSeconds: number;
+    /** Summed duration of ALL its settled stages, in seconds. */
+    readonly totalStageSeconds: number;
+    /**
+     * Summed duration of every stage EXCEPT the sampled harness's own - the work
+     * a fresh sample cannot observe. Same units as `totalStageSeconds`.
+     */
+    readonly uncoveredStageSeconds: number;
+}
+
+export interface UncoveredCostInput {
+    /** Seconds the sample's rate projects for the remaining backlog. */
+    readonly parseSeconds: number;
+    /** The machine's own last successful run, when there is one. */
+    readonly prior?: PriorRunObservation | undefined;
+}
+
+export interface UncoveredCostEstimate {
+    /** Seconds of work the sample did not observe. */
+    readonly seconds: number;
+    /** How it was reached - always reported, never implied. */
+    readonly basis: "prior-run" | "fallback-factor";
+}
+
+/**
+ * Is this prior observation safe to divide by and scale from? Every field has to
+ * be a finite positive number, and the uncovered share cannot exceed the whole -
+ * a malformed row must fall through to the fallback rather than produce a
+ * confident wrong number.
+ */
+const usablePrior = (
+    prior: PriorRunObservation | undefined,
+): prior is PriorRunObservation =>
+    prior !== undefined &&
+    Number.isFinite(prior.wallSeconds) && prior.wallSeconds > 0 &&
+    Number.isFinite(prior.totalStageSeconds) && prior.totalStageSeconds > 0 &&
+    Number.isFinite(prior.uncoveredStageSeconds) && prior.uncoveredStageSeconds > 0 &&
+    prior.uncoveredStageSeconds <= prior.totalStageSeconds;
+
+/**
+ * Estimate the cost of everything the calibration sample did not measure.
+ *
+ * Pure, so every branch is testable without a store or a clock. Never negative.
+ * A zero `parseSeconds` with no history yields zero rather than a fabricated
+ * number: with nothing measured and nothing remembered, the honest answer is
+ * "no estimate", which the caller already renders.
+ */
+export const estimateUncoveredSeconds = (
+    input: UncoveredCostInput,
+): UncoveredCostEstimate => {
+    const prior = input.prior;
+    if (usablePrior(prior)) {
+        // Convert stage-seconds to WALL seconds using that run's own observed
+        // overlap, rather than a parallelism constant: wall x (uncovered share
+        // of stage-seconds). Same run, same machine, same concurrency, so the
+        // ratio needs no calibration of its own.
+        const share = prior.uncoveredStageSeconds / prior.totalStageSeconds;
+        // Deliberately NOT scaled by the backlog. The uncovered stages are
+        // dominated by work whose size is the corpus and the repo set, not the
+        // backlog: on the measured warm re-pass over the SAME corpus,
+        // `claude-config` even got more expensive (203s -> 637s) while the
+        // backlog went to nearly nothing. Scaling this term down with the
+        // backlog would reproduce the original bug in the warm case.
+        return { seconds: Math.round(prior.wallSeconds * share), basis: "prior-run" };
+    }
+    const parse = Math.max(0, input.parseSeconds);
+    if (parse === 0) return { seconds: 0, basis: "fallback-factor" };
+    return {
+        seconds: Math.round(parse * (UNCOVERED_COST_FALLBACK_FACTOR - 1)),
+        basis: "fallback-factor",
+    };
+};

--- a/apps/axctl/src/ingest/dry-run.test.ts
+++ b/apps/axctl/src/ingest/dry-run.test.ts
@@ -59,6 +59,8 @@ const baseResult = (over: Partial<DryRunResult> = {}): DryRunResult => ({
     sampled: { items: 30, seconds: 2.1 },
     ratePerSec: 14.3,
     etaSeconds: 210,
+    parseSeconds: 84,
+    uncovered: { seconds: 126, basis: "prior-run" },
     rough: false,
     populated: false,
     upToDate: false,

--- a/apps/axctl/src/ingest/dry-run.ts
+++ b/apps/axctl/src/ingest/dry-run.ts
@@ -188,6 +188,15 @@ const EMPTY_TALLY: SessionTally = { claude: 0, codex: 0, pi: 0, total: 0 };
  * timed-out run had stages cut short, so its durations would under-predict in
  * exactly the case that matters. Unsettled stages (`ended_at IS NULL`) are
  * excluded for the same reason.
+ *
+ * KNOWN ERROR BAR, stated rather than hidden. `ingest_stage.source` is the stage
+ * KEY, so `source <> 'claude'` drops every claude-keyed row - the sampled
+ * `transcripts` stage AND the `subagents` stage the sample does not measure
+ * (183s and 131s respectively on the cold run). So the uncovered term is
+ * slightly LOW, by whatever the non-sampled siblings of the sampled source cost:
+ * about 7% of the term on the measured warm run. That direction is the same one
+ * the original bug ran in, so it is worth naming; splitting it needs a stage-key
+ * column the sample can match on, which does not exist yet.
  */
 const dbPriorUncovered = (
     write: CacheWriteService,

--- a/apps/axctl/src/ingest/dry-run.ts
+++ b/apps/axctl/src/ingest/dry-run.ts
@@ -22,6 +22,11 @@ import { AxConfig } from "@ax/lib/config";
 import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
 import type { DbError } from "@ax/lib/errors";
+import {
+    estimateUncoveredSeconds,
+    type PriorRunObservation,
+    type UncoveredCostEstimate,
+} from "./derive-cost.ts";
 import { ingestTranscripts } from "./transcripts.ts";
 import { ingestCodex } from "./codex.ts";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
@@ -89,6 +94,13 @@ export interface DryRunResult {
     /** projected seconds for the REMAINING backfill, or null when no rate could
      *  be measured (or nothing remains). */
     readonly etaSeconds: number | null;
+    /** The sampled parse component of `etaSeconds` - remaining / measured rate.
+     *  This alone was the WHOLE estimate before #831, and it is the part that
+     *  shrinks as the backlog shrinks. */
+    readonly parseSeconds: number | null;
+    /** Everything the sample could not observe: ~35 other stages. Null when no
+     *  estimate was possible at all. See `./derive-cost.ts`. */
+    readonly uncovered: UncoveredCostEstimate | null;
     /** true when the sample was small (time-boxed early), so the ETA is noisy. */
     readonly rough: boolean;
     /** true when the graph already has sessions. Kept for backward compat; no
@@ -165,6 +177,59 @@ const countJsonl = (
     });
 
 const EMPTY_TALLY: SessionTally = { claude: 0, codex: 0, pi: 0, total: 0 };
+
+/**
+ * What this machine's last SUCCESSFUL run cost, split into the part a fresh
+ * sample can observe and the part it cannot (#831).
+ *
+ * Returns WALL time alongside stage-seconds because the two differ by the run's
+ * concurrency (measured: 8,371 stage-seconds over 5,136s wall), and the caller
+ * needs wall time. Restricted to `status = 'ok'` runs on purpose - a partial or
+ * timed-out run had stages cut short, so its durations would under-predict in
+ * exactly the case that matters. Unsettled stages (`ended_at IS NULL`) are
+ * excluded for the same reason.
+ */
+const dbPriorUncovered = (
+    write: CacheWriteService,
+    sampledSource: string,
+): Effect.Effect<PriorRunObservation | undefined, never> =>
+    write
+        .rows(
+            Schema.Struct({
+                wall_secs: Schema.Number,
+                total_secs: Schema.Number,
+                uncovered_secs: Schema.Number,
+            }),
+            `WITH last_ok AS (
+                 SELECT id, started_at, ended_at FROM ingest_run
+                 WHERE status = 'ok' AND ended_at IS NOT NULL
+                 ORDER BY started_at DESC LIMIT 1
+             )
+             SELECT
+                 date_diff('millisecond', r.started_at, r.ended_at) / 1000.0 AS wall_secs,
+                 coalesce(sum(date_diff('millisecond', s.started_at, s.ended_at)), 0) / 1000.0 AS total_secs,
+                 coalesce(sum(CASE WHEN s.source <> ?
+                     THEN date_diff('millisecond', s.started_at, s.ended_at) ELSE 0 END), 0) / 1000.0 AS uncovered_secs
+             FROM last_ok r
+             LEFT JOIN ingest_stage s
+               ON s.run = r.id AND s.status = 'ok' AND s.ended_at IS NOT NULL
+             GROUP BY r.started_at, r.ended_at`,
+            [sampledSource],
+        )
+        .pipe(
+            Effect.map((rows): PriorRunObservation | undefined => {
+                const row = rows[0];
+                if (row === undefined) return undefined;
+                return {
+                    wallSeconds: row.wall_secs,
+                    totalStageSeconds: row.total_secs,
+                    uncoveredStageSeconds: row.uncovered_secs,
+                };
+            }),
+            // A malformed or absent prior is not an error - the pure estimator
+            // validates every field and falls back to the shipped factor.
+            Effect.orElseSucceed(() => undefined),
+        );
 
 /** Per-source session counts already in the graph. One cheap aggregate (no
  *  derefs), so it stays fast even on a large graph. Compared against the
@@ -265,6 +330,8 @@ export const estimateIngest = (
                 sampled: { items: 0, seconds: 0 },
                 ratePerSec: null,
                 etaSeconds: null,
+                parseSeconds: null,
+                uncovered: null,
                 rough: false,
                 populated,
                 upToDate: true,
@@ -284,9 +351,39 @@ export const estimateIngest = (
             : (yield* ingestTranscripts(write, { sinceDays: opts.sinceDays, limit: cap, deadlineMs })).sessions;
         const seconds = (now() - t0) / 1000;
 
-        const { ratePerSec, etaSeconds } = computeEstimate(remaining.total, items, seconds);
-        const rough = ratePerSec !== null && items < ROUGH_SAMPLE_THRESHOLD;
-        return { sources, inGraph, remaining, sampled: { items, seconds }, ratePerSec, etaSeconds, rough, populated, upToDate: false };
+        const { ratePerSec, etaSeconds: parseSeconds } = computeEstimate(remaining.total, items, seconds);
+
+        // The sample timed ONE harness's transcript parsing. The run also does
+        // sidecar discovery, git history, config/skill scanning and the derive
+        // chain - and assuming those cost zero is what made this estimate ~3x
+        // low (#831). Prefer this machine's own last successful run over any
+        // shipped constant.
+        const prior = yield* dbPriorUncovered(write, useCodex ? "codex" : "claude");
+        const uncovered = parseSeconds === null
+            ? null
+            : estimateUncoveredSeconds({ parseSeconds, prior });
+        const etaSeconds = parseSeconds === null || uncovered === null
+            ? null
+            : parseSeconds + uncovered.seconds;
+
+        // "rough" now also covers an estimate whose uncovered half is a shipped
+        // factor rather than a local measurement - the first-run case, where the
+        // number is an order of magnitude rather than a prediction.
+        const rough = ratePerSec !== null &&
+            (items < ROUGH_SAMPLE_THRESHOLD || uncovered?.basis === "fallback-factor");
+        return {
+            sources,
+            inGraph,
+            remaining,
+            sampled: { items, seconds },
+            ratePerSec,
+            etaSeconds,
+            parseSeconds,
+            uncovered,
+            rough,
+            populated,
+            upToDate: false,
+        };
     });
 
 /** Render the dry-run result for humans (Paxel-style) or as JSON for the agent. */
@@ -300,6 +397,8 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
                 sampled: result.sampled,
                 ratePerSec: result.ratePerSec,
                 etaSeconds: result.etaSeconds,
+                parseSeconds: result.parseSeconds,
+                uncovered: result.uncovered,
                 rough: result.rough,
                 populated: result.populated,
                 upToDate: result.upToDate,
@@ -367,6 +466,20 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
     // the full total; on a partially-populated one it's labelled accordingly.
     const label = result.populated ? "remaining" : "total";
     lines.push(`  ${label}: ${remaining.total.toLocaleString()} sessions   ETA ${eta}${roughTag} on this machine`);
+    // Show the split. The parse half is what the sample measured; the other half
+    // is ~35 stages it never touched, and hiding it is what made this estimate
+    // ~3x low (#831). Naming the basis keeps the number from reading as a
+    // precision it does not have.
+    if (result.parseSeconds !== null && result.uncovered !== null) {
+        const basis = result.uncovered.basis === "prior-run"
+            ? "measured on your last successful run"
+            : "estimated - no prior run to measure";
+        lines.push(
+            `    ${formatDuration(result.parseSeconds)} reading transcripts` +
+            ` + ${formatDuration(result.uncovered.seconds)} for the other stages` +
+            ` (git, sidecars, skills, derives; ${basis})`,
+        );
+    }
     lines.push(`  run it: ax ingest   (watch live in ax studio → http://127.0.0.1:${DEFAULT_DASHBOARD_PORT})`);
     return lines.join("\n");
 }


### PR DESCRIPTION
Closes #831.

## The bug

`ax ingest --dry-run` estimated **`~33m44s`**. The run took **5,136s** - about 3x
more. The estimator was not doing bad arithmetic; it was answering a narrower
question than the one asked. It times a sample of sessions from ONE harness,
derives a sessions/sec rate, and multiplies by the remaining session count.

Per-stage durations from that very run show what that covers:

| stage | seconds |
| --- | --- |
| claude-sidecars | 2,507 |
| signals | 2,256 |
| codex | 1,629 |
| git | 945 |
| session-health | 221 |
| proposals | 218 |
| claude-config | 203 |
| **claude** (the sampled stage) | **18** |

The estimate priced the 18s stage and implicitly priced the other ~35 stages at
zero.

## The fix

Total is now the sampled parse term (unchanged) **plus an uncovered term**, taken
from this machine's own last successful `ok` run: its **wall** time, times the
share of its stage-seconds that the sample cannot observe. Local history beats
any constant this repo could ship, because the uncovered cost depends on corpus
shape (a Codex-heavy corpus carries ~10x the `turn` rows per session), repo
count, and disk.

Both halves of the output now name their basis - `prior-run` or
`fallback-factor` - in JSON and in the human line, and the `rough` flag also
trips on the fallback. An estimate that hides how it was reached invites exactly
the false confidence that made a 900s default look reasonable against a
34-minute job.

## Two model errors caught before shipping, both by checking the store

**Stage-seconds are not wall seconds.** The first working version summed the
uncovered stages' durations and reported that sum as time. Querying the real
store: the last `ok` run had **1,916 stage-seconds** over **638.8s wall**. Cold,
it was 8,371 over 5,136s. Stages run concurrently, so that version would have
replaced a 3x under-estimate with a ~3x over-estimate. The observation shape
therefore carries `wallSeconds`, `totalStageSeconds` and `uncoveredStageSeconds`,
and the conversion happens in exactly one place. A test asserts the converted
figure and asserts it is *less than* the raw stage-second sum.

**"Derives scale with the corpus" is false.** An earlier version blamed
whole-corpus derive stages and sized them per 1,000 turns. The warm re-pass
refutes it: `signals` went **2,256s cold to 21s warm** (107x) because derive
stages ARE windowed by the since-window. A per-turn derive coefficient would
over-predict a warm run by an order of magnitude. Both false starts are recorded
in the module docstring so the next reader does not re-derive them.

The uncovered term is also, deliberately, **not scaled by the backlog**. On the
warm re-pass over the same corpus, `claude-config` got *more* expensive (203s ->
637s) while the backlog went to nearly nothing. Scaling this term down with the
backlog would rebuild the original bug in the warm case, and a test asserts it
does not.

## Verification

- The new SQL was run against the real 5.4 GB snapshot before shipping; it
  returns `wall_secs 638.826 / total_secs 1916.728 / uncovered_secs 1904.04`, so
  the estimator's uncovered term for a warm run is ~635s.
- `bunx tsc --noEmit -p tsconfig.json` clean, including `*.test.ts`.
- 7 new pure tests (`derive-cost.test.ts`), 21 in `dry-run.test.ts` still pass.
- `check:timestamp-cast`, `check:raw-numeric-cast`, `check:no-node-fs` clean.
- Full suite: **6,027 pass / 7 fail / 4 errors**. Baseline on this branch is
  6,030 / 4 / 4. The 3 extra failures were **my own test environment**, not this
  change: I exported `AX_NO_AUTO_INGEST=1`, and three freshness-drive tests in
  `ingest-staleness.test.ts` assert the spawn that flag suppresses. Re-run
  without it: **13 pass / 0 fail**. The 4 remaining failures and 4 errors are
  pre-existing (electron install under `apps/studio-desktop`).
- The published snapshot survived the full suite at 4,392 sessions and the same
  byte size.

## What this does not do

It does not size the ingest deadline from the estimate. #830's deadline is
deliberately independent, and it should stay that way until this estimator has
been checked against more than one machine's history - the whole lesson here is
that one measurement is an order of magnitude, not a prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
