### PR TITLE
docs: v3 plan — events + SQL models, built on v2

### DIFF
--- a/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
+++ b/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
@@ -1,0 +1,123 @@
+# v3 — events + SQL models, built ON v2 (not a rewrite)
+
+Status: PLAN. v2 (#849) merges to main untouched by this. Every phase ships
+independently, is reversible, and gates on a measurement. Prototype:
+session scratchpad `proto/` (329 loc, full-corpus runs cited below).
+
+## Thesis
+
+The self_ms instrument (#865/#866) proved an ingest run is ~100% database
+time (628s of a 621s wall). ax is not a parser that uses a database; it is a
+database whose input is JSONL. So: JS shrinks to parsers + scheduler; DuckDB
+derives; events are the source of truth.
+
+## Learnings this plan is built from (all measured, this week, this machine)
+
+| learning | receipt |
+| --- | --- |
+| derives belong in the engine | self sum 628.1s ≈ run wall 621.3s (1.01x) |
+| wall clock lies at concurrency >1 | stage sums 2.99–3.75x wall; serial exactly 1.00x (#841) |
+| batch >> row-by-row | 633k rows loaded in 1.2s via read_ndjson vs per-row FFI |
+| full pipeline potential | proto cold 14.4s vs v2 5,136s; warm no-op 0.2s vs 621s |
+| judgment baked at ingest is expensive to fix | a classifier fix = re-ingest 5.6 GB; as SQL model = ~0.1s rebuild |
+| rewrites re-earn old bugs | proto reproduced watermark + type-inference bug classes in 10 min |
+| parsers are the crown jewels | claude parser 2,000 loc of harness knowledge vs proto's 60 |
+| the shape is validated externally | alfredvc/cct converged on transcripts→DuckDB+skills independently |
+
+## Non-goals
+
+No engine change. No new daemon. Judgment sidecar untouched. CLI/MCP surface
+stable. No parser rewrite ever — parsers migrate only behind golden-corpus
+replay tests.
+
+## Phases
+
+### Phase 0 — safety + instruments (prereqs, partly landed)
+
+- **#837 budget-at-seam FIRST** (active data loss: subagents stage output
+  discarded every run at 0.0ms self time). Enforce derive cap on self_ms at
+  the seam: refuse the next call when budget spent; typed error; stage
+  settles clean. Wall-clock watchdog stays, demoted to `hung` detector.
+- Golden corpus: one real (sanitized) transcript per provider committed as
+  fixture + replay test asserting normalized row shapes. Replaces
+  parity-by-grep as the parser contract. Blocks all later parser touches.
+- Landed already: self_ms (#866), named skips (#863), AX_PIPELINE_CONCURRENCY (#864).
+- Trio rides here: #869 COMMENT ON codegen (S, standalone).
+
+### Phase 1 — driver swap (async under the same seam)
+
+- Replace the synchronous bun:ffi internals of CacheRead/withCacheWrite with
+  the threaded promise-based DuckDB client. Interface unchanged; callers
+  untouched.
+- SPIKE FIRST: napi module embeddability in the `bun build --compile` binary
+  (same class of problem as the dylib embed). Spike outcome decides: full
+  swap, or neo-on-source + FFI-on-binary (accepted complexity), or stop.
+- Gates: full suite green; self attribution still ~1.0x; a timeout can now
+  actually preempt a query (retire #837's cooperative workaround later).
+
+### Phase 2 — batch writers
+
+- Provider stages write NDJSON spool → one `INSERT OR REPLACE ... FROM
+  read_ndjson(..., columns=...)` per table. Explicit columns always
+  (inference ban — proto bug). PK dedup replaces per-writer idempotency care.
+- Trio rides here: #867 attribution fields (parser touch + 4 columns +
+  `--reparse=claude`), done WITH the batch-writer touch to avoid re-touching.
+- Gate: cold backfill wall time; expectation parse-bound (~minutes, not 85).
+
+### Phase 3 — derives → SQL models, one at a time
+
+- Model runner: `models/*.sql`, `-- inputs:` headers, topo-run inside DuckDB,
+  registered as stages in the EXISTING StageRegistry (ledger, progress,
+  budget unchanged).
+- Port order by measured self_ms: turn-content-blocks (302.2s) →
+  run-evidence (99.6s) → outcomes (53.6s) = 455s of 628s. Then opportunistic.
+- Contract per port: old TS stage kept behind a flag one release; shadow-run
+  both on the real store; row-for-row diff clean; then delete TS.
+- A model without a watermark predicate must declare `full_rebuild` visibly.
+- Trio rides here: #868 cache-bust lens ships as a model (corroborate vs raw
+  cache-token deltas; proposal minting per open question below).
+
+### Phase 4 — events as the contract
+
+- Freeze `ev_*` tables as the normalized layer; segment export/import =
+  remote/sandbox accumulation (parked idea lands free).
+- BlobPointer branded type (pointer-vs-path compile error).
+- Watermark keyed by content hash, not absolute path (merge-safe).
+
+### Phase 5 — learning layer (gated prototype)
+
+- Harvest free labels (landed/reverted/repair episodes/sidecar verdicts) →
+  features model (SQL) → LLM-as-labeler for gaps (dojo surplus quota) →
+  train tiny (logistic/GBT, CPU, seconds) → weights-as-table → inference as
+  a SQL model in the DAG, versioned.
+- Ship gate: beats the regex baseline (JUDGMENT_GUARD_RE first) on held-out
+  labels, else the regex stays. Regexes become features, never deleted first.
+
+## Sequencing + effort (rough)
+
+0: #837 ~0.5d · golden corpus ~1d · #869 ~0.5d
+1: spike ~0.5d, swap ~1–2d
+2: ~1–2d + #867 ~0.5d (+ reparse run)
+3: ~0.5–1d per stage ported, 3 stages to capture 72% of DB time · #868 ~1d
+4: ~1–2d
+5: prototype ~1d, then evidence decides
+
+## Kill criteria
+
+- Phase 1 spike fails binary embed AND dual-driver is judged too complex → stay FFI, Phases 2–3 still proceed (they help regardless).
+- Any Phase 3 shadow diff not clean after 2 fix rounds → that stage stays TS, move on.
+- Phase 5 model loses to regex → don't ship, keep labels accumulating.
+
+## Unresolved questions
+
+1. #868 proposals: auto-mint into `ax improve`, or human-gated behind review?
+   (asked, unanswered)
+2. Phase 1: is the napi client embeddable in the compiled binary? (spike)
+3. Phase 4 content-hash watermark: migration cost over 4.7k existing rows —
+   re-hash all on first run, or lazy per-touch?
+4. Live progress granularity: when a derive runs inside one SQL statement,
+   per-stage progress events collapse to start/end — acceptable, or does the
+   Studio Live tab need statement-level progress?
+5. Do v3 phases wait for #849 to merge, or land on the sweep branch too?
+   (Trio: sweep, per decision 2026-08-18. Phases: default wait for #849
+   unless told otherwise.)


### PR DESCRIPTION
The v3 direction as a phased plan, per discussion 2026-08-18. Built ON v2 —
no rewrite, every phase independently shippable and reversible, every claim
tied to a measurement from this week (#841/#865/#866 instrumentation + the
329-loc full-corpus prototype: cold 14.4s vs 5,136s, warm no-op 0.2s vs 621s).

Phases: 0 safety+instruments (#837 first — active data loss) → 1 async driver
swap under the unchanged seam (spike gates it) → 2 batch writers → 3 derives
ported to SQL models one at a time in self_ms order (455s of 628s in three
stages) → 4 events as the merge contract → 5 learning layer behind a
beats-the-regex gate.

The cct-adoption trio (#869/#867/#868) is slotted into phases 0/2/3.

Five unresolved questions are listed at the bottom; #868's proposal-minting
gate is the one that needs an owner decision before Phase 3 reaches it.

Plan doc only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)