### PR TITLE
feat(ingest): v3 Phase 2 - NDJSON spool + batch writers for JSONL providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,16 @@ or write. Getting it wrong does not error; it returns a wrong answer.
 - **Writes** take `withCacheWrite` under `withIngestLock`, against the live file,
   and publish at the end of the run. Ingest stages read their own run's writes
   through the WRITE service, not `CacheRead` - the snapshot does not have them yet.
+- **High-volume JSONL-provider writes spool** (#886): the claude/codex/pi/omp
+  stages wrap their write service in `withTableSpool` (`@ax/lib/duckdb/spool`),
+  which buffers 15 hot tables in memory and lands them as one
+  `read_ndjson(...) ON CONFLICT ("id") DO UPDATE` load per (table,
+  column-signature) per flush; the shared jsonl work-unit flushes at 25k pending
+  rows + stage end and DEFERS watermarks past the flush. Consequence: a spooled
+  row is invisible to SQL until the flush, so a table any stage reads back
+  same-run MUST stay direct - the allowlist + per-table rationale live on
+  `INGEST_SPOOL_TABLES` (`apps/axctl/src/ingest/jsonl-work-unit.ts`), pinned by
+  test. `session`, `skill`, and `plan_item` are the load-bearing exclusions.
 - **Decisions** (proposal, verdict, experiment, session_label) go to the SQLite
   sidecar via `Judgment`, never to the cache. A cache rebuild must not lose them.
 - A command declares what it needs in its `RuntimeManifest`

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1,6 +1,7 @@
 import { Effect, FileSystem, Path, PlatformError, Schema, Stream } from "effect";
 import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
 import type { DbError } from "@ax/lib/errors";
 import { SkillName } from "@ax/lib/brands";
 import { AxConfig } from "@ax/lib/config";
@@ -55,7 +56,7 @@ import { estimateCost } from "./model-pricing.ts";
 import { codexSourceForThread } from "./source-origin.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
-import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { canonicalCwdInRepoScope, readCodexSessionCwd } from "./codex-scope.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
@@ -1433,9 +1434,17 @@ export interface CodexStats {
 }
 
 export const ingestCodex = Effect.fn("codex.ingest")(
-    function* (write: CacheWriteService, opts: Partial<CodexIngestOpts> = {}) {
+    function* (directWrite: CacheWriteService, opts: Partial<CodexIngestOpts> = {}) {
         const cfg = yield* AxConfig;
         const path = yield* Path.Path;
+        const spoolFs = yield* FileSystem.FileSystem;
+        // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool; the
+        // shadowed `write` routes every write in this stage through it. The
+        // per-session agent_event DELETE stays a pass-through exec and fires
+        // before that session's first append, so delete-before-insert holds.
+        const spoolDir = yield* spoolFs.makeTempDirectory({ prefix: "ax-spool-codex-" }).pipe(Effect.orDie);
+        const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
+        const write = withTableSpool(directWrite, spool);
         // Shared across all files this stage run: the agent_event ghost-index
         // rebuild fires at most once, memoized so file concurrency awaits one
         // in-flight rebuild + a failed rebuild is observable (#680).
@@ -1506,6 +1515,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
             sourceKind: "codex_session",
             forceEnv: "AX_REDERIVE_CODEX",
             source: "codex",
+            spool,
             ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
             ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
@@ -1764,6 +1774,10 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         // a manual `bun scripts/repair-agent-event-index.ts` followed by a clean
         // ingest that never re-triggers the heal). Skip the clear only when a
         // file exhausted the ladder THIS run - that just-written marker stays.
+        // Safety net for any future post-loop write; the work-unit already
+        // flushed everything the loop buffered. Then drop the scratch dir.
+        yield* spool.flush(write);
+        yield* spoolFs.remove(spoolDir, { recursive: true }).pipe(Effect.ignore);
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
             records: recordCount(),

--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Schema } from "effect";
+import { parseDuckdbColumnDefs } from "@ax/schema/duckdb-ddl";
+import type { CacheWriteError } from "@ax/lib/duckdb/seam";
+import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
 import { DbError } from "@ax/lib/errors";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import {
     INGEST_RUN_HEARTBEAT_EVERY_FILES,
+    INGEST_SPOOL_TABLES,
     runJsonlProviderFiles,
     shouldHeartbeatIngestRun,
 } from "./jsonl-work-unit.ts";
@@ -94,6 +98,91 @@ describe("runJsonlProviderFiles on real DuckDB", () => {
         ));
         expect(forced).toMatchObject({ files: 1, skippedUnchanged: 0 });
         expect(processed).toEqual(["a.jsonl", "a.jsonl"]);
+    });
+});
+
+describe("spool mode", () => {
+    test("INGEST_SPOOL_TABLES: every member is in the DDL; the survey's exclusions are not members", () => {
+        for (const table of INGEST_SPOOL_TABLES) {
+            expect(parseDuckdbColumnDefs(table).length).toBeGreaterThan(0);
+        }
+        // The #886 read-back survey verdicts. Adding one of these to the spool
+        // set silently breaks a same-run read-back or a keyed-DELETE ordering;
+        // see the INGEST_SPOOL_TABLES doc for which one.
+        for (const excluded of ["session", "skill", "skill_revision", "plan", "plan_item", "ingest_file_state"]) {
+            expect(INGEST_SPOOL_TABLES).not.toContain(excluded);
+        }
+    });
+
+    dtest("rows land and watermarks are DEFERRED to the flush; a failed file never marks", async () => {
+        const dir = tempDir("ax-jsonl-spool-");
+        let rowsAfter = -1;
+        let marksAfter = -1;
+        let markPaths: string[] = [];
+        await runWithPlatform(publishCacheFixture(dir, dylibPath, (write) =>
+            Effect.gen(function* () {
+                const spool = makeTableSpool({ tables: ["tool"], dir: `${dir}/spool` });
+                const spooled = withTableSpool(write, spool);
+                const result = yield* runJsonlProviderFiles(spooled, {
+                    candidates: [candidate("a.jsonl", 10), candidate("bad.jsonl", 20), candidate("b.jsonl", 30)],
+                    sourceKind: "codex_session",
+                    forceEnv: "AX_REDERIVE_TEST",
+                    source: "codex",
+                    spool,
+                    processFile: (item): Effect.Effect<boolean, DbError | CacheWriteError> =>
+                        item.path === "bad.jsonl"
+                            ? Effect.fail(new DbError({ operation: "query", message: "boom" }))
+                            : spooled.put("tool", { id: `tool:${item.path}`, name: item.path }).pipe(Effect.as(true)),
+                });
+                expect(result.files).toBe(2);
+                // The loop is over, so the final flush ran: rows AND marks
+                // are visible together.
+                const rows = yield* write.rows(
+                    Schema.Struct({ count: Schema.Number }),
+                    "SELECT count(*)::INTEGER AS count FROM tool",
+                );
+                rowsAfter = rows[0]!.count;
+                const marks = yield* write.rows(
+                    Schema.Struct({ path: Schema.String }),
+                    "SELECT path FROM ingest_file_state ORDER BY path",
+                );
+                marksAfter = marks.length;
+                markPaths = marks.map((m) => m.path);
+            }),
+        ));
+        expect(rowsAfter).toBe(2);
+        expect(marksAfter).toBe(2);
+        expect(markPaths).toEqual(["a.jsonl", "b.jsonl"]);
+    });
+
+    dtest("a second run skips the files the deferred marks covered", async () => {
+        const dir = tempDir("ax-jsonl-spool-skip-");
+        let second: unknown;
+        await runWithPlatform(publishCacheFixture(dir, dylibPath, (write) =>
+            Effect.gen(function* () {
+                const run = (processed: string[]) =>
+                    Effect.gen(function* () {
+                        const spool = makeTableSpool({ tables: ["tool"], dir: `${dir}/spool` });
+                        const spooled = withTableSpool(write, spool);
+                        return yield* runJsonlProviderFiles(spooled, {
+                            candidates: [candidate("a.jsonl", 10), candidate("b.jsonl", 20)],
+                            sourceKind: "codex_session",
+                            forceEnv: "AX_REDERIVE_TEST",
+                            source: "codex",
+                            spool,
+                            processFile: (item) =>
+                                spooled
+                                    .put("tool", { id: `tool:${item.path}`, name: item.path })
+                                    .pipe(Effect.as(true), Effect.tap(() => Effect.sync(() => processed.push(item.path)))),
+                        });
+                    });
+                yield* run([]);
+                const processedSecond: string[] = [];
+                second = yield* run(processedSecond);
+                expect(processedSecond).toEqual([]);
+            }),
+        ));
+        expect(second).toMatchObject({ files: 0, skippedUnchanged: 2 });
     });
 });
 

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -25,13 +25,62 @@
 
 import { Effect } from "effect";
 import type { DbError } from "@ax/lib/errors";
