### PR TITLE
test: a skipped test now names itself and its missing precondition (#847)

### DIFF
--- a/apps/axctl/src/cli/commands/dojo.test.ts
+++ b/apps/axctl/src/cli/commands/dojo.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
 import {
     isValidKind,
     localDate,
@@ -330,9 +331,10 @@ describe("spar-score skill-spar brief dispatch (pure)", () => {
 // ---------------------------------------------------------------------------
 
 const LIVE_SMOKE = process.env["AX_LIVE_SMOKE"] === "1";
+const liveTest = gatedTest({ reason: "AX_LIVE_SMOKE=1 is not set", when: !LIVE_SMOKE });
 
 describe("spar-plan --skill live smoke", () => {
-    test.skipIf(!LIVE_SMOKE)(
+    liveTest(
         "writes a skill brief that round-trips through parseSkillSparBrief",
         () => {
             // Use 'caveman' as a well-known skill - it is installed in .ax/skills.

--- a/apps/axctl/src/cli/lint.test.ts
+++ b/apps/axctl/src/cli/lint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -23,7 +24,8 @@ describe("axctl improve lint", () => {
     // repo's opt-in for that class of test; it no longer implies a running
     // server, because none exists to run.
     const e2eEnabled = process.env.AX_E2E_DB === "1";
-    test.skipIf(!e2eEnabled)("clean run on an empty dir exits 0", () => {
+    const e2eTest = gatedTest({ reason: "AX_E2E_DB=1 is not set", when: !e2eEnabled });
+    e2eTest("clean run on an empty dir exits 0", () => {
         const root = mkdtempSync(join(tmpdir(), "ax-cli-lint-"));
         writeFileSync(join(root, "CLAUDE.md"), "no markers");
         // cwd-independent: `src/cli/index.ts` resolves only from apps/axctl, and

--- a/apps/axctl/src/hooks/sdk-cli.e2e.test.ts
+++ b/apps/axctl/src/hooks/sdk-cli.e2e.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -21,12 +22,13 @@ const AXCTL_DIR = join(import.meta.dir, "..", "..");
 const CLI_ENTRY = join(AXCTL_DIR, "src", "cli", "index.ts");
 
 const e2eDb = process.env.AX_E2E_DB === "1";
+const dbTest = gatedTest({ reason: "AX_E2E_DB=1 is not set", when: !e2eDb });
 
 const runCli = (...args: string[]) =>
     spawnSync("bun", [CLI_ENTRY, ...args], { encoding: "utf-8", cwd: AXCTL_DIR });
 
 describe("ax hooks install (issue #564 - file-not-found)", () => {
-    test.skipIf(!e2eDb)(
+    dbTest(
         "missing file exits non-zero with a clear 'file not found' (not the $bunfs import noise)",
         () => {
             const missing = join(mkdtempSync(join(tmpdir(), "ax-hook-e2e-")), "missing.ts");
@@ -54,6 +56,12 @@ describe("ax hooks install (issue #564 - file-not-found)", () => {
 describe("ax hooks init/install on a compiled binary (issue #573)", () => {
     const compiledBin = process.env.AX_E2E_COMPILED_BIN;
     const enabled = !!compiledBin && e2eDb;
+    const compiledTest = gatedTest({
+        reason: compiledBin
+            ? "AX_E2E_DB=1 is not set"
+            : "no compiled axctl binary on disk (run `bun run build`)",
+        when: !enabled,
+    });
 
     const runBin = (home: string, ...args: string[]) =>
         spawnSync(compiledBin!, args, {
@@ -68,7 +76,7 @@ describe("ax hooks init/install on a compiled binary (issue #573)", () => {
         return home;
     };
 
-    test.skipIf(!enabled)("init writes standalone bundled .js hooks and exits 0", () => {
+    compiledTest("init writes standalone bundled .js hooks and exits 0", () => {
         const home = mkdtempSync(join(tmpdir(), "ax-bin-home-"));
         const cli = runBin(home, "hooks", "init");
         expect(cli.status).toBe(0);
@@ -82,7 +90,7 @@ describe("ax hooks init/install on a compiled binary (issue #573)", () => {
         expect(readFileSync(rd, "utf8")).not.toContain('from "@ax/hooks-sdk');
     });
 
-    test.skipIf(!enabled)("a written hook fires standalone via bun (offline, exit 0)", () => {
+    compiledTest("a written hook fires standalone via bun (offline, exit 0)", () => {
         const home = initHome();
         const rd = join(home, ".ax/hooks/route-dispatch.js");
         const fired = spawnSync("bun", [rd], {
@@ -94,7 +102,7 @@ describe("ax hooks init/install on a compiled binary (issue #573)", () => {
         expect(fired.status).toBe(0);
     });
 
-    test.skipIf(!enabled)("install registers a bundled hook (binary imports the .js for meta)", () => {
+    compiledTest("install registers a bundled hook (binary imports the .js for meta)", () => {
         const home = initHome();
         const rd = join(home, ".ax/hooks/route-dispatch.js");
         const cli = runBin(home, "hooks", "install", rd, "--providers=claude");

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,7 @@
     "./sqlite": "./src/sqlite/index.ts",
     "./duckdb/internal": "./src/duckdb/internal.ts",
     "./testing/duckdb-dylib": "./src/testing/duckdb-dylib.ts",
+    "./testing/gated-test": "./src/testing/gated-test.ts",
     "./testing/cache": "./src/testing/cache.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",
     "./*": {

--- a/packages/lib/src/testing/gated-test.test.ts
+++ b/packages/lib/src/testing/gated-test.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { gateDecision, REQUIRE_PRECONDITIONS_ENV } from "./gated-test.ts";
+
+// The registration path cannot be unit-tested - bun forbids registering a test
+// from inside a running one - so the decision is a pure function and this
+// asserts that instead.
+describe("gateDecision", () => {
+    test("runs when the precondition is present", () => {
+        expect(gateDecision("t", { reason: "unused", when: false }, false))
+            .toEqual({ mode: "run" });
+    });
+
+    test("a skip announcement names BOTH the test and the reason", () => {
+        // Naming only one of them is what made the original drift unprovable:
+        // a count with no names, or a reason with no test (#847).
+        const decision = gateDecision("installs a hook", { reason: "AX_E2E_DB=1 is not set", when: true }, false);
+        expect(decision.mode).toBe("skip");
+        expect(decision).toEqual({
+            mode: "skip",
+            announcement: "test skipped: installs a hook - AX_E2E_DB=1 is not set",
+        });
+    });
+
+    test("the require flag turns the same gate into a failure that says how to fix it", () => {
+        const decision = gateDecision("installs a hook", { reason: "AX_E2E_DB=1 is not set", when: true }, true);
+        expect(decision.mode).toBe("fail");
+        if (decision.mode !== "fail") throw new Error("unreachable");
+        expect(decision.message).toContain("precondition missing: AX_E2E_DB=1 is not set");
+        expect(decision.message).toContain(REQUIRE_PRECONDITIONS_ENV);
+    });
+
+    test("names the env var that turns a skip into a failure", () => {
+        // Pinned as a value, not prose: the CI workflow and the docs both have
+        // to spell it identically.
+        expect(REQUIRE_PRECONDITIONS_ENV).toBe("AX_TEST_REQUIRE_PRECONDITIONS");
+    });
+});

--- a/packages/lib/src/testing/gated-test.ts
+++ b/packages/lib/src/testing/gated-test.ts
@@ -1,0 +1,92 @@
+import { test } from "bun:test";
+
+/**
+ * A `test` that skips ONLY when a named precondition is absent, and says so.
+ *
+ * `bun test` prints a skip COUNT with no names, so a run that quietly loses
+ * coverage still reads as "the same pre-existing failures". Four runs on four
+ * branches of the v2 sweep each reported 11 skips against a baseline of 7, and
+ * three separate agents each noticed the drift, each decided it was benign, and
+ * none could prove it - because nothing named the four tests that had converted
+ * from pass to skip (#847).
+ *
+ * A skip that depends on ambient state has to say so out loud:
+ *
+ * ```ts
+ * const dbTest = gatedTest({ reason: "AX_E2E_DB=1 is not set", when: !e2eDb });
+ * dbTest("installs a hook end to end", () => { ... });
+ * ```
+ *
+ * On a run where the precondition is present this is exactly `test`. Where it
+ * is absent, the test is skipped AND a `test skipped:` line names the test and
+ * the reason, so the reason appears in the same output as the count.
+ */
+export interface GatedTestOptions {
+    /** Why the test cannot run - phrased as the MISSING thing, e.g.
+     *  `"AX_DUCKDB_DYLIB is not set"`. It is printed verbatim. */
+    readonly reason: string;
+    /** True when the precondition is ABSENT and the test must be skipped. */
+    readonly when: boolean;
+}
+
+/**
+ * Set in CI to turn every gated skip into a hard failure.
+ *
+ * A skip is acceptable on a laptop that has no DuckDB dylib; it is not
+ * acceptable on a gate that is supposed to prove the code works. With this set,
+ * a missing precondition fails loudly at the site instead of subtracting one
+ * from a count nobody reads.
+ */
+export const REQUIRE_PRECONDITIONS_ENV = "AX_TEST_REQUIRE_PRECONDITIONS";
+
+/** Every reason a test was skipped this run, in declaration order. Exported so
+ *  a reporter (or a test of this helper) can assert on it. */
+export const skippedPreconditions: Array<{ name: string; reason: string }> = [];
+
+/** What a gate decides, separated from the act of registering a test so it can
+ *  be asserted directly - bun forbids registering a test from inside a running
+ *  one, so the registration path itself is not unit-testable. */
+export type GateDecision =
+    | { readonly mode: "run" }
+    | { readonly mode: "skip"; readonly announcement: string }
+    | { readonly mode: "fail"; readonly message: string };
+
+export const gateDecision = (
+    name: string,
+    opts: GatedTestOptions,
+    requirePreconditions: boolean,
+): GateDecision => {
+    if (!opts.when) return { mode: "run" };
+    if (requirePreconditions) {
+        return {
+            mode: "fail",
+            message: `precondition missing: ${opts.reason}. ` +
+                `${REQUIRE_PRECONDITIONS_ENV}=1 forbids skipping it here - ` +
+                "provide the precondition or unset that variable.",
+        };
+    }
+    return { mode: "skip", announcement: `test skipped: ${name} - ${opts.reason}` };
+};
+
+export const gatedTest = (opts: GatedTestOptions) =>
+    (name: string, fn: Parameters<typeof test>[1]): void => {
+        const decision = gateDecision(
+            name,
+            opts,
+            process.env[REQUIRE_PRECONDITIONS_ENV] === "1",
+        );
+        if (decision.mode === "run") {
+            test(name, fn);
+            return;
+        }
+        if (decision.mode === "fail") {
+            test(name, () => {
+                throw new Error(decision.message);
+            });
+            return;
+        }
+        skippedPreconditions.push({ name, reason: opts.reason });
+        // Named on stdout so the reason lands in the same output as the count.
+        console.log(decision.announcement);
+        test.skip(name, fn);
+    };

--- a/scripts/bench/run.test.ts
+++ b/scripts/bench/run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -96,8 +97,12 @@ describe("bench runner skip", () => {
 
 describe("bench runner suite", () => {
     const duckdb = resolveDuckdbBin();
+    const duckdbTest = gatedTest({
+        reason: "no duckdb binary resolvable (set AX_DUCKDB_BIN or put duckdb on PATH)",
+        when: !duckdb,
+    });
 
-    test.skipIf(!duckdb)("prints the metric table and exits 0 against the mini fixture", () => {
+    duckdbTest("prints the metric table and exits 0 against the mini fixture", () => {
         if (!duckdb) return;
         const fixture = mkdtempSync(join(tmpdir(), "ax-bench-mini-"));
         temps.push(fixture);
@@ -117,7 +122,7 @@ describe("bench runner suite", () => {
         expect(r.exitCode).toBe(0);
     }, 120_000);
 
-    test.skipIf(!duckdb)("exits non-zero when a target is tightened past the measured value", () => {
+    duckdbTest("exits non-zero when a target is tightened past the measured value", () => {
         if (!duckdb) return;
         const fixture = mkdtempSync(join(tmpdir(), "ax-bench-tight-"));
         temps.push(fixture);
@@ -132,7 +137,7 @@ describe("bench runner suite", () => {
         expect(r.out).toContain("BM25 top-20");
     }, 120_000);
 
-    test.skipIf(!duckdb)("rejects a fixture where every table is empty instead of silently passing", () => {
+    duckdbTest("rejects a fixture where every table is empty instead of silently passing", () => {
         if (!duckdb) return;
         const fixture = makeEmptyFixture();
         temps.push(fixture);

--- a/scripts/build-duckdb.test.ts
+++ b/scripts/build-duckdb.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
 import { spawnSync } from "node:child_process";
 import {
     accessSync,
@@ -12,6 +13,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+const binTest = gatedTest({
+    reason: "AX_DUCKDB_BIN is not set (no built duckdb binary to exercise)",
+    when: !process.env.AX_DUCKDB_BIN,
+});
+const dylibTest = gatedTest({
+    reason: "AX_DUCKDB_DYLIB is not set (no built libduckdb to exercise)",
+    when: !process.env.AX_DUCKDB_DYLIB,
+});
 
 const repoRoot = join(import.meta.dir, "..");
 
@@ -133,7 +143,7 @@ chmod +x "$2/build/release/duckdb"
     // needs to name a SPECIFIC just-built shell to smoke, not "find any
     // duckdb", so it reads the env var directly rather than through the
     // auto-preferring duckdbBinPath() resolver.
-    test.skipIf(!process.env.AX_DUCKDB_BIN)(
+    binTest(
         "the built shell completes the real air-gap FTS and JSON smoke test",
         () => {
             const result = spawnSync(
@@ -149,7 +159,7 @@ chmod +x "$2/build/release/duckdb"
         },
     );
 
-    test.skipIf(!process.env.AX_DUCKDB_DYLIB)(
+    dylibTest(
         "the emitted dynamic library completes the real air-gap FTS and JSON smoke test",
         () => {
             // Mirror build-duckdb.sh's smoke_duckdb_dylib: run against a


### PR DESCRIPTION
Closes #847 — and answers its open question with a measurement rather than a
guess.

## The problem

`bun test` prints a skip **count** with no names. A branch can lose four tests'
worth of coverage and still read as "the same 4 pre-existing failures". That is
exactly the shape that let three separate agents each notice the drift, each
decide it was benign, and each be unable to prove it.

## What this does

`gatedTest` (`@ax/lib/testing/gated-test`) replaces the six conditional
`test.skipIf` sites. When the precondition is present it is exactly `test`.
When it is absent:

```
test skipped: prints the metric table and exits 0 against the mini fixture - no duckdb binary resolvable (set AX_DUCKDB_BIN or put duckdb on PATH)
test skipped: install registers a bundled hook (binary imports the .js for meta) - no compiled axctl binary on disk (run `bun run build`)
test skipped: clean run on an empty dir exits 0 - AX_E2E_DB=1 is not set
```

The reason lands in the same output as the count. `AX_TEST_REQUIRE_PRECONDITIONS=1`
turns every such skip into a failure that says how to fix it, for gates that are
supposed to prove the code works.

The decision is a pure function (`gateDecision`) with its own tests — bun
forbids registering a test from inside a running one, so the registration path
itself is not unit-testable.

## The answer to the mystery

With the names visible, the four that flip are measured. Same worktree, same
env, only `dist/` differing:

| | skips |
| --- | --- |
| `dist/` present | **7** |
| `dist/` absent | **11** |

The four are the ones keyed on a resolvable duckdb **binary**, which
`bun run build` leaves in `dist/duckdb/`:

- 3 × `scripts/bench/run.test.ts`
- 1 × `packages/schema/src/duckdb-load.test.ts`

`AX_DUCKDB_DYLIB` — which every run in the issue's table set — covers the
**library**, not the shell. A worktree where someone had run a build ran them;
a fresh worktree skipped them. That is the whole difference between the
6,030/7 baseline and the 11s on the four PR branches.

**All 11 skips are now accounted for by name** (10 through `gatedTest`, the
11th through `duckdb-load.test.ts`'s own self-naming `test.skip`).

## Not done here

CI does not set `AX_TEST_REQUIRE_PRECONDITIONS=1` yet. The `verify` job does not
build `dist/axctl`, so three compiled-binary hook tests would fail rather than
skip. Provisioning that build is a separate change; the knob is ready for it.

## Verification

6,086 pass / 11 skip / 4 fail / 4 errors in 112s — base branch is 6,082 with
the same 4 fail / 4 errors (this adds the 4 `gateDecision` tests). Both
typecheck gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)