### PR TITLE
fix(ingest): a forked codex rollout took the fork source's identity (#796)

### DIFF
--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -91,6 +91,52 @@ describe("Codex transcript extraction", () => {
         expect(compacted.outputExcerpt).toBe("hello");
     });
 
+    test("a forked/subagent rollout keeps its OWN id, not the fork source's (#796)", () => {
+        // Codex writes TWO adjacent session_meta records for a forked or
+        // subagent thread: the file's own first, then the fork source's as a
+        // header. Taking the second gave the file the ancestor's identity, so
+        // the file's session was never written and its turns collided with the
+        // ancestor's own file on turnRecordKey(session, seq).
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-14T15:28:13.994Z",
+                payload: {
+                    id: "child-thread",
+                    forked_from_id: "parent-thread",
+                    thread_source: "subagent",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-14T15:28:13.905Z",
+                    source: { subagent: { thread_spawn: { parent_thread_id: "parent-thread" } } },
+                },
+            }),
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-14T15:28:13.996Z",
+                payload: {
+                    id: "parent-thread",
+                    thread_source: "user",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-14T14:34:35.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-14T15:28:20.000Z",
+                payload: { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+            }),
+        ]);
+
+        expect(extracted?.session.id).toBe("child-thread");
+        expect(extracted?.session.thread_source).toBe("subagent");
+        // Lineage survives even though the top-level field is absent here -
+        // it is read from the nested thread_spawn / forked_from_id fallbacks.
+        expect(extracted?.session.parent_thread_id).toBe("parent-thread");
+        // `every` on an empty array is vacuously true, so pin the count first.
+        expect(extracted?.turns.length).toBeGreaterThan(0);
+        expect(extracted?.turns.every((turn) => turn.session === "child-thread")).toBe(true);
+    });
+
     test("extracts turn_context model and token_count usage rollup", () => {
         const extracted = __testExtractCodexJsonlLines([
             JSON.stringify({

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -482,6 +482,25 @@ interface MutableCodexExtract {
     tokenUsage: CodexTokenUsage | null;
 }
 
+/**
+ * The thread this session was spawned from, across the three shapes codex has
+ * written it in. The top-level `parent_thread_id` covers most files; a subagent
+ * meta also nests it under `source.subagent.thread_spawn`, and `forked_from_id`
+ * carries the same value. Measured over the 529 files affected by #796 on one
+ * machine: top-level 519, nested 529, `forked_from_id` 529, and the nested and
+ * forked values agreed in all 529 - so the fallbacks recover the 10 that the
+ * top-level read alone dropped.
+ */
+function codexParentThreadId(payload: Record<string, unknown>): string | null {
+    const top = stringField(payload, "parent_thread_id");
+    if (top !== null) return top;
+    const source = isRecord(payload.source) ? payload.source : null;
+    const subagent = source && isRecord(source.subagent) ? source.subagent : null;
+    const spawn = subagent && isRecord(subagent.thread_spawn) ? subagent.thread_spawn : null;
+    const nested = spawn ? stringField(spawn, "parent_thread_id") : null;
+    return nested ?? stringField(payload, "forked_from_id");
+}
+
 function createCodexExtractor(
     filePath: string,
     payloadMaxBytes = DEFAULT_CODEX_PAYLOAD_MAX_BYTES,
@@ -835,6 +854,20 @@ function createCodexExtractor(
             }
 
             if (type === "session_meta" && payload) {
+                // A rollout file for a FORKED or SUBAGENT thread carries TWO
+                // adjacent `session_meta` records: its own first, then the
+                // FORK SOURCE's as a header. Reassigning on the second one
+                // gave the file the ancestor's identity, so the file's real
+                // session was never written and every record in it landed on
+                // the ancestor's id, colliding with that ancestor's own file
+                // on `turnRecordKey(session, seq)`.
+                //
+                // The file's own meta is always first: measured across 529
+                // affected files on one machine, the first meta's `id` equals
+                // the filename's uuid in 529 of 529, and 300 sampled
+                // correctly-ingested files carry exactly one meta - so this
+                // guard cannot disturb the working population. (#796)
+                if (session) return;
                 const rawPayloadTimestamp = stringField(payload, "timestamp");
                 const payloadTimestamp = validIsoTimestamp(rawPayloadTimestamp);
                 if (rawPayloadTimestamp !== null && !payloadTimestamp) {
@@ -850,7 +883,7 @@ function createCodexExtractor(
                     model: stringField(payload, "model"),
                     reasoning_effort: null,
                     thread_source: stringField(payload, "thread_source"),
-                    parent_thread_id: stringField(payload, "parent_thread_id"),
+                    parent_thread_id: codexParentThreadId(payload),
                     started_at: startedAt,
                     ended_at: endedAt,
                 };


### PR DESCRIPTION
Backport of #860 to `main`, so the next v1 release carries it rather than
making the reporter wait for v2.

Codex writes **two adjacent `session_meta` records** for a forked or subagent
thread — the file's own first, then the fork source's as a header:

```
line 1  session_meta  id=019e271a…  thread_source=subagent  forked_from_id=019e2531…
line 2  session_meta  id=019e2531…  thread_source=user
line 3+ …596 records, all belonging to the child…
```

The extractor reassigned `session` on every one, so the second won. The file's
own session was never written, its records landed on the **ancestor's** id
(colliding with that ancestor's own file on `turnRecordKey(session, seq)`), and
the watermark recorded the file as done — so `--dry-run` counts it as
un-ingested forever and every later run is an exact no-op. That is the
reporter's "residue is inert and grows".

| | |
| --- | --- |
| codex `.jsonl` on disk | 3,184 |
| `ingest_file_state` rows | 3,184 |
| sessions in the graph | 2,655 |
| **gap** | **529** |

All 529 have ≥ 2 `session_meta`, all are `thread_source: "subagent"`, and the
first meta's id equals the filename's uuid in **529 of 529**. 300 sampled
correctly-ingested files carry exactly one meta, so locking to the first meta
cannot disturb the working population.

Lineage now also reads the nested `source.subagent.thread_spawn` and
`forked_from_id` when the top-level `parent_thread_id` is absent — of the same
529, top-level covered 519 and the fallbacks covered all 529, agreeing with
each other in all 529.

Verified on the v2 branch end to end against a real affected file: before, one
session under the ancestor's id holding the child's 100 turns; after, the
child's own id with source `codex-subagent` holding them. Both typecheck gates
clean here; `codex.test.ts` passes with the new regression test.

**Existing stores need `ax ingest --reparse=codex`** — the watermark already
calls these files done.

Note: #796 also reports 31 claude and 70 pi sessions in the residue. That half
is not reproduced here and is not claimed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)