### PR TITLE
fix(skills): bloat reported the page size as the total

### DIFF
--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -308,10 +308,10 @@ const cmdSkillsBloat = (input: SkillsBloatInput) =>
     Effect.gen(function* () {
         const budgetTokens = requirePositiveInt("skills bloat", "budget", input.budgetTokens);
         const limit = requirePositiveInt("skills bloat", "limit", input.limit);
-        const rows = yield* fetchSkillBloat({ budgetTokens, limit });
+        const { rows, total } = yield* fetchSkillBloat({ budgetTokens, limit });
 
         if (input.json) {
-            console.log(prettyPrint({ budgetTokens, skills: rows }));
+            console.log(prettyPrint({ budgetTokens, total, skills: rows }));
             return;
         }
         if (rows.length === 0) {
@@ -327,9 +327,13 @@ const cmdSkillsBloat = (input: SkillsBloatInput) =>
                 `${fmtCount(r.bytes)} B  used=${fmtCount(r.invocations)}`,
             );
         }
+        // Say what was withheld. Reporting the page size as the total made
+        // `--limit` silently change a number the user reads as a fact.
+        const shown = rows.length < total ? ` (showing top ${fmtCount(rows.length)})` : "";
         console.log(
-            `\n${rows.length} skill${rows.length === 1 ? "" : "s"} over the ` +
-            `${fmtCount(budgetTokens)}-token budget. Trim toward high-signal; length is not effort.`,
+            `\n${fmtCount(total)} skill${total === 1 ? "" : "s"} over the ` +
+            `${fmtCount(budgetTokens)}-token budget${shown}. ` +
+            `Trim toward high-signal; length is not effort.`,
         );
     });
 

--- a/apps/axctl/src/queries/skill-bloat.test.ts
+++ b/apps/axctl/src/queries/skill-bloat.test.ts
@@ -22,7 +22,7 @@ describe("estimateTokens", () => {
 
 describe("fetchSkillBloat", () => {
     it("flags only skills over the token budget, with overBy + estTokens", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
             makeMockDb([
                 // statement 1: skill rows (bytes)
@@ -40,7 +40,7 @@ describe("fetchSkillBloat", () => {
     });
 
     it("skips synthetic shims and null-bytes skills", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
             makeMockDb([
                 [
@@ -56,8 +56,27 @@ describe("fetchSkillBloat", () => {
         ]);
     });
 
+    // `--limit` is a page size, not a filter. Reporting the page as the total
+    // told a user with 40 bloated skills that they had 4 (#dogfood).
+    it("reports the pre-limit total alongside the limited page", async () => {
+        const { rows, total } = await run(
+            fetchSkillBloat({ budgetTokens: 100, limit: 2 }),
+            makeMockDb([
+                [
+                    { id: "skill:a", name: "a", bytes: 4000, dir_path: "/s/a" },
+                    { id: "skill:b", name: "b", bytes: 3000, dir_path: "/s/b" },
+                    { id: "skill:c", name: "c", bytes: 2000, dir_path: "/s/c" },
+                    { id: "skill:d", name: "d", bytes: 1000, dir_path: "/s/d" },
+                ],
+                [],
+            ]),
+        );
+        expect(rows).toHaveLength(2);
+        expect(total).toBe(4);
+    });
+
     it("sorts by estTokens desc and respects limit", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 0, limit: 2 }),
             makeMockDb([
                 [
@@ -72,7 +91,7 @@ describe("fetchSkillBloat", () => {
     });
 
     it("collapses plugin-namespace twins (same content_hash), keeps bare name, sums invocations", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
             makeMockDb([
                 [
@@ -91,7 +110,7 @@ describe("fetchSkillBloat", () => {
     });
 
     it("does NOT collapse distinct skills that lack a content_hash", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
             makeMockDb([
                 [
@@ -105,7 +124,7 @@ describe("fetchSkillBloat", () => {
     });
 
     it("returns empty when every skill is within budget", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
             makeMockDb([
                 [{ id: "skill:lean", name: "lean", bytes: 4000, dir_path: "/s/lean" }],
@@ -116,7 +135,7 @@ describe("fetchSkillBloat", () => {
     });
 
     it("returns empty when no data", async () => {
-        const rows = await run(
+        const { rows } = await run(
             fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
             makeMockDb([[], []]),
         );

--- a/apps/axctl/src/queries/skill-bloat.ts
+++ b/apps/axctl/src/queries/skill-bloat.ts
@@ -111,5 +111,11 @@ export const fetchSkillBloat = Effect.fn("queries.fetchSkillBloat")(function* (
     );
 
     deduped.sort((a, b) => b.estTokens - a.estTokens);
-    return deduped.slice(0, input.limit).map(({ contentHash: _ch, ...row }) => row);
+    // `total` is the count BEFORE the limit. The renderer used to report
+    // `rows.length`, so `--limit=4` announced "4 skills over budget" on a
+    // machine with 40 - a page size printed as a fact about the user's setup.
+    return {
+        total: deduped.length,
+        rows: deduped.slice(0, input.limit).map(({ contentHash: _ch, ...row }) => row),
+    };
 });


### PR DESCRIPTION
Found while dogfooding v2 on a real store.

```
$ ax skills bloat --limit=4
...
4 skills over the 2,000-token budget. Trim toward high-signal; length is not effort.

$ ax skills bloat --limit=50
...
40 skills over the 2,000-token budget. Trim toward high-signal; length is not effort.
```

Same machine, same budget, same moment. `--limit` is a page size, but the footer
counted `rows.length` **after** the slice, so a display flag silently changed a
number the reader takes as a fact about their own setup — and the smaller,
friendlier-looking number is the one a default invocation is most likely to
produce.

## Fix

`fetchSkillBloat` returns `{ total, rows }`, with `total` counted before the
slice. The footer names what was withheld:

```
40 skills over the 2,000-token budget (showing top 4). Trim toward high-signal; length is not effort.
```

`--json` gains the same `total` field, so a programmatic caller can tell a
complete answer from a page.

## Verification

Run against the real store from source — the output above is the actual new
footer. Plus a unit test that four over-budget skills with `limit: 2` return two
rows and `total: 4`, and the seven existing call sites rebound to the new shape.
`bunx tsc --noEmit -p tsconfig.json` and `bun run typecheck` clean;
`skill-bloat.test.ts` 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
