### PR TITLE
fix(ci): bench workflow installs dependencies before running the suite

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           bun-version: "1.3.10"
 
+      # The suite imports workspace packages (@ax/lib/testing/gated-test since
+      # #863); without an install, bun cannot resolve them and the job fails.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # Official DuckDB CLI (not brew). Pinned to v1.5.5 to match the
       # duckdb-spike / #757 recipe. Skip cleanly when the asset cannot be
       # fetched quickly — this job tests the harness, not dylib CI.


### PR DESCRIPTION
Bench failed on the #849 merge commit: `Cannot find module '@ax/lib/testing/gated-test' from scripts/bench/run.test.ts`. The workflow never ran `bun install`; that worked until #863 made the bench tests import a workspace package. Adds the install step. The Bench run on THIS PR is the proof (workflow edits are the case where we wait for CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)