### PR TITLE
feat(ingest): record each stage's OWN database time on ingest_stage (#865)

### DIFF
--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -17,6 +17,7 @@ import {
     writeIngestStageFinish,
     writeIngestStageStart,
 } from "./telemetry.ts";
+import { CurrentStageSelfTime, makeStageSelfTime } from "@ax/lib/duckdb/self-time";
 import { runPipeline } from "./stage/runner.ts";
 import { selectByKeys, selectByTag } from "./stage/select.ts";
 import { StageRegistry, type IngestStageError, type StageRegistryShape } from "./stage/registry.ts";
@@ -188,11 +189,14 @@ export const settleStage = (
     ledgerKey: { readonly runId: string; readonly source: string; readonly stage: string },
     eventName: { readonly source: string; readonly stage: string },
     exit: Exit.Exit<BaseStageStats, IngestStageError>,
+    /** The stage's own database time, from the accumulator `wrapStage` provided.
+     *  Omitted by callers that have none (tests crafting an `Exit` directly). */
+    selfMs?: number | null,
 ): Effect.Effect<void, CacheWriteError> => {
     if (Exit.isSuccess(exit)) {
         const counts = numericCounts(exit.value);
         return Effect.gen(function* () {
-            yield* writeIngestStageFinish(write, { ...ledgerKey, status: "ok", counts });
+            yield* writeIngestStageFinish(write, { ...ledgerKey, status: "ok", counts, selfMs });
             yield* writeIngestEvent(write, {
                 ...ledgerKey,
                 level: "info",
@@ -206,7 +210,7 @@ export const settleStage = (
     const cause = exit.cause;
     const settle = (status: "error" | "interrupted", message: string) =>
         Effect.gen(function* () {
-            yield* writeIngestStageFinish(write, { ...ledgerKey, status, errorText: message });
+            yield* writeIngestStageFinish(write, { ...ledgerKey, status, errorText: message, selfMs });
             yield* writeIngestEvent(write, {
                 ...ledgerKey,
                 level: "error",
@@ -241,8 +245,18 @@ const wrapStage = (
         run: (ctx: IngestContext, write: CacheWriteService) =>
             Effect.gen(function* () {
                 yield* writeIngestStageStart(write, ledgerKey);
-                return yield* Effect.onExit(stageDef.run(ctx, write), (exit) =>
-                    settleStage(write, ledgerKey, eventName, exit),
+                // One accumulator per stage, provided as a `Context.Reference`
+                // so the stage's internal fan-out (claude parses 8 files at a
+                // time) charges to the same total. Read on the exit path, after
+                // the body has finished adding to it.
+                const selfTime = makeStageSelfTime();
+                return yield* Effect.onExit(
+                    Effect.provideService(
+                        stageDef.run(ctx, write),
+                        CurrentStageSelfTime,
+                        selfTime,
+                    ),
+                    (exit) => settleStage(write, ledgerKey, eventName, exit, selfTime.ms),
                 );
             }),
     };

--- a/apps/axctl/src/ingest/telemetry.ts
+++ b/apps/axctl/src/ingest/telemetry.ts
@@ -190,22 +190,35 @@ export type IngestStageOutcome =
         readonly counts?: Record<string, number>;
     };
 
-/** Settle a stage row and bump the run heartbeat. */
+/**
+ * Settle a stage row and bump the run heartbeat.
+ *
+ * `self_ms` is the stage's OWN database time, and it is not a nicety: with the
+ * pipeline running 4 stages at once, `ended_at - started_at` is mostly other
+ * stages' work, because every DuckDB call is a synchronous `bun:ffi` call that
+ * blocks the one JS thread. Measured on a real store, `claude-config` read
+ * 0.4s serially against 380.2s concurrently (#841, #865). `null` means the
+ * caller had no accumulator - a runner-side settle for a stage that never ran.
+ */
 export const writeIngestStageFinish = (
     write: CacheWriteService,
     input: {
         readonly runId: string;
         readonly source: string;
         readonly stage: string;
+        readonly selfMs?: number | null | undefined;
     } & IngestStageOutcome,
 ): Effect.Effect<void, CacheWriteError> =>
     Effect.gen(function* () {
         yield* write.exec(
-            "UPDATE ingest_stage SET status = ?, ended_at = CURRENT_TIMESTAMP, counts = ?, error_text = ? WHERE id = ?",
+            "UPDATE ingest_stage SET status = ?, ended_at = CURRENT_TIMESTAMP, counts = ?, error_text = ?, self_ms = ? WHERE id = ?",
             [
                 input.status,
                 jsonParam(input.counts ?? {}),
                 input.status === "ok" ? null : input.errorText,
+                input.selfMs === undefined || input.selfMs === null
+                    ? null
+                    : Math.round(input.selfMs),
                 ingestStageId(input.runId, input.source, input.stage),
             ],
         );

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,6 +15,7 @@
     "./duckdb": "./src/duckdb/index.ts",
     "./sqlite": "./src/sqlite/index.ts",
     "./duckdb/internal": "./src/duckdb/internal.ts",
+    "./duckdb/self-time": "./src/duckdb/self-time.ts",
     "./testing/duckdb-dylib": "./src/testing/duckdb-dylib.ts",
     "./testing/gated-test": "./src/testing/gated-test.ts",
     "./testing/cache": "./src/testing/cache.ts",

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -50,6 +50,7 @@
  */
 import { BunFileSystem } from "@effect/platform-bun";
 import { Context, Effect, FileSystem, Layer, Option, Schema, Semaphore } from "effect";
+import { chargeStageSelfTime } from "./self-time.ts";
 import { ingestLockHeldHere } from "../ingest-lock.ts";
 import {
     openDuckDbService,
@@ -329,11 +330,13 @@ type WithConnection = <A, E, R>(
 
 /** The read half of the service, over a connection-borrowing combinator. */
 const readerOver = (withConnection: WithConnection, path: string): CacheReadService => {
+    // Every statement is charged to the stage that issued it, if any - see
+    // ./self-time.ts for why per-stage wall clock cannot be read as cost.
     const raw: CacheReadService["raw"] = (sql, params) =>
-        withConnection((conn) => conn.query(sql, params));
+        chargeStageSelfTime(withConnection((conn) => conn.query(sql, params)));
 
     const rows: CacheReadService["rows"] = (schema, sql, params) =>
-        withConnection((conn) => conn.queryAs(schema, sql, params));
+        chargeStageSelfTime(withConnection((conn) => conn.queryAs(schema, sql, params)));
 
     const first = <S extends Schema.Top>(
         schema: S,
@@ -799,7 +802,8 @@ const writerOver = (
         return conn.exec(sql, stripped.params);
     };
 
-    const exec: CacheWriteService["exec"] = (sql, params) => execScrubbed(sql, params);
+    const exec: CacheWriteService["exec"] = (sql, params) =>
+        chargeStageSelfTime(execScrubbed(sql, params));
 
     /**
      * One upsert covering `rows`, all of which must share `columns`.
@@ -899,7 +903,7 @@ const writerOver = (
                 const batch = rows.slice(start, start + PUT_BATCH_ROWS);
                 const sql = yield* insertStatement(table, columns, stamped, batch.length);
                 const params = batch.flatMap((row) => columns.map((column) => row[column]));
-                yield* execScrubbed(sql, params);
+                yield* chargeStageSelfTime(execScrubbed(sql, params));
             }
         });
 

--- a/packages/lib/src/duckdb/self-time.test.ts
+++ b/packages/lib/src/duckdb/self-time.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import {
+    chargeStageSelfTime,
+    CurrentStageSelfTime,
+    makeStageSelfTime,
+} from "./self-time.ts";
+
+const busy = (ms: number) =>
+    Effect.sync(() => {
+        // A synchronous spin, which is what a bun:ffi DuckDB call looks like to
+        // the event loop - the whole point of measuring it.
+        const until = performance.now() + ms;
+        while (performance.now() < until) { /* spin */ }
+        return "done";
+    });
+
+describe("chargeStageSelfTime", () => {
+    test("charges a call to the stage accumulator in scope", async () => {
+        const acc = makeStageSelfTime();
+        const result = await Effect.runPromise(
+            Effect.provideService(chargeStageSelfTime(busy(20)), CurrentStageSelfTime, acc),
+        );
+        expect(result).toBe("done");
+        expect(acc.calls).toBe(1);
+        expect(acc.ms).toBeGreaterThanOrEqual(15);
+    });
+
+    test("sums across calls, including ones made from a forked child fiber", async () => {
+        // A stage's internal fan-out (claude parses 8 files at a time) has to
+        // charge to the SAME total, which is what makes Context.Reference the
+        // right mechanism - it is inherited by child fibers.
+        const acc = makeStageSelfTime();
+        await Effect.runPromise(
+            Effect.provideService(
+                Effect.forEach([10, 10, 10], () => chargeStageSelfTime(busy(10)), {
+                    concurrency: 3,
+                }),
+                CurrentStageSelfTime,
+                acc,
+            ),
+        );
+        expect(acc.calls).toBe(3);
+        expect(acc.ms).toBeGreaterThanOrEqual(20);
+    });
+
+    test("outside a stage the effect is untouched and nothing is recorded", async () => {
+        // The CLI, the dashboard and every test read through the same seam. No
+        // accumulator means no bookkeeping and no behaviour change.
+        const result = await Effect.runPromise(chargeStageSelfTime(busy(1)));
+        expect(result).toBe("done");
+    });
+
+    test("a failed call is still charged - it consumed the thread", async () => {
+        const acc = makeStageSelfTime();
+        const exit = await Effect.runPromiseExit(
+            Effect.provideService(
+                chargeStageSelfTime(Effect.flatMap(busy(15), () => Effect.fail("boom"))),
+                CurrentStageSelfTime,
+                acc,
+            ),
+        );
+        expect(exit._tag).toBe("Failure");
+        expect(acc.calls).toBe(1);
+        expect(acc.ms).toBeGreaterThanOrEqual(10);
+    });
+});

--- a/packages/lib/src/duckdb/self-time.ts
+++ b/packages/lib/src/duckdb/self-time.ts
@@ -1,0 +1,66 @@
+import { Context, Effect } from "effect";
+
+/**
+ * How much of a stage's wall clock was its OWN database work.
+ *
+ * `ingest_stage` records wall clock, and with `PIPELINE_CONCURRENCY = 4` that
+ * is not a stage's cost. Every DuckDB call goes through SYNCHRONOUS `bun:ffi`,
+ * so it blocks the single JS thread while it runs; a stage's start-to-end gap
+ * therefore includes every other stage's turn. Measured over three warm passes
+ * on one real store, the stage rows summed to 1.00x of wall clock when the
+ * pipeline was serialized and 2.99x-3.75x when it was not, and `claude-config`
+ * read 0.4s serially against 380.2s concurrently (#841, #865).
+ *
+ * Attribution is EXACT rather than sampled, and for the same reason the problem
+ * exists: the FFI is synchronous, so exactly one call is ever in flight, and the
+ * fiber that awaits it is the fiber that issued it.
+ */
+export interface StageSelfTime {
+    /** Milliseconds spent inside this stage's own DuckDB calls. */
+    ms: number;
+    /** How many calls that was, so a mean is available without a second field. */
+    calls: number;
+}
+
+export const makeStageSelfTime = (): StageSelfTime => ({ ms: 0, calls: 0 });
+
+/**
+ * The accumulator the CURRENT stage is charging its database calls to, or null
+ * outside a stage (CLI reads, the dashboard, tests).
+ *
+ * A `Context.Reference` is inherited by child fibers, which is what makes this
+ * correct for stages that fan out internally (claude parses 8 files at a time).
+ * Same mechanism as `LiveSpanRef` in `../live-traces/LiveTrace.ts`.
+ */
+export const CurrentStageSelfTime: Context.Reference<StageSelfTime | null> = Context
+    .Reference<StageSelfTime | null>("@ax/duckdb/CurrentStageSelfTime", {
+        defaultValue: () => null,
+    });
+
+/**
+ * Charge `call`'s elapsed time to whichever stage is running.
+ *
+ * Outside a stage the accumulator is null and the effect is returned untouched,
+ * so the only cost on the CLI/dashboard read path is one context lookup. The
+ * timer stops on EVERY exit - success, failure, interruption - because a call
+ * that was interrupted still consumed the thread.
+ */
+export const chargeStageSelfTime = <A, E, R>(
+    call: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+    // `withFiber` reads the reference off the RUNNING fiber, which is the same
+    // read `LiveTraceLogger` does (../live-traces/Logger.ts). Going through the
+    // fiber keeps the requirement channel clean: charging a call must not add
+    // a service dependency to every caller of the seam.
+    Effect.withFiber((fiber) => {
+        const acc = fiber.getRef(CurrentStageSelfTime);
+        if (acc === null) return call;
+        const startedAt = performance.now();
+        return Effect.ensuring(
+            call,
+            Effect.sync(() => {
+                acc.ms += performance.now() - startedAt;
+                acc.calls += 1;
+            }),
+        );
+    });

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -188,6 +188,21 @@ const engineFor = (table: string): OwningEngine =>
 // polymorphic in real writers (see the POLYMORPHIC EDGES note in
 // schema.duckdb.sql's header). These columns have no Surreal DEFINE FIELD
 // counterpart, so the strict field<->column equality below must allow them.
+/**
+ * Columns that exist in v2 and have no Surreal `DEFINE FIELD` to map onto,
+ * because they were added AFTER the engine cutover.
+ *
+ * This parity suite compares the DuckDB schema against the retired Surreal DDL,
+ * which is a useful bridge while the two are meant to agree - and a false alarm
+ * for anything v2 grew on its own. Each entry has to name why the column has no
+ * Surreal counterpart, so this list stays a record rather than a silencer.
+ */
+const V2_ONLY_COLUMNS: Readonly<Record<string, readonly string[]>> = {
+    // Stage self-time: the Surreal-era ledger only had wall clock, and wall
+    // clock is what #865 showed to be unusable at PIPELINE_CONCURRENCY > 1.
+    ingest_stage: ["self_ms"],
+};
+
 const POLYMORPHIC_EDGE_EXTRA_COLUMNS: Readonly<Record<string, readonly string[]>> = {
     concerns: ["in_table", "out_table"],
     resulted_in: ["in_table", "out_table"],
@@ -219,6 +234,7 @@ describe("column-set parity (Surreal field set == owning engine's column set)", 
                 expected.add("out_id");
             }
             for (const extra of POLYMORPHIC_EDGE_EXTRA_COLUMNS[table] ?? []) expected.add(extra);
+            for (const extra of V2_ONLY_COLUMNS[table] ?? []) expected.add(extra);
             for (const f of fields) expected.add(renamedColumn(f));
 
             for (const c of expected) {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -1393,8 +1393,18 @@ CREATE TABLE IF NOT EXISTS ingest_stage (
     started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     ended_at TIMESTAMP,
     counts VARCHAR,  -- JSON
-    error_text VARCHAR
+    error_text VARCHAR,
+    self_ms BIGINT  -- this stage's OWN DuckDB time; see the ALTER below
 );
+-- `ended_at - started_at` is WALL CLOCK, and with 4 stages running at once that
+-- is mostly other stages' work: every DuckDB call is a synchronous bun:ffi call
+-- that blocks the single JS thread. Measured on a real store, `claude-config`
+-- read 0.4s serialized against 380.2s concurrent (#841, #865). `self_ms` is the
+-- summed duration of the stage's own calls, so it is comparable across runs.
+-- The ALTER is what reaches an EXISTING database: `CREATE TABLE IF NOT EXISTS`
+-- never adds a column to a table that is already there, and this file is
+-- replayed on every write as the self-heal. Both are idempotent.
+ALTER TABLE ingest_stage ADD COLUMN IF NOT EXISTS self_ms BIGINT;
 CREATE INDEX IF NOT EXISTS ingest_stage_run ON ingest_stage(run, started_at);
 
 CREATE TABLE IF NOT EXISTS ingest_event (


### PR DESCRIPTION
Closes #865. Gives #841 and #837 the number neither could get.

## The problem

`ended_at - started_at` is wall clock. With `PIPELINE_CONCURRENCY = 4` that is
mostly *other* stages' work — every DuckDB call is a synchronous `bun:ffi` call
that blocks the single JS thread, so a stage's gap includes every other stage's
turn.

## What this adds

`self_ms`: the summed duration of the stage's own DuckDB calls.

Attribution is **exact rather than sampled**, for the same reason the problem
exists — the FFI is synchronous, so exactly one call is ever in flight and the
fiber awaiting it is the fiber that issued it. A `Context.Reference` carries the
accumulator (the same mechanism `LiveSpanRef` uses), so a stage's internal
fan-out charges to the same total. Outside a stage the reference is null and the
effect is returned untouched: the CLI, the dashboard and every test pay one
context lookup and nothing else.

## Measured on the real store — one warm pass, run wall 621.3s

| stage | wall | **self** | queue |
| --- | ---: | ---: | ---: |
| `claude-config` | 616.7s | **0.0s** | 616.7s |
| `git` | 366.5s | **26.6s** | 339.9s |
| `turn-content-blocks` | 329.6s | **302.2s** | 27.4s |
| `claude` / subagents | 300.2s | **0.0s** | 300.2s |
| `claude-sidecars` | 292.1s | **0.3s** | 291.9s |
| `classifier-results` | 115.7s | **11.5s** | 104.2s |
| `github-pr` | 101.6s | **28.3s** | 73.4s |
| `run-evidence` | 101.5s | **99.6s** | 1.9s |
| `outcomes` | 57.2s | **53.6s** | 3.6s |
| `session-health` | 29.2s | **25.5s** | 3.7s |

```
all stages:  wall sum 2,471.2s (3.98x the run)   self sum 628.1s (1.01x)
```

**The self-times sum to the run's own duration.** That is the check that the
attribution is right — and it is not a tautology, since the wall sum comes to
nearly four times the same run.

## Two things this says that the wall clock never could

**Nearly all of an ingest run's time is spent inside DuckDB calls, not in JSON
parsing.** 628.1s of database time inside a 621.3s run. That kills the
worker-pool-for-parsing idea outright, and points optimisation at the three
stages that actually cost something: `turn-content-blocks` (302.2s),
`run-evidence` (99.6s), `outcomes` (53.6s) — which is also exactly the pair #841
identified as having no incremental path, plus the one stage over the cap.

**It prices the #837 data loss exactly.** `claude`/`subagents` is killed at the
300-second cap having spent **zero milliseconds** in the database. Not "less than
we thought" — none. Its output is discarded on every concurrent run, which is
every normal run.

## Notes for review

- **`CREATE TABLE IF NOT EXISTS` never adds a column to a table that already
  exists.** The DDL is replayed as the write-time self-heal, so it carries an
  explicit `ALTER TABLE ingest_stage ADD COLUMN IF NOT EXISTS self_ms BIGINT`
  beside the declaration. I verified DuckDB accepts that form and is idempotent
  against the shipped build before relying on it.
- **The Surreal-parity suite failed on this, correctly.** `self_ms` has no
  `DEFINE FIELD` counterpart because it was added after the engine cutover.
  Rather than weaken the check, `V2_ONLY_COLUMNS` records the exemption and
  requires a stated reason per entry, so it stays a record and not a silencer.
- Error bar: self sum is 1.01x, marginally over 1. The read path's snapshot
  re-open does async `fs.stat` inside the timed region, so two stages can
  briefly overlap there. Negligible at this scale, and it does not affect any
  conclusion above.

## Verification

6,091 pass / 11 skip / 4 fail / 4 errors in 112s — base branch is 6,087 with the
same 4 fail / 4 errors (this adds the four self-time tests). Both typecheck
gates clean. The table above is from a real warm pass on the 3,329-session
store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)