### PR TITLE
fix(install): make `curl | sh` work on Debian and Ubuntu (#797)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ verdicts. The next session reads what worked.
 ## 60 seconds in
 
 ```bash
-curl -fsSL ax.necmttn.com/install | sh
+curl -fsSL ax.necmttn.com/install | bash
 PATH="$HOME/.local/bin:$PATH" ax setup   # agent skills + first ingest + doctor
 ```
 
@@ -56,7 +56,7 @@ A note from Neco (ax's founder): ax is early and I'm hungry for feedback - every
 
 CONTRIBUTE-BACK (do this whenever a trigger below fires; never publish anything without showing it to me first and getting an explicit yes): Triggers - a step fails; a fact you report looks wrong or surprising to me; you spot a clear bug or improvement in ax itself. When one fires: ask me 2-3 sharp questions to pin down what I expected, which command/hook/agent is involved, and how often - enough for a repro. Then draft a GitHub issue for github.com/Necmttn/ax, show me the full draft, and on my yes file it via `gh` (the ax-repo skill). If a session is the evidence, run `ax share --dry-run` first, show me the redacted gist, and only publish with `ax share` on my yes - then link it in the issue.
 
-1. INSTALL - run `curl -fsSL ax.necmttn.com/install | sh` to install the ax CLI. Reference: https://ax.necmttn.com/docs
+1. INSTALL - run `curl -fsSL ax.necmttn.com/install | bash` to install the ax CLI. Reference: https://ax.necmttn.com/docs
 
 2. INGEST MY HISTORY - first run `ax ingest --dry-run` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run `ax ingest` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run `ax serve` and open http://127.0.0.1:1738. If it fails or lands zero data after finishing, that's a CONTRIBUTE-BACK trigger. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use.
 

--- a/apps/axctl/README.md
+++ b/apps/axctl/README.md
@@ -12,7 +12,7 @@ transcripts or code.
 ## Install
 
 ```bash
-curl -fsSL ax.necmttn.com/install | sh
+curl -fsSL ax.necmttn.com/install | bash
 PATH="$HOME/.local/bin:$PATH"
 ```
 

--- a/apps/site/app/components/how-sections/act-why.tsx
+++ b/apps/site/app/components/how-sections/act-why.tsx
@@ -5,7 +5,7 @@ import { Link } from "@tanstack/react-router";
 // receipt) and graph-not-vector. Ends with an install CTA + /routing + /features.
 // Never links the ADR index.
 
-const INSTALL_CMD = "curl -fsSL ax.necmttn.com/install | sh";
+const INSTALL_CMD = "curl -fsSL ax.necmttn.com/install | bash";
 
 export function ActWhy() {
   return (

--- a/apps/studio/src/Shell.tsx
+++ b/apps/studio/src/Shell.tsx
@@ -93,7 +93,7 @@ function ShareChrome({ children }: { children: ReactNode }) {
                 <p className="share-footer-copy">
                     Trace your own agent sessions - every turn, tool call, and dollar, on your machine.
                 </p>
-                <code className="share-footer-install">curl -fsSL https://ax.necmttn.com/install | sh</code>
+                <code className="share-footer-install">curl -fsSL https://ax.necmttn.com/install | bash</code>
                 <a
                     className="share-footer-link"
                     href="https://ax.necmttn.com"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,43 @@
 #!/usr/bin/env bash
+# --- POSIX preamble: everything above the `set` line must parse under dash. ---
+#
+# The documented command is `curl ... | bash`, but `| sh` is what people have in
+# their scrollback and in older copies of the README. On Debian and Ubuntu
+# `/bin/sh` is dash, which rejects `set -o pipefail` on the very next line and
+# aborts before the banner ever prints (#797). macOS hides this: its `/bin/sh`
+# is bash in POSIX mode and accepts pipefail.
+#
+# dash reads a piped script incrementally, so an early `exec`/`exit` here is
+# reached before it ever parses the `[[ ]]` and `local` below - verified against
+# /bin/dash with the body intact. Re-exec under bash when we can; otherwise say
+# exactly what to run instead of failing on a shell builtin.
+if [ -z "${BASH_VERSION:-}" ]; then
+  # Running as `sh install.sh`: the script is a real file, so just re-run it.
+  # `$0` is the SHELL BINARY when the script arrives on stdin (`/bin/dash` is
+  # itself a readable file), so a bare `-f` test would `exec bash /bin/dash`.
+  # Read the first line instead and require a shebang - a shell binary starts
+  # with its object-format magic, never `#!`.
+  _ax_head=""
+  if [ -f "$0" ]; then
+    IFS= read -r _ax_head < "$0" 2>/dev/null || _ax_head=""
+  fi
+  case "$_ax_head" in
+    "#!"*) exec bash "$0" "$@" ;;
+  esac
+  # Piped on stdin: the text is already half-consumed and cannot be handed to
+  # bash, so fetch it again. Only the shell changes; the same URL is used.
+  _ax_url="${AXCTL_INSTALL_URL:-https://ax.necmttn.com/install}"
+  if command -v bash >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
+    # pipefail matters here: without it a failed fetch pipes nothing into bash
+    # and the installer "succeeds" with exit 0 having installed nothing.
+    exec bash -c 'set -o pipefail; curl -fsSL "$1" | bash -s -- "${@:2}"' _ "$_ax_url" "$@"
+  fi
+  echo "ax installer: this script needs bash, and this shell is not bash." >&2
+  echo "Run:  curl -fsSL ${_ax_url} | bash" >&2
+  exit 1
+fi
+# --- end POSIX preamble ---
+
 set -euo pipefail
 
 REPO="${AXCTL_REPO:-Necmttn/ax}"

--- a/packages/onboarding-prompt/src/index.ts
+++ b/packages/onboarding-prompt/src/index.ts
@@ -19,7 +19,7 @@ export const DASHBOARD_PORT = 1738;
 
 /** Install one-liner + docs. Single-sourced here for the INSTALL step and for
  *  any surface that wants to show the install command, so it can't drift. */
-export const AX_INSTALL_CMD = "curl -fsSL ax.necmttn.com/install | sh";
+export const AX_INSTALL_CMD = "curl -fsSL ax.necmttn.com/install | bash";
 export const AX_DOCS_URL = "https://ax.necmttn.com/docs";
 
 const HEADER =


### PR DESCRIPTION
Closes #797.

`curl -fsSL ax.necmttn.com/install | sh` aborts on any system where `/bin/sh`
is dash — the default on Debian and Ubuntu. Line 2 is `set -euo pipefail`, and
dash rejects `pipefail`:

```
$ curl -fsSL ax.necmttn.com/install | sh
sh: 2: set: Illegal option -o pipefail
```

Nothing installs, and the banner never prints so the failure reads as noise.
macOS hides it: its `/bin/sh` is bash in POSIX mode and accepts `pipefail`.

## Why not port the script to POSIX

The body is thoroughly bash — `[[ ]]`, `local`, arrays, across 402 lines. A
port is a rewrite of the one script whose failure mode is "the user has no ax",
and it would be verified only on the machine that already worked.

## What this does instead

The file opens with a preamble that dash can parse, before the first bashism:

- **`sh install.sh`** — the script is a real file, so re-exec it under bash.
- **Piped on stdin** — the text is already half-consumed and cannot be handed
  to bash, so re-fetch the same URL and run that under bash. `pipefail` is set
  inside that shell; without it a failed fetch pipes nothing into bash and the
  installer "succeeds" with exit 0 having installed nothing.
- **No bash at all** — print the exact command to run, rather than failing on a
  shell builtin.

One trap worth naming: `$0` is the **shell binary** when the script arrives on
stdin (`/bin/dash` is itself a readable file), so a bare `[ -f "$0" ]` test
execs `bash /bin/dash` → `cannot execute binary file`. The file case reads the
first line and requires a shebang instead.

## Verification

Against the real `/bin/dash`, with the bash body intact — dash reads a piped
script incrementally and reaches the preamble's `exec` before parsing any
`[[ ]]` below it.

| path | result |
| --- | --- |
| `curl … \| dash` against a live URL | banner prints, install proceeds |
| `curl … \| dash` against a dead URL | exit 7, not a silent 0 |
| `dash install.sh --help` | help prints (re-exec via file) |
| `bash install.sh --help` | unchanged |

Docs now say `\| bash`, which skips the extra fetch: README, `apps/axctl/README`,
the studio share footer, the site's install block, and the single-source
`AX_INSTALL_CMD` in `@ax/onboarding-prompt` (its tests pass). `\| sh` keeps
working for every copy already in someone's scrollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)