### PR TITLE
fix(cost): coverage line printed the attribution share 100x too small (#881)

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -520,8 +520,10 @@ const cmdCostAttribution = (input: {
         render("skill (native)", result.skills);
         render("agent (native)", result.agents);
 
-        const turnShare = cov.totalTurns > 0 ? cov.attributedTurns / cov.totalTurns : 0;
-        const costShare = cov.totalCostUsd > 0 ? cov.attributedCostUsd / cov.totalCostUsd : 0;
+        // `pct` renders a 0-100 value (n.toFixed(1) + "%"), not a 0-1 fraction
+        // (#881: 64,153/166,677 printed as "0.4%").
+        const turnShare = cov.totalTurns > 0 ? (100 * cov.attributedTurns) / cov.totalTurns : 0;
+        const costShare = cov.totalCostUsd > 0 ? (100 * cov.attributedCostUsd) / cov.totalCostUsd : 0;
         console.log(
             `coverage: ${integer(cov.attributedTurns)}/${integer(cov.totalTurns)} claude usage rows ` +
                 `(${pct(turnShare)}) carry native attribution - ${usd(cov.attributedCostUsd)} of ${usd(cov.totalCostUsd)} (${pct(costShare)})`,


### PR DESCRIPTION
Fixes #881.

`pct()` (cli/render.ts) renders a 0-100 value (`n.toFixed(1) + "%"`), but `cmdCostAttribution`'s coverage line handed it 0-1 fractions. Real output read:

```
coverage: 64,153/166,677 claude usage rows (0.4%) ... (0.3%)
```

After the fix, against the same snapshot:

```
coverage: 64,153/166,677 claude usage rows (38.5%) carry native attribution - $6666.5286 of $26013.1921 (25.6%)
```

Display-only; JSON output carries raw counts and is unchanged. Local gates: `bunx tsc --noEmit -p tsconfig.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)