### PR TITLE
fix(api): a wrong request now says so - 404 for unknown paths, a body on a 400 (#855)

### DIFF
--- a/apps/axctl/src/dashboard/contract/sessions.test.ts
+++ b/apps/axctl/src/dashboard/contract/sessions.test.ts
@@ -114,6 +114,21 @@ describe("sessions handlers - missing required query param", () => {
         // id is required in the contract schema - HttpApi should reject with 400
         expect(res.status).toBe(400);
     });
+
+    test("a validation 400 carries a body naming the request and the contract surfaces", async () => {
+        // `HttpApiSchemaError` documents itself as responding with an EMPTY 400.
+        // Zero bytes reads as a broken server, and the primary consumer of this
+        // API is an agent that has to self-correct from the response alone
+        // (#855).
+        const { handler } = make();
+        const res = await handler(get("/api/session-orchestration"));
+        expect(res.status).toBe(400);
+        const body = await res.json() as Record<string, unknown>;
+        expect(body.error).toBe("bad_request");
+        expect(body.message).toContain("GET /api/session-orchestration");
+        expect(body.docs).toBe("http://127.0.0.1:1738/docs");
+        expect(body.openapi).toBe("http://127.0.0.1:1738/openapi.json");
+    });
 });
 
 describe("sessions handlers - basic responses", () => {

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -212,7 +212,7 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
         handler: async (request) => {
             const active = current;
             try {
-                return await active.handler(request);
+                return await withBodyOnValidationFailure(await active.handler(request), request);
             } catch (err) {
                 if (current === active) {
                     current = build();
@@ -224,3 +224,38 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
         dispose: () => current.dispose(),
     };
 }
+
+/**
+ * Give a request-validation failure a body.
+ *
+ * `HttpApiSchemaError` - what a params/headers/query/payload decode failure is
+ * wrapped in - documents itself as responding "as an empty `400 Bad Request`".
+ * Zero bytes is indistinguishable from a broken server, and the primary
+ * consumer of this API is an agent that has to self-correct from the response
+ * alone. One reader lost most of a day to it, reporting a healthy route as dead
+ * because their own probe omitted a required parameter (#855).
+ *
+ * The error's `kind` and `cause` are not reachable from out here, so this does
+ * not name the offending field; it names the request and points at the two
+ * surfaces this same daemon serves that DO describe the contract. A 400 that
+ * already carries a body is passed through untouched, so a handler that
+ * explains itself keeps its own words.
+ */
+const withBodyOnValidationFailure = async (
+    response: Response,
+    request: Request,
+): Promise<Response> => {
+    if (response.status !== 400) return response;
+    // The empty respondable carries NO headers at all - not even
+    // `content-length: 0` - so emptiness has to be read off the body itself.
+    // Cloning a 400 is cheap, and a 400 that already carries a body returns
+    // here untouched.
+    if ((await response.clone().text()) !== "") return response;
+    const url = new URL(request.url);
+    return jsonResponse({
+        error: "bad_request",
+        message: `${request.method} ${url.pathname} failed request validation - a parameter, header, or body did not match the endpoint's schema.`,
+        docs: `${url.origin}/docs`,
+        openapi: `${url.origin}/openapi.json`,
+    }, 400);
+};

--- a/apps/axctl/src/dashboard/router/routes/live.test.ts
+++ b/apps/axctl/src/dashboard/router/routes/live.test.ts
@@ -214,34 +214,34 @@ describe("dashboard live routes", () => {
         expect(text).toContain("db down");
     });
 
-    test("POST /api/image falls through to legacy API not_found", async () => {
+    test("POST /api/image falls through to the legacy API 404", async () => {
         const { handleDashboardRequest } = await import("../../server.ts");
         const res = await handleDashboardRequest(
             new Request("http://127.0.0.1:1738/api/image", { method: "POST" }),
         );
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ error: "not_found" });
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "not_found", path: "/api/image" });
     });
 
-    test("GET /api/ingest falls through to legacy API not_found", async () => {
+    test("GET /api/ingest falls through to the legacy API 404", async () => {
         const { handleDashboardRequest } = await import("../../server.ts");
         const res = await handleDashboardRequest(
             new Request("http://127.0.0.1:1738/api/ingest"),
         );
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ error: "not_found" });
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "not_found", path: "/api/ingest" });
     });
 
     test("POST /api/ingest without a booted server falls through to not_found", async () => {
         // The in-browser ingest trigger was retired in studio ephemeral
         // (wave 3) - it is neither a contract route nor a legacy table row
         // anymore, so any request to it (booted server or not) answers the
-        // /api/* not_found quirk.
+        // /api/* 404.
         const { handleDashboardRequest } = await import("../../server.ts");
         const res = await handleDashboardRequest(
             new Request("http://127.0.0.1:1738/api/ingest", { method: "POST", body: "{}" }),
         );
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ error: "not_found" });
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "not_found", path: "/api/ingest" });
     });
 });

