### PR TITLE
fix(dashboard): stop advertising a dead graph-explorer link, wire up the orphaned orchestration panel

### DIFF
--- a/apps/axctl/src/dashboard/capabilities.test.ts
+++ b/apps/axctl/src/dashboard/capabilities.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression coverage for #834: three routes the studio advertised (or that
+ * *looked* registered) turned out to be unreachable in practice - an
+ * env-gated experiment (`graph-explorer`) linked unconditionally from the
+ * Lab page, a fully-retired endpoint (`graph-health`) that still answered
+ * with a plausible-looking JSON body, and a route (`session-orchestration`)
+ * whose own frontend caller was never mounted. `/api/version`'s capability
+ * list is what the studio uses for feature detection, so this file pins the
+ * invariant end to end: every advertised capability resolves to a route that
+ * is actually live, and the one CONDITIONAL capability (`graph-explorer`)
+ * only appears in the list exactly when the route behind it is functional -
+ * never advertised-but-dead, never live-but-unadvertised.
+ */
+import { describe, expect, test } from "bun:test";
+import { baseApiCapabilities, dashboardApiCapabilities, isGraphExplorerEnabled } from "./capabilities.ts";
+import { isContractRequest } from "./contract/web-handler.ts";
+import { matchRoute } from "./router/router.ts";
+import { routeTable } from "./router/table.ts";
+
+/** One concrete (method, path) known to be served by each base capability -
+ *  taken from the inline comment already documenting it in capabilities.ts. */
+const CAPABILITY_PROBE: Record<(typeof baseApiCapabilities)[number], { method: string; path: string }> = {
+    "skills": { method: "GET", path: "/api/skills" },
+    "decisions": { method: "GET", path: "/api/decisions" },
+    "workflow": { method: "GET", path: "/api/workflow" },
+    "sessions": { method: "GET", path: "/api/sessions" },
+    "episodes": { method: "GET", path: "/api/episodes/abc" },
+    "projects": { method: "GET", path: "/api/projects/abc" },
+    "skill-graph": { method: "GET", path: "/api/skill-graph" },
+    "recall": { method: "GET", path: "/api/recall" },
+    "tools": { method: "GET", path: "/api/tool-failures" },
+    "wrapped": { method: "GET", path: "/api/wrapped" },
+    "improve": { method: "GET", path: "/api/improve" },
+    "next-actions": { method: "GET", path: "/api/next-actions" },
+    "improve-analyze": { method: "GET", path: "/api/improve/analyze-brief" },
+    "wrapped-generate": { method: "GET", path: "/api/wrapped/generate-brief" },
+    "improve-impact": { method: "GET", path: "/api/improve/abc/impact" },
+    "events": { method: "GET", path: "/api/events" },
+    "image": { method: "GET", path: "/api/image" },
+    "otlp": { method: "POST", path: "/v1/metrics" },
+};
+
+/** Is (method, path) actually routed somewhere - contract OR legacy table?
+ *  Mirrors the real dispatch order in server.ts's handleDashboardRequest. */
+function isLive(method: string, path: string): boolean {
+    if (isContractRequest(method, path)) return true;
+    return matchRoute(routeTable, method, path).kind === "matched";
+}
+
+describe("capability list <-> live route set agreement (#834)", () => {
+    test("every base (always-advertised) capability resolves to a live route", () => {
+        for (const capability of baseApiCapabilities) {
+            const probe = CAPABILITY_PROBE[capability];
+            expect(probe, `no probe registered for capability "${capability}" - add one above`).toBeDefined();
+            expect(
+                isLive(probe.method, probe.path),
+                `capability "${capability}" advertises ${probe.method} ${probe.path}, but nothing routes it`,
+            ).toBe(true);
+        }
+    });
+
+    test("graph-explorer capability is advertised iff the flag that gates its route is on", () => {
+        const off = dashboardApiCapabilities({});
+        const on = dashboardApiCapabilities({ AX_ENABLE_GRAPH_EXPLORER: "1" });
+        expect(isGraphExplorerEnabled({})).toBe(false);
+        expect(off).not.toContain("graph-explorer");
+        expect(isGraphExplorerEnabled({ AX_ENABLE_GRAPH_EXPLORER: "1" })).toBe(true);
+        expect(on).toContain("graph-explorer");
+        // graph-explorer is a legacy (non-contract) route by design - it lives
+        // outside the contract until it graduates or dies.
+        expect(isContractRequest("GET", "/api/graph-explorer")).toBe(false);
+        expect(matchRoute(routeTable, "GET", "/api/graph-explorer").kind).toBe("matched");
+    });
+
+    test("graph-health is neither routed nor advertised - fully retired, not a live capability", () => {
+        // Studio ephemeral (wave 3) retired this endpoint on purpose: it would
+        // mean re-opening a dependency (an admin health scan) that doesn't
+        // belong on a process that reads a published snapshot and exits (see
+        // contract/system.ts's module doc). Confirm it stays that way on both
+        // sides: no route answers it, and no capability claims it.
+        expect(isContractRequest("GET", "/api/graph-health")).toBe(false);
+        expect(matchRoute(routeTable, "GET", "/api/graph-health").kind).toBe("unmatched");
+        for (const capability of dashboardApiCapabilities({ AX_ENABLE_GRAPH_EXPLORER: "1" })) {
+            expect(capability).not.toBe("graph-health");
+        }
+    });
+
+    test("session-orchestration is contract-routed (covered by the coarse 'sessions' capability)", () => {
+        // Unlike graph-health, this route IS live end to end (verified against
+        // a real handler in sessions.test.ts / 834-probe evidence) - #834's
+        // report of an "empty body" came from probing it without the required
+        // `id` query param, which every id-keyed contract route does (see
+        // session-summary, same schema). It is not itself broken or dead; it
+        // just has no live frontend caller yet (apps/studio's OrchestrationPanel
+        // is now wired into the session canvas - see routes/canvas.tsx).
+        expect(isContractRequest("GET", "/api/session-orchestration")).toBe(true);
+    });
+});

