### PR TITLE
perf(ingest): AX_PIPELINE_CONCURRENCY, and what it proves about stage timings (#841)

### DIFF
--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@ax/lib/live-traces/Sink";
 import type { TraceEvent } from "@ax/lib/live-traces/types";
 import { LiveTrace } from "@ax/lib/live-traces/index";
-import { annotateStageProgress, deriveStageTimeoutSeconds, heartbeatSeconds, PIPELINE_CONCURRENCY, runPipeline as runPipelineWithWrite, stageFileFailureAnnotator, topoLayers } from "./runner.ts";
+import { annotateStageProgress, deriveStageTimeoutSeconds, heartbeatSeconds, PIPELINE_CONCURRENCY, pipelineConcurrency, runPipeline as runPipelineWithWrite, stageFileFailureAnnotator, topoLayers } from "./runner.ts";
 import { BaseStageStats, IngestContext, StageMeta, type StageDef } from "./types.ts";
 import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 
@@ -111,6 +111,22 @@ describe("runPipeline", () => {
     // runner must dispatch claude as soon as its deps complete, regardless of
     // any sibling dep-free stage still running. See ADR-0007 / commit bded64b
     // for the legacy `pipeline.ts` path this replaced.
+    it("AX_PIPELINE_CONCURRENCY overrides the default, and only when it is >= 1", () => {
+        // Serializing the pipeline is how a stage's wall time becomes its OWN
+        // cost: every DuckDB call is a synchronous bun:ffi call that blocks the
+        // event loop, so with stages interleaved a stage's measured seconds
+        // include time spent inside OTHER stages' calls. Measured: claude-config
+        // reported 637s in a concurrent warm pass and 0.5s running alone (#841).
+        expect(pipelineConcurrency({} as NodeJS.ProcessEnv)).toBe(PIPELINE_CONCURRENCY);
+        expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "1" } as NodeJS.ProcessEnv)).toBe(1);
+        expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "8" } as NodeJS.ProcessEnv)).toBe(8);
+        // A floor of 1: 0 would deadlock the semaphore, and a fraction or a
+        // typo must not silently halve the pipeline.
+        expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "0" } as NodeJS.ProcessEnv)).toBe(PIPELINE_CONCURRENCY);
+        expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "banana" } as NodeJS.ProcessEnv)).toBe(PIPELINE_CONCURRENCY);
+        expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "2.7" } as NodeJS.ProcessEnv)).toBe(2);
+    });
+
     it("does not let a dep-free long stage block downstream stages whose deps are met", async () => {
         // Implicit dependency: if the semaphore had only 1 permit, git would
         // hold it forever (parked on `released`) and claude could never run.

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -12,6 +12,22 @@ import type { BaseStageStats, IngestContext, StageDef } from "./types.ts";
  *  × internal fan-out is already heavy. */
 export const PIPELINE_CONCURRENCY = 4;
 
+/**
+ * Effective stage concurrency, with an `AX_PIPELINE_CONCURRENCY` override.
+ *
+ * Every DuckDB call is a SYNCHRONOUS `bun:ffi` call, so it blocks the whole
+ * event loop while it runs - no other fiber makes progress. With several stages
+ * interleaved, a stage's measured wall time therefore includes time the thread
+ * spent inside OTHER stages' calls, and per-stage seconds stop being a cost
+ * measure. Setting this to 1 serializes the pipeline so each stage's wall time
+ * IS its own cost, which is how the #841 warm-vs-cold table can be read
+ * honestly. 0 or an unparseable value keeps the default.
+ */
+export const pipelineConcurrency = (env: NodeJS.ProcessEnv = process.env): number => {
+    const raw = nonNegativeNumberEnv(env.AX_PIPELINE_CONCURRENCY, 0);
+    return raw >= 1 ? Math.floor(raw) : PIPELINE_CONCURRENCY;
+};
+
 /** How often the pipeline logs which stages are still running, so a hung or
  *  slow stage is attributable instead of looking like a silent stall (#671).
  *  Env override `AX_INGEST_HEARTBEAT_SECONDS`; 0 disables. Exported for tests. */
@@ -172,7 +188,7 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
         for (const s of stages) {
             deferreds.set(s.meta.key, yield* Deferred.make<S, E>());
         }
-        const sem = yield* Semaphore.make(PIPELINE_CONCURRENCY);
+        const sem = yield* Semaphore.make(pipelineConcurrency());
 
         // Stages currently executing (permit acquired, run not yet resolved). The
         // heartbeat reads this so a hang is attributable to a specific stage (#671).


### PR DESCRIPTION
Answers #841. Adds one env knob; the value is the measurement it made possible.

## The instrument was broken

`ingest_stage` records wall clock. Every DuckDB call goes through **synchronous
`bun:ffi`**, so it blocks the one JS thread while it runs. With
`PIPELINE_CONCURRENCY = 4`, a stage's start-to-end gap therefore includes every
other stage's turn — and which stages overlap it differs run to run.

`AX_PIPELINE_CONCURRENCY=1` serializes the pipeline, so each stage's wall clock
*is* its own cost. Default unchanged at 4; floor of 1; `0` or a typo keeps the
default. Unit-tested.

## Three warm passes, same real store (3,329 sessions), same `--since=3650`

| run | concurrency | wall | stage-seconds | ratio |
| --- | --- | --- | --- | --- |
| A | 4 | 896.9s | 2,683.6s | **2.99x** |
| B | 1 | 667.1s | 666.9s | **1.00x** |
| C | 4 | 635.0s | 2,384.1s | **3.75x** |

Serial sums to 1.00x. Concurrent claims three to nearly four times more seconds
than actually elapsed. You cannot spend 2,684 seconds inside 897.

## What that does to the issue's own table

| stage | serial (real) | concurrent A | concurrent C |
| --- | --- | --- | --- |
| `git` | **2.1s** | 634.3s | 371.6s |
| `claude-config` | **0.4s** | 380.2s | 358.9s |
| `proposals` | **0.7s** | 194.9s | 196.8s |
| `claude-sidecars` | **0.9s** | 53.8s | 37.2s |
| `session-health` | **26.8s** | 202.0s | 204.2s |
| `github-pr` | **21.8s** | 112.1s | 134.2s |
| `run-evidence` | **114.2s** | 108.8s | 110.7s |
| `outcomes` | **58.3s** | 58.3s | 65.5s |

The headline — "claude-config got 3.1x SLOWER warm" — is retracted by its own
data. That stage does **0.4 seconds** of work. `git`, called out at 945s cold
and 417s warm, does **2.1 seconds**.

**The issue's other finding stands, and is the real content:** `run-evidence`
and `outcomes` sit at ~1.0x. They have no incremental path at all, which is
precisely why theirs were the only honest numbers on the list.

## A stage is being killed for other stages' work

`claude` / `subagents`, same corpus, minutes apart:

| run | | |
| --- | --- | --- |
| B (serial) | `ok` | **2.1s** |
| A (concurrent) | `interrupted` | 302.0s |
| C (concurrent) | `interrupted` | 301.8s |

A stage that does two seconds of work trips a 300-second cap on every
concurrent run — which is every normal run, since 4 is the default. Its output
is dropped each time. That is #837's cap firing on a wall clock that is mostly
other stages, and it is live data loss rather than a theoretical concern.

By contrast `turn-content-blocks` is interrupted in **all three** runs and
measures **335.1s serially** — genuinely over the cap, correctly stopped.

## What I did not conclude

Serial finished 230s faster than run A on 79% less CPU, which looked like
concurrency costing a third of the runtime. It was not. Run B followed run A
and simply had less to do. Run C — concurrency 4 again, straight after the
serial pass — came in at **635.0s, faster than serial's 667.1s**. Concurrency
is fine for throughput and the default stays 4. Without that third pass this PR
would have reported a 34% win that does not exist.

## The durable fix, not in this PR

Record `self_ms` per stage — the summed duration of that stage's own DuckDB
calls — so the timings are honest without serializing. Filed separately with
the plumbing sketch, because it needs a schema column and a write-seam change.
`wall_ms - self_ms` is then the queueing, which is the number that actually
says whether concurrency is helping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)