--- a/apps/axctl/src/dashboard/server.test.ts
+++ b/apps/axctl/src/dashboard/server.test.ts
@@ -156,10 +156,16 @@ describe("dashboard server", () => {
         expect(body.capabilities).toContain("sessions");
     });
 
-    test("unknown /api/* path preserves the legacy 200 not_found quirk", async () => {
+    test("unknown /api/* path is a 404 that names the path", async () => {
+        // Was a 200 carrying `{"error":"not_found"}` - read as success by every
+        // client, cache and uptime check, and indistinguishable from a route
+        // that answers with an error body (#855).
         const res = await handleDashboardRequest(new Request("http://127.0.0.1:1738/api/definitely-not-a-route"));
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ error: "not_found" });
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({
+            error: "not_found",
+            path: "/api/definitely-not-a-route",
+        });
     });
 
     // GET / serves the studio SPA (embedded or on-disk) or, failing that, the

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -43,7 +43,15 @@ export async function handleDashboardRequest(
     }
     const routed = await dispatch(routeTable, req, url, runner, serve);
     if (routed !== null) return routed;
-    if (url.pathname.startsWith("/api/")) return jsonResponse({ error: "not_found" });
+    // 404, not the legacy 200. A 200 body saying `not_found` is read as success
+    // by every HTTP client, cache, retry policy and uptime check, and it makes a
+    // caller's typo indistinguishable from a route that answers with an error.
+    // One reader spent part of a day treating an unregistered path as "a
+    // specially retired endpoint that answers with a plausible error body" and
+    // filed it as such (#855).
+    if (url.pathname.startsWith("/api/")) {
+        return jsonResponse({ error: "not_found", path: url.pathname }, 404);
+    }
     if (req.method === "GET") {
         // Studio is served by this process itself, same-origin, so the SPA fetches
         // /api/* from the same host:port with no mixed-content / Private Network


### PR DESCRIPTION
Closes #855.

Both defects made a caller's own mistake indistinguishable from a broken
server. The primary consumer of this API is an agent that has to self-correct
from the response alone, and neither response gave it anything to work with.

## 1. Unknown `/api/*` returned 200

```
GET /api/totally-made-up   200  {"error":"not_found"}
```

Every HTTP client, cache, retry policy and uptime check reads 200 as success.
The issue's author spent part of a day treating an unregistered path as "a
specially retired endpoint that answers with a plausible error body" and wrote
that into a ticket.

Now:

```
GET /api/totally-made-up   404  {"error":"not_found","path":"/api/totally-made-up"}
```

`server.test.ts` pinned the old behaviour explicitly ("preserves the legacy 200
not_found quirk"); it now asserts the 404. Three tests in
`router/routes/live.test.ts` asserted the same 200 for retired routes
(`/api/image`, `GET|POST /api/ingest`) and are updated with it. No runtime
consumer read the 200 — checked across `apps/studio` and `apps/axctl`.

## 2. A validation failure returned 400 with zero bytes

```
GET /api/session-orchestration    400   0B
```

This is `HttpApiSchemaError`, which documents itself as responding "as an empty
`400 Bad Request`". Two things worth recording for whoever touches this next:

- It carries **no headers at all** — not even `content-length: 0` — so
  emptiness has to be read off the body, not the header. My first attempt
  guarded on `content-length === "0"` and never fired.
- Its `kind` (`Params`/`Headers`/`Query`/`Payload`) and `cause` are not
  reachable from the web-handler seam, so this does **not** name the offending
  field. Doing that needs router middleware against a beta API, and the issue
  explicitly asked not to guess at it.

What it does instead is name the request and point at the two contract surfaces
this same daemon already serves:

```json
{
  "error": "bad_request",
  "message": "GET /api/session-orchestration failed request validation - a parameter, header, or body did not match the endpoint's schema.",
  "docs": "http://127.0.0.1:1738/docs",
  "openapi": "http://127.0.0.1:1738/openapi.json"
}
```

A 400 that already carries a body passes through untouched, so a handler that
explains itself keeps its own words.

## Verification

6,082 pass / 11 skip / 4 fail / 4 errors in 113s — base branch is 6,081 with
the same 4 fail / 4 errors. Both typecheck gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)