### PR TITLE
fix(blob-gc): refuse a reference set that holds no pointers, not just an empty one

### DIFF
--- a/packages/lib/src/blob-gc.test.ts
+++ b/packages/lib/src/blob-gc.test.ts
@@ -152,6 +152,74 @@ describe("gcFileBuckets", () => {
         }).pipe(Effect.provide(layer))));
     });
 
+    dtest("skips when the reference set is non-empty but holds no pointers", async () => {
+        // The case the size check cannot see, and the one that actually fired.
+        // `session.raw_file` is contracted to hold `<bucket>:/<name>`, but the
+        // v2 codex parser writes the absolute SOURCE path. The set is then large
+        // and entirely unmatchable, so every blob reads as unreferenced.
+        // Measured on a real machine: 4,393 such rows, 2,727 blobs deleted,
+        // 1.9 GB gone in one global ingest.
+        const referenced = await referencedFrom(
+            [
+                "/Users/someone/.codex/sessions/2026/08/17/rollout.jsonl",
+                "/Users/someone/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+            ],
+            "ax-blobgc-badshape-",
+        );
+        const layer = PlatformLayer;
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "live.jsonl"), "keep me");
+
+            const result = yield* gcFileBuckets(root, {
+                isGlobalIngest: true,
+                referenced,
+                minAgeMs: 0,
+            });
+
+            expect(result.skipped).toBe(true);
+            expect(result.removed).toBe(0);
+            expect(result.skipReason).toMatch(/not one is a blob pointer/);
+            expect(yield* fs.exists(path.join(transcripts, "live.jsonl"))).toBe(true);
+        }).pipe(Effect.provide(layer))));
+    });
+
+    dtest("one well-formed pointer is enough to let GC run", async () => {
+        // The guard asks "is this producer writing pointers at all", not "is
+        // every row a pointer" - a mixed set must not disable GC entirely.
+        const referenced = await referencedFrom(
+            [filePointer("transcripts", "keep.jsonl"), "/Users/someone/.codex/raw.jsonl"],
+            "ax-blobgc-mixed-",
+        );
+        const layer = PlatformLayer;
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "keep.jsonl"), "referenced");
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "unreferenced");
+
+            const result = yield* gcFileBuckets(root, {
+                isGlobalIngest: true,
+                referenced,
+                minAgeMs: 0,
+            });
+
+            expect(result.skipped).toBe(false);
+            expect(result.removed).toBe(1);
+            expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(false);
+        }).pipe(Effect.provide(layer))));
+    });
+
     dtest("spares an unreferenced blob younger than the age guard", async () => {
         const referenced = await referencedFrom(
             [filePointer("transcripts", "keep.jsonl")],

--- a/packages/lib/src/blob-gc.ts
+++ b/packages/lib/src/blob-gc.ts
@@ -1,5 +1,5 @@
 import { Effect, FileSystem, Option, Path, Schema } from "effect";
-import { filePointer } from "./blob-pointer.ts";
+import { filePointer, isBlobPointer } from "./blob-pointer.ts";
 import { cacheRows } from "./duckdb/query.ts";
 import type { CacheRead } from "./duckdb/seam.ts";
 import { orAbsent, skipNotFound } from "./shared/fs-error.ts";
@@ -113,6 +113,29 @@ export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
         return skip(
             "the session reference set is empty (0 rows with raw_file); refusing to run blob GC " +
                 "against an empty reference set, which would delete every blob",
+        );
+    }
+
+    // A NON-EMPTY set of the WRONG SHAPE is the same hazard, and it is the one
+    // that actually fired. `session.raw_file` is contracted to hold a
+    // `<bucket>:/<name>` pointer (see blob-pointer.ts), but a parser can write
+    // the absolute SOURCE path instead - the v2 codex parser does exactly that
+    // (`const rawPointer = filePath`), under a comment still claiming it
+    // snapshots into the bucket. The set then has thousands of entries, none of
+    // which can ever match `filePointer(bucket, entry)`, so every blob on disk
+    // reads as unreferenced and the size check above waves it through.
+    //
+    // Measured, on a real machine: 4,393 rows in the reference set, 0 of them
+    // pointers, and one global ingest deleted 2,727 blobs - the whole 1.9 GB
+    // bucket store. Requiring at least one well-formed pointer turns "the
+    // reference set is structurally wrong" from a silent mass delete into a
+    // skip with a reason, which is what the empty-set guard was always for.
+    if (!Array.from(referenced).some(isBlobPointer)) {
+        return skip(
+            `the session reference set holds ${referenced.size} value(s) but not one is a ` +
+                "blob pointer (`<bucket>:/<name>`) - every blob would read as unreferenced. " +
+                "Refusing to run blob GC against a reference set of the wrong shape; the " +
+                "producer of session.raw_file is writing something else (see blob-pointer.ts)",
         );
     }
 

--- a/packages/lib/src/blob-pointer.ts
+++ b/packages/lib/src/blob-pointer.ts
@@ -7,3 +7,14 @@
  * database SDK.
  */
 export const filePointer = (bucket: string, path: string): string => `${bucket}:/${path}`;
+
+/**
+ * Does this string have the shape {@link filePointer} produces?
+ *
+ * Deliberately structural and not a bucket allowlist: GC uses it to answer "is
+ * this reference set made of pointers at all", and a pointer into a bucket GC
+ * does not scan is still evidence the producer is writing pointers. An absolute
+ * filesystem path (`/Users/...`) fails it, which is the case that matters -
+ * that is what a parser writes when it stores the source path instead.
+ */
+export const isBlobPointer = (value: string): boolean => /^[A-Za-z0-9_-]+:\/[^/]/.test(value);


### PR DESCRIPTION
Found by dogfooding v2 on a real machine. A single global `ax ingest` deleted the
**entire blob store**.

```
ingest: maintenance - otel pruned 1 row(s) + 0 edge(s); blob gc removed 2727/2727 blob(s)
```

Before: `~/.local/share/ax/buckets` = **1.9 GB**. After: **0 B**, both buckets
empty. Note the ratio — 2727 of 2727. Not a pruning pass; a wipe.

## Cause

GC builds its reference set from `session.raw_file`, which `blob-pointer.ts`
contracts to hold `<bucket>:/<name>`. The v2 codex parser writes the absolute
**source path** instead:

```ts
// Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
// best-effort cold storage for modest files.
const rawPointer = filePath;
```

The comment still describes a bucket snapshot that the code no longer performs.
Measured on this store: 4,393 sessions, 4,393 with `raw_file`, and every value
looking like

```
/Users/necmttn/.codex/sessions/2026/08/17/rollout-….jsonl
/Users/necmttn/Library/Application Support/Cursor/User/globalStorage/state.vscdb
```

None of those can ever equal `filePointer(bucket, entry)`, so every file in every
bucket read as unreferenced, aged past the 24h guard, and was removed.

## Why the existing guard did not catch it

It is right there, and its reasoning is exactly correct:

```ts
if (referenced.size === 0) {
    return skip("... refusing to run blob GC against an empty reference set, which would delete every blob");
}
```

The hazard was never emptiness — it was **unmatchability**, and emptiness is only
its most obvious form. A set of 4,393 unmatchable strings has identical
consequences and a reassuring `size`.

## Fix

GC now also requires at least one entry with the pointer shape, and skips with a
reason naming the producer when none has it.

**One is enough, deliberately.** The question is "is the producer emitting
pointers at all", not "is every row a pointer" — a mixed set must still collect
real orphans rather than disable GC. A test pins both directions.

## Verification

Two new tests in `blob-gc.test.ts`, both against real files on disk, because the
property is about whether a file still exists:

- a non-empty reference set of absolute source paths ⇒ `skipped`, `removed: 0`,
  and the blob is still there (this test fails on `main` by deleting it);
- a mixed set with one real pointer ⇒ GC runs, keeps the referenced blob,
  removes the orphan.

8 pass in that file. `bunx tsc --noEmit -p tsconfig.json` and `bun run typecheck`
both clean.

## What this deliberately does not decide

Whether v2 should snapshot raw transcripts into the buckets at all. The code and
its own comment disagree, and the answer changes disk footprint for every user,
so it is a product call rather than something to infer from a stale comment.
Filed separately. Until it is answered, this PR makes the failure mode a skip
with an explanation instead of a silent 1.9 GB delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
