### PR TITLE
fix(release): build an Intel macOS asset so Intel Macs have any install path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,6 +45,11 @@ jobs:
         include:
           - runner: macos-14
             artifact: axctl-darwin-arm64
+          # Intel macOS. `scripts/build-duckdb.sh` branches on `uname -s` only, so
+          # this leg builds a native x64 libduckdb with no arch-specific casing,
+          # and `install.sh` already maps `x86_64` -> `x64` (#835).
+          - runner: macos-13
+            artifact: axctl-darwin-x64
           - runner: ubuntu-24.04
             artifact: axctl-linux-x64
     steps:
@@ -143,7 +148,7 @@ jobs:
         run: |
           set -euo pipefail
           # Keep in sync with the build-artifacts matrix.
-          expected="axctl-darwin-arm64.tar.gz axctl-linux-x64.tar.gz checksums.txt"
+          expected="axctl-darwin-arm64.tar.gz axctl-darwin-x64.tar.gz axctl-linux-x64.tar.gz checksums.txt"
           have="$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json assets --jq '.assets[].name')"
           missing=""
           for asset in $expected; do

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,7 @@ Releases are managed by Release Please and GitHub Release artifacts.
 4. Merge the Release Please PR.
 5. Confirm the release workflow uploads:
    - `axctl-darwin-arm64.tar.gz`
+   - `axctl-darwin-x64.tar.gz`
    - `axctl-linux-x64.tar.gz`
    - `checksums.txt`
 6. Verify install/update from the published release:


### PR DESCRIPTION
Closes #835.

## The gap

`gh release view v0.39.3 --json assets` returns exactly three things:

```
axctl-darwin-arm64.tar.gz   28,897,153
axctl-linux-x64.tar.gz      46,733,542
checksums.txt                      185
```

There is no `axctl-darwin-x64.tar.gz`, so an Intel Mac has no supported
download. "Build from source" is not a fallback here - the v2 binary embeds a
compiled libduckdb, and CI's own `DuckDB v1.5.5 (fts static)` job measures that
build at ~18 minutes. So the honest state today is: **no install path at all**
for an Intel Mac, which is what a Homebrew formula ran into.

## The change

One matrix entry on a `macos-13` runner, the asset assertion that the comment
directly above it already asks to keep in sync, and the same list in
`RELEASING.md`.

## Two things I checked rather than assumed

The issue's fix sketch stops at the matrix entry, and a matrix entry alone would
be a guess about two other files:

- **`scripts/build-duckdb.sh` has no architecture casing.** It branches on
  `uname -s` (Darwin vs Linux) only - no `uname -m`, no
  `CMAKE_OSX_ARCHITECTURES` - so a `macos-13` runner produces a native x64
  `libduckdb.dylib` with no further change.
- **`install.sh` already resolves the new asset name.** It maps
  `x86_64|amd64 -> x64` and `Darwin -> darwin` (lines 119-129), so it will
  request `axctl-darwin-x64.tar.gz` as soon as the asset exists. No installer
  change is needed, and none is included here.

## The cost, stated up front

The release legs build DuckDB from source: `writeManifestReusingBuild` falls
through to `build-duckdb.sh` when the dist dir is empty, and this workflow has no
DuckDB download step. So this adds a second 20-60 minute leg to every release.

That is bounded, not risky. `fail-fast: false` on the matrix and the
publish-on-partial design in `publish-artifacts` mean a failing x64 leg still
lets the platforms that did build get published - the v0.29.0 incident, where one
flaky test zeroed out every asset and made `latest` 404, is exactly what that
design exists to prevent. The `Verify release has every expected asset` step will
now fail loudly if x64 is missing, which is the correct signal rather than a
silent gap.

## Verification

The only executable change is the workflow itself, which cannot be exercised
outside a real release. What is verifiable locally is verified: the file parses,
the asset name matches what `install.sh` computes for a Darwin/x86_64 host, and
the expected-asset list now matches the matrix. The first release after this
merges is the real test, and the assertion step is what will report it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
