### PR TITLE
fix(ingest): cap derive stages on their own database time, not wall clock

### DIFF
--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -17,7 +17,11 @@ import {
     writeIngestStageFinish,
     writeIngestStageStart,
 } from "./telemetry.ts";
-import { CurrentStageSelfTime, makeStageSelfTime } from "@ax/lib/duckdb/self-time";
+import {
+    CurrentStageSelfTime,
+    CurrentStageSelfTimeBudget,
+    makeStageSelfTime,
+} from "@ax/lib/duckdb/self-time";
 import { runPipeline } from "./stage/runner.ts";
 import { selectByKeys, selectByTag } from "./stage/select.ts";
 import { StageRegistry, type IngestStageError, type StageRegistryShape } from "./stage/registry.ts";
@@ -256,7 +260,17 @@ const wrapStage = (
                         CurrentStageSelfTime,
                         selfTime,
                     ),
-                    (exit) => settleStage(write, ledgerKey, eventName, exit, selfTime.ms),
+                    // Settle writes go through the SAME charged seam as the
+                    // stage's own calls, so a stage stopped for exhausting its
+                    // self-time budget (#837) must not have its ledger write
+                    // refused by the very budget it exhausted: clear the budget
+                    // for the finalizer.
+                    (exit) =>
+                        Effect.provideService(
+                            settleStage(write, ledgerKey, eventName, exit, selfTime.ms),
+                            CurrentStageSelfTimeBudget,
+                            null,
+                        ),
                 );
             }),
     };

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -8,7 +8,12 @@ import {
 } from "@ax/lib/live-traces/Sink";
 import type { TraceEvent } from "@ax/lib/live-traces/types";
 import { LiveTrace } from "@ax/lib/live-traces/index";
-import { annotateStageProgress, deriveStageTimeoutSeconds, heartbeatSeconds, PIPELINE_CONCURRENCY, pipelineConcurrency, runPipeline as runPipelineWithWrite, stageFileFailureAnnotator, topoLayers } from "./runner.ts";
+import { annotateStageProgress, deriveStageHungSeconds, deriveStageTimeoutSeconds, heartbeatSeconds, PIPELINE_CONCURRENCY, pipelineConcurrency, runPipeline as runPipelineWithWrite, stageFileFailureAnnotator, topoLayers } from "./runner.ts";
+import {
+    chargeStageSelfTime,
+    CurrentStageSelfTime,
+    makeStageSelfTime,
+} from "@ax/lib/duckdb/self-time";
 import { BaseStageStats, IngestContext, StageMeta, type StageDef } from "./types.ts";
 import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 
@@ -386,6 +391,15 @@ describe("heartbeatSeconds / deriveStageTimeoutSeconds", () => {
         expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "abc" })).toBe(30);
     });
 
+    it("deriveStageHungSeconds: default 1800, honors override, rejects negative/NaN", () => {
+        expect(deriveStageHungSeconds({})).toBe(1800);
+        expect(deriveStageHungSeconds({ AX_STAGE_HUNG_SECONDS: "120" })).toBe(120);
+        expect(deriveStageHungSeconds({ AX_STAGE_HUNG_SECONDS: "0" })).toBe(0);
+        expect(deriveStageHungSeconds({ AX_STAGE_HUNG_SECONDS: "" })).toBe(1800);
+        expect(deriveStageHungSeconds({ AX_STAGE_HUNG_SECONDS: "-1" })).toBe(1800);
+        expect(deriveStageHungSeconds({ AX_STAGE_HUNG_SECONDS: "nope" })).toBe(1800);
+    });
+
     it("deriveStageTimeoutSeconds: default 300, honors override, rejects negative/NaN", () => {
         expect(deriveStageTimeoutSeconds({})).toBe(300);
         expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "120" })).toBe(120);
@@ -397,7 +411,7 @@ describe("heartbeatSeconds / deriveStageTimeoutSeconds", () => {
     });
 });
 
