### PR TITLE
fix(ingest): snapshot raw transcripts into the buckets again (#854)

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -4,6 +4,7 @@ import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { DbError } from "@ax/lib/errors";
 import { SkillName } from "@ax/lib/brands";
 import { AxConfig } from "@ax/lib/config";
+import { blobName, putBlobFromFile } from "@ax/lib/blob-store";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
@@ -1400,6 +1401,7 @@ export interface CodexStats {
 export const ingestCodex = Effect.fn("codex.ingest")(
     function* (write: CacheWriteService, opts: Partial<CodexIngestOpts> = {}) {
         const cfg = yield* AxConfig;
+        const path = yield* Path.Path;
         // Shared across all files this stage run: the agent_event ghost-index
         // rebuild fires at most once, memoized so file concurrency awaits one
         // in-flight rebuild + a failed rebuild is observable (#680).
@@ -1445,6 +1447,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
         if (opts.onProgress) yield* opts.onProgress({ totalFiles: files.length, totalBytes });
         const rawMaxBytes = cfg.knobs.codexRawMaxBytes;
+        const bucketsDir = path.join(cfg.paths.dataDir, "buckets");
         const progressEvery = cfg.knobs.codexProgressEvery;
         const flushEvery = cfg.knobs.codexFlushEvery;
         const concurrency = cfg.knobs.codexConcurrency;
@@ -1651,8 +1654,21 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 // best-effort cold storage for modest files. Large Codex sessions
                 // are parsed line-by-line above; reading them again just to copy the
                 // raw transcript can dominate benchmark runs.
+                //
+                // Falls back to the SOURCE PATH when the snapshot is skipped or
+                // fails, so `raw_file` still locates the transcript while the
+                // harness keeps it - see blob-gc.ts for why that fallback shape
+                // has to stay distinguishable from a real pointer.
                 if (snapshotRaw) yield* emitProgress(3);
-                const rawPointer = filePath;
+                const rawPointer = snapshotRaw
+                    ? (yield* putBlobFromFile(
+                        bucketsDir,
+                        "codex_artifacts",
+                        blobName(completedSession.id, ".jsonl"),
+                        filePath,
+                        { maxBytes: rawMaxBytes, sizeBytes },
+                    )) ?? filePath
+                    : filePath;
 
                 // Final session upsert carries the latest ended_at and raw artifact
                 // pointer after the streaming writes have completed.

--- a/apps/axctl/src/ingest/transcripts.parity.test.ts
+++ b/apps/axctl/src/ingest/transcripts.parity.test.ts
@@ -116,4 +116,24 @@ describe("claude normalized-batch parity", () => {
         expect(batch.compactions.length).toBeGreaterThan(0);
         expect(extractToolFileEvidence(extracted!.toolCalls).length).toBeGreaterThan(0);
     });
+
+    it("carries session.raw_file as a top-level rawFile, not only inside `raw`", () => {
+        // The normalized session write resolves `raw_file` as
+        // `rawFile ?? sourcePath ?? null` and runs AFTER the claude stage's own
+        // session upsert. When this field is missing, that later write silently
+        // replaces the blob POINTER with the SOURCE PATH, and every snapshot on
+        // disk becomes unreferenced - the reference-set shape blob GC deletes
+        // (#854). A copy nested under `raw` is not enough; the writer never
+        // reads it.
+        const extracted = __testExtractClaudeJsonlLines(
+            fixtureLines(), "-Users-necmttn-Projects-ax", "claude-parity-session",
+        );
+        expect(extracted).not.toBeNull();
+        extracted!.session.raw_file = "transcripts:/claude-parity-session.jsonl";
+
+        const batch = toClaudeNormalizedBatch(
+            extracted!, extracted!.skillRelations, extracted!.invocations,
+        );
+        expect(batch.sessions[0]?.rawFile).toBe("transcripts:/claude-parity-session.jsonl");
+    });
 });

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -6,6 +6,7 @@ import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { resolveSkillName } from "@ax/lib/skill-id";
 import { skillRowId } from "@ax/lib/stable-id";
+import { blobName, putBlobFromFile } from "@ax/lib/blob-store";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
@@ -1324,8 +1325,28 @@ const upsertSessions = (write: CacheWriteService, sessions: Session[]) =>
  * Snapshot the original transcript jsonl into the `transcripts` bucket and
  * return the file pointer string to persist on `session.raw_file`. Failures
  * are logged but do not abort ingest - the bucket is best-effort cold storage.
+ *
+ * Falls back to the SOURCE PATH when the snapshot is skipped (oversized, or
+ * disabled with `AX_CLAUDE_RAW_MAX_BYTES=0`) or fails, so `raw_file` still
+ * locates the transcript for as long as the harness keeps it. That fallback is
+ * why blob GC checks the reference set's SHAPE and not just its size: a store
+ * where every snapshot was skipped holds paths, not pointers, and must not read
+ * as "nothing is referenced" (see @ax/lib/blob-gc).
  */
-const snapshotTranscript = (_sessionId: string, filePath: string) => Effect.succeed(filePath);
+const snapshotTranscript = (
+    sessionId: string,
+    filePath: string,
+    bucketsDir: string,
+    maxBytes: number,
+    sizeBytes: number,
+) =>
+    putBlobFromFile(
+        bucketsDir,
+        "transcripts",
+        blobName(sessionId, ".jsonl"),
+        filePath,
+        { maxBytes, sizeBytes },
+    ).pipe(Effect.map((pointer) => pointer ?? filePath));
 
 // Claude turn rows are NEVER agent_event-linked (the transcript
 // extractor keys provider events by tool/turn uuid, not by turn seq), so the
@@ -1493,6 +1514,13 @@ export const toClaudeNormalizedBatch = (
         project: extracted.session.project,
         model: extracted.session.model,
         sourcePath: extracted.sourcePath,
+        // The normalized session write derives `raw_file` as
+        // `rawFile ?? sourcePath`, and it runs AFTER the `upsertSessions` call
+        // that carries the blob pointer. Omitting `rawFile` here therefore
+        // OVERWROTE every snapshot pointer with the source path, leaving the
+        // blobs on disk with nothing referencing them - which is exactly the
+        // reference-set shape that made blob GC delete the whole store (#854).
+        rawFile: extracted.session.raw_file,
         raw: {
             source: "claude_transcript",
             rawFile: extracted.session.raw_file,
@@ -1709,6 +1737,8 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
         let hookCommandInvocationCount = 0;
         let malformedLineCount = 0;
         const concurrency = cfg.knobs.claudeConcurrency;
+        const rawMaxBytes = cfg.knobs.claudeRawMaxBytes;
+        const bucketsDir = path.join(cfg.paths.dataDir, "buckets");
         const recordCount = () =>
             turnCount +
             invCount +
@@ -1835,6 +1865,9 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 const pointer = yield* snapshotTranscript(
                     extracted.session.id,
                     candidate.path,
+                    bucketsDir,
+                    rawMaxBytes,
+                    candidate.sizeBytes,
                 );
                 extracted.session.raw_file = pointer;
                 yield* upsertSessions(write, [extracted.session]);

--- a/packages/lib/src/blob-store.test.ts
+++ b/packages/lib/src/blob-store.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, FileSystem, Layer, Path, PlatformError } from "effect";
+import { blobName, putBlobFromFile } from "./blob-store.ts";
+import { isBlobPointer } from "./blob-pointer.ts";
+
+const PlatformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+/** Fail `copyFile` for every path, to exercise the best-effort branch against a
+ *  genuine `PlatformError` rather than a permission-bit trick that behaves
+ *  differently for root-run CI. */
+const withFailingCopy = (): Layer.Layer<FileSystem.FileSystem> =>
+    Layer.effect(
+        FileSystem.FileSystem,
+        Effect.map(FileSystem.FileSystem, (fs) => ({
+            ...fs,
+            copyFile: (from: string, to: string) =>
+                Effect.fail(
+                    PlatformError.systemError({
+                        _tag: "PermissionDenied",
+                        module: "FileSystem",
+                        method: "copyFile",
+                        pathOrDescriptor: `${from} -> ${to}`,
+                    }),
+                ),
+        })),
+    ).pipe(Layer.provide(BunFileSystem.layer));
+
+const inTempDir = <A>(
+    body: (
+        root: string,
+        source: string,
+    ) => Effect.Effect<A, unknown, FileSystem.FileSystem | Path.Path>,
+    layer: Layer.Layer<FileSystem.FileSystem | Path.Path> = PlatformLayer,
+): Promise<A> =>
+    Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped();
+        const source = path.join(root, "session.jsonl");
+        yield* fs.writeFileString(source, "line-1\nline-2\n");
+        return yield* body(path.join(root, "buckets"), source);
+    })).pipe(Effect.provide(layer)) as Effect.Effect<A>);
+
+describe("blobName", () => {
+    test("keeps a plain session id and appends the extension", () => {
+        expect(blobName("019a3f10-8c22-7000-9000-abc", ".jsonl"))
+            .toBe("019a3f10-8c22-7000-9000-abc.jsonl");
+    });
+
+    test("collapses separators, so the name stays ONE path segment", () => {
+        // A name holding a `/` would make GC rebuild a pointer no reference set
+        // can match, and delete the file on its next global pass.
+        expect(blobName("session:../../etc/passwd", ".jsonl"))
+            .toBe("session_.._.._etc_passwd.jsonl");
+    });
+
+    test("an empty id still yields a usable name", () => {
+        expect(blobName("", ".jsonl")).toBe("unnamed.jsonl");
+    });
+});
+
+describe("putBlobFromFile", () => {
+    test("copies the source into the bucket and returns a well-formed pointer", async () => {
+        const result = await inTempDir((buckets, source) => Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const pointer = yield* putBlobFromFile(
+                buckets,
+                "transcripts",
+                "abc.jsonl",
+                source,
+                { maxBytes: 1024, sizeBytes: 14 },
+            );
+            const written = path.join(buckets, "transcripts", "abc.jsonl");
+            return {
+                pointer,
+                content: yield* fs.readFileString(written),
+                // The `.partial` staging file must never survive a good copy.
+                partial: yield* fs.exists(`${written}.partial`),
+            };
+        }));
+
+        expect(result.pointer).toBe("transcripts:/abc.jsonl");
+        expect(isBlobPointer(result.pointer ?? "")).toBe(true);
+        expect(result.content).toBe("line-1\nline-2\n");
+        expect(result.partial).toBe(false);
+    });
+
+    test("skips a source larger than maxBytes and writes nothing", async () => {
+        const result = await inTempDir((buckets, source) => Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const pointer = yield* putBlobFromFile(
+                buckets,
+                "transcripts",
+                "big.jsonl",
+                source,
+                { maxBytes: 4, sizeBytes: 14 },
+            );
+            return { pointer, bucketExists: yield* fs.exists(buckets) };
+        }));
+
+        expect(result.pointer).toBeNull();
+        expect(result.bucketExists).toBe(false);
+    });
+
+    test("maxBytes 0 disables snapshotting entirely", async () => {
+        const pointer = await inTempDir((buckets, source) =>
+            putBlobFromFile(buckets, "transcripts", "off.jsonl", source, {
+                maxBytes: 0,
+                sizeBytes: 1,
+            }),
+        );
+        expect(pointer).toBeNull();
+    });
+
+    test("stats the source when the caller does not know its size", async () => {
+        const pointer = await inTempDir((buckets, source) =>
+            putBlobFromFile(buckets, "transcripts", "stat.jsonl", source, { maxBytes: 4 }),
+        );
+        // 14 bytes on disk against a 4-byte cap - the cap must be applied to the
+        // stat'd size, not waved through as "caller said nothing".
+        expect(pointer).toBeNull();
+    });
+
+    test("a missing source is skipped, not fatal", async () => {
+        const pointer = await inTempDir((buckets, source) =>
+            putBlobFromFile(
+                buckets,
+                "transcripts",
+                "gone.jsonl",
+                `${source}.does-not-exist`,
+                { maxBytes: 1024, sizeBytes: 1 },
+            ),
+        );
+        expect(pointer).toBeNull();
+    });
+
+    test("a copy failure returns null and leaves no .partial behind", async () => {
+        const result = await inTempDir(
+            (buckets, source) => Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                const path = yield* Path.Path;
+                const pointer = yield* putBlobFromFile(
+                    buckets,
+                    "codex_artifacts",
+                    "fail.jsonl",
+                    source,
+                    { maxBytes: 1024, sizeBytes: 14 },
+                );
+                const dir = path.join(buckets, "codex_artifacts");
+                return {
+                    pointer,
+                    entries: yield* fs.readDirectory(dir),
+                };
+            }),
+            Layer.mergeAll(withFailingCopy(), BunPath.layer),
+        );
+
+        expect(result.pointer).toBeNull();
+        expect(result.entries).toEqual([]);
+    });
+});

