### PR TITLE
feat(ingest): read Claude's native attribution fields onto turn_token_usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,7 @@ real skill with `dir_path = "(opencode)"` and hide it from those same views.
 `ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
 `ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. Subagent origin = any `*-subagent` source (`claude-subagent` + `codex-subagent`). MCP: `cost_models`, `cost_split`.
 `ax cost routability [--days=N] [--min-run=1] [--json]` - main-thread routability lens: of main-agent spend, how much sat in routable class-runs (gather, mechanical-impl/niche-research) vs genuine judgment, with est savings repriced one tier down. **Claude AND Codex** are classified + repriced SEPARATELY (output is split per-provider with a combined total): Claude routables drop to haiku/sonnet, Codex to gpt-5-nano/gpt-5-mini (same-vendor; cross-provider repricing is nonsense). Codex subagent cost is excluded from codex-main via the `codex-subagent` source (see #553). Deterministic - turn-level classification from tool composition + `JUDGMENT_GUARD_RE` text guard (the `thinking_tokens` signal is dead - 0 on ~97% of turns - so it's dropped; `--min-run` groups consecutive same-class turns, default 1). Codex tools don't map 1:1 to Claude's Read/Edit/Write - `codexToolClass` disambiguates the overloaded `exec_command` via `command_norm` (read-like rg/cat/git diff vs write/build sed/git add/bun test; ambiguous norms like bare `sed` stay on main, conservative). Codex turns are PER-EVENT so cost is fragmented across `tool_call`/`function_call_output`/`reasoning`/`assistant` rows; `buildSpans` role-kinds them (work/boundary/carry/skip) and folds tool-output cost onto the action that produced it. Other providers (opencode/cursor/pi) are not yet classified and contribute $0. MCP: `cost_routability`. Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md.
+`ax cost attribution [--days=N] [--limit=N] [--json]` - cost by NATIVE harness attribution (#867). Claude Code (since ~2026-05) stamps `attributionSkill`/`attributionAgent` on each billing event plus `diagnostics.cache_miss_reason` (an OBJECT - `.type` is stored) and `api_error_status` (unobserved locally; stored as text). The parser lands them as 4 nullable columns on `turn_token_usage` (claude sources only; null on other providers and on pre-cutover history until `ax ingest --reparse=claude` backfills). Rollups per skill + per agent (cost/tokens/turns/sessions), cache-miss + api-error mixes, and a coverage line so a mostly-null window reads as "data not there yet", not "cheap". Ground truth vs the `invoked`-edge inference - divergence is a signal. Query: `apps/axctl/src/queries/attribution-cost.ts`. MCP: `cost_attribution`.
 `ax cost images [--days=N] [--limit=N] [--json]` - image-read context lens: per-session bytes of image tool outputs (`content_type:binary` via the `has_content` edge), split main-thread vs subagent. Surfaces screenshots that persist in the main context window and re-bill across every later turn - the cue to route visual judgment to a subagent (the `ln`/efficient-dispatch "isolate heavy context" pattern). Deref-free over `has_content` + `spawned` (`apps/axctl/src/queries/image-context.ts`); est tokens is a bytes/4 proxy (image vision billing differs).
 
 ### Telemetry-enriched insights
@@ -546,14 +547,14 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 23 tools
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 24 tools
 (`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
 `skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
 `session_metrics`, `sessions_churn`, `signal_show`, `cost_models`, `cost_split`, `cost_images`,
-`cost_routability`, `otel`, `runs_evidence`, `dispatches`, `dispatches_advice`, `dojo_agenda`, `directives_list`) so an agent can query the graph in-context.
+`cost_routability`, `cost_attribution`, `otel`, `runs_evidence`, `dispatches`, `dispatches_advice`, `dojo_agenda`, `directives_list`) so an agent can query the graph in-context.
 Works from source AND from the compiled binary - DuckDB is a native dep, but
 `libduckdb` is embedded at build time, so a `tools/list` handshake against
-`dist/axctl mcp` returns all 23. Mutating
+`dist/axctl mcp` returns all 24. Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
 exposed; `sessions_churn` takes an explicit `project` path instead of `--here`.
 

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -20,6 +20,7 @@ import {
 } from "../../queries/cost-analytics.ts";
 import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";
 import { fetchImageContext } from "../../queries/image-context.ts";
+import { fetchAttributionCost, type AttributionRow } from "../../queries/attribution-cost.ts";
 import {
     buildCostModelsNext,
     buildCostSplitNext,
@@ -468,12 +469,104 @@ const costImagesCommand = Command.make(
 );
 
 // ---------------------------------------------------------------------------
+// ax cost attribution [--days=N] [--limit=N] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdCostAttribution = (input: {
+    readonly sinceDays: number;
+    readonly limit: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const read = yield* CacheRead;
+        const result = yield* fetchAttributionCost(read, { sinceDays: input.sinceDays, limit: input.limit });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        const cov = result.coverage;
+        if (cov.attributedTurns === 0) {
+            console.log("(no natively-attributed usage rows in the requested window)");
+            console.log(
+                "Claude Code writes attributionSkill/attributionAgent since ~2026-05; " +
+                    "pre-existing sessions read null until `ax ingest --reparse=claude` backfills them.",
+            );
+            return;
+        }
+
+        type Row = { name: string; turns: string; sessions: string; tokens: string; cost: string };
+        const render = (kind: string, rows: ReadonlyArray<AttributionRow>): void => {
+            if (rows.length === 0) return;
+            const rendered: Row[] = rows.map((r) => ({
+                name: r.name.slice(0, 40),
+                turns: integer(r.turns),
+                sessions: integer(r.sessions),
+                tokens: integer(r.tokens),
+                cost: usd(r.costUsd),
+            }));
+            const cols: Column<Row>[] = [
+                { header: kind, get: (r) => r.name, min: 24 },
+                { header: "turns", get: (r) => r.turns, align: "right", min: 6 },
+                { header: "sessions", get: (r) => r.sessions, align: "right", min: 8 },
+                { header: "tokens", get: (r) => r.tokens, align: "right", min: 12 },
+                { header: "cost", get: (r) => r.cost, align: "right", min: 9 },
+            ];
+            console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
+            console.log();
+        };
+
+        render("skill (native)", result.skills);
+        render("agent (native)", result.agents);
+
+        const turnShare = cov.totalTurns > 0 ? cov.attributedTurns / cov.totalTurns : 0;
+        const costShare = cov.totalCostUsd > 0 ? cov.attributedCostUsd / cov.totalCostUsd : 0;
+        console.log(
+            `coverage: ${integer(cov.attributedTurns)}/${integer(cov.totalTurns)} claude usage rows ` +
+                `(${pct(turnShare)}) carry native attribution - ${usd(cov.attributedCostUsd)} of ${usd(cov.totalCostUsd)} (${pct(costShare)})`,
+        );
+        if (result.cacheMissReasons.length > 0) {
+            const mix = result.cacheMissReasons.map((r) => `${r.reason}×${integer(r.turns)}`).join(", ");
+            console.log(`cache misses: ${mix}`);
+        }
+        if (result.apiErrors.length > 0) {
+            const mix = result.apiErrors.map((r) => `${r.status}×${integer(r.turns)}`).join(", ");
+            console.log(`api errors: ${mix}`);
+        }
+        console.log(`\n(${input.sinceDays} days; native = harness-stamped, cross-check vs invoked-edge inference)`);
+    });
+
+const costAttributionCommand = Command.make(
+    "attribution",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)),
+        limit: positiveLimit(20),
+        json: jsonFlag,
+    },
+    ({ days, limit, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax cost attribution: --days must be a positive integer (got "${days}")`);
+        }
+        if (!Number.isInteger(limit) || limit <= 0) {
+            fail(`ax cost attribution: --limit must be a positive integer (got "${limit}")`);
+        }
+        return cmdCostAttribution({ sinceDays: days, limit, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Cost by NATIVE harness attribution (attributionSkill/attributionAgent per billing event, #867) " +
+        "with cache-miss + api-error mix. --days=N (default 14)  --limit=N (default 20)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
 // ax cost (group command)
 // ---------------------------------------------------------------------------
 
 export const costCommand = Command.make("cost").pipe(
     Command.withDescription(
-        "Model/cost analytics: per-model rollup, top sessions, main-vs-subagent split, image context cost",
+        "Model/cost analytics: per-model rollup, top sessions, main-vs-subagent split, image context cost, native attribution",
     ),
     Command.withSubcommands([
         costModelsCommand,
@@ -481,6 +574,7 @@ export const costCommand = Command.make("cost").pipe(
         costSplitCommand,
         costRoutabilityCommand,
         costImagesCommand,
+        costAttributionCommand,
     ]),
 );
 

--- a/apps/axctl/src/ingest/line-schemas.ts
+++ b/apps/axctl/src/ingest/line-schemas.ts
@@ -45,6 +45,12 @@ export const ClaudeTranscriptLine = Schema.Struct({
     uuid: lenient(Schema.String),
     model: lenient(Schema.String),
     isCompactSummary: lenient(Schema.Boolean),
+    // Native attribution (#867, present since ~2026-05): the harness stamps
+    // the skill/agent a billing event belongs to on the ENTRY, camelCase.
+    attributionSkill: lenient(Schema.String),
+    attributionAgent: lenient(Schema.String),
+    // Never observed locally yet (cct consumes it); probed tolerantly.
+    api_error_status: Schema.optionalKey(Schema.Unknown),
     message: lenient(Schema.Struct({
         model: lenient(Schema.String),
         isCompactSummary: lenient(Schema.Boolean),
@@ -54,6 +60,12 @@ export const ClaudeTranscriptLine = Schema.Struct({
             output_tokens: lenientFiniteNumber,
             cache_creation_input_tokens: lenientFiniteNumber,
             cache_read_input_tokens: lenientFiniteNumber,
+        })),
+        // Cache forensics (#867): `cache_miss_reason` is an OBJECT
+        // (`{"type": ...}`), not a flat string - extract `.type` downstream.
+        diagnostics: lenient(Schema.Struct({
+            cache_miss_reason: Schema.optionalKey(Schema.Unknown),
+            api_error_status: Schema.optionalKey(Schema.Unknown),
         })),
     })),
 });

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1633,6 +1633,68 @@ describe("claude token usage", () => {
         expect(extracted?.turnTokenUsages[1]?.model).toBe("claude-opus-4-8");
     });
 
+    test("reads native attribution + cache forensics per usage row (#867)", () => {
+        const usage = {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        const lines = [
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a1",
+                timestamp: "2026-06-01T10:00:01.000Z",
+                // The harness stamps attribution on the ENTRY, camelCase.
+                attributionSkill: "artifact-design",
+                api_error_status: 529,
+                message: {
+                    role: "assistant",
+                    model: "claude-opus-4-8",
+                    content: "ok",
+                    usage,
+                    // cache_miss_reason is an OBJECT - only .type is kept.
+                    diagnostics: { cache_miss_reason: { type: "previous_message_not_found" } },
+                },
+            }),
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a2",
+                timestamp: "2026-06-01T10:00:02.000Z",
+                attributionAgent: "design-curator",
+                message: { role: "assistant", model: "claude-opus-4-8", content: "done", usage },
+            }),
+            // Pre-cutover shape: no attribution anywhere -> all null.
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a3",
+                timestamp: "2026-06-01T10:00:03.000Z",
+                message: { role: "assistant", model: "claude-opus-4-8", content: "old", usage },
+            }),
+        ];
+        const extracted = __testExtractClaudeJsonlLines(lines, "-tmp", "cl-attr");
+        const rows = extracted!.turnTokenUsages;
+        expect(rows).toHaveLength(3);
+        expect(rows[0]).toMatchObject({
+            attributionSkill: "artifact-design",
+            attributionAgent: null,
+            cacheMissReasonType: "previous_message_not_found",
+            apiErrorStatus: "529",
+        });
+        expect(rows[1]).toMatchObject({
+            attributionSkill: null,
+            attributionAgent: "design-curator",
+            cacheMissReasonType: null,
+            apiErrorStatus: null,
+        });
+        expect(rows[2]).toMatchObject({
+            attributionSkill: null,
+            attributionAgent: null,
+            cacheMissReasonType: null,
+            apiErrorStatus: null,
+        });
+    });
+
     test("prices the session via the built-in catalog", () => {
         const extracted = __testExtractClaudeJsonlLines(
             usageLines("claude-opus-4-8"),

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -188,6 +188,14 @@ function asContentBlocks(input: unknown): Record<string, unknown>[] {
     return Array.isArray(input) ? input.filter(isRecord) : [];
 }
 
+/** `api_error_status` (#867) has never been observed locally, so its type is
+ *  unpinned upstream - accept a string or a finite number, store as text. */
+function scalarToString(value: unknown): string | null {
+    if (typeof value === "string" && value.length > 0) return value;
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+    return null;
+}
+
 function messageKind(role: string, content: unknown, textExcerpt: string | null): string {
     const blocks = asContentBlocks(content);
     if (blocks.length > 0 && blocks.every((block) => stringField(block, "type") === "tool_result")) {
@@ -295,6 +303,12 @@ interface ClaudeTurnTokenUsage {
     cacheReadInputTokens: number;
     freshInputTokens: number;
     estimatedTokens: number;
+    /** Native harness attribution (#867), null before the ~2026-05 cutover. */
+    attributionSkill: string | null;
+    attributionAgent: string | null;
+    /** `message.diagnostics.cache_miss_reason.type` - the reason is an object. */
+    cacheMissReasonType: string | null;
+    apiErrorStatus: string | null;
 }
 
 interface FileExtract {
@@ -1024,6 +1038,14 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                 usageCompletion += completion;
                 usageCacheCreation += cacheCreation;
                 usageCacheRead += cacheRead;
+                // Native attribution + cache forensics (#867). The harness
+                // stamps `attributionSkill`/`attributionAgent` on the entry
+                // (camelCase); `cache_miss_reason` is an OBJECT under
+                // `message.diagnostics` - only its `.type` is kept. All null
+                // before the ~2026-05 harness cutover, so readers need
+                // non-null denominators.
+                const diagnostics = message?.diagnostics ?? null;
+                const cacheMissReason = diagnostics?.cache_miss_reason;
                 // Per-turn usage drives the inspector's per-turn cost rail.
                 turnTokenUsages.push({
                     seq,
@@ -1035,6 +1057,12 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                     cacheReadInputTokens: cacheRead,
                     freshInputTokens: freshInput,
                     estimatedTokens: freshInput + cacheCreation + cacheRead + completion,
+                    attributionSkill: entry.attributionSkill ?? null,
+                    attributionAgent: entry.attributionAgent ?? null,
+                    cacheMissReasonType: isRecord(cacheMissReason)
+                        ? stringField(cacheMissReason, "type")
+                        : null,
+                    apiErrorStatus: scalarToString(entry.api_error_status ?? diagnostics?.api_error_status),
                 });
             }
             const messageContent = message?.content;
@@ -1640,6 +1668,10 @@ const writeClaudeTokenUsageRows = (
             pricing_source: cost.pricingSource,
             usage_source: "claude_transcript.message_usage",
             usage_quality: "provider_turn",
+            attribution_skill: turnUsage.attributionSkill,
+            attribution_agent: turnUsage.attributionAgent,
+            cache_miss_reason_type: turnUsage.cacheMissReasonType,
+            api_error_status: turnUsage.apiErrorStatus,
             raw: null,
             ts: tsParam(turnUsage.ts),
         });

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_TOOLS = [
     "cost_models",
     "cost_split",
     "cost_images",
+    "cost_attribution",
     "cost_routability",
     "otel",
     "runs_evidence",

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -25,6 +25,7 @@ const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     cost_models: ["days"],
     cost_split: ["days"],
     cost_images: ["days", "limit"],
+    cost_attribution: ["days", "limit"],
     cost_routability: ["days", "min_run"],
     otel: ["days"],
     runs_evidence: ["sessionId"],

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -76,6 +76,7 @@ import { COST_DEFAULT_WINDOW_DAYS, fetchCostModels, fetchCostSplit } from "../qu
 import { OTEL_DEFAULT_WINDOW_DAYS, fetchOtelRollup } from "../queries/otel-rollup.ts";
 import { fetchRunEvidence } from "../queries/run-evidence.ts";
 import { fetchImageContext } from "../queries/image-context.ts";
+import { fetchAttributionCost } from "../queries/attribution-cost.ts";
 import { fetchRoutability } from "../queries/routability.ts";
 import { fetchDispatches, fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { fetchAdviceLedger } from "../queries/advice-ledger.ts";
@@ -734,6 +735,35 @@ const costImagesTool: AxMcpTool = defineMcpTool({
     },
 });
 
+const costAttributionTool: AxMcpTool = defineMcpTool({
+    name: "cost_attribution",
+    runtime: "cache",
+    description:
+        "Cost by NATIVE harness attribution (#867): Claude Code stamps attributionSkill/attributionAgent on each billing event; this rolls up cost/tokens/turns per skill and per agent, plus cache_miss_reason and api_error_status mixes and a coverage line (share of claude usage rows carrying attribution - null before ~2026-05 and until a --reparse=claude backfill). Ground truth to cross-check against invoked-edge skill attribution; divergence is itself a signal.",
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 14)."),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Max rows per rollup (default 20)."),
+    },
+    run: async (args, rt) => {
+        const sinceDays = args.days ?? COST_DEFAULT_WINDOW_DAYS;
+        const limit = args.limit ?? 20;
+        return await rt.runPromise(Effect.gen(function* () {
+            const read = yield* CacheRead;
+            return yield* fetchAttributionCost(read, { sinceDays, limit });
+        }));
+    },
+});
+
 const otelTool: AxMcpTool = defineMcpTool({
     name: "otel",
     runtime: "full",
@@ -955,6 +985,7 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     costModelsTool,
     costSplitTool,
     costImagesTool,
+    costAttributionTool,
     costRoutabilityTool,
     otelTool,
     runsEvidenceTool,

--- a/apps/axctl/src/queries/attribution-cost.duckdb.test.ts
+++ b/apps/axctl/src/queries/attribution-cost.duckdb.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `fetchAttributionCost` (#867) against a REAL published DuckDB snapshot.
+ *
+ * Pins three things a mocked seam cannot see:
+ *  1. The window bound actually FILTERS (one row is seeded 60 days back and
+ *     the same read runs at two widths).
+ *  2. Non-claude sources are excluded - a codex usage row must not leak into
+ *     the coverage denominator, or attribution coverage reads artificially low.
+ *  3. FILTER-clause coverage math: attributed vs total rows/cost.
+ */
+import { describe, expect } from "bun:test";
+import { Effect } from "effect";
+import { CacheRead } from "@ax/lib/duckdb/seam";
+import { publishCacheFixture, readFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { fetchAttributionCost } from "./attribution-cost.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("attribution cost", { requireFts: true });
+
+const hoursAgo = (h: number): Date => new Date(Date.now() - h * 60 * 60 * 1000);
+const daysAgo = (d: number): Date => new Date(Date.now() - d * 24 * 60 * 60 * 1000);
+
+const SESSION_A = "019e2531-b552-7b53-a029-c780adbb6560";
+const SESSION_B = "019e2531-ffff-7b53-a029-c780adbb6561";
+
+interface UsageSeed {
+    readonly id: string;
+    readonly session: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly source: string;
+    readonly costUsd: number;
+    readonly skill?: string | null;
+    readonly agent?: string | null;
+    readonly cacheMiss?: string | null;
+    readonly apiError?: string | null;
+}
+
+const usageRow = (seed: UsageSeed) => ({
+    id: seed.id,
+    session: seed.session,
+    turn: seed.id,
+    seq: seed.seq,
+    source: seed.source,
+    model: "claude-opus-4-8",
+    prompt_tokens: 1000n,
+    completion_tokens: 100n,
+    cache_creation_input_tokens: 0n,
+    cache_read_input_tokens: 0n,
+    fresh_input_tokens: 1000n,
+    estimated_tokens: 1100n,
+    estimated_cost_usd: seed.costUsd,
+    usage_source: "claude_transcript.message_usage",
+    usage_quality: "provider_turn",
+    attribution_skill: seed.skill ?? null,
+    attribution_agent: seed.agent ?? null,
+    cache_miss_reason_type: seed.cacheMiss ?? null,
+    api_error_status: seed.apiError ?? null,
+    ts: seed.ts,
+});
+
+describe("fetchAttributionCost over a published snapshot", () => {
+    dtest("rolls up native attribution with a filtering window and claude-only coverage", async () => {
+        const dir = tempDir("attribution-cost");
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    // Two attributed skill rows in-window, distinct sessions.
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:1", session: SESSION_A, seq: 1, ts: hoursAgo(2),
+                        source: "claude", costUsd: 2, skill: "artifact-design",
+                        cacheMiss: "previous_message_not_found",
+                    }));
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:2", session: SESSION_B, seq: 1, ts: hoursAgo(3),
+                        source: "claude-subagent", costUsd: 1, skill: "artifact-design",
+                        agent: "design-curator", apiError: "529",
+                    }));
+                    // Unattributed claude row - counts in coverage denominator only.
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:3", session: SESSION_A, seq: 2, ts: hoursAgo(4),
+                        source: "claude", costUsd: 4,
+                    }));
+                    // OUTSIDE the 7-day window - proves the bound filters.
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:old", session: SESSION_A, seq: 3, ts: daysAgo(60),
+                        source: "claude", costUsd: 50, skill: "artifact-design",
+                    }));
+                    // A codex row with attribution-shaped nulls - must not
+                    // enter the claude coverage denominator.
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:codex", session: SESSION_B, seq: 4, ts: hoursAgo(1),
+                        source: "codex", costUsd: 9,
+                    }));
+                }),
+            ),
+        );
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+
+        const { week, quarter } = await Effect.runPromise(
+            Effect.gen(function* () {
+                const read = yield* CacheRead;
+                return {
+                    week: yield* fetchAttributionCost(read, { sinceDays: 7, limit: 20 }),
+                    quarter: yield* fetchAttributionCost(read, { sinceDays: 90, limit: 20 }),
+                };
+            }).pipe(Effect.provide(layer)),
+        );
+
+        // Skill rollup: 2 in-window turns across 2 sessions, $3.
+        expect(week.skills).toEqual([
+            { name: "artifact-design", turns: 2, sessions: 2, costUsd: 3, tokens: 2200 },
+        ]);
+        expect(week.agents).toEqual([
+            { name: "design-curator", turns: 1, sessions: 1, costUsd: 1, tokens: 1100 },
+        ]);
+        expect(week.cacheMissReasons).toEqual([{ reason: "previous_message_not_found", turns: 1 }]);
+        expect(week.apiErrors).toEqual([{ status: "529", turns: 1 }]);
+
+        // Coverage: 3 claude rows in-window (codex excluded), 2 attributed.
+        expect(week.coverage).toEqual({
+            totalTurns: 3,
+            attributedTurns: 2,
+            totalCostUsd: 7,
+            attributedCostUsd: 3,
+        });
+
+        // The wider window picks up the 60-day-old row.
+        expect(quarter.skills[0]?.turns).toBe(3);
+        expect(quarter.skills[0]?.costUsd).toBe(53);
+    });
+});

--- a/apps/axctl/src/queries/attribution-cost.ts
+++ b/apps/axctl/src/queries/attribution-cost.ts
@@ -1,0 +1,162 @@
+/**
+ * `ax cost attribution` (#867): cost by NATIVE harness attribution.
+ *
+ * Claude Code (since ~2026-05) stamps `attributionSkill`/`attributionAgent`
+ * on each billing event, plus `diagnostics.cache_miss_reason`. The ingest
+ * parser lands them on `turn_token_usage` (claude sources only; null on
+ * every other provider and on all pre-cutover history until a
+ * `--reparse=claude` backfill). This is GROUND TRUTH per billing event -
+ * unlike `invoked`-edge attribution, which is an inference from Skill-tool
+ * calls; divergence between the two is itself a signal.
+ *
+ * Flat GROUP BYs over `turn_token_usage`, no derefs. Every rollup uses a
+ * non-null filter, and coverage reports how much of the window's claude
+ * spend carries attribution at all - without it, a mostly-null window would
+ * read as "this skill is cheap" instead of "the data is not there yet".
+ */
+import { Effect, Schema } from "effect";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import type { CacheReadService } from "@ax/lib/duckdb/seam";
+
+export interface AttributionRow {
+    /** The skill or agent name exactly as the harness stamped it. */
+    readonly name: string;
+    readonly turns: number;
+    readonly sessions: number;
+    readonly costUsd: number;
+    readonly tokens: number;
+}
+
+export interface CacheMissRow {
+    readonly reason: string;
+    readonly turns: number;
+}
+
+export interface ApiErrorRow {
+    readonly status: string;
+    readonly turns: number;
+}
+
+export interface AttributionCostResult {
+    readonly skills: ReadonlyArray<AttributionRow>;
+    readonly agents: ReadonlyArray<AttributionRow>;
+    readonly cacheMissReasons: ReadonlyArray<CacheMissRow>;
+    readonly apiErrors: ReadonlyArray<ApiErrorRow>;
+    readonly coverage: {
+        /** claude-source usage rows in the window */
+        readonly totalTurns: number;
+        /** ...of which carry a skill or agent attribution */
+        readonly attributedTurns: number;
+        readonly totalCostUsd: number;
+        readonly attributedCostUsd: number;
+    };
+}
+
+export interface AttributionCostInput {
+    readonly sinceDays: number;
+    readonly limit: number;
+}
+
+const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+const RollupRow = Schema.Struct({
+    name: Schema.String,
+    turns: NumberFromBigIntColumn,
+    sessions: NumberFromBigIntColumn,
+    cost_usd: Schema.NullOr(Schema.Number),
+    tokens: NumberFromBigIntColumn,
+});
+
+const CountRow = Schema.Struct({
+    name: Schema.String,
+    turns: NumberFromBigIntColumn,
+});
+
+const CoverageRow = Schema.Struct({
+    total_turns: NumberFromBigIntColumn,
+    attributed_turns: NumberFromBigIntColumn,
+    total_cost_usd: Schema.NullOr(Schema.Number),
+    attributed_cost_usd: Schema.NullOr(Schema.Number),
+});
+
+const rollupSql = (column: "attribution_skill" | "attribution_agent"): string => `
+    SELECT ${column} AS name,
+           count(*) AS turns,
+           count(DISTINCT session) AS sessions,
+           sum(estimated_cost_usd) AS cost_usd,
+           CAST(coalesce(sum(estimated_tokens), 0) AS BIGINT) AS tokens
+    FROM turn_token_usage
+    WHERE ${column} IS NOT NULL AND source LIKE 'claude%' AND ts > ?
+    GROUP BY ${column}
+    ORDER BY cost_usd DESC NULLS LAST`;
+
+const countSql = (column: "cache_miss_reason_type" | "api_error_status"): string => `
+    SELECT ${column} AS name, count(*) AS turns
+    FROM turn_token_usage
+    WHERE ${column} IS NOT NULL AND source LIKE 'claude%' AND ts > ?
+    GROUP BY ${column}
+    ORDER BY turns DESC`;
+
+const COVERAGE_SQL = `
+    SELECT count(*) AS total_turns,
+           count(*) FILTER (WHERE attribution_skill IS NOT NULL OR attribution_agent IS NOT NULL) AS attributed_turns,
+           coalesce(sum(estimated_cost_usd), 0) AS total_cost_usd,
+           coalesce(sum(estimated_cost_usd) FILTER (WHERE attribution_skill IS NOT NULL OR attribution_agent IS NOT NULL), 0) AS attributed_cost_usd
+    FROM turn_token_usage
+    WHERE source LIKE 'claude%' AND ts > ?`;
+
+const toRow = (raw: typeof RollupRow.Type): AttributionRow => ({
+    name: raw.name,
+    turns: raw.turns,
+    sessions: raw.sessions,
+    costUsd: raw.cost_usd ?? 0,
+    tokens: raw.tokens,
+});
+
+const EMPTY_RESULT: AttributionCostResult = {
+    skills: [],
+    agents: [],
+    cacheMissReasons: [],
+    apiErrors: [],
+    coverage: { totalTurns: 0, attributedTurns: 0, totalCostUsd: 0, attributedCostUsd: 0 },
+};
+
+const ColumnProbeRow = Schema.Struct({ n: NumberFromBigIntColumn });
+
+export const fetchAttributionCost = Effect.fn("queries.fetchAttributionCost")(
+    function* (read: CacheReadService, input: AttributionCostInput) {
+        // A snapshot PUBLISHED before this release predates the #867 ALTERs -
+        // the columns appear on the next ingest's publish. Probe instead of
+        // erroring, so the first post-upgrade read degrades to the empty
+        // state (whose copy already says how to backfill).
+        const probe = yield* read.rows(
+            ColumnProbeRow,
+            `SELECT CAST(count(*) AS BIGINT) AS n FROM information_schema.columns
+             WHERE table_name = 'turn_token_usage' AND column_name = 'attribution_skill'`,
+        );
+        if ((probe[0]?.n ?? 0) === 0) return EMPTY_RESULT;
+
+        const cutoff = new Date(Date.now() - sqlWindowDays(input.sinceDays) * 86_400_000);
+        const cap = Math.max(1, Math.trunc(input.limit));
+
+        const skills = yield* read.rows(RollupRow, rollupSql("attribution_skill"), [cutoff]);
+        const agents = yield* read.rows(RollupRow, rollupSql("attribution_agent"), [cutoff]);
+        const cacheMiss = yield* read.rows(CountRow, countSql("cache_miss_reason_type"), [cutoff]);
+        const apiErrors = yield* read.rows(CountRow, countSql("api_error_status"), [cutoff]);
+        const coverage = (yield* read.rows(CoverageRow, COVERAGE_SQL, [cutoff]))[0];
+
+        const result: AttributionCostResult = {
+            skills: skills.slice(0, cap).map(toRow),
+            agents: agents.slice(0, cap).map(toRow),
+            cacheMissReasons: cacheMiss.map((r) => ({ reason: r.name, turns: r.turns })),
+            apiErrors: apiErrors.map((r) => ({ status: r.name, turns: r.turns })),
+            coverage: {
+                totalTurns: coverage?.total_turns ?? 0,
+                attributedTurns: coverage?.attributed_turns ?? 0,
+                totalCostUsd: coverage?.total_cost_usd ?? 0,
+                attributedCostUsd: coverage?.attributed_cost_usd ?? 0,
+            },
+        };
+        return result;
+    },
+);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -329,6 +329,7 @@ The 17 tools, each mirroring the matching CLI command:
 - **cost_models** - per-model token and cost rollup (`ax cost models`).
 - **cost_split** - cost matrix split by origin x model (`ax cost split`).
 - **cost_routability** - main-thread routable-spend lens with est savings (`ax cost routability`).
+- **cost_attribution** - cost by native harness attribution: per-skill/per-agent rollup with cache-miss + api-error mix (`ax cost attribution`).
 - **otel** - OTLP receiver health: signal freshness, session coverage, cost cross-check (`ax otel`).
 - **dispatches** - subagent dispatch analytics and routing candidates (`ax dispatches`).
 - **dojo_agenda** - dojo training agenda: budget envelope + prioritized work items (`ax dojo agenda`).

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -201,6 +201,9 @@ const V2_ONLY_COLUMNS: Readonly<Record<string, readonly string[]>> = {
     // Stage self-time: the Surreal-era ledger only had wall clock, and wall
     // clock is what #865 showed to be unusable at PIPELINE_CONCURRENCY > 1.
     ingest_stage: ["self_ms"],
+    // Native harness attribution + cache forensics (#867) - fields Claude Code
+    // started writing ~2026-05, after the Surreal schema froze.
+    turn_token_usage: ["attribution_skill", "attribution_agent", "cache_miss_reason_type", "api_error_status"],
 };
 
 const POLYMORPHIC_EDGE_EXTRA_COLUMNS: Readonly<Record<string, readonly string[]>> = {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -1258,9 +1258,22 @@ CREATE TABLE IF NOT EXISTS turn_token_usage (
     pricing_source VARCHAR,
     usage_source VARCHAR NOT NULL,
     usage_quality VARCHAR NOT NULL,
+    -- Native harness attribution + cache forensics (#867), Claude only, null
+    -- before the ~2026-05 harness cutover AND on every other provider - reads
+    -- need FILTER (WHERE col IS NOT NULL) denominators.
+    attribution_skill VARCHAR,  -- raw transcript field is camelCase attributionSkill
+    attribution_agent VARCHAR,
+    cache_miss_reason_type VARCHAR,  -- message.diagnostics.cache_miss_reason is an OBJECT; this is its .type
+    api_error_status VARCHAR,  -- unobserved locally so far; stored as text, numeric upstream shapes stringified
     raw VARCHAR,
     ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+-- Self-heal replays the DDL but CREATE TABLE IF NOT EXISTS never adds columns
+-- to an existing table (#865/#866) - each new column needs its own ALTER.
+ALTER TABLE turn_token_usage ADD COLUMN IF NOT EXISTS attribution_skill VARCHAR;
+ALTER TABLE turn_token_usage ADD COLUMN IF NOT EXISTS attribution_agent VARCHAR;
+ALTER TABLE turn_token_usage ADD COLUMN IF NOT EXISTS cache_miss_reason_type VARCHAR;
+ALTER TABLE turn_token_usage ADD COLUMN IF NOT EXISTS api_error_status VARCHAR;
 CREATE UNIQUE INDEX IF NOT EXISTS turn_token_usage_turn ON turn_token_usage(turn);
 CREATE INDEX IF NOT EXISTS turn_token_usage_session_seq ON turn_token_usage(session, seq);
 CREATE INDEX IF NOT EXISTS turn_token_usage_model ON turn_token_usage(model_ref, ts);


### PR DESCRIPTION
Closes #867. Queue item 3 of the v3 execution goal.

**Parser**: the claude extractor reads the native attribution family per usage row - `attributionSkill`/`attributionAgent` (top-level on the entry, camelCase - measured), `message.diagnostics.cache_miss_reason.type` (the reason is an OBJECT), and `api_error_status` (never observed locally; probed tolerantly at entry + diagnostics level, stored as text). Lands as 4 nullable VARCHAR columns on `turn_token_usage`, claude sources only.

**DDL**: columns in the CREATE plus the `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` quartet - the self-heal replays the DDL but never adds columns to an existing table (#865/#866). Parity test allowlist (`V2_ONLY_COLUMNS`) records them as born-after-Surreal.

**Read surface**: `ax cost attribution [--days --limit --json]` + MCP `cost_attribution` (24 tools now). Per-skill + per-agent rollups, cache-miss/api-error mixes, and a coverage line (share of claude usage rows carrying attribution) so a mostly-null window cannot read as "this skill is cheap". The query probes `information_schema` for the columns and degrades to the empty state on a pre-upgrade published snapshot - verified live: `ax cost attribution` against the current real snapshot prints the empty state with the backfill hint instead of erroring.

**Tests**: extractor unit test (attributed / agent-only / pre-cutover rows); a real-DuckDB published-snapshot test pinning window filtering, claude-only coverage denominators (a codex row must not deflate coverage), and the FILTER-clause math; MCP roster pins updated.

**Backfill**: pre-existing sessions read null until `ax ingest --reparse=claude` (I will run it post-merge).

Verified: `bunx tsc --noEmit` clean, `bun run typecheck` clean, `check:timestamp-cast` + `check:raw-numeric-cast` clean, full `bun test` with `AX_DUCKDB_DYLIB` + `AX_DUCKDB_REQUIRE_FTS=1` + temp `AX_DATA_DIR`: 6112 pass / 4 fail + 4 errors = the known-exempt studio-desktop electron env set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)