-describe("derive-stage watchdog (#671)", () => {
+describe("derive-stage hung detector (#671, demoted by #837)", () => {
     // Set/restore env vars around an async body (runPipeline reads them at call time).
     const withEnv = async (vars: Record<string, string>, fn: () => Promise<void>): Promise<void> => {
         const saved: Record<string, string | undefined> = {};
@@ -418,7 +432,7 @@ describe("derive-stage watchdog (#671)", () => {
     const ctx = () => IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
 
     it("fails a hung derive stage OPEN so the run finishes and downstream still runs", async () => {
-        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+        await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const ran: string[] = [];
             const hang: StageDef = {
                 meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
@@ -439,16 +453,16 @@ describe("derive-stage watchdog (#671)", () => {
             expect(ran).toEqual(["after"]);
             const summaries = results.map((r) => r.summary).sort();
             expect(summaries).toContain("after");
-            expect(summaries).toContain("timed out (watchdog)");
+            expect(summaries).toContain("timed out (hung detector)");
         });
     });
 
     it("reports the capped stage as `timeout`, naming the cap that fired (#840)", async () => {
         // Without this, the stage's own finalizer can only say "interrupted" -
         // it cannot know a watchdog cap was the reason. The precise status is
-        // the difference between "raise AX_STAGE_TIMEOUT_SECONDS" and "debug a
+        // the difference between "raise AX_STAGE_HUNG_SECONDS" and "debug a
         // stage that was working fine".
-        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+        await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const rec = outcomeRecorder();
             const hang: StageDef = {
                 meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
@@ -460,12 +474,12 @@ describe("derive-stage watchdog (#671)", () => {
             expect(rec.seen).toHaveLength(1);
             expect(rec.seen[0]!.key).toBe("hang");
             expect(rec.seen[0]!.status).toBe("timeout");
-            expect(rec.seen[0]!.errorText).toContain("AX_STAGE_TIMEOUT_SECONDS");
+            expect(rec.seen[0]!.errorText).toContain("AX_STAGE_HUNG_SECONDS");
         });
     });
 
     it("reports nothing when no stage is capped", async () => {
-        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+        await withEnv({ AX_STAGE_HUNG_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const rec = outcomeRecorder();
             const fine: StageDef = {
                 meta: StageMeta.make({ key: "fine", deps: [], tags: ["derive"] }),
@@ -479,7 +493,7 @@ describe("derive-stage watchdog (#671)", () => {
     });
 
     it("still completes when no recorder is supplied (the hook is optional)", async () => {
-        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+        await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const hang: StageDef = {
                 meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
                 run: () => Effect.never,
@@ -487,12 +501,12 @@ describe("derive-stage watchdog (#671)", () => {
             const results = await Effect.runPromise(
                 runPipeline([hang], ctx()) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
             );
-            expect(results[0]!.summary).toBe("timed out (watchdog)");
+            expect(results[0]!.summary).toBe("timed out (hung detector)");
         });
     });
 
     it("does NOT watchdog a non-derive (ingest) stage that runs past the cap", async () => {
-        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+        await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const slowIngest: StageDef = {
                 meta: StageMeta.make({ key: "slow", deps: [], tags: ["ingest"] }),
                 run: () =>
@@ -504,6 +518,137 @@ describe("derive-stage watchdog (#671)", () => {
                 runPipeline([slowIngest], ctx()) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
             );
             expect(results[0]!.summary).toBe("real");
+        });
+    });
+});
+
+describe("derive self-time budget (#837)", () => {
+    const withEnv = async (vars: Record<string, string>, fn: () => Promise<void>): Promise<void> => {
+        const saved: Record<string, string | undefined> = {};
+        for (const k of Object.keys(vars)) {
+            saved[k] = process.env[k];
+            process.env[k] = vars[k];
+        }
+        try {
+            await fn();
+        } finally {
+            for (const k of Object.keys(vars)) {
+                if (saved[k] === undefined) delete process.env[k];
+                else process.env[k] = saved[k];
+            }
+        }
+    };
+
+    const ctx = () => IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
+
+    /** What a synchronous DuckDB call looks like to the event loop. */
+    const busy = (ms: number) =>
+        Effect.sync(() => {
+            const until = performance.now() + ms;
+            while (performance.now() < until) { /* spin */ }
+        });
+
+    /** A stage body issuing `calls` charged calls of `ms` each, with its own
+     *  accumulator - exactly the shape `wrapStage` provides in production
+     *  (accumulator INSIDE the stage, budget provided by the runner OUTSIDE). */
+    const chargingStage = (
+        key: string,
+        tags: ReadonlyArray<"ingest" | "derive">,
+        callsMs: ReadonlyArray<number>,
+    ): StageDef => ({
+        meta: StageMeta.make({ key, deps: [], tags }),
+        run: () =>
+            Effect.provideService(
+                Effect.forEach(callsMs, (ms) => chargeStageSelfTime(busy(ms))).pipe(
+                    Effect.as(BaseStageStats.make({ durationMs: 0, summary: `${key} ok` })),
+                ),
+                CurrentStageSelfTime,
+                makeStageSelfTime(),
+            ),
+    });
+
+    it("stops a derive whose OWN database time exceeds the budget, fails OPEN, downstream runs", async () => {
+        // 30ms budget; first charged call spends ~40ms (charged AFTER it
+        // returns - a synchronous call cannot be preempted), so the SECOND
+        // call is refused. Wall clock never enters into it.
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.03", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const rec = outcomeRecorder();
+            const ran: string[] = [];
+            const after: StageDef = {
+                meta: StageMeta.make({ key: "after", deps: ["greedy"], tags: ["derive"] }),
+                run: () =>
+                    Effect.sync(() => {
+                        ran.push("after");
+                        return BaseStageStats.make({ durationMs: 0, summary: "after" });
+                    }),
+            };
+            const results = await Effect.runPromise(
+                runPipeline([chargingStage("greedy", ["derive"], [40, 5]), after], ctx(), {
+                    recordStageOutcome: rec.recordStageOutcome,
+                }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(ran).toEqual(["after"]);
+            const summaries = results.map((r) => r.summary);
+            expect(summaries).toContain("self-time budget exceeded");
+            expect(rec.seen).toHaveLength(1);
+            expect(rec.seen[0]!.key).toBe("greedy");
+            expect(rec.seen[0]!.status).toBe("timeout");
+            expect(rec.seen[0]!.errorText).toContain("self-time");
+            expect(rec.seen[0]!.errorText).toContain("AX_STAGE_TIMEOUT_SECONDS");
+        });
+    });
+
+    it("a derive under its self-time budget is untouched", async () => {
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const rec = outcomeRecorder();
+            const results = await Effect.runPromise(
+                runPipeline([chargingStage("light", ["derive"], [2, 2])], ctx(), {
+                    recordStageOutcome: rec.recordStageOutcome,
+                }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(results[0]!.summary).toBe("light ok");
+            expect(rec.seen).toEqual([]);
+        });
+    });
+
+    it("an ingest-tagged stage is exempt even when it spends heavily", async () => {
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0.03", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const results = await Effect.runPromise(
+                runPipeline([chargingStage("provider", ["ingest"], [40, 5])], ctx()) as Effect.Effect<
+                    ReadonlyArray<BaseStageStats>,
+                    never,
+                    never
+                >,
+            );
+            expect(results[0]!.summary).toBe("provider ok");
+        });
+    });
+
+    it("AX_STAGE_TIMEOUT_SECONDS=0 disables the budget", async () => {
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "0", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const results = await Effect.runPromise(
+                runPipeline([chargingStage("unbounded", ["derive"], [40, 5])], ctx()) as Effect.Effect<
+                    ReadonlyArray<BaseStageStats>,
+                    never,
+                    never
+                >,
+            );
+            expect(results[0]!.summary).toBe("unbounded ok");
+        });
+    });
+
+    it("a non-budget defect from a derive stage still propagates", async () => {
+        // The catch handler must ONLY absorb the budget refusal - any other
+        // defect keeps crashing the pipeline as before.
+        await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
+            const boom: StageDef = {
+                meta: StageMeta.make({ key: "boom", deps: [], tags: ["derive"] }),
+                run: () => Effect.die(new Error("unrelated defect")),
+            };
+            const exit = await Effect.runPromiseExit(
+                runPipeline([boom], ctx()) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+            expect(exit._tag).toBe("Failure");
         });
     });
 });
@@ -575,7 +720,7 @@ describe("runPipeline derive budget (#697)", () => {
             }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
         );
 
-        // Bounded by the deadline (150ms), NOT by AX_STAGE_TIMEOUT_SECONDS (300s).
+        // Bounded by the deadline (150ms), NOT by AX_STAGE_HUNG_SECONDS (1800s).
         // Either summary proves the DEADLINE (not the 300s static cap) bounded
         // the stage: "timed out" if the budget read still saw time left when
         // the stage started, "skipped" if CI scheduling slop pushed pipeline

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -1,8 +1,12 @@
-import { Deferred, Effect, Fiber, Option, Semaphore } from "effect";
+import { Cause, Deferred, Effect, Fiber, Option, Semaphore } from "effect";
 import { LiveTrace } from "@ax/lib/live-traces/index";
 import { nonNegativeNumberEnv } from "@ax/lib/shared/env-number";
 import type { FileFailureSnapshot } from "../file-isolation.ts";
 import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import {
+    CurrentStageSelfTimeBudget,
+    StageSelfTimeBudgetExceeded,
+} from "@ax/lib/duckdb/self-time";
 import { INGEST_FILE_FAILURES_KEY } from "../stream-events.ts";
 import { deriveReserveMs, deriveStageBudget } from "./derive-budget.ts";
 import type { BaseStageStats, IngestContext, StageDef } from "./types.ts";
@@ -35,15 +39,34 @@ export const heartbeatSeconds = (env: NodeJS.ProcessEnv = process.env): number =
     return nonNegativeNumberEnv(env.AX_INGEST_HEARTBEAT_SECONDS, 30);
 };
 
-/** Hard per-stage cap applied to `derive`-tagged stages ONLY. Derives reshape
- *  already-ingested rows and should finish fast; one that runs past this cap is
- *  stuck (a hung query, #671) and is failed OPEN - a warning plus empty stats -
- *  so the rest of the pipeline still completes and exits. Heavy ingest/provider
+/** Per-stage SELF-TIME budget applied to `derive`-tagged stages ONLY: how many
+ *  seconds a derive may spend inside its OWN DuckDB calls. Enforced
+ *  cooperatively at the seam (`chargeStageSelfTime`): once the accumulator
+ *  crosses the budget, the NEXT call is refused and the stage fails OPEN with a
+ *  `timeout` row, so the rest of the pipeline still completes.
+ *
+ *  Self time, not wall clock, because every DuckDB call is a synchronous
+ *  `bun:ffi` call blocking the one JS thread: under PIPELINE_CONCURRENCY=4 a
+ *  stage's wall clock is mostly OTHER stages' calls, and a wall cap killed a
+ *  stage whose own cost was 2.1s on every concurrent run while a genuinely
+ *  heavy one could not be preempted at all (#837, #841). Heavy ingest/provider
  *  stages (claude, codex, git) are deliberately exempt: a full backfill
  *  legitimately runs for many minutes. Env override `AX_STAGE_TIMEOUT_SECONDS`;
  *  0 disables. Exported for tests. */
 export const deriveStageTimeoutSeconds = (env: NodeJS.ProcessEnv = process.env): number => {
     return nonNegativeNumberEnv(env.AX_STAGE_TIMEOUT_SECONDS, 300);
+};
+
+/** Wall-clock HUNG detector for `derive`-tagged stages - the demoted remainder
+ *  of the old wall-clock watchdog. It cannot preempt a synchronous FFI call
+ *  (the event loop is blocked while one runs) and it no longer measures cost -
+ *  that is the self-time budget's job. What it still catches: a derive that is
+ *  idle or stuck somewhere that DOES yield (an awaited promise, a lock, a bug
+ *  outside the FFI), which self time by definition never charges. Generous by
+ *  default for that reason. Env override `AX_STAGE_HUNG_SECONDS`; 0 disables
+ *  the static part (a run deadline still applies). Exported for tests. */
+export const deriveStageHungSeconds = (env: NodeJS.ProcessEnv = process.env): number => {
+    return nonNegativeNumberEnv(env.AX_STAGE_HUNG_SECONDS, 1800);
 };
 
 /** Annotate the active stage span with the numeric fields of its result stats
@@ -193,7 +216,8 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
         // Stages currently executing (permit acquired, run not yet resolved). The
         // heartbeat reads this so a hang is attributable to a specific stage (#671).
         const inFlight = new Set<string>();
-        const stageTimeoutMs = deriveStageTimeoutSeconds() * 1000;
+        const selfBudgetMs = deriveStageTimeoutSeconds() * 1000;
+        const hungCapMs = deriveStageHungSeconds() * 1000;
         const deadlineMs = opts.deadlineMs ?? null;
         const reserveMs = opts.reserveMs ?? deriveReserveMs();
 
@@ -214,14 +238,19 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                         "ingest.stage.tags": s.meta.tags.join(","),
                     }),
                 );
-                // Watchdog: cap `derive` stages so one stuck or backlogged derive
-                // can't wedge the run OR push the pass past its deadline (#671,
-                // #697). Fails OPEN - a warning plus sentinel stats - because
-                // downstream deps only await this Deferred (they never read its
-                // value; they re-query the DB), and the totals roll-up skips
-                // `durationMs` + non-numeric fields, so an empty BaseStageStats is
-                // safe. Heavy provider stages (claude, codex, git) are exempt: a
-                // full backfill legitimately runs for many minutes.
+                // Guards on `derive` stages, all failing OPEN - a warning plus
+                // sentinel stats - because downstream deps only await this
+                // Deferred (they never read its value; they re-query the DB),
+                // and the totals roll-up skips `durationMs` + non-numeric
+                // fields, so an empty BaseStageStats is safe. Heavy provider
+                // stages (claude, codex, git) are exempt. Three layers:
+                //  1. skip: no wall budget left before the run deadline (#697)
+                //  2. self-time budget: the stage's own DuckDB time, enforced
+                //     at the seam between calls - the authoritative cost cap
+                //     (#837); wall clock could neither measure cost under
+                //     concurrency nor preempt a synchronous FFI call
+                //  3. hung detector: generous wall-clock race for a derive
+                //     stuck somewhere that yields (self time never sees those)
                 // Suspended so `Date.now()` is read at stage START (post-deps,
                 // post-permit) - reading it at build time would hand every stage
                 // the budget the FIRST one had.
@@ -229,12 +258,11 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                     ? body
                     : Effect.suspend(() => {
                         const budget = deriveStageBudget({
-                            staticCapMs: stageTimeoutMs,
+                            staticCapMs: hungCapMs,
                             deadlineMs,
                             nowMs: Date.now(),
                             reserveMs,
                         });
-                        if (budget._tag === "uncapped") return body;
                         if (budget._tag === "skip") {
                             const reason = `skipped - ${budget.reason}`;
                             return Effect.logWarning(
@@ -256,15 +284,64 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                                 } as unknown as S),
                             );
                         }
+                        // Self-time budget. `provideService` scopes the budget
+                        // to the stage BODY only: the catch handler below and
+                        // the settle writes (`wrapStage` exempts its own
+                        // finalizer) run outside it, so the bookkeeping that
+                        // reports the refusal is never itself refused.
+                        const selfCapSeconds = Math.round(selfBudgetMs / 1000);
+                        const selfGuarded = selfBudgetMs <= 0 ? body : Effect
+                            .provideService(body, CurrentStageSelfTimeBudget, selfBudgetMs)
+                            .pipe(
+                                Effect.catchCause((cause) => {
+                                    const exceeded = cause.reasons
+                                        .filter(Cause.isDieReason)
+                                        .map((reason) => reason.defect)
+                                        .find((defect): defect is StageSelfTimeBudgetExceeded =>
+                                            defect instanceof StageSelfTimeBudgetExceeded
+                                        );
+                                    if (exceeded === undefined) return Effect.failCause(cause);
+                                    const spentSeconds = Math.round(exceeded.selfMs / 1000);
+                                    return Effect.logWarning(
+                                        `ingest: derive stage '${s.meta.key}' spent ${spentSeconds}s in its own ` +
+                                            `database calls against a ${selfCapSeconds}s budget - stopping it ` +
+                                            `(failed open; work already written is kept) so the run can finish. ` +
+                                            `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
+                                    ).pipe(
+                                        // Overwrite the `error` row the stage's
+                                        // own finalizer just wrote (the refusal
+                                        // surfaces as a defect) with the precise
+                                        // budget that fired. `self_ms` survives
+                                        // the overwrite via COALESCE in the
+                                        // finish SQL.
+                                        Effect.andThen(
+                                            opts.recordStageOutcome?.(s.meta.key, {
+                                                status: "timeout",
+                                                errorText:
+                                                    `timed out - spent ${spentSeconds}s in its own database calls ` +
+                                                    `against the ${selfCapSeconds}s self-time budget over ` +
+                                                    `${exceeded.calls} calls (raise or disable with ` +
+                                                    `AX_STAGE_TIMEOUT_SECONDS); work already written is kept and ` +
+                                                    `the run continued without this stage`,
+                                            }) ?? Effect.void,
+                                        ),
+                                        Effect.as({
+                                            durationMs: exceeded.selfMs,
+                                            summary: "self-time budget exceeded",
+                                        } as unknown as S),
+                                    );
+                                }),
+                            );
+                        if (budget._tag === "uncapped") return selfGuarded;
                         const capSeconds = Math.round(budget.capMs / 1000);
-                        return body.pipe(
+                        return selfGuarded.pipe(
                             Effect.timeoutOrElse({
                                 duration: budget.capMs,
                                 orElse: () =>
                                     Effect.logWarning(
-                                        `ingest: derive stage '${s.meta.key}' exceeded ${capSeconds}s - ` +
-                                            `skipping it (failed open) so the run can finish. ` +
-                                            `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
+                                        `ingest: derive stage '${s.meta.key}' still running after ${capSeconds}s ` +
+                                            `of wall clock (hung detector) - skipping it (failed open) so the ` +
+                                            `run can finish. Raise/disable with AX_STAGE_HUNG_SECONDS.`,
                                     ).pipe(
                                         // Overwrite the `interrupted` row the
                                         // stage's own finalizer just wrote with
@@ -276,14 +353,14 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                                             opts.recordStageOutcome?.(s.meta.key, {
                                                 status: "timeout",
                                                 errorText:
-                                                    `timed out - exceeded the ${capSeconds}s derive watchdog cap ` +
-                                                    `(raise or disable with AX_STAGE_TIMEOUT_SECONDS); ` +
+                                                    `hung - still running after the ${capSeconds}s wall-clock hung ` +
+                                                    `detector (raise or disable with AX_STAGE_HUNG_SECONDS); ` +
                                                     `the run continued without this stage`,
                                             }) ?? Effect.void,
                                         ),
                                         Effect.as({
                                             durationMs: budget.capMs,
-                                            summary: "timed out (watchdog)",
+                                            summary: "timed out (hung detector)",
                                         } as unknown as S),
                                     ),
                             }),

--- a/apps/axctl/src/ingest/telemetry.ts
+++ b/apps/axctl/src/ingest/telemetry.ts
@@ -211,7 +211,12 @@ export const writeIngestStageFinish = (
 ): Effect.Effect<void, CacheWriteError> =>
     Effect.gen(function* () {
         yield* write.exec(
-            "UPDATE ingest_stage SET status = ?, ended_at = CURRENT_TIMESTAMP, counts = ?, error_text = ?, self_ms = ? WHERE id = ?",
+            // COALESCE: a runner-side overwrite (`timeout`/`skipped`, #840/#837)
+            // carries no selfMs, and it must not null out the value the stage's
+            // own finalizer just recorded - self_ms IS the evidence for why a
+            // self-time budget fired. Nothing legitimately resets self_ms to
+            // null once written.
+            "UPDATE ingest_stage SET status = ?, ended_at = CURRENT_TIMESTAMP, counts = ?, error_text = ?, self_ms = COALESCE(?, self_ms) WHERE id = ?",
             [
                 input.status,
                 jsonParam(input.counts ?? {}),

--- a/packages/lib/src/duckdb/self-time.test.ts
+++ b/packages/lib/src/duckdb/self-time.test.ts
@@ -3,7 +3,9 @@ import { Effect } from "effect";
 import {
     chargeStageSelfTime,
     CurrentStageSelfTime,
+    CurrentStageSelfTimeBudget,
     makeStageSelfTime,
+    StageSelfTimeBudgetExceeded,
 } from "./self-time.ts";
 
 const busy = (ms: number) =>
@@ -63,5 +65,86 @@ describe("chargeStageSelfTime", () => {
         expect(exit._tag).toBe("Failure");
         expect(acc.calls).toBe(1);
         expect(acc.ms).toBeGreaterThanOrEqual(10);
+    });
+});
+
+describe("self-time budget enforcement (#837)", () => {
+    const provideBoth = <A, E, R>(
+        effect: import("effect").Effect.Effect<A, E, R>,
+        acc: ReturnType<typeof makeStageSelfTime>,
+        budgetMs: number | null,
+    ) =>
+        Effect.provideService(
+            Effect.provideService(effect, CurrentStageSelfTime, acc),
+            CurrentStageSelfTimeBudget,
+            budgetMs,
+        );
+
+    test("a call under budget runs; the one AFTER the budget is spent is refused", async () => {
+        const acc = makeStageSelfTime();
+        // First call allowed at acc.ms=0 and overshoots (a synchronous FFI
+        // call cannot be preempted - it is charged after it returns).
+        await Effect.runPromise(provideBoth(chargeStageSelfTime(busy(15)), acc, 10));
+        expect(acc.calls).toBe(1);
+        expect(acc.ms).toBeGreaterThanOrEqual(10);
+        // Second call refused before it starts: no charge, tagged defect.
+        const exit = await Effect.runPromiseExit(
+            provideBoth(chargeStageSelfTime(busy(50)), acc, 10),
+        );
+        expect(exit._tag).toBe("Failure");
+        if (exit._tag === "Failure") {
+            const defect = exit.cause.reasons
+                .filter((r) => r._tag === "Die")
+                .map((r) => (r as { defect: unknown }).defect)
+                .find((d) => d instanceof StageSelfTimeBudgetExceeded);
+            expect(defect).toBeInstanceOf(StageSelfTimeBudgetExceeded);
+            const e = defect as StageSelfTimeBudgetExceeded;
+            expect(e.budgetMs).toBe(10);
+            expect(e.calls).toBe(1);
+            expect(e.selfMs).toBeGreaterThanOrEqual(10);
+        }
+        expect(acc.calls).toBe(1); // the refused call was never charged
+    });
+
+    test("a null budget never refuses", async () => {
+        const acc = makeStageSelfTime();
+        acc.ms = 1e9;
+        const result = await Effect.runPromise(
+            provideBoth(chargeStageSelfTime(busy(1)), acc, null),
+        );
+        expect(result).toBe("done");
+    });
+
+    test("a budget without an accumulator cannot enforce and passes through", async () => {
+        // No accumulator = nothing counting, so there is nothing to compare
+        // the budget against. Only stages (which get an accumulator from
+        // wrapStage) are ever budgeted.
+        const result = await Effect.runPromise(
+            Effect.provideService(
+                chargeStageSelfTime(busy(1)),
+                CurrentStageSelfTimeBudget,
+                0,
+            ),
+        );
+        expect(result).toBe("done");
+    });
+
+    test("clearing the budget in an inner scope exempts bookkeeping writes", async () => {
+        // wrapStage clears the budget around its settle finalizer so a stage
+        // stopped for exhausting the budget can still write its own ledger row.
+        const acc = makeStageSelfTime();
+        acc.ms = 1e9;
+        const result = await Effect.runPromise(
+            provideBoth(
+                Effect.provideService(
+                    chargeStageSelfTime(busy(1)),
+                    CurrentStageSelfTimeBudget,
+                    null,
+                ),
+                acc,
+                10,
+            ),
+        );
+        expect(result).toBe("done");
     });
 });

--- a/packages/lib/src/duckdb/self-time.ts
+++ b/packages/lib/src/duckdb/self-time.ts
@@ -1,4 +1,4 @@
-import { Context, Effect } from "effect";
+import { Context, Data, Effect } from "effect";
 
 /**
  * How much of a stage's wall clock was its OWN database work.
@@ -38,6 +38,43 @@ export const CurrentStageSelfTime: Context.Reference<StageSelfTime | null> = Con
     });
 
 /**
+ * The self-time budget (ms) the CURRENT derive stage may spend inside its own
+ * DuckDB calls, or null when nothing is enforcing one (provider stages, CLI
+ * reads, tests). Provided by the ingest runner around derive-tagged stage
+ * bodies ONLY.
+ *
+ * This exists because a wall-clock cap measures the wrong quantity here: every
+ * DuckDB call is a synchronous `bun:ffi` call that blocks the one JS thread,
+ * so under PIPELINE_CONCURRENCY=4 a stage's wall clock is mostly OTHER stages'
+ * calls. Measured on a real store, a stage whose own cost was 2.1s tripped a
+ * 300s wall cap on every concurrent run and had its output discarded (#837).
+ * Self time is the stage's actual cost, so it is what the cap must bind.
+ */
+export const CurrentStageSelfTimeBudget: Context.Reference<number | null> = Context
+    .Reference<number | null>("@ax/duckdb/CurrentStageSelfTimeBudget", {
+        defaultValue: () => null,
+    });
+
+/**
+ * Raised (as a DEFECT, via `Effect.die`) when a stage has already spent its
+ * self-time budget and asks for another database call. A defect rather than a
+ * typed failure so the seam's signature stays `Effect<A, E, R>` - callers of
+ * `CacheRead`/`CacheWriteService` never see this in their error channel; only
+ * the ingest runner catches it (by `instanceof`, out of `cause.reasons`) and
+ * converts it to a fail-open `timeout` stage outcome.
+ *
+ * Enforcement is cooperative and happens BETWEEN calls: a synchronous FFI call
+ * already in flight cannot be preempted (the event loop is blocked - the exact
+ * reason the wall-clock watchdog could not do this job, #837), so one long
+ * call may overshoot the budget and it is the NEXT call that is refused.
+ */
+export class StageSelfTimeBudgetExceeded extends Data.TaggedError("StageSelfTimeBudgetExceeded")<{
+    readonly selfMs: number;
+    readonly budgetMs: number;
+    readonly calls: number;
+}> {}
+
+/**
  * Charge `call`'s elapsed time to whichever stage is running.
  *
  * Outside a stage the accumulator is null and the effect is returned untouched,
@@ -55,6 +92,21 @@ export const chargeStageSelfTime = <A, E, R>(
     Effect.withFiber((fiber) => {
         const acc = fiber.getRef(CurrentStageSelfTime);
         if (acc === null) return call;
+        const budgetMs = fiber.getRef(CurrentStageSelfTimeBudget);
+        if (budgetMs !== null && acc.ms >= budgetMs) {
+            // Refuse the call outright: the stage has spent its budget, and
+            // issuing one more synchronous FFI call would block the thread for
+            // an unbounded further stretch. Work already persisted stays
+            // persisted (ingest is incremental); the runner converts this
+            // defect into a `timeout` row so the refusal is visible (#837).
+            return Effect.die(
+                new StageSelfTimeBudgetExceeded({
+                    selfMs: acc.ms,
+                    budgetMs,
+                    calls: acc.calls,
+                }),
+            );
+        }
         const startedAt = performance.now();
         return Effect.ensuring(
             call,


### PR DESCRIPTION
Closes #837.

## The bug

The 300s derive cap (\`AX_STAGE_TIMEOUT_SECONDS\`) measured wall clock. Every DuckDB call is a synchronous \`bun:ffi\` call that blocks the one JS thread, so at \`PIPELINE_CONCURRENCY=4\` a stage's wall clock is mostly other stages' calls. Measured on a real store (#841/#865 evidence on the issue):

| run | \`claude/subagents\` status | duration |
| --- | --- | --- |
| serial | \`ok\` | **2.1s** |
| concurrent | \`interrupted\` | 302.0s |
| concurrent | \`interrupted\` | 301.8s |

A stage with a real cost of two seconds lost its output on every normal run. And the same wall-clock timer could not preempt a genuinely heavy derive (2,256s past a 300s cap, reported \`ok\`) because a synchronous FFI call never yields to the timer.

## The fix

- **\`AX_STAGE_TIMEOUT_SECONDS\` (default 300) now budgets a derive's SELF DuckDB time** — the quantity the cap was always meant to bind. Enforced cooperatively at the seam: once the #865 accumulator crosses the budget, \`chargeStageSelfTime\` refuses the NEXT call with a \`StageSelfTimeBudgetExceeded\` defect (a call in flight cannot be preempted; the refusal happens between calls, which is the only place enforcement is possible). The runner converts the defect to a fail-open \`timeout\` row naming spend, calls, and budget. Work already written is kept.
- **The wall-clock watchdog is demoted to a hung detector** (\`AX_STAGE_HUNG_SECONDS\`, default 1800, 0 disables). It catches only a derive stuck somewhere that yields (awaited promise, lock) — the case self time never charges. The run-deadline skip (#697) is unchanged.
- **\`wrapStage\` clears the budget around its settle finalizer** — the ledger write reporting the refusal goes through the same charged seam and must not be refused by the budget it reports.
- **Finish SQL sets \`self_ms\` via COALESCE** — the runner-side \`timeout\`/\`skipped\` overwrite (#840) carried no selfMs and was nulling the recorded value, which is exactly the evidence for why the budget fired.

With defaults, \`claude/subagents\` (self 0.0–2.1s) never trips again, and \`turn-content-blocks\` (self ~335s) still does — the behavior the cap was written for.

## Not changed

A derive that finishes all its work while over budget stays \`ok\` — its output is complete and \`self_ms\` on the row exposes the overrun honestly. Chunked/resumable derives remain #689.

## Verification

- Both typecheck gates clean (\`bunx tsc --noEmit -p tsconfig.json\` + \`bun run typecheck\`).
- New tests: seam refusal semantics (first call may overshoot, next is refused, no charge on refusal, inner-scope exemption), runner conversion to \`timeout\` + fail-open + downstream still runs, ingest-tag exemption, 0-disables, non-budget defects still propagate.
- Existing watchdog tests updated to the hung knob; full repo suite: 6,112 pass. The only 4 failures are pre-existing \`apps/studio-desktop\` electron-binary environment failures in the worktree, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)