--- a/packages/lib/src/blob-store.ts
+++ b/packages/lib/src/blob-store.ts
@@ -1,0 +1,97 @@
+import { Effect, FileSystem, Path } from "effect";
+import { filePointer } from "./blob-pointer.ts";
+
+/**
+ * Writing a raw transcript into a local file bucket, and getting back the
+ * `<bucket>:/<name>` pointer that `session.raw_file` is contracted to hold.
+ *
+ * v1 did this through SurrealDB's `putFile` bucket API. v2 has no database
+ * engine to ask, so the bucket is just a directory under the data dir and the
+ * copy is a filesystem copy. That is not a downgrade: nothing ever read a blob
+ * back THROUGH the engine (the pointer is a plain string by design - see
+ * blob-pointer.ts), so the engine was only ever a file writer with extra steps.
+ *
+ * Snapshots are COLD STORAGE and nothing in ax fails without them. Harnesses
+ * rotate and prune their own transcript directories, so the copy is the only
+ * durable record of a session's raw bytes once the source is gone. Every
+ * failure here is therefore best-effort: it logs and returns null, and the
+ * caller keeps whatever fallback it had.
+ */
+
+/**
+ * A blob's on-disk name must be one path segment: GC lists the bucket
+ * directory and rebuilds each pointer as `filePointer(bucket, entry)`, so a
+ * name holding a separator would produce a pointer no reference set can match
+ * and a file GC would delete on its next global pass.
+ */
+export const blobName = (sessionId: string, extension: string): string => {
+    const safe = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+    return `${safe === "" ? "unnamed" : safe}${extension}`;
+};
+
+export interface PutBlobOptions {
+    /**
+     * Skip the copy when the source is larger than this. 0 disables
+     * snapshotting entirely, which is how a user opts out of the disk cost.
+     */
+    readonly maxBytes: number;
+    /** Source size the caller already stat'd, to save a second stat. */
+    readonly sizeBytes?: number;
+}
+
+/**
+ * Copy `sourcePath` into `<bucketsDir>/<bucket>/<name>` and return its pointer,
+ * or null when the snapshot was skipped or failed.
+ *
+ * The copy lands on a `.partial` sibling first and is renamed into place, so a
+ * reader (or GC) never observes a half-written blob under its final name. A
+ * `.partial` left by a crashed run is not a blob GC candidate either: GC
+ * rebuilds pointers from directory entries, finds `.partial` unreferenced, and
+ * removes it once it is a day old.
+ */
+export const putBlobFromFile = Effect.fn("blobStore.putBlobFromFile")(function* (
+    bucketsDir: string,
+    bucket: string,
+    name: string,
+    sourcePath: string,
+    opts: PutBlobOptions,
+) {
+    if (opts.maxBytes <= 0) return null;
+
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const sizeBytes = opts.sizeBytes ?? (yield* fs.stat(sourcePath).pipe(
+        Effect.map((info) => Number(info.size)),
+        Effect.orElseSucceed(() => Number.POSITIVE_INFINITY),
+    ));
+    if (sizeBytes > opts.maxBytes) return null;
+
+    const dir = path.join(bucketsDir, bucket);
+    const target = path.join(dir, name);
+    const partial = `${target}.partial`;
+
+    const written = yield* Effect.gen(function* () {
+        yield* fs.makeDirectory(dir, { recursive: true });
+        yield* fs.copyFile(sourcePath, partial);
+        yield* fs.rename(partial, target);
+        return true;
+    }).pipe(
+        Effect.catchTag("PlatformError", (err) =>
+            Effect.gen(function* () {
+                yield* Effect.logDebug("blob snapshot failed", {
+                    bucket,
+                    name,
+                    source: sourcePath,
+                    message: err.message,
+                });
+                // Leave no half-copy behind under a name a later run would
+                // rename into place on top of.
+                yield* Effect.ignore(fs.remove(partial));
+                return false;
+            }),
+        ),
+    );
+
+    return written ? filePointer(bucket, name) : null;
+});

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -27,6 +27,9 @@ export interface AxConfigShape {
     };
     readonly knobs: {
         readonly claudeConcurrency: number;
+        /** cap (bytes) on a claude transcript ax snapshots into the
+         *  `transcripts` bucket; 0 disables the snapshot entirely */
+        readonly claudeRawMaxBytes: number;
         readonly codexConcurrency: number;
         readonly codexProgressEvery: number;
         readonly codexFlushEvery: number;
@@ -43,6 +46,7 @@ const HOME = homedir();
 
 const DEFAULTS = {
     claudeConcurrency: 4,
+    claudeRawMaxBytes: 5 * 1024 * 1024,
     codexConcurrency: 1,
     codexProgressEvery: 10,
     codexFlushEvery: 500,
@@ -162,6 +166,10 @@ const snapshotConfig: Effect.Effect<AxConfigShape, never, FileSystem.FileSystem>
                 codexFlushEvery: yield* positiveInt(
                     "AX_CODEX_FLUSH_EVERY",
                     DEFAULTS.codexFlushEvery,
+                ),
+                claudeRawMaxBytes: yield* nonNegativeInt(
+                    "AX_CLAUDE_RAW_MAX_BYTES",
+                    DEFAULTS.claudeRawMaxBytes,
                 ),
                 codexRawMaxBytes: yield* nonNegativeInt(
                     "AX_CODEX_RAW_MAX_BYTES",


### PR DESCRIPTION
Closes #854.

## The decision

#854 asked whether v2 should snapshot raw transcripts into the local buckets at
all — the code and its own comments disagreed, and the answer changes disk
footprint for every user. **Keep it.** Harnesses rotate and prune their own
transcript directories, so the copy is the only durable record of a session's
raw bytes once the source file is gone.

## What was broken

v1 copied each parsed transcript into a file bucket and stored a
`<bucket>:/<name>` pointer on `session.raw_file`. The copy went through
SurrealDB's `putFile`, so the v2 port dropped it in both parsers and left
`raw_file` holding the **source path** — under comments still describing a
snapshot. That is the reference-set shape that made blob GC read every blob as
unreferenced and delete a 1.9 GB store.

## What this does

- **`@ax/lib/blob-store`** does the copy on the filesystem, no database in the
  path: stage to a `.partial` sibling, `rename` into place, return the pointer.
  Every failure is best-effort — it logs, returns `null`, and removes the
  half-copy so a later run never renames on top of one.
- **Both parsers fall back to the source path** when the snapshot is skipped or
  fails, so `raw_file` still locates the transcript while the harness keeps it.
  That fallback is precisely why blob GC checks the reference set's *shape* and
  not just its size.
- **Claude gets the size cap codex already had**: `AX_CLAUDE_RAW_MAX_BYTES`,
  default 5 MB, `0` disables snapshotting entirely. v1 had **no** cap on the
  claude side — that is how the store reached 1.9 GB.
- **`toClaudeNormalizedBatch` now carries a top-level `rawFile`.** A second bug,
  found while verifying this one: the normalized session write resolves
  `raw_file` as `rawFile ?? sourcePath` and runs *after* the claude stage's own
  upsert, so an omitted `rawFile` silently replaced the pointer with the source
  path. Measured before the fix: 0 of 13 claude sessions kept a pointer while 9
  blobs sat on disk unreferenced. A regression test pins it.

## Verification

Local, no CI wait.

- Both typecheck gates clean (`bunx tsc --noEmit -p tsconfig.json` and
  `bun run typecheck`).
- Full suite: **6080 pass / 11 skip / 4 fail / 4 errors** in 111s. The base
  branch reads 6070 pass with the same 4 fail / 4 errors (electron install,
  db-down) — this adds 10 passing tests and no new failures.
- **End to end on the real machine.** Scoped `ingest --stages=claude,codex
  --since=1` into a temp `AX_DATA_DIR`:

  | | before | after |
  |---|---|---|
  | sessions with a pointer | 1 of 14 | 10 of 14 |
  | blobs on disk | 10 | 10 |
  | `.partial` leftovers | 0 | 0 |

  The 4 sessions that still store a path are all transcripts over the 5 MB cap
  (6.7 MB, 6.8 MB, 7.2 MB, 32.8 MB) — the designed skip.

## Known cost, stated plainly

Snapshotting reintroduces real disk use: v1's store reached 1.9 GB. The cap
bounds each file, not the total. The largest sessions are also the ones the cap
skips, so a user who wants those preserved must raise
`AX_CLAUDE_RAW_MAX_BYTES`, and a user who wants none of it sets it to `0`.

The blobs deleted by the GC bug are not recoverable from ax — only from
whatever source files still exist under `~/.claude` and `~/.codex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)