-import { fileWatermark } from "@ax/lib/duckdb/watermark";
+import { fileWatermark, WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import type { TableSpool } from "@ax/lib/duckdb/spool";
+import type { DuckDbParam } from "@ax/lib/duckdb/types";
 import { type FileFailureCollector, type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 import type { JsonlFileCandidate } from "./walk-jsonl.ts";
 
 /** One cheap heartbeat per this many successfully committed provider files. */
 export const INGEST_RUN_HEARTBEAT_EVERY_FILES = 25;
+
+/**
+ * The tables a JSONL provider stage routes through the NDJSON spool (#886).
+ *
+ * Membership is NOT a volume judgment alone - it is the read-back survey's
+ * verdict (issue #886): a table may spool ONLY if no provider stage reads it
+ * back in the same run, because a spooled row is invisible to SQL until flush.
+ * The survey pinned three exclusions and one ordering rule:
+ *
+ *  - `session` stays DIRECT: git ingest reads `session.checkout` it wrote
+ *    lines earlier, and the subagents stage backfills rows it wrote same-run.
+ *  - `skill` stays DIRECT: `relateToolCallSkill` probes `skillExists` before
+ *    minting a ghost row, and the catalog reads in the provider stages must
+ *    see the `skills`/`commands` stages' rows.
+ *  - `plan_item` stays DIRECT: its writer DELETEs by (plan, external_id/seq)
+ *    immediately before inserting - keys OTHER than id, so the pass-through
+ *    DELETE could race rows already sitting in a buffer.
+ *  - `agent_event`/`agent_event_child` spool ONLY because their per-session
+ *    DELETE fires once per session per run, BEFORE the first row for that
+ *    session is appended (see spool.ts "DELETE ORDERING").
+ *
+ * Cross-STAGE reads (claude-sidecars reads `tool_call`; derive stages read
+ * everything) are safe because every buffered row flushes before the stage
+ * returns.
+ */
+export const INGEST_SPOOL_TABLES: ReadonlyArray<string> = [
+    "turn",
+    "tool_call",
+    "turn_token_usage",
+    "session_token_usage",
+    "agent_provider",
+    "agent_session",
+    "agent_event",
+    "agent_event_child",
+    "harness_hook_event",
+    "hook_command_invocation",
+    "invoked",
+    "concerns",
+    "tool",
+    "file",
+    "compaction",
+];
+
+/** Flush once this many rows sit in the spool. Bounds memory (a `turn` row
+ *  carries full text, so 25k rows is on the order of tens of MB) while keeping
+ *  each `read_ndjson` load big enough to amortize. */
+export const SPOOL_FLUSH_PENDING_ROWS = 25_000;
 
 /** Pure throttle decision, exported so the cadence cannot regress silently. */
 export const shouldHeartbeatIngestRun = (completedFiles: number): boolean =>
@@ -61,6 +110,14 @@ export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate
     readonly deadlineMs?: number;
     /** Per-file concurrency. Defaults to 1 (sequential) to match the providers. */
     readonly concurrency?: number | "unbounded";
+    /**
+     * The stage's NDJSON spool, when its writes route through `withTableSpool`.
+     * The work-unit then owns the flush cadence AND defers every watermark to
+     * the flush that lands its rows: marks are snapshotted BEFORE the spool
+     * drains, then written only after the drained rows are in the table, so a
+     * crash between the two re-processes those files instead of skipping them.
+     */
+    readonly spool?: TableSpool;
     /**
      * Parse + write ONE file. Mutate provider-owned counters here, and read the
      * live `loop` accessor for any progress emits. Return `true` on success
@@ -103,6 +160,35 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
             },
         };
 
+        // Spool mode: watermarks are DEFERRED - collected here and written only
+        // after the flush that lands their files' rows. Snapshot order inside
+        // `flushCycle` is what keeps the invariant: marks are spliced FIRST,
+        // then the spool drains. A mark enqueued before the splice covers a
+        // file whose appends all happened before it completed, so every row it
+        // covers is in the drained buffers; rows appended by files still in
+        // flight stay buffered, and their marks are not in this snapshot.
+        const pendingMarks: Array<Record<string, DuckDbParam>> = [];
+        let flushing = false;
+        const flushCycle = (spool: TableSpool): Effect.Effect<void, CacheWriteError> =>
+            Effect.gen(function* () {
+                // Under file-concurrency two fibers can cross the threshold
+                // together; the loser skips - the next threshold crossing or
+                // the final flush picks its rows up.
+                if (flushing) return;
+                flushing = true;
+                yield* Effect.gen(function* () {
+                    const marks = pendingMarks.splice(0);
+                    yield* spool.flush(write);
+                    if (marks.length > 0) yield* write.putMany(WATERMARK_TABLE, marks);
+                }).pipe(
+                    Effect.ensuring(
+                        Effect.sync(() => {
+                            flushing = false;
+                        }),
+                    ),
+                );
+            });
+
         yield* Effect.forEach(
             opts.candidates,
             (candidate, index) =>
@@ -124,8 +210,14 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                             if (!committed) return;
                             files += 1;
                             const completedFiles = files;
-                            // Commit ONLY after writes succeed.
-                            yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
+                            // Commit ONLY after writes succeed. With a spool,
+                            // "succeed" includes the flush, so the mark is
+                            // deferred to the flush cycle instead.
+                            if (opts.spool !== undefined) {
+                                pendingMarks.push(wm.row(candidate.path, candidate.mtimeMs, candidate.sizeBytes));
+                            } else {
+                                yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
+                            }
                             if (opts.runId !== undefined && shouldHeartbeatIngestRun(completedFiles)) {
                                 // Courtesy signal only: a transient heartbeat
                                 // failure must never fail or roll back ingest.
@@ -137,9 +229,31 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                         }),
                     );
                     activeFiles -= 1;
+                    // Cadence check OUTSIDE the isolate: a flush failure means
+                    // the write path itself is broken, and that fails the
+                    // stage instead of masquerading as one bad file.
+                    if (opts.spool !== undefined && opts.spool.pendingRows() >= SPOOL_FLUSH_PENDING_ROWS) {
+                        yield* flushCycle(opts.spool);
+                    }
                 }),
             { concurrency: opts.concurrency ?? 1, discard: true },
         );
+
+        // Final flush: every buffered row and every deferred mark lands before
+        // the loop reports. All fibers are done, so `flushing` cannot be held.
+        if (opts.spool !== undefined) {
+            yield* flushCycle(opts.spool);
+            // Spooled values bypass the seam's bound-param NUL scrub, so its
+            // end-of-run warning cannot see them; surface the spool's own count
+            // here with the same rationale (silent sanitising is the failure
+            // class the seam refuses).
+            const totals = opts.spool.totals();
+            if (totals.nulValues > 0) {
+                yield* Effect.logWarning(
+                    `ax cache: spool stripped NUL bytes (U+0000) from ${totals.nulValues} text value(s) for ${opts.source} - a DuckDB VARCHAR cannot carry U+0000; the rest of each value was stored intact.`,
+                );
+            }
+        }
 
         yield* failures.report;
         return { files, skippedUnchanged, failures };

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -3,6 +3,7 @@ import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
 import type { DbError } from "@ax/lib/errors";
 import {
     type ToolCallSkillRelationWrite,
@@ -35,7 +36,7 @@ import {
     type MutableToolCallWrite,
 } from "./normalized/tool-call-write.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
-import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { decodePiTranscriptLine } from "./line-schemas.ts";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { walkJsonlFilesLenient } from "./walk-jsonl.ts";
@@ -751,9 +752,14 @@ interface PiIngestOpts {
  * force-rederive env. See {@link ingestPi} / {@link ingestOmp}.
  */
 const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.ingest`)(
-    function* (write: CacheWriteService, opts: Partial<PiIngestOpts> = {}) {
+    function* (directWrite: CacheWriteService, opts: Partial<PiIngestOpts> = {}) {
         const cfg = yield* AxConfig;
         const fs = yield* FileSystem.FileSystem;
+        // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool; the
+        // shadowed `write` routes every write in this stage through it.
+        const spoolDir = yield* fs.makeTempDirectory({ prefix: `ax-spool-${desc.provider}-` }).pipe(Effect.orDie);
+        const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
+        const write = withTableSpool(directWrite, spool);
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
         const files = yield* walkJsonlFilesLenient(cfg.paths[desc.dirKey], cutoff);
         let fileCount = 0;
@@ -771,6 +777,7 @@ const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.i
         // completed files, like claude/codex.
         const result = yield* runJsonlProviderFiles(write, {
             candidates: files,
+            spool,
             sourceKind: desc.sourceKind,
             forceEnv: desc.forceEnv,
             source: desc.provider,
@@ -807,6 +814,11 @@ const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.i
                 return true;
             }),
         });
+
+        // Safety net for any future post-loop write; the work-unit already
+        // flushed everything the loop buffered. Then drop the scratch dir.
+        yield* spool.flush(write);
+        yield* fs.remove(spoolDir, { recursive: true }).pipe(Effect.ignore);
 
         return {
             files: fileCount,

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1,6 +1,7 @@
 import { Effect, FileSystem, Option, Path, PlatformError, Schema, Stream } from "effect";
 import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
 import type { DbError } from "@ax/lib/errors";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
@@ -66,7 +67,7 @@ import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import { estimateCost, isSyntheticModel, normalizeModelName } from "./model-pricing.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
-import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import {
     extractClaudeCompaction,
     type CompactionWrite,
@@ -1726,10 +1727,19 @@ export interface TranscriptStats {
 }
 
 export const ingestTranscripts = Effect.fn("transcripts.ingest")(
-    function* (write: CacheWriteService, opts: Partial<IngestOpts> = {}) {
+    function* (directWrite: CacheWriteService, opts: Partial<IngestOpts> = {}) {
         const cfg = yield* AxConfig;
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
+        // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool and
+        // land as one read_ndjson load per (table, signature) per flush.
+        // Everything else - session, skill, watermarks, reads, the per-session
+        // agent_event DELETE - passes through to the direct path. The shadowed
+        // `write` below routes EVERY write in this stage through the decorator;
+        // the work-unit owns the flush cadence and defers watermarks past it.
+        const spoolDir = yield* fs.makeTempDirectory({ prefix: "ax-spool-claude-" }).pipe(Effect.orDie);
+        const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
+        const write = withTableSpool(directWrite, spool);
         const transcriptsDir = cfg.paths.transcriptsDir;
         const cutoff = opts.sinceDays
             ? Date.now() - opts.sinceDays * 86400 * 1000
@@ -1855,6 +1865,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             sourceKind: "claude_transcript",
             forceEnv: "AX_REDERIVE_CLAUDE",
             source: "claude",
+            spool,
             ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
             ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
@@ -1978,6 +1989,11 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 attributes: { "file.path": candidate.path, "file.size": candidate.sizeBytes },
             })),
         });
+        // Safety net for any FUTURE write added after the loop: the work-unit
+        // already flushed everything the loop buffered. Then drop the scratch
+        // dir (flushed files are already unlinked; this catches strays).
+        yield* spool.flush(write);
+        yield* fs.remove(spoolDir, { recursive: true }).pipe(Effect.ignore);
         yield* Effect.logDebug("transcript ingest complete", {
             files,
             records: recordCount(),

--- a/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
+++ b/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
@@ -76,7 +76,38 @@ replay tests.
   (inference ban — proto bug). PK dedup replaces per-writer idempotency care.
 - Trio rides here: #867 attribution fields (parser touch + 4 columns +
   `--reparse=claude`), done WITH the batch-writer touch to avoid re-touching.
+  ~~done WITH the batch-writer touch~~ **Retracted in place**: #867 landed
+  FIRST (#878 + reparse backfill), decoupled, because the attribution data was
+  wanted before the writer work started. The "avoid re-touching" premise cost
+  nothing - the spool wraps the write seam, not the parser, so the two changes
+  never touched the same lines.
 - Gate: cold backfill wall time; expectation parse-bound (~minutes, not 85).
+
+**DONE (#886).** `makeTableSpool` + `withTableSpool`
+(`packages/lib/src/duckdb/spool.ts`): rows for 15 high-volume tables buffer in
+memory (grouped by (table, sorted-column-signature), deduped by id last-wins)
+and land as one `INSERT ... SELECT ... FROM read_ndjson(file, columns={from
+the committed DDL}) ON CONFLICT ("id") DO UPDATE` per group per flush.
+NOT `INSERT OR REPLACE` as this section originally said - the shorthand fails
+on this schema's secondary UNIQUE indexes (retracted in place; the seam's
+`insertStatement` already knew this). The three JSONL provider stages
+(claude/codex/pi+omp) shadow their write service with the decorator; the
+shared work-unit owns the flush cadence (25k pending rows + stage end) and
+DEFERS watermarks past the flush that lands their rows, so the durable
+contract (mark only after rows landed) is unchanged at window granularity.
+The table set is the #886 read-back survey's verdict, pinned by test:
+`session`/`skill`/`plan_item` stay direct (same-run read-backs / keyed
+DELETE); `agent_event`/`agent_event_child` spool because their per-session
+DELETE is guarded to fire before the session's first append. Receipts: 7-day
+claude window into a fresh store 42.5s → 15.9s wall (2.7x, and the unchanged
+skills/commands+derive stages dilute the write-path speedup); row-count parity
+across 19 tables against a direct-write baseline (only the actively-growing
+live session file differed, by single digits, on both sides' bench runs);
+bigint 2^53+1 exact round-trip, ISO-Z→TIMESTAMP ms-precision in the ICU-less
+build, narrow-signature no-NULL-overwrite, and delete-pass-through ordering
+all pinned in `spool.test.ts`. OpenCode/Cursor (SQLite-store providers, no
+work-unit) and the git/otel writers stay on the direct path - candidates for
+a follow-up, not blockers.
 
 ### Phase 3 — derives → SQL models, one at a time
 

--- a/packages/lib/src/duckdb/spool.test.ts
+++ b/packages/lib/src/duckdb/spool.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The NDJSON spool, against a REAL live database.
+ *
+ * Everything that matters here is a round trip through `read_ndjson`: that a
+ * bigint survives above 2^53, that an ISO-Z timestamp casts into an ICU-less
+ * TIMESTAMP column, that a narrower signature cannot NULL a column it never
+ * carried, and that flush-then-read equals what `putMany` would have written.
+ * None of that is visible to a mock.
+ */
+import { describe, expect, test } from "bun:test";
+import { Effect, FileSystem, Path } from "effect";
+import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
+import { withIngestLock } from "../ingest-lock.ts";
+import { runWithPlatform } from "../testing/cache-fixture.ts";
+import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
+import { withCacheWrite, type CacheWriteService } from "./seam.ts";
+import { makeTableSpool, withTableSpool, type TableSpool } from "./spool.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("cache spool");
+
+/** One ingest "run" against a live database in `dir` - lock held, schema
+ *  applied - mirroring watermark.test.ts. */
+const asIngestRun = <A>(
+    dir: string,
+    body: (write: CacheWriteService, spool: TableSpool, spoolDir: string) => Effect.Effect<A, unknown, never>,
+): Promise<A> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const path = yield* Path.Path;
+            const fs = yield* FileSystem.FileSystem;
+            const lockPath = path.join(dir, "ingest.lock");
+            const spoolDir = path.join(dir, "spool");
+            yield* fs.makeDirectory(spoolDir, { recursive: true });
+            const outcome = yield* withIngestLock(
+                {
+                    lockPath,
+                    command: "spool-test",
+                    staleMs: 60_000,
+                    onBusy: () => Effect.die("the ingest lock was busy in a single-process test"),
+                },
+                withCacheWrite(
+                    {
+                        livePath: path.join(dir, "live.duckdb"),
+                        lockPath,
+                        snapshotPath: path.join(dir, "snapshot.duckdb"),
+                        schemaSql: DUCKDB_SCHEMA_SQL,
+                        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                    },
+                    (write) => {
+                        const spool = makeTableSpool({
+                            tables: ["tool", "file", "invoked", "turn_token_usage"],
+                            dir: spoolDir,
+                        });
+                        return body(write, spool, spoolDir);
+                    },
+                ),
+            );
+            if (outcome._tag !== "completed") throw new Error(`ingest run did not complete: ${outcome._tag}`);
+            return outcome.value;
+        }) as Effect.Effect<A, unknown, FileSystem.FileSystem | Path.Path>,
+    );
+
+describe("makeTableSpool", () => {
+    dtest("flush lands buffered rows; a spooled row is invisible before it", async () => {
+        const dir = tempDir("spool-basic");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("tool", [
+                    { id: "tool:one", name: "Read", provider: "claude" },
+                    { id: "tool:two", name: "Edit", provider: "claude" },
+                ]);
+                expect(spool.pendingRows()).toBe(2);
+
+                const before = yield* write.raw("SELECT count(*) AS n FROM tool");
+                expect(before.rows[0]!["n"]).toBe(0n);
+
+                const outcome = yield* spool.flush(write);
+                expect(outcome.rows).toBe(2);
+                expect(outcome.statements).toBe(1);
+                expect(spool.pendingRows()).toBe(0);
+
+                const after = yield* write.raw("SELECT name FROM tool ORDER BY id");
+                expect(after.rows.map((r) => r["name"])).toEqual(["Read", "Edit"]);
+            }),
+        );
+    });
+
+    dtest("a bigint above 2^53 round-trips EXACTLY through the NDJSON path", async () => {
+        const dir = tempDir("spool-bigint");
+        const exact = 9007199254740993n; // 2^53 + 1: a double would corrupt it
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("turn_token_usage", [
+                    {
+                        id: "ttu:1",
+                        session: "s1",
+                        turn: "t1",
+                        seq: 1,
+                        source: "claude",
+                        prompt_tokens: exact,
+                        estimated_tokens: 0,
+                        usage_source: "provider_events",
+                        usage_quality: "exact",
+                    },
+                ]);
+                yield* spool.flush(write);
+                const got = yield* write.raw("SELECT prompt_tokens FROM turn_token_usage WHERE id = 'ttu:1'");
+                expect(got.rows[0]!["prompt_tokens"]).toBe(exact);
+            }),
+        );
+    });
+
+    dtest("a Date lands in a TIMESTAMP column at millisecond precision (ISO-Z parses without ICU)", async () => {
+        const dir = tempDir("spool-ts");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("invoked", [
+                    {
+                        id: "inv:1",
+                        in_id: "turn:1",
+                        out_id: "skill:1",
+                        ts: new Date("2026-08-18T10:20:30.123Z"),
+                        turn_has_error: false,
+                        was_corrected: false,
+                    },
+                ]);
+                yield* spool.flush(write);
+                const got = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts_text FROM invoked WHERE id = 'inv:1'");
+                expect(got.rows[0]!["ts_text"]).toBe("2026-08-18 10:20:30.123");
+            }),
+        );
+    });
+
+    dtest("same id twice in ONE window dedups last-wins (DuckDB rejects in-statement key dups)", async () => {
+        const dir = tempDir("spool-dedup");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("tool", [{ id: "tool:dup", name: "first", provider: "claude" }]);
+                spool.append("tool", [{ id: "tool:dup", name: "second", provider: "claude" }]);
+                expect(spool.pendingRows()).toBe(1);
+                yield* spool.flush(write);
+                const got = yield* write.raw("SELECT name FROM tool WHERE id = 'tool:dup'");
+                expect(got.rows[0]!["name"]).toBe("second");
+            }),
+        );
+    });
+
+    dtest("a later flush upserts over an earlier one, like back-to-back putMany", async () => {
+        const dir = tempDir("spool-upsert");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("tool", [{ id: "tool:u", name: "before", provider: "claude" }]);
+                yield* spool.flush(write);
+                spool.append("tool", [{ id: "tool:u", name: "after", provider: "claude" }]);
+                yield* spool.flush(write);
+                const got = yield* write.raw("SELECT count(*) AS n, min(name) AS name FROM tool WHERE id = 'tool:u'");
+                expect(got.rows[0]!["n"]).toBe(1n);
+                expect(got.rows[0]!["name"]).toBe("after");
+            }),
+        );
+    });
+
+    dtest("a NARROWER signature cannot NULL a column it never carried", async () => {
+        const dir = tempDir("spool-ragged");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("file", [{ id: "file:1", path: "/a.ts", lang: "ts" }]);
+                yield* spool.flush(write);
+                // The narrow update (no `lang`) goes to its own signature group
+                // and its ON CONFLICT SET list does not name `lang`.
+                spool.append("file", [{ id: "file:1", path: "/a-moved.ts" }]);
+                yield* spool.flush(write);
+                const got = yield* write.raw("SELECT path, lang FROM file WHERE id = 'file:1'");
+                expect(got.rows[0]!["path"]).toBe("/a-moved.ts");
+                expect(got.rows[0]!["lang"]).toBe("ts");
+            }),
+        );
+    });
+
+    dtest("two signatures in one window load as separate statements", async () => {
+        const dir = tempDir("spool-sig");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("file", [{ id: "file:wide", path: "/w.ts", lang: "ts" }]);
+                spool.append("file", [{ id: "file:narrow", path: "/n.ts" }]);
+                const outcome = yield* spool.flush(write);
+                expect(outcome.rows).toBe(2);
+                expect(outcome.statements).toBe(2);
+                const got = yield* write.raw("SELECT count(*) AS n FROM file");
+                expect(got.rows[0]!["n"]).toBe(2n);
+            }),
+        );
+    });
+
+    dtest("strips U+0000 from text values and counts what it scrubbed", async () => {
+        const dir = tempDir("spool-nul");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("tool", [{ id: "tool:nul", name: "bad\u0000name", provider: "claude" }]);
+                yield* spool.flush(write);
+                expect(spool.totals().nulValues).toBe(1);
+                const got = yield* write.raw("SELECT name FROM tool WHERE id = 'tool:nul'");
+                expect(got.rows[0]!["name"]).toBe("badname");
+            }),
+        );
+    });
+
+    dtest("flush unlinks its spool files", async () => {
+        const dir = tempDir("spool-unlink");
+        await asIngestRun(dir, (write, spool, spoolDir) =>
+            Effect.gen(function* () {
+                spool.append("tool", [{ id: "tool:f", name: "x", provider: "claude" }]);
+                yield* spool.flush(write);
+                const left = yield* Effect.promise(() =>
+                    Array.fromAsync(new Bun.Glob("*").scan({ cwd: spoolDir })),
+                );
+                expect(left).toEqual([]);
+            }),
+        );
+    });
+
+    test("refuses a row whose column the DDL does not declare", () => {
+        const spool = makeTableSpool({ tables: ["tool"], dir: "/nonexistent" });
+        expect(() => spool.append("tool", [{ id: "t", nonsense: "x" }])).toThrow(/does not declare/);
+    });
+
+    test("refuses a non-string id and a missing id", () => {
+        const spool = makeTableSpool({ tables: ["invoked"], dir: "/nonexistent" });
+        expect(() => spool.append("invoked", [{ id: 5, in_id: "a", out_id: "b" }])).toThrow(/non-string id/);
+        expect(() => spool.append("invoked", [{ in_id: "a", out_id: "b" }])).toThrow(/`id`/);
+    });
+
+    test("refuses a ragged batch within one append, like putMany", () => {
+        const spool = makeTableSpool({ tables: ["tool"], dir: "/nonexistent" });
+        expect(() =>
+            spool.append("tool", [
+                { id: "a", name: "x" },
+                { id: "b", name: "y", provider: "claude" },
+            ]),
+        ).toThrow(/ragged/);
+    });
+
+    test("refuses a table missing from the allowlist and an unknown table", () => {
+        const spool = makeTableSpool({ tables: ["tool"], dir: "/nonexistent" });
+        expect(() => spool.append("turn", [{ id: "t" }])).toThrow(/allowlist/);
+        expect(() => makeTableSpool({ tables: ["no_such_table"], dir: "/nonexistent" })).toThrow(
+            /no columns found/,
+        );
+    });
+
+    test("refuses a bigint outside int64, like the bind path", () => {
+        const spool = makeTableSpool({ tables: ["turn_token_usage"], dir: "/nonexistent" });
+        expect(() =>
+            spool.append("turn_token_usage", [
+                {
+                    id: "ttu:big",
+                    session: "s",
+                    turn: "t",
+                    seq: 1,
+                    source: "x",
+                    prompt_tokens: 2n ** 64n,
+                    estimated_tokens: 0,
+                    usage_source: "u",
+                    usage_quality: "q",
+                },
+            ]),
+        ).toThrow(/64-bit/);
+    });
+});
+
+describe("withTableSpool", () => {
+    dtest("routes spooled tables to the buffer and everything else straight through", async () => {
+        const dir = tempDir("spool-decorator");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                const spooled = withTableSpool(write, spool);
+                yield* spooled.put("tool", { id: "tool:s", name: "Read" });
+                // `session` is not in this spool's table set: it writes NOW.
+                yield* spooled.put("session", {
+                    id: "sess:1",
+                    source: "claude",
+                    started_at: new Date("2026-08-18T00:00:00Z"),
+                });
+                const mid = yield* write.raw(
+                    "SELECT (SELECT count(*) FROM tool) AS tools, (SELECT count(*) FROM session) AS sessions",
+                );
+                expect(mid.rows[0]!["tools"]).toBe(0n);
+                expect(mid.rows[0]!["sessions"]).toBe(1n);
+
+                // exec passes through immediately - the delete-before-flush
+                // ordering the agent_event writers rely on.
+                yield* spooled.exec("DELETE FROM session WHERE id = ?", ["sess:1"]);
+                yield* spool.flush(write);
+                const end = yield* write.raw(
+                    "SELECT (SELECT count(*) FROM tool) AS tools, (SELECT count(*) FROM session) AS sessions",
+                );
+                expect(end.rows[0]!["tools"]).toBe(1n);
+                expect(end.rows[0]!["sessions"]).toBe(0n);
+            }),
+        );
+    });
+});

--- a/packages/lib/src/duckdb/spool.ts
+++ b/packages/lib/src/duckdb/spool.ts
@@ -1,0 +1,365 @@
+/**
+ * NDJSON spool for high-volume ingest writes (v3 Phase 2, #886).
+ *
+ * `putMany` binds every value of every row as a prepared-statement parameter -
+ * correct, and measured too slow at corpus scale: an ingest run is ~100%
+ * database time, and the same rows load orders of magnitude faster through one
+ * `read_ndjson` scan per table. So a SPOOLED table's rows accumulate in memory
+ * across many files and land as ONE
+ * `INSERT ... SELECT ... FROM read_ndjson(...) ON CONFLICT ("id") DO UPDATE`
+ * per (table, column-signature) per flush.
+ *
+ * WHAT THIS MODULE PRESERVES from the seam's bound-param path (`seam.ts`
+ * `putMany`/`insertStatement` - drift here is silent data corruption):
+ *
+ *  - EXPLICIT COLUMNS ALWAYS. `read_ndjson` runs with a `columns={...}` map
+ *    generated from the committed DDL (`@ax/schema` `parseDuckdbColumnDefs`),
+ *    never inference - the v3 proto re-earned an inference bug within minutes.
+ *  - PER-SIGNATURE BATCHES. Two writes to the same table may carry DIFFERENT
+ *    column subsets (nullable columns omitted). One merged file would make
+ *    `read_ndjson` yield NULL for a row's missing keys, and the upsert would
+ *    then overwrite existing values the narrower statement never touches. Rows
+ *    are grouped by their sorted column signature, one load per group. (Within
+ *    ONE flush, the order of two same-id rows in DIFFERENT signature groups is
+ *    unspecified - same nondeterminism two interleaved putMany calls had.)
+ *  - LAST WRITE WINS PER id. Ingest legitimately re-emits the same row many
+ *    times per run (`tool` and `file` on every tool call) and relies on upsert
+ *    dedup. DuckDB REJECTS a statement whose source carries two rows with the
+ *    same conflict key, so each buffer dedups by id at append - the later row
+ *    replaces the earlier one, which is exactly what back-to-back upserts did.
+ *  - THE `id` INVARIANT + explicit conflict target. `INSERT OR REPLACE` is
+ *    unusable on this schema (secondary UNIQUE indexes); the conflict target is
+ *    `("id")`, the same statement shape as the seam's.
+ *  - `WRITE_STAMPED_COLUMNS`: a caller value for a stamped column is dropped
+ *    and the SELECT list emits `CURRENT_TIMESTAMP` instead.
+ *  - NUL STRIPPING. Spooled values bypass the seam's bound-param scrub, so the
+ *    serializer strips U+0000 itself and counts what it scrubbed, mirroring
+ *    `nulStripped` (sanitising silently is the failure class the seam refuses).
+ *  - BIGINT EXACTNESS. JSON has no bigint: a `bigint` is emitted as a DECIMAL
+ *    STRING and the column's declared type (BIGINT) casts it back losslessly
+ *    inside DuckDB - never through a JS double. Range-guarded to int64 exactly
+ *    like the bind path.
+ *
+ * WHAT CHANGES, deliberately (a documented trade, not an accident):
+ *
+ *  - VISIBILITY. A spooled row is invisible to SQL until `flush`. Only tables
+ *    with NO same-run read-back may spool; the #886 survey pinned the set
+ *    (`INGEST_SPOOL_TABLES` in the jsonl work-unit) and `session`/`skill`/the
+ *    plan family stay on the direct path.
+ *  - DELETE ORDERING. `exec` (e.g. the once-per-session `DELETE FROM
+ *    agent_event`) passes through IMMEDIATELY while inserts land at flush.
+ *    That preserves delete-before-insert ONLY because every such DELETE fires
+ *    before the first append for its session (guarded once per session per
+ *    run). A DELETE issued after rows for its key were appended would miss
+ *    them - do not add one.
+ *  - FAILURE GRAIN. A flush failure loses the whole window, not one file. The
+ *    durable contract is unchanged - ingest was never per-file transactional,
+ *    and a watermark still only commits AFTER its rows land (the work-unit
+ *    defers marks past the flush) - only the retry batch grows.
+ *
+ * Runtime module - no `node:fs`/`node:path`; `Bun.write`/`Bun.file` for the
+ * spool files, `posixPath` for joins.
+ */
+import { Effect } from "effect";
+import { parseDuckdbColumnDefs } from "@ax/schema/duckdb-ddl";
+import { posixPath } from "../shared/path.ts";
+import { DuckDbQueryError } from "./errors.ts";
+import { WRITE_STAMPED_COLUMNS, type CacheWriteError, type CacheWriteService } from "./seam.ts";
+import type { DuckDbParam } from "./types.ts";
+
+/** Mirror of the bind path's int64 bounds (client.ts `bindableBigInt`). */
+const I64_MIN = -(2n ** 63n);
+const I64_MAX = 2n ** 63n - 1n;
+
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export interface SpoolTotals {
+    /** Rows landed through the spool since construction. */
+    readonly rows: number;
+    /** Load statements issued (one per (table, signature) per flush). */
+    readonly statements: number;
+    /** Text values that carried a U+0000 and were scrubbed. */
+    readonly nulValues: number;
+}
+
+export interface SpoolFlushOutcome {
+    readonly rows: number;
+    readonly statements: number;
+}
+
+export interface TableSpool {
+    /** The tables this spool intercepts. */
+    readonly tables: ReadonlySet<string>;
+    /** Buffer rows for `table` (must be in {@link tables}). Enforces the same
+     *  invariants as the seam's `putMany` (string `id` on every row, no ragged
+     *  batch within one call). Synchronous; throws `DuckDbQueryError`. */
+    readonly append: (table: string, rows: ReadonlyArray<Readonly<Record<string, DuckDbParam>>>) => void;
+    /** Rows currently buffered across all tables (post-dedup). */
+    readonly pendingRows: () => number;
+    /** Land every buffered row. Rows appended DURING the flush (concurrent
+     *  fibers mid-file) stay buffered for the next one. */
+    readonly flush: (write: CacheWriteService) => Effect.Effect<SpoolFlushOutcome, CacheWriteError>;
+    /** Running totals for end-of-stage reporting. */
+    readonly totals: () => SpoolTotals;
+}
+
+export interface TableSpoolOptions {
+    /** Tables allowed to spool. Every entry must exist in the DDL. */
+    readonly tables: ReadonlyArray<string>;
+    /** Scratch dir for the NDJSON files. The caller owns its lifecycle (create
+     *  a temp dir, remove it after the last flush); flushed files are unlinked
+     *  best-effort as each load lands. */
+    readonly dir: string;
+    /** DDL override for tests. Defaults to the committed schema. */
+    readonly ddlSql?: string;
+}
+
+/** JSON-safe encoding of one value, matching the bind path's semantics. */
+const encodeValue = (
+    table: string,
+    column: string,
+    value: DuckDbParam,
+    onNul: () => void,
+): string | number | boolean | null => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "boolean" || typeof value === "number") return value;
+    if (typeof value === "bigint") {
+        if (value < I64_MIN || value > I64_MAX) {
+            throw new DuckDbQueryError({
+                sql: `spool INSERT INTO ${table}`,
+                message:
+                    `spooled value for ${table}.${column} (${value}) is outside the signed 64-bit range this ` +
+                    "store binds integers at; pass it as text (and store the column as VARCHAR or HUGEINT).",
+            });
+        }
+        return value.toString();
+    }
+    if (value instanceof Date) return value.toISOString();
+    if (value.includes("\u0000")) {
+        onNul();
+        return value.replaceAll("\u0000", "");
+    }
+    return value;
+};
+
+interface SpoolBuffer {
+    readonly table: string;
+    /** Sorted signature columns, the emit order of every line's keys. */
+    readonly columns: ReadonlyArray<string>;
+    /** id -> serialized NDJSON line (sans newline). Later append wins. */
+    readonly lines: Map<string, string>;
+}
+
+export const makeTableSpool = (options: TableSpoolOptions): TableSpool => {
+    const tables = new Set(options.tables);
+
+    /** table -> (column -> DDL type): the `columns={...}` source of truth. */
+    const columnTypes = new Map<string, ReadonlyMap<string, string>>();
+    for (const table of tables) {
+        if (!IDENTIFIER.test(table)) {
+            throw new DuckDbQueryError({
+                sql: "",
+                message: `refusing to spool table ${JSON.stringify(table)}: not a bare identifier`,
+            });
+        }
+        const defs = parseDuckdbColumnDefs(table, options.ddlSql);
+        if (defs.length === 0) {
+            throw new DuckDbQueryError({
+                sql: "",
+                message: `refusing to spool table "${table}": no columns found in the DDL - the columns={} map would be empty`,
+            });
+        }
+        for (const def of defs) {
+            if (!IDENTIFIER.test(def.name) || !/^[A-Z]+$/.test(def.type)) {
+                throw new DuckDbQueryError({
+                    sql: "",
+                    message:
+                        `refusing to spool table "${table}": column ${JSON.stringify(def.name)} of type ` +
+                        `${JSON.stringify(def.type)} does not fit the single-word shape the columns={} builder emits`,
+                });
+            }
+        }
+        columnTypes.set(table, new Map(defs.map((d) => [d.name, d.type])));
+    }
+
+    /** key = `${table} ${signature}` */
+    const buffers = new Map<string, SpoolBuffer>();
+
+    let totalRows = 0;
+    let totalStatements = 0;
+    let nulValues = 0;
+    let flushSeq = 0;
+
+    const append: TableSpool["append"] = (table, rows) => {
+        if (rows.length === 0) return;
+        if (!tables.has(table)) {
+            throw new DuckDbQueryError({
+                sql: `spool INSERT INTO ${table}`,
+                message: `table "${table}" is not in this spool's allowlist - route it through putMany`,
+            });
+        }
+        const stamped = WRITE_STAMPED_COLUMNS[table];
+        const types = columnTypes.get(table)!;
+
+        const columnsOf = (row: Readonly<Record<string, DuckDbParam>>): string[] =>
+            Object.keys(row).filter((c) => c !== stamped);
+
+        const columns = columnsOf(rows[0]!);
+        if (!columns.includes("id")) {
+            throw new DuckDbQueryError({
+                sql: `spool INSERT INTO ${table}`,
+                message: `spooled rows for ${table} need an \`id\` on every row (same invariant as putMany); got [${columns.join(", ")}]`,
+            });
+        }
+        for (const column of columns) {
+            if (!types.has(column)) {
+                throw new DuckDbQueryError({
+                    sql: `spool INSERT INTO ${table}`,
+                    message:
+                        `spooled row for ${table} carries column "${column}" which the DDL does not declare - ` +
+                        "an explicit columns={} map cannot be built for it",
+                });
+            }
+        }
+        const sorted = [...columns].sort();
+        const signature = sorted.join(",");
+        const key = `${table} ${signature}`;
+        let buffer = buffers.get(key);
+        if (buffer === undefined) {
+            buffer = { table, columns: sorted, lines: new Map() };
+            buffers.set(key, buffer);
+        }
+
+        for (let i = 0; i < rows.length; i += 1) {
+            const row = rows[i]!;
+            if (i > 0) {
+                const rowSignature = [...columnsOf(row)].sort().join(",");
+                if (rowSignature !== signature) {
+                    throw new DuckDbQueryError({
+                        sql: `spool INSERT INTO ${table}`,
+                        message:
+                            `spooled batch for ${table} is ragged: row ${i} has [${rowSignature}] while row 0 has ` +
+                            `[${signature}]. Split into separate appends (same rule as putMany).`,
+                    });
+                }
+            }
+            const id = row["id"];
+            if (typeof id !== "string" || id.length === 0) {
+                throw new DuckDbQueryError({
+                    sql: `spool INSERT INTO ${table}`,
+                    message: `spooled row ${i} for ${table} has a non-string id (${typeof id}); every id in this schema is VARCHAR`,
+                });
+            }
+            const out: Record<string, unknown> = {};
+            for (const column of buffer.columns) {
+                out[column] = encodeValue(table, column, row[column], () => {
+                    nulValues += 1;
+                });
+            }
+            buffer.lines.set(id, JSON.stringify(out));
+        }
+    };
+
+    const loadStatement = (buffer: SpoolBuffer, filePath: string): string => {
+        const stamped = WRITE_STAMPED_COLUMNS[buffer.table];
+        const types = columnTypes.get(buffer.table)!;
+        const quoted = buffer.columns.map((c) => `"${c}"`);
+        const columnsMap = buffer.columns.map((c) => `'${c}': '${types.get(c)!}'`).join(", ");
+        const allColumns = stamped === undefined ? quoted : [...quoted, `"${stamped}"`];
+        const selectList = stamped === undefined ? quoted.join(", ") : `${quoted.join(", ")}, CURRENT_TIMESTAMP`;
+        const updates = allColumns.filter((c) => c !== '"id"').map((c) => `${c} = excluded.${c}`);
+        const onConflict = updates.length === 0 ? "DO NOTHING" : `DO UPDATE SET ${updates.join(", ")}`;
+        const escapedPath = filePath.replace(/'/g, "''");
+        return (
+            `INSERT INTO "${buffer.table}" (${allColumns.join(", ")}) ` +
+            `SELECT ${selectList} FROM read_ndjson('${escapedPath}', ` +
+            `format = 'newline_delimited', columns = {${columnsMap}}) ` +
+            `ON CONFLICT ("id") ${onConflict}`
+        );
+    };
+
+    const flush: TableSpool["flush"] = (write) =>
+        Effect.gen(function* () {
+            // Snapshot-and-clear synchronously: rows appended by fibers still
+            // mid-file after this point belong to the NEXT flush, together
+            // with their files' watermarks (the work-unit snapshots marks
+            // BEFORE calling flush, so a mark is never committed ahead of a
+            // row it covers).
+            const drained = [...buffers.values()].filter((b) => b.lines.size > 0);
+            buffers.clear();
+            if (drained.length === 0) return { rows: 0, statements: 0 };
+
+            flushSeq += 1;
+            let rows = 0;
+            let statements = 0;
+            for (const buffer of drained) {
+                const filePath = posixPath.join(options.dir, `${buffer.table}-${flushSeq}-${statements}.ndjson`);
+                yield* Effect.tryPromise({
+                    try: async () => {
+                        let text = "";
+                        for (const line of buffer.lines.values()) text += `${line}\n`;
+                        await Bun.write(filePath, text, { createPath: true });
+                    },
+                    catch: (err) =>
+                        new DuckDbQueryError({
+                            sql: `spool INSERT INTO ${buffer.table}`,
+                            message: `failed to write the spool file ${filePath}: ${
+                                err instanceof Error ? err.message : String(err)
+                            }`,
+                        }),
+                });
+                // Through the seam's exec, so self-time charging and write
+                // error mapping stay exactly as putMany's.
+                yield* write.exec(loadStatement(buffer, filePath));
+                rows += buffer.lines.size;
+                statements += 1;
+                yield* Effect.tryPromise({
+                    try: () => Bun.file(filePath).unlink(),
+                    catch: () => undefined,
+                }).pipe(Effect.ignore);
+            }
+            totalRows += rows;
+            totalStatements += statements;
+            return { rows, statements };
+        });
+
+    return {
+        tables,
+        append,
+        pendingRows: () => {
+            let n = 0;
+            for (const b of buffers.values()) n += b.lines.size;
+            return n;
+        },
+        flush,
+        totals: () => ({ rows: totalRows, statements: totalStatements, nulValues }),
+    };
+};
+
+const appendVia = (
+    spool: TableSpool,
+    table: string,
+    rows: ReadonlyArray<Readonly<Record<string, DuckDbParam>>>,
+): Effect.Effect<void, CacheWriteError> =>
+    Effect.try({
+        try: () => spool.append(table, rows),
+        catch: (err) =>
+            err instanceof DuckDbQueryError
+                ? err
+                : new DuckDbQueryError({
+                      sql: `spool INSERT INTO ${table}`,
+                      message: err instanceof Error ? err.message : String(err),
+                  }),
+    });
+
+/**
+ * Wrap a `CacheWriteService` so `put`/`putMany` for the spool's tables buffer
+ * instead of writing; everything else - `exec`, reads, other tables - passes
+ * through untouched. The caller owns the flush cadence (the jsonl work-unit)
+ * and MUST flush before committing any watermark covering buffered rows.
+ */
+export const withTableSpool = (write: CacheWriteService, spool: TableSpool): CacheWriteService => ({
+    ...write,
+    putMany: (table, rows) => (spool.tables.has(table) ? appendVia(spool, table, rows) : write.putMany(table, rows)),
+    put: (table, row) => (spool.tables.has(table) ? appendVia(spool, table, [row]) : write.put(table, row)),
+});

--- a/scripts/check-raw-numeric-cast.ts
+++ b/scripts/check-raw-numeric-cast.ts
@@ -57,6 +57,9 @@ const EXCLUDED_FILES: readonly string[] = [
     "scripts/check-raw-numeric-cast.ts",
     // This guard's own tests: the banned shape IS the fixture there.
     "scripts/check-raw-numeric-cast.test.ts",
+    // The spool's bigint round-trip test asserts the RAW bigint survives the
+    // NDJSON path exactly - a CAST would defeat the assertion.
+    "packages/lib/src/duckdb/spool.test.ts",
 ];
 
 /**


### PR DESCRIPTION
Closes #886. Phase 2 of the v3 events-and-SQL-models plan (`docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md`).

## What

High-volume ingest writes stop going through per-value bound parameters. The claude/codex/pi/omp stages wrap their `CacheWriteService` in `withTableSpool`: rows for 15 hot tables buffer in memory and land as one

```sql
INSERT INTO t (cols) SELECT cols FROM read_ndjson('<spool file>', columns = {...from the committed DDL})
ON CONFLICT ("id") DO UPDATE SET col = excluded.col, ...
```

per (table, column-signature) per flush. Explicit `columns={}` always (the v3 proto re-earned an inference bug within minutes); explicit conflict target (`INSERT OR REPLACE` fails on this schema's secondary UNIQUE indexes - the plan text said OR REPLACE and is retracted in place).

## Semantics preserved

- **Per-signature batches**: a narrower write cannot NULL a column it never carried (pinned by test).
- **Last-write-wins per id**: buffers dedup at append - DuckDB rejects a statement whose source repeats a conflict key.
- **bigint exactness**: emitted as decimal strings, cast back through the DDL's BIGINT - 2^53+1 round-trips exactly (pinned).
- **Delete ordering**: `exec` passes through immediately; `agent_event`'s once-per-session DELETE fires before that session's first append.
- **Watermark contract**: the work-unit DEFERS marks past the flush that lands their rows (marks snapshotted before the buffer drains). A crash retries the window - ingest was never per-file transactional.
- **NUL stripping + counts**, surfaced as the same end-of-run warning class.

## What changed deliberately

A spooled row is invisible to SQL until flush. The table set is the #886 read-back survey's verdict, pinned by test: `session`, `skill`, `plan_item` stay direct (same-run read-backs / keyed DELETE). OpenCode/Cursor + git/otel writers stay direct (follow-up candidates, not blockers).

## Receipts

- 7-day claude window into a fresh store: **42.5s → 15.9s wall (2.7x)** - and the unchanged skills/commands/derive stages dilute the pure write-path speedup.
- Row-count parity across 19 tables vs a direct-write baseline; the only deltas were single-digit rows in the actively-growing live session transcript.
- Local gates: strict tsc clean, `bun run typecheck` clean, full `bun test` 6146 tests with only the known studio-desktop electron exemptions, `check:timestamp-cast` + `check:raw-numeric-cast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)