### PR TITLE
fix(duckdb): canonicalize the engine path before staging the napi symlink (#884)

### DIFF
--- a/packages/lib/src/duckdb/binding.ts
+++ b/packages/lib/src/duckdb/binding.ts
@@ -44,6 +44,7 @@ import { Effect, FileSystem, type PlatformError } from "effect";
 import { createRequire } from "node:module";
 import { posixPath } from "../shared/path.ts";
 import { stageAndRename } from "../staged-rename.ts";
+import { canonicalPath } from "./canonical-path.ts";
 import { dylibCacheDir } from "./dylib.ts";
 import { DuckDbDylibError } from "./errors.ts";
 import type * as NodeApi from "@duckdb/node-api";
@@ -254,7 +255,15 @@ export const loadNodeApiOver = (
     options: LoadNodeApiOptions,
 ): Effect.Effect<DuckDbNodeApi, DuckDbDylibError> =>
     Effect.gen(function* () {
-        const dylibPath = options.dylibPath;
+        // CANONICALIZE FIRST (#884): the engine path feeds the stage-dir
+        // digest, the memo compare, and - critically - the staged SYMLINK's
+        // target. A relative spelling (CI smokes pass `dist/duckdb/
+        // libduckdb.so`) stored verbatim becomes a symlink target relative to
+        // the STAGE DIR, i.e. dangling - the addon's `$ORIGIN`/`@loader_path`
+        // lookup then fails with "cannot open shared object file". Canonical
+        // also means a relative and an absolute spelling of the SAME engine
+        // share one memo entry instead of tripping the one-engine refusal.
+        const dylibPath = yield* canonicalPath(fs, options.dylibPath);
         const nodeBindingPath =
             options.nodeBindingPath ??
             (yield* Effect.try({

--- a/packages/lib/src/duckdb/client.test.ts
+++ b/packages/lib/src/duckdb/client.test.ts
@@ -2,7 +2,7 @@ import { BunFileSystem } from "@effect/platform-bun";
 import { describe, expect, test } from "bun:test";
 import { Effect, Fiber, FileSystem, Schema } from "effect";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { loadNodeApiOver } from "./binding.ts";
 import { DuckDb, DuckDbLayer, DuckDbLiveWith, decodeCell } from "./client.ts";
@@ -725,6 +725,24 @@ describe("binding one-engine-per-process", () => {
                     expect(failure._tag).toBe("DuckDbDylibError");
                     expect(failure.message).toContain("already loaded");
                 }
+            }).pipe(Effect.provide(BunFileSystem.layer)),
+        ),
+    );
+
+    // #884: a RELATIVE spelling of the loaded engine is the same engine, not a
+    // conflict - and, on the first load, must never become the staged
+    // symlink's target verbatim (a stage-dir-relative target dangles, which is
+    // exactly how main CI's linux smoke broke). Canonicalization covers both.
+    dtest(
+        "a relative spelling of the same dylib resolves to the loaded engine",
+        withDuckDb(() =>
+            Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                const absolute = process.env.AX_DUCKDB_DYLIB!;
+                const rel = relative(process.cwd(), absolute);
+                expect(rel.startsWith("/")).toBe(false);
+                const api = yield* loadNodeApiOver(fs, { dylibPath: rel });
+                expect(typeof api.DuckDBInstance.create).toBe("function");
             }).pipe(Effect.provide(BunFileSystem.layer)),
         ),
     );


### PR DESCRIPTION
Fixes #884 (main CI red since #883).

The linux `duckdb.node` DOES carry `RUNPATH $ORIGIN` - the staged sibling is searched. The defect was ours: `binding.ts` symlinked the engine using the caller's path verbatim, so the relative `dist/duckdb/libduckdb.so` the CI smoke passes became a symlink target relative to the stage dir - dangling. macOS gates were green only because every local invocation passed absolute paths.

`loadNodeApiOver` now canonicalizes the dylib path (existing `canonicalPath` helper) before the memo compare, the stage digest, and the symlink. Regression pinned two ways: a new test loads the engine through a relative spelling, and the scenario was reproduced by hand (`cd /tmp && AX_DUCKDB_DYLIB=<relative> ax cost models` fails on the old code, works on this branch, with fresh stage dirs).

Gate for THIS PR is the linux `DuckDB v1.5.5 (fts static)` CI job - the failing platform cannot be verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)