--- a/apps/studio/src/routes/canvas.tsx
+++ b/apps/studio/src/routes/canvas.tsx
@@ -383,6 +383,18 @@ export function CanvasRoute() {
                 <span>click a pill → detail (toggle in-place / focus / both)</span>
             </div>
 
+            {/* Orchestration drill-in: the subagent fan-out/parallel/sequential
+                timeline for the focused session, when it dispatched any -
+                the "click a pill to drill into its orchestration timeline"
+                promised at the top of this file (#834 - the panel existed
+                but nothing ever rendered it). */}
+            {(() => {
+                const sel = focusId ? sessions.find((s) => s.id === focusId) : undefined;
+                return sel && sel.subagent_count > 0
+                    ? <OrchestrationPanel sessionId={sel.id} onClose={() => setSelected(null)} />
+                    : null;
+            })()}
+
             {focusId && (detailMode === "focus" || detailMode === "both")
                 ? <FocusDetail sessionId={focusId} onClose={() => setSelected(null)} />
                 : null}

--- a/apps/studio/src/routes/lab.tsx
+++ b/apps/studio/src/routes/lab.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { api } from "../api.ts";
 
 /**
  * Lab - hidden power-user area (footer link, no nav tab).
@@ -7,8 +9,26 @@ import { Link } from "@tanstack/react-router";
  * POST /api/query; studio is ephemeral now - it opens a published snapshot
  * and exits when the last client disconnects, so there is no daemon left to
  * hold an ad-hoc query console open against. Retired rather than reworked.)
+ *
+ * Graph explorer is gated server-side behind AX_ENABLE_GRAPH_EXPLORER=1
+ * (`/api/graph-explorer` answers 404 `graph_explorer_disabled` otherwise -
+ * see dashboard/router/routes/insights.ts). The link used to render
+ * unconditionally regardless of that flag, so most visitors clicked into a
+ * dead end (#834) - the daemon's `/api/version` capability list is the
+ * single source of truth for whether the flag is on, so gate on it here too.
  */
 export function LabRoute() {
+    // Same query key IngestSplash already uses for its own /api/version probe
+    // (mounted on every route via InstrumentChrome) - shares that cache entry
+    // instead of firing a second identical request.
+    const version = useQuery({
+        queryKey: ["daemon-version"],
+        queryFn: () => api.version(),
+        staleTime: 60_000,
+        retry: false,
+    });
+    const graphExplorerEnabled = version.data?.capabilities.includes("graph-explorer") ?? false;
+
     return (
         <section className="panel">
             <header>
@@ -20,9 +40,19 @@ export function LabRoute() {
                 <Link to="/canvas" className="badge review" style={{ textDecoration: "none" }}>
                     Session canvas →
                 </Link>
-                <Link to="/graph" className="badge review" style={{ textDecoration: "none" }}>
-                    Graph explorer →
-                </Link>
+                {graphExplorerEnabled ? (
+                    <Link to="/graph" className="badge review" style={{ textDecoration: "none" }}>
+                        Graph explorer →
+                    </Link>
+                ) : (
+                    <span
+                        className="badge review"
+                        style={{ opacity: 0.5, cursor: "not-allowed" }}
+                        title="Disabled - set AX_ENABLE_GRAPH_EXPLORER=1 on the daemon to enable this experimental endpoint."
+                    >
+                        Graph explorer (disabled) →
+                    </span>
+                )}
                 <Link to="/lab/sigils" className="badge review" style={{ textDecoration: "none" }}>
                     Archetype sigils →
                 </Link>


### PR DESCRIPTION
## Summary

Fixes #834. Measured all three routes against real handler chains in-process (no port bound, per the worktree's testing guidance) before deciding anything.

| Route | Verdict | Evidence |
|---|---|---|
| `GET /api/graph-health` | Already fully retired | Not in the contract, not in the legacy router, absent from `dashboardApiCapabilities()`. Its `{"error":"not_found"}` body is the documented "legacy 200 not_found quirk" every unmatched `/api/*` path gets (already pinned by `server.test.ts`). Nothing to implement or unregister - it's correctly gone already. |
| `GET /api/graph-explorer` | Working as designed, frontend bug fixed | It's a deliberate, env-gated experiment (`AX_ENABLE_GRAPH_EXPLORER=1`) already correctly excluded from the capability list when off. The real bug: `apps/studio/src/routes/lab.tsx`'s "Graph explorer →" link rendered unconditionally, so the common case (flag off) really was "an entry point to nothing." Fixed by gating the link on the `graph-explorer` capability from `/api/version`. |
| `GET /api/session-orchestration` | Not dead - fixed the missing frontend wiring | Hit with a real `id`, it returns a correct 200 payload. The "empty body" report came from probing it without the required `id` query param - a framework-level quirk shared by every id-keyed contract route (verified `/api/session-summary` reproduces it identically), not specific to this route. The actual defect: `OrchestrationPanel` in `canvas.tsx` was fully built (queries the endpoint, renders a subagent timeline) but never mounted anywhere - the file's own header comment promises "click a pill to drill into its orchestration timeline" and nothing did that. Wired it in. |

## Judgment calls (per the brief - no one was available to ask)

- **graph-health**: treated as done already rather than re-implementing or re-unregistering something that's already correctly absent on both sides (routing + capabilities).
- **graph-explorer**: kept the server-side flag as-is (it reads as deliberate, not a bug) and fixed only the frontend's unconditional link, since that's the actual "advertised capability that's dead" the issue is about.
- **session-orchestration**: chose "implement" over "unregister" - the backend already works correctly with real data, and a whole polished frontend component (subagent timeline bars, wait-band merging, task labels) existed and simply had no caller. Wiring it up is strictly more valuable than deleting working code, and matches the file's own stated intent.

## Test added

`apps/axctl/src/dashboard/capabilities.test.ts` - the "capability list and live route set agree" regression the issue asked for. Every entry in `baseApiCapabilities` is checked against a live route (contract-routed or legacy-table-routed); the one conditional capability (`graph-explorer`) is checked both directions - advertised iff its flag is on, route matched either way. This test would have caught the Lab.tsx link bug immediately had it existed before.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` - clean.
- `apps/studio`'s own `bun run typecheck` (after `bun run build` to generate the route tree, which the root tsconfig excludes `apps/studio/**` from) - only 3 pre-existing errors remain, in `api.ts`/`ingest-splash.tsx`. Confirmed unrelated by stashing this diff and reproducing the identical 3 errors on the unmodified tree.
- `apps/studio`'s own `bun test` - 338 pass / 0 fail, before and after.
- Targeted `bun test` (capabilities/sessions/system/insights/server route tests) - 52 pass / 0 fail.
- Full repo `bun test` (`AX_DUCKDB_DYLIB` + `AX_DUCKDB_REQUIRE_FTS=1` + fresh `AX_DATA_DIR`), run twice for stability: **6027 pass / 11 skip / 4 fail / 4 errors** across 652 files, both runs identical. The 4 errors are the documented pre-existing electron install failures under `apps/studio-desktop`. The 4 fails (3 "db down" in `next-actions.test.ts`, 1 `session_label` table mismatch in `report.test.ts`) are pre-existing and unrelated to any file this PR touches - confirmed by `git status` showing only `canvas.tsx`, `lab.tsx`, and the new test file changed, none of which any other test imports. Pass/skip counts land at 6027/11 vs. the worktree brief's documented 6030/7 baseline (651 files); this is a 1-file, 1-net-test delta unaccounted for by my +4 new tests, so treating it as pre-existing drift in the baseline snapshot rather than a regression - fail and error counts, the two figures that would actually indicate a break, match exactly.
- `bun run check:timestamp-cast`, `check:raw-numeric-cast`, `check:no-node-fs` - all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)