### PR TITLE
fix(schema): register schema_comment_state in the DuckDB table manifest

### DIFF
--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -34,8 +34,16 @@ describe("coverage of the Surreal schema", () => {
     });
 
     test("the DDL adds no table the Surreal schema never had", () => {
+        // schema.surql is frozen migration-fidelity proof; tables born AFTER the
+        // v2 cutover are enumerated here instead of edited into it. Anything not
+        // on this list must have a Surreal counterpart.
+        const bornAfterSurreal = new Set([
+            "schema_comment_state", // #869 COMMENT ON bookkeeping
+        ]);
         const surrealSet = new Set(surrealTables.map((t) => t.table));
-        expect(duckTables.filter((t) => !surrealSet.has(t))).toEqual([]);
+        expect(duckTables.filter((t) => !surrealSet.has(t) && !bornAfterSurreal.has(t))).toEqual([]);
+        // ...and the allowlist cannot rot: every entry must still exist in the DDL.
+        expect([...bornAfterSurreal].filter((t) => !duckTableSet.has(t))).toEqual([]);
     });
 
     test("table names are unique", () => {

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -107,6 +107,7 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     workflow_snapshot: { kind: "node", stage: "active", note: "Precomputed dashboard workflow payload used by /api/workflow." },
     phase_span: { kind: "node", stage: "staged", note: "Session workflow phase spans and phase-level counters." },
     skill_candidate: { kind: "node", stage: "active", note: "Evidence-backed candidate skills or guardrails." },
+    schema_comment_state: { kind: "node", stage: "active", note: "Self-documenting catalog bookkeeping (#869): hash of the last-applied COMMENT ON script, so routine opens skip re-applying (WAL crash-safety)." },
     ingest_run: { kind: "node", stage: "active", note: "Top-level ingest execution telemetry." },
     ingest_stage: { kind: "node", stage: "active", note: "Per-stage ingest execution telemetry." },
     ingest_event: { kind: "node", stage: "active", note: "Append-like ingest progress events." },

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -1515,7 +1515,8 @@ CREATE INDEX IF NOT EXISTS skill_candidate_status ON skill_candidate(status, cre
 -- this DuckDB build (replay fails, live db unopenable), so the apply path
 -- CHECKPOINTs immediately and this row keeps every later open comment-free.
 CREATE TABLE IF NOT EXISTS schema_comment_state (
-    id VARCHAR PRIMARY KEY,  -- always 'comments'
+    -- always 'comments'
+    id VARCHAR PRIMARY KEY,
     comments_hash VARCHAR NOT NULL,  -- stableDigest of the emitted COMMENT ON script
     applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
Main CI (`verify`) is red on `8642afa2` and `cbb90ca1`: 8 fails in the duckdb-schema test family.

Root cause: #873 (#869) added the `schema_comment_state` bookkeeping table to the DDL and to `SCHEMA_TABLES`, but not to `TABLE_METADATA` in `packages/schema/src/duckdb-tables.ts`. `buildManifest()` throws at import - the designed tripwire - and takes the family down.

Repairs:
- **duckdb-tables.ts**: add the missing manifest entry (`node`/`active`, note mirrors `SCHEMA_TABLES`).
- **schema.duckdb.sql**: move the `id` column's trailing `-- always 'comments'` above the line. The row-identity guard matches `id VARCHAR PRIMARY KEY,?$` exactly; the COMMENT ON codegen reads above-line comments too, so the generated column comment survives.
- **duckdb-schema.test.ts**: `schema.surql` is frozen migration-fidelity proof ("do not add to it"), so the never-had coverage test gets an explicit `bornAfterSurreal` allowlist with a rot guard, instead of an edit to the retired DDL.

Verified locally: `bunx tsc --noEmit` clean, `bun run typecheck` clean, full `bun test` with `AX_DUCKDB_DYLIB` + `AX_DUCKDB_REQUIRE_FTS=1` + temp `AX_DATA_DIR` green except the 4 known-exempt studio-desktop electron env failures. The previously failing 4 schema test files pass (41 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)