### PR TITLE
fix(studio): nav rail linked 8 of 22 registered routes

### DIFF
--- a/apps/studio/src/instrument/instrument.css
+++ b/apps/studio/src/instrument/instrument.css
@@ -190,6 +190,9 @@
 .v-mc-rail-g { display: grid; place-items: center; }
 .v-mc-rail-label { display: none; }
 .v-mc-rail-toggle { margin-top: auto; }
+/* separates the rail's overview/explore/manage clusters (#829) */
+.v-mc-rail-divider { width: 22px; height: 1px; background: var(--border); margin: 4px 0; flex: none; }
+.v-mc.nav-expanded .v-mc-rail-divider { width: 100%; }
 /* expanded rail: widen the grid track + lay each item out as glyph + page name */
 .v-mc.nav-expanded { grid-template-columns: 208px 1fr; }
 .v-mc.nav-expanded .v-mc-rail { align-items: stretch; padding-left: 12px; padding-right: 12px; }

--- a/apps/studio/src/instrument/shell.tsx
+++ b/apps/studio/src/instrument/shell.tsx
@@ -2,21 +2,30 @@
  *  Mission Control and Wrapped both render inside it so the rail nav is shared.
  *  The rail collapses (icons only) / expands (icons + page names); the choice
  *  persists in localStorage. Default is collapsed for the live daemon and
- *  expanded in the mock/demo build (so walkthroughs read the page names). */
+ *  expanded in the mock/demo build (so walkthroughs read the page names).
+ *
+ *  The entries themselves live in `../nav/manifest.ts` (single source shared
+ *  with the route-coverage test) - do not hand-edit a nav list here. */
 import { useState, type ReactNode } from "react";
 import { ForesightLink } from "@ax/foresight";
+import { NAV_ENTRIES } from "../nav/manifest.ts";
 import "./instrument.css";
 
-export const RAIL = [
-    { g: "◢", to: "/", label: "mission control", exact: true },
-    { g: "≣", to: "/sessions", label: "sessions" },
-    { g: "◷", to: "/workflow", label: "workflow" },
-    { g: "⎈", to: "/improve", label: "improve" },
-    { g: "◧", to: "/cost", label: "cost" },
-    { g: "◳", to: "/team", label: "team metrics" },
-    { g: "✦", to: "/skills", label: "skills" },
-    { g: "⚙", to: "/lab", label: "lab" },
-] as const;
+export { NAV_ENTRIES as RAIL };
+
+/** A thin divider renders between adjacent entries whose group differs, so
+ *  the 13-entry rail reads as three clusters (overview/explore/manage)
+ *  instead of one long list - see manifest.ts for why grouped over flat. */
+function railWithDividers() {
+    const out: Array<{ kind: "entry"; entry: (typeof NAV_ENTRIES)[number] } | { kind: "divider"; key: string }> = [];
+    NAV_ENTRIES.forEach((entry, i) => {
+        if (i > 0 && NAV_ENTRIES[i - 1].group !== entry.group) {
+            out.push({ kind: "divider", key: `div-${entry.group}` });
+        }
+        out.push({ kind: "entry", entry });
+    });
+    return out;
+}
 
 const NAV_KEY = "ax:studio-nav-expanded";
 const STUDIO_MOCK = import.meta.env.VITE_STUDIO_MOCK === "true";
@@ -47,14 +56,18 @@ export function InstrumentShell({ children }: { children: ReactNode }) {
             <div className={`v-mc${expanded ? " nav-expanded" : ""}`}>
                 <nav className="v-mc-rail" aria-label="primary">
                     <div className="logo">ax</div>
-                    {RAIL.map((r) => (
-                        <ForesightLink key={r.to} to={r.to} title={r.label} aria-label={r.label}
-                            activeOptions={{ exact: (r as { exact?: boolean }).exact ?? false }}
-                            activeProps={{ className: "on" }}>
-                            <span className="v-mc-rail-g" aria-hidden="true">{r.g}</span>
-                            <span className="v-mc-rail-label">{r.label}</span>
-                        </ForesightLink>
-                    ))}
+                    {railWithDividers().map((item) =>
+                        item.kind === "divider" ? (
+                            <div key={item.key} className="v-mc-rail-divider" aria-hidden="true" />
+                        ) : (
+                            <ForesightLink key={item.entry.to} to={item.entry.to} title={item.entry.label} aria-label={item.entry.label}
+                                activeOptions={{ exact: item.entry.exact ?? false }}
+                                activeProps={{ className: "on" }}>
+                                <span className="v-mc-rail-g" aria-hidden="true">{item.entry.g}</span>
+                                <span className="v-mc-rail-label">{item.entry.label}</span>
+                            </ForesightLink>
+                        )
+                    )}
                     <button
                         type="button"
                         className="v-mc-rail-toggle"

--- a/apps/studio/src/nav/manifest.test.ts
+++ b/apps/studio/src/nav/manifest.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { router } from "../router.tsx";
+import { NAV_ENTRIES, NAV_EXCLUSIONS } from "./manifest.ts";
+
+/** Every path the router actually registers, read off the live routeTree
+ *  (not hand-copied) - this is what makes the test catch route 23. */
+function registeredRoutePaths(): string[] {
+    const root = router.routeTree as unknown as { children?: ReadonlyArray<{ fullPath: string }> };
+    return (root.children ?? []).map((r) => r.fullPath);
+}
+
+/** A route segment like `$sessionId` or `$slug` - these legitimately have no
+ *  static rail entry, so they're excluded from the coverage check by pattern
+ *  rather than by name (a new parameterized route needs no manifest edit). */
+const isParameterized = (path: string): boolean => path.includes("$");
+
+describe("studio nav rail route coverage (#829)", () => {
+    const registered = registeredRoutePaths();
+
+    test("sanity: the route tree still has routes to check", () => {
+        expect(registered.length).toBeGreaterThan(0);
+    });
+
+    test("every non-parameterized route is either linked from the rail or explicitly excluded with a reason", () => {
+        const navPaths = new Set(NAV_ENTRIES.map((e) => e.to));
+        const exclusionPaths = new Set(NAV_EXCLUSIONS.map((e) => e.to));
+
+        const missing = registered.filter(
+            (path) => !isParameterized(path) && !navPaths.has(path) && !exclusionPaths.has(path),
+        );
+
+        expect(missing).toEqual([]);
+    });
+
+    test("every nav entry points at a route the router actually registers (no dead links)", () => {
+        const registeredSet = new Set(registered);
+        const dangling = NAV_ENTRIES.filter((e) => !registeredSet.has(e.to)).map((e) => e.to);
+        expect(dangling).toEqual([]);
+    });
+
+    test("every exclusion still names a real, registered route (no stale exclusions)", () => {
+        const registeredSet = new Set(registered);
+        const stale = NAV_EXCLUSIONS.filter((e) => !registeredSet.has(e.to)).map((e) => e.to);
+        expect(stale).toEqual([]);
+    });
+
+    test("every exclusion carries a non-trivial reason", () => {
+        for (const exclusion of NAV_EXCLUSIONS) {
+            expect(exclusion.reason.length).toBeGreaterThan(10);
+        }
+    });
+
+    test("no path is both a nav entry and an exclusion", () => {
+        const navPaths = new Set(NAV_ENTRIES.map((e) => e.to));
+        const overlap = NAV_EXCLUSIONS.filter((e) => navPaths.has(e.to)).map((e) => e.to);
+        expect(overlap).toEqual([]);
+    });
+});

--- a/apps/studio/src/nav/manifest.ts
+++ b/apps/studio/src/nav/manifest.ts
@@ -1,0 +1,83 @@
+/** Single source of truth for the studio nav rail.
+ *
+ *  #829: the rail (`instrument/shell.tsx`) hard-coded 8 entries while the
+ *  router registered 22 routes - 14 of them held live data (49 top commands
+ *  on /usage, 92 failures on /tools, 396 nodes on /canvas, ...) with no link
+ *  to reach them. The fix here is the MECHANISM, not the icon count: every
+ *  route the router registers must show up in exactly one of the two lists
+ *  below, and `manifest.test.ts` walks the live `routeTree` to enforce it -
+ *  a route added without a nav decision fails the test instead of going dark.
+ */
+
+export type NavGroup = "overview" | "explore" | "manage";
+
+export interface NavEntry {
+    /** Glyph shown in the collapsed rail. */
+    readonly g: string;
+    /** Route path - must match a `path` given to `createRoute` in router.tsx. */
+    readonly to: string;
+    readonly label: string;
+    /** `activeOptions.exact` - only "/" needs this (every other path is a
+     *  unique prefix). */
+    readonly exact?: boolean;
+    readonly group: NavGroup;
+}
+
+/** Grouped (not flat) because the fixed set grew from 8 to 13 entries - past
+ *  ~8 icons a flat rail stops being scannable at a glance. Groups answer
+ *  "where do I look for X": overview = state of the world, explore = drill
+ *  into a graph/data surface, manage = act on what you found. Order within a
+ *  group is deliberate (most-used first), not alphabetical. */
+export const NAV_ENTRIES: readonly NavEntry[] = [
+    // overview - state of the world right now
+    { g: "◢", to: "/", label: "mission control", exact: true, group: "overview" },
+    { g: "≣", to: "/sessions", label: "sessions", group: "overview" },
+    { g: "◧", to: "/cost", label: "cost", group: "overview" },
+    { g: "▤", to: "/usage", label: "usage", group: "overview" },
+    { g: "◳", to: "/team", label: "team metrics", group: "overview" },
+
+    // explore - graph / data surfaces you drill into
+    { g: "◷", to: "/workflow", label: "workflow", group: "explore" },
+    { g: "✦", to: "/skills", label: "skills", group: "explore" },
+    { g: "◈", to: "/skills/graph", label: "skill graph", group: "explore" },
+    { g: "◫", to: "/graph", label: "graph explorer", group: "explore" },
+    { g: "▦", to: "/canvas", label: "canvas", group: "explore" },
+    { g: "⚑", to: "/tools", label: "tool failures", group: "explore" },
+
+    // manage - act on what you found
+    { g: "⎈", to: "/improve", label: "improve", group: "manage" },
+    { g: "⚙", to: "/lab", label: "lab", group: "manage" },
+];
+
+export interface NavExclusion {
+    readonly to: string;
+    readonly reason: string;
+}
+
+/** Registered, non-parameterized routes deliberately left off the rail.
+ *  Parameterized routes (`$sessionId`, `$slug`, ...) are excluded by
+ *  `manifest.test.ts` automatically (no static nav entry makes sense for
+ *  them) and do NOT need an entry here. Everything else must be listed with
+ *  a reason - an unreasoned exclusion is exactly the #829 bug in a new coat. */
+export const NAV_EXCLUSIONS: readonly NavExclusion[] = [
+    {
+        to: "/mc",
+        reason:
+            "duplicate alias of / - same MissionControl component, and Shell.tsx already treats /mc as an instrument-chrome route alongside /",
+    },
+    {
+        to: "/sessions/compare",
+        reason:
+            "static path but only meaningful with a pre-selected ?ids= session set; reached from within /sessions (a compare action on selected rows), not a standalone destination",
+    },
+    {
+        to: "/lab/sigils",
+        reason:
+            "hidden design-iteration page - source comment on SigilGalleryRoute says explicitly 'no nav tab'; reached only via a link from /lab",
+    },
+    {
+        to: "/narration-demo",
+        reason:
+            "prototype showcase for the Story review surface fixture (sample narration + turns), not a real data view",
+    },
+];


### PR DESCRIPTION
## Summary

`apps/studio/src/instrument/shell.tsx` hard-coded 8 nav entries while the router (`apps/studio/src/router.tsx`) registers 22 routes. 14 of the unlinked routes hold live data - `/usage` (49 top commands, 27 reliability rows), `/tools` (92 failures), `/canvas` (396 nodes / 317 edges), `/graph`, `/skills/graph` - reachable only by typing a URL. This is the ticket the user actually felt: they reported aggregated metrics (most-used command, cost) as missing, when every number was live behind an unlinked route.

## What changed

- **Mechanism, not a hand-typed list.** Moved the rail's entries into `apps/studio/src/nav/manifest.ts`: `NAV_ENTRIES` (linked routes) + `NAV_EXCLUSIONS` (registered, non-parameterized routes deliberately left off, each with a required reason). `shell.tsx` now renders from `NAV_ENTRIES` instead of an inline array.
- **A test that fails when route 23 shows up unlinked**: `apps/studio/src/nav/manifest.test.ts` walks the *live* `router.routeTree` (not a hand-copied list) and asserts every non-parameterized route is either a `NAV_ENTRIES` link or a reasoned `NAV_EXCLUSIONS` entry, plus reverse checks (no dead nav links, no stale exclusions, no path in both lists). Parameterized routes (`$sessionId`, `$slug`, ...) are excluded automatically by pattern - no manifest edit needed for those.

## Judgment calls (recorded here per the brief)

- **Added to the rail** (previously unlinked, non-parameterized, non-demo): `/tools`, `/skills/graph`, `/graph`, `/canvas`, `/usage`. These are the routes the ticket's evidence actually points at - live data with no path in.
- **Excluded, with reasons** (see `NAV_EXCLUSIONS` in `manifest.ts`):
  - `/mc` - duplicate alias of `/`, renders the exact same `MissionControl` component; `Shell.tsx` already treats `/mc` as an instrument-chrome route alongside `/`. Linking both would just be two icons for one page.
  - `/sessions/compare` - a static path, but only meaningful with a pre-selected `?ids=` session set. It's a compare *action* reached from within `/sessions`, not a standalone destination - a bare nav link would 404-ish (empty compare view).
  - `/lab/sigils` - the route's own source comment says "Hidden design-iteration page ... no nav tab", reached only via a link from `/lab`. Respecting the existing intent rather than overriding it.
  - `/narration-demo` - explicitly a "prototype showcase" for the Story review surface fixture (sample narration + turns), not a real data view.
- **Grouped, not flat.** 8 → 13 entries pushed the rail past where a flat icon list stays scannable at a glance, so I grouped into `overview` (state of the world: mission control, sessions, cost, usage, team) / `explore` (drill into a graph/data surface: workflow, skills, skill graph, graph explorer, canvas, tool failures) / `manage` (act on what you found: improve, lab), with a thin CSS divider between clusters. Order within each group is deliberate (most-used first), not alphabetical.
- **Not touched**: `/wrapped` (`routes/wrapped.tsx`) exists as a component and is referenced in `Shell.tsx`'s instrument-chrome path check, but is **not registered in the route tree at all** (not one of the 22 routes, confirmed by walking `router.routeTree.children`). It's unreachable by any route today, which is a different bug than "registered but unlinked" - out of scope for this ticket since the brief's evidence is specifically about the 22 registered routes.

## What I measured

- `router.routeTree.children` at runtime (via a throwaway script) confirms exactly 22 registered routes with clean `fullPath` values, matching the ticket's count.
- `bunx tsc --noEmit -p tsconfig.json` - clean, no errors.
- `bun test apps/studio/src/nav/manifest.test.ts` - 6 pass, 0 fail (route-coverage assertions, dead-link check, stale-exclusion check, reason-quality check).
- `check:timestamp-cast`, `check:raw-numeric-cast`, `check:no-node-fs` - all clean.
- Full `bun test`: 6029 pass / 11 skip / 4 fail / 4 errors across 652 files. The 4 fail + 4 errors are pre-existing (electron install failures under `apps/studio-desktop`, a DuckDB catalog drift in `report.test.ts`, `db down` in `next-actions.test.ts`, a spool-lock race in `hooks/telemetry.test.ts`) and don't touch any file this PR changes - confirmed by grepping the failure/skip output for `apps/studio/src/nav` or `shell.tsx`/`instrument`, no hits. Pass/skip counts drift slightly from the stated baseline (6030/7/4/4) beyond the 6 new tests I added; the drift traces to `apps/studio-desktop` (electron/bun-spawn flakiness) and DB-availability-dependent tests elsewhere in the suite, not to anything in this change's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)