### PR TITLE
fix(insights): stop rendering every timestamp as "ue Aug 18 2026 02:"

### DIFF
--- a/apps/axctl/src/cli/insights-format.test.ts
+++ b/apps/axctl/src/cli/insights-format.test.ts
@@ -2,6 +2,33 @@ import { describe, expect, test } from "bun:test";
 import { formatInsightRows } from "./insights-format.ts";
 
 describe("formatInsightRows", () => {
+    // The DuckDB read seam decodes a TIMESTAMP to a JS Date, not an ISO string.
+    // The old formatter sliced the Date's string form to 19 chars and then
+    // replaced "T" with a space, which ate the T of "Tue" - every `ax insights`
+    // row rendered `ue Aug 18 2026 02:` on a real store.
+    test("renders a Date timestamp as UTC, not a mangled Date.toString()", () => {
+        const out = formatInsightRows("friction", [
+            { kind: "tool_error", ts: new Date("2026-08-18T02:36:34.830Z"), text: "boom", project: "ax" },
+        ]);
+        expect(out).toContain("2026-08-18 02:36:34");
+        expect(out).not.toContain("ue Aug");
+        expect(out).not.toContain("GMT");
+    });
+
+    test("still renders an ISO string timestamp the same way", () => {
+        const out = formatInsightRows("friction", [
+            { kind: "tool_error", ts: "2026-08-18T02:36:34.830Z", text: "boom", project: "ax" },
+        ]);
+        expect(out).toContain("2026-08-18 02:36:34");
+    });
+
+    test("an invalid Date renders empty rather than \"Invalid Date\"", () => {
+        const out = formatInsightRows("friction", [
+            { kind: "tool_error", ts: new Date("nonsense"), text: "boom", project: "ax" },
+        ]);
+        expect(out).not.toContain("Invalid");
+    });
+
     test("renders reactions as compact user-to-assistant pairs", () => {
         const output = formatInsightRows("reactions", [
             {

--- a/apps/axctl/src/cli/insights-format.ts
+++ b/apps/axctl/src/cli/insights-format.ts
@@ -7,10 +7,31 @@ type InsightRow = Record<string, unknown>;
 const numberOf = (value: unknown): number | null =>
     typeof value === "number" && Number.isFinite(value) ? value : null;
 
+/**
+ * `2026-08-18 02:36:34`, from either a Date or an ISO string.
+ *
+ * This used to be a bare `text.slice(0, 19).replace("T", " ")`, which was
+ * correct only while timestamps arrived as ISO strings. The DuckDB read seam
+ * decodes a TIMESTAMP column to a JS `Date`, whose string form is
+ * `Tue Aug 18 2026 02:36:34 GMT+0300 (...)`. Sliced to 19 that becomes
+ * `Tue Aug 18 2026 02:` - and then `.replace("T", " ")` ate the T of "Tue",
+ * so every `ax insights` row rendered `ue Aug 18 2026 02:`. Thirteen call
+ * sites in this file, all of them wrong the same way.
+ *
+ * UTC, matching every other ax surface. The positional swap replaces ISO's
+ * date/time separator by INDEX rather than by search, so a value that happens
+ * to carry an earlier "T" cannot be corrupted the same way twice.
+ */
 const compactDate = (value: unknown): string => {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? "" : isoToCompact(value.toISOString());
+    }
     const text = textOf(value);
-    return text.length >= 19 ? text.slice(0, 19).replace("T", " ") : text;
+    if (text.length < 19) return text;
+    return text[10] === "T" ? isoToCompact(text) : text.slice(0, 19);
 };
+
+const isoToCompact = (iso: string): string => `${iso.slice(0, 10)} ${iso.slice(11, 19)}`;
 
 const truncate = (value: unknown, max = 180): string => truncateText(value, max);
 


### PR DESCRIPTION
Found while dogfooding v2 on a real store. Every row of every `ax insights` view
printed a broken timestamp:

```
1. tool_error  cost$=$6.190   ue Aug 18 2026 00:
2. user_correction  cost$=$6.190  Mon Aug 17 2026 23:
3. tool_error  cost$=$6.190  Mon Aug 17 2026 23:
```

No seconds, a corrupted weekday, and local time where every other ax surface
prints UTC.

## Cause

```ts
const compactDate = (value: unknown): string => {
    const text = textOf(value);
    return text.length >= 19 ? text.slice(0, 19).replace("T", " ") : text;
};
```

That is correct for an ISO string, which is what SurrealDB returned. The DuckDB
read seam decodes a TIMESTAMP column to a JS `Date`, and `Date`'s string form is
`Tue Aug 18 2026 02:36:34 GMT+0300 (...)`. Sliced to 19 characters that is
`Tue Aug 18 2026 02:` — and then `.replace("T", " ")` matched the **T of "Tue"**
and ate it.

Two independent mistakes compounding: an assumption about the input type that the
engine swap invalidated, and a search-and-replace where the thing being searched
for can legitimately appear earlier in the string.

Thirteen call sites in this file, so this was not one view — it was `friction`,
`reactions`, `signals`, `classifiers`, `harness candidates` and every `last=`
field.

## Fix

`compactDate` now takes a `Date` or an ISO string and normalizes both to
`2026-08-18 02:36:34` in UTC. The date/time separator is replaced **by index**
rather than by search, so a value carrying an earlier `T` cannot be corrupted the
same way twice. An invalid `Date` renders empty rather than `Invalid Date`.

## Verification

Three regression tests in `insights-format.test.ts`: a `Date` renders as UTC with
no `GMT` and no `ue Aug`; an ISO string still renders identically; an invalid
`Date` does not leak `Invalid Date`. 12 pass in that file. `bunx tsc --noEmit -p
tsconfig.json` and `bun run typecheck` both clean.

## Separately, and not fixed here

In the output above, six consecutive rows read `cost$=$6.190`. That is not a
rendering bug — the OTLP enrichment is session-grain, so every friction event in
one session carries that session's cost. But a per-row column labelled `cost$`
reads as the cost of that event, which is not what it is. Worth relabelling, in
its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
