### PR TITLE
feat(ingest): v3 Phase 3 - SQL model runner v1 + run-evidence as SQL models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,8 +313,17 @@ transcripts; the shared contract + deterministic builders live in
 re-derive overwrites). Refs default to `ref_only` (no raw payloads); `backing`
 is verifier-DERIVED from the source, never a producer trust label - no promotion.
 
-The `run-evidence` ingest derive-stage (`apps/axctl/src/ingest/derive-run-evidence.ts`,
-incremental by the since-window, idempotent UPSERTs) normalizes EIGHT structural
+The `run-evidence` ingest derive-stage (incremental by the since-window,
+idempotent UPSERTs) is a **SQL MODEL pair** since #888
+(`apps/axctl/src/ingest/models/run-evidence-{event,ref}.sql`, run by
+`models/runner.ts` - header contract `-- model:`/`-- inputs:`/`-- rebuild:`,
+window via `SET VARIABLE since_days`): the whole derivation executes inside
+DuckDB, verification comes from the STAMPED `command_outcome.check_family`
+column (written by the outcomes stage; the TS classifier in check-family.ts is
+the single source - never re-implement it in SQL), and a version-marked cutover
+wipes + fully re-derives when the model SQL changes. The TS builders in
+`derive-run-evidence.ts` remain one release behind `AX_RUN_EVIDENCE_IMPL=ts`
+with row-for-row parity pinned. It normalizes EIGHT structural
 sources (`RUN_EVIDENCE_DERIVED_KINDS`): `tool_call`->tool_observation/tool_backed,
 `command_outcome`->verification/verifier_backed (ONLY genuine checks via
 `checkFamilyFromCommand` - not every success), `compaction`->boundary/derived (+

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -30,7 +30,7 @@ import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { stableDigest } from "@ax/lib/ids";
 import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
-import { checkFamilyFromCommand } from "./check-family.ts";
+import { checkFamilyFromCommand, isCheckFamily } from "./check-family.ts";
 import {
     runEvidenceEventRecordKey,
     runEvidenceRefRecordKey,
@@ -38,6 +38,7 @@ import {
     type RunEvidenceKind,
     type RunEvidenceRefWrite,
 } from "@ax/lib/shared/run-evidence";
+import { runRunEvidenceModels } from "./models/run-evidence-models.ts";
 import {
     BaseStageStats,
     IngestContext,
@@ -79,6 +80,9 @@ interface CommandOutcomeRow {
     readonly kind?: string | null;
     readonly status?: string | null;
     readonly commandNorm?: string | null;
+    /** Stamped at outcomes-write time (#888); rows from before the stamp are
+     *  NULL and fall back to the old norm-only classification below. */
+    readonly checkFamily?: string | null;
 }
 
 interface CompactionRow {
@@ -233,7 +237,9 @@ const toVerification = (row: CommandOutcomeRow, provider: string): RunEvidenceEv
     // `Read`/`ls` succeeding would become verifier_backed evidence, violating the
     // no-promotion rule. A `verification` is ONLY a genuine check (test / build /
     // lint / typecheck), identified by the command's check family (#578 review).
-    const family = checkFamilyFromCommand(row.commandNorm ?? null);
+    // The stamped column (text-first, #888) is authoritative; the norm-only
+    // fallback keeps pre-stamp history classified as before.
+    const family = isCheckFamily(row.checkFamily) ? row.checkFamily : checkFamilyFromCommand(row.commandNorm ?? null);
     if (family === null) return null;
     return {
         sessionId: row.session,
@@ -518,7 +524,8 @@ const toolCallSql = (since: number | undefined): string =>
      FROM tool_call WHERE session IS NOT NULL ${sinceAnd(since)}`;
 
 export const commandOutcomeSql = (since: number | undefined): string =>
-    `SELECT id, session, tool_call AS toolCall, CAST(ts AS VARCHAR) AS ts, kind, status, command_norm AS commandNorm
+    `SELECT id, session, tool_call AS toolCall, CAST(ts AS VARCHAR) AS ts, kind, status, command_norm AS commandNorm,
+            check_family AS checkFamily
      FROM command_outcome WHERE session IS NOT NULL ${sinceAnd(since)}`;
 
 // `tokens_before` is BIGINT and this stage reads through `write.raw`, which
@@ -680,6 +687,12 @@ export class RunEvidenceStats extends BaseStageStats.extend<RunEvidenceStats>("R
  * Run-evidence stage - normalizes structural graph rows into the
  * `run_evidence_event` ledger (#578). Incremental by the ingest since-window;
  * idempotent UPSERTs keyed by (session, source_table, source_id). Tags: derive.
+ *
+ * Default implementation is the SQL MODEL pair (#888, v3 Phase 3) - the whole
+ * derivation runs inside DuckDB, no rows cross the JS boundary. The TS
+ * builders above stay as the shadow implementation behind
+ * `AX_RUN_EVIDENCE_IMPL=ts` for one release (parity pinned by
+ * models/run-evidence-parity.test.ts); after that release they are deleted.
  */
 export const runEvidenceStage: StageDef<RunEvidenceStats, never, CacheWriteError> = {
     meta: StageMeta.make({
@@ -690,10 +703,21 @@ export const runEvidenceStage: StageDef<RunEvidenceStats, never, CacheWriteError
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();
-            const result = yield* deriveRunEvidence(write, sinceDaysFromCtx(ctx));
+            if (process.env.AX_RUN_EVIDENCE_IMPL === "ts") {
+                const result = yield* deriveRunEvidence(write, sinceDaysFromCtx(ctx));
+                return RunEvidenceStats.make({
+                    durationMs: Date.now() - t0,
+                    summary: `derived ${result.written} run-evidence events, ${result.refsWritten} refs (ts shadow)`,
+                    written: result.written,
+                    refsWritten: result.refsWritten,
+                });
+            }
+            const result = yield* runRunEvidenceModels(write, sinceDaysFromCtx(ctx));
             return RunEvidenceStats.make({
                 durationMs: Date.now() - t0,
-                summary: `derived ${result.written} run-evidence events, ${result.refsWritten} refs`,
+                summary: `derived ${result.written} run-evidence events, ${result.refsWritten} refs (sql model${
+                    result.rebuilt ? `, version cutover: rebuilt + ${result.backfilled} check_family backfilled` : ""
+                })`,
                 written: result.written,
                 refsWritten: result.refsWritten,
             });

--- a/apps/axctl/src/ingest/models/models.test.ts
+++ b/apps/axctl/src/ingest/models/models.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The SQL model header contract + drift pins (#888).
+ *
+ * No database: these tests read the .sql files as text and hold them to the
+ * declarations they make - inputs must be real tables, and the one list that
+ * duplicates a TS constant (the edit-tool names in run-evidence-ref.sql) is
+ * pinned to its source of truth so the two cannot drift silently.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseDuckdbTables } from "@ax/schema/duckdb-ddl";
+import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
+import { parseModelHeader } from "./runner.ts";
+import {
+    RUN_EVIDENCE_EVENT_MODEL,
+    RUN_EVIDENCE_MODELS,
+    RUN_EVIDENCE_REF_MODEL,
+    runEvidenceModelVersion,
+} from "./run-evidence-models.ts";
+
+const TABLES = new Set(parseDuckdbTables());
+
+describe("model header contract", () => {
+    test("every registered model declares model/inputs/rebuild and targets a real table", () => {
+        for (const model of RUN_EVIDENCE_MODELS) {
+            const header = parseModelHeader(model.sql);
+            expect(header.model).toBe(model.name);
+            expect(TABLES.has(header.model)).toBe(true);
+            expect(header.inputs.length).toBeGreaterThan(0);
+            for (const input of header.inputs) {
+                expect({ model: model.name, input, known: TABLES.has(input) }).toEqual({
+                    model: model.name,
+                    input,
+                    known: true,
+                });
+            }
+            expect(["incremental", "full_rebuild"]).toContain(header.rebuild);
+        }
+    });
+
+    test("an incremental model actually reads the since_days variable", () => {
+        for (const model of RUN_EVIDENCE_MODELS) {
+            if (parseModelHeader(model.sql).rebuild === "incremental") {
+                expect(model.sql).toContain("getvariable('since_days')");
+            }
+        }
+    });
+
+    test("a headerless file is refused", () => {
+        expect(() => parseModelHeader("SELECT 1")).toThrow(/header contract/);
+    });
+
+    test("the ICU-less clock spelling is used wherever the models read the clock", () => {
+        for (const model of RUN_EVIDENCE_MODELS) {
+            for (const match of model.sql.matchAll(/CURRENT_TIMESTAMP/g)) {
+                const before = model.sql.slice(Math.max(0, match.index - 6), match.index);
+                expect(before).toContain("CAST(");
+            }
+        }
+    });
+});
+
+describe("drift pins", () => {
+    test("the ref model's edit-tool list equals EDIT_TOOL_NAMES lowercased", () => {
+        const m = /lower\(tc\.name\) IN \(([^)]+)\)/.exec(RUN_EVIDENCE_REF_MODEL.sql);
+        expect(m).not.toBeNull();
+        const sqlNames = m![1]!
+            .split(",")
+            .map((s) => s.trim().replace(/^'|'$/g, ""))
+            .sort();
+        const tsNames = [...EDIT_TOOL_NAMES].map((n) => n.toLowerCase()).sort();
+        expect(sqlNames).toEqual(tsNames);
+    });
+
+    test("the event model consumes the STAMPED check_family, never re-classifying", () => {
+        expect(RUN_EVIDENCE_EVENT_MODEL.sql).toContain("check_family IS NOT NULL");
+        // Guard against someone porting the classifier into SQL: no token maps.
+        expect(RUN_EVIDENCE_EVENT_MODEL.sql).not.toMatch(/vitest|pytest|golangci/);
+    });
+
+    test("the model version moves when the SQL moves", () => {
+        const v = runEvidenceModelVersion();
+        expect(v).toHaveLength(16);
+        // Stable across calls (it seeds the cutover marker).
+        expect(runEvidenceModelVersion()).toBe(v);
+    });
+
+    test("the policy-decision effect list matches the TS query's", () => {
+        expect(RUN_EVIDENCE_EVENT_MODEL.sql).toContain(
+            "('blocked', 'injected_context', 'modified_input', 'notified')",
+        );
+    });
+});

--- a/apps/axctl/src/ingest/models/run-evidence-event.sql
+++ b/apps/axctl/src/ingest/models/run-evidence-event.sql
@@ -1,0 +1,211 @@
+-- model: run_evidence_event
+-- inputs: session, tool_call, command_outcome, compaction, plan_snapshot, turn, hook_command_invocation, checkout, spawned
+-- rebuild: incremental
+--
+-- The run-evidence event ledger (#578), derived INSIDE DuckDB (#888) - this
+-- replaces the TS round trip (12 reads -> JS map -> putMany) that cost ~74s
+-- per ingest. Semantics mirror derive-run-evidence.ts's pure mappers, which
+-- stay in the tree as the shadow implementation (AX_RUN_EVIDENCE_IMPL=ts) for
+-- one release; the parity test diffs the two row-for-row on the natural key.
+--
+-- DELIBERATE DIFFERENCES from the TS builders (rebuildable-cache freedoms):
+--  * id = md5(session <US> source_table <US> source_id) - stableDigest is
+--    Bun.hash and cannot be computed in SQL. The cutover wipes TS-era rows
+--    (version-marked), so the two schemes never coexist.
+--  * verification uses the STAMPED command_outcome.check_family (#471
+--    text-first fix) - the TS classifier stays the single source of truth,
+--    stamped at outcomes-write time; this model never re-classifies.
+--
+-- Window: SET VARIABLE since_days (NULL/unset = full derivation).
+-- ICU-less build: the clock MUST be spelled CAST(CURRENT_TIMESTAMP AS TIMESTAMP).
+INSERT INTO run_evidence_event (
+    id, session, root_session, parent_session, ts, provider, kind, backing,
+    turn, tool_call, agent_event, compaction, plan_snapshot, command_outcome,
+    hook_invocation, artifact, file, checkout, "commit",
+    source_table, source_id, summary, content_hash, input_hash, output_hash, attrs
+)
+WITH RECURSIVE
+params AS (
+    SELECT CASE
+        WHEN getvariable('since_days') IS NULL THEN NULL
+        ELSE CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(getvariable('since_days') AS INTEGER) * INTERVAL '1 day')
+    END AS cutoff
+),
+-- Parent/root lineage from `spawned` (parent -> child). min(in_id) makes a
+-- duplicate-parent child deterministic; depth cap 32 guards cycles (the TS
+-- walker's seen-set equivalent).
+parent_of AS (
+    SELECT out_id AS child, min(in_id) AS parent
+    FROM spawned
+    WHERE in_id IS NOT NULL AND out_id IS NOT NULL AND in_id <> out_id
+    GROUP BY 1
+),
+walk AS (
+    SELECT child, parent, parent AS root, 1 AS depth FROM parent_of
+    UNION ALL
+    SELECT w.child, w.parent, p.parent AS root, w.depth + 1
+    FROM walk w
+    JOIN parent_of p ON p.child = w.root
+    WHERE w.depth < 32
+),
+lineage AS (
+    SELECT child, any_value(parent) AS parent, arg_max(root, depth) AS root
+    FROM walk GROUP BY child
+),
+src AS (
+    -- tool_call -> tool_observation (tool_backed). The NULL link columns are
+    -- CAST here because UNION type inference reads the FIRST branch: a bare
+    -- NULL types as INTEGER and the repo_state branch's checkout id would
+    -- then fail to cast.
+    SELECT tc.session AS session, tc.ts AS ts, 'tool_observation' AS kind, 'tool_backed' AS backing,
+           CAST(NULL AS VARCHAR) AS turn, tc.id AS tool_call,
+           CAST(NULL AS VARCHAR) AS compaction, CAST(NULL AS VARCHAR) AS plan_snapshot,
+           CAST(NULL AS VARCHAR) AS command_outcome, CAST(NULL AS VARCHAR) AS hook_invocation,
+           CAST(NULL AS VARCHAR) AS checkout,
+           'tool_call' AS source_table, tc.id AS source_id,
+           tc.name AS summary,
+           -- Chains start from '{}': merge-patch drops a NULL only when it is
+           -- in the PATCH argument, so a json_object base would keep null keys.
+           json_merge_patch(json_merge_patch(json_merge_patch('{}',
+               json_object('tool', tc.name)),
+               json_object('has_error', coalesce(tc.has_error, FALSE))),
+               json_object('command_norm', tc.command_norm)) AS attrs
+    FROM tool_call tc, params p
+    WHERE tc.session IS NOT NULL AND (p.cutoff IS NULL OR tc.ts > p.cutoff)
+
+    UNION ALL
+    -- command_outcome -> verification (verifier_backed): ONLY genuine checks,
+    -- via the stamped check_family (never re-classified here).
+    SELECT co.session, co.ts, 'verification', 'verifier_backed',
+           NULL, co.tool_call, NULL, NULL,
+           co.id, NULL, NULL,
+           'command_outcome', co.id,
+           co.check_family || ': ' || coalesce(co.status, '?'),
+           json_merge_patch(json_merge_patch(json_merge_patch('{}',
+               json_object('family', co.check_family)),
+               json_object('kind', co.kind)),
+               json_object('status', co.status))
+    FROM command_outcome co, params p
+    WHERE co.session IS NOT NULL AND co.check_family IS NOT NULL
+      AND (p.cutoff IS NULL OR co.ts > p.cutoff)
+
+    UNION ALL
+    -- compaction -> boundary (derived): a system-recorded lifecycle boundary.
+    SELECT c.session, c.ts, 'boundary', 'derived',
+           NULL, NULL, c.id, NULL,
+           NULL, NULL, NULL,
+           'compaction', c.id,
+           'compaction (' || coalesce(c.strategy, '?')
+               || CASE WHEN c.trigger IS NOT NULL THEN ', ' || c.trigger ELSE '' END || ')',
+           json_merge_patch(json_merge_patch(json_merge_patch('{}',
+               json_object('trigger', c.trigger)),
+               json_object('strategy', c.strategy)),
+               json_object('tokens_before', CAST(c.tokens_before AS DOUBLE)))
+    FROM compaction c, params p
+    WHERE c.session IS NOT NULL AND (p.cutoff IS NULL OR c.ts > p.cutoff)
+
+    UNION ALL
+    -- compaction summary TEXT -> derived_summary, keyed 'compaction_summary'
+    -- so it cannot collide with the boundary event off the same row.
+    SELECT c.session, c.ts, 'derived_summary', 'derived',
+           NULL, NULL, c.id, NULL,
+           NULL, NULL, NULL,
+           'compaction_summary', c.id,
+           c.summary, NULL
+    FROM compaction c, params p
+    WHERE c.session IS NOT NULL AND c.summary IS NOT NULL AND c.summary <> ''
+      AND (p.cutoff IS NULL OR c.ts > p.cutoff)
+
+    UNION ALL
+    -- plan_snapshot -> task_state (tool_backed: TodoWrite / update_plan).
+    SELECT ps.session, ps.ts, 'task_state', 'tool_backed',
+           NULL, NULL, NULL, ps.id,
+           NULL, NULL, NULL,
+           'plan_snapshot', ps.id,
+           ps.summary, NULL
+    FROM plan_snapshot ps, params p
+    WHERE ps.session IS NOT NULL AND (p.cutoff IS NULL OR ps.ts > p.cutoff)
+
+    UNION ALL
+    -- earliest `task` user turn per session -> objective (selection, not NLP).
+    SELECT t.session, t.ts, 'objective', 'derived',
+           t.id, NULL, NULL, NULL,
+           NULL, NULL, NULL,
+           'turn', t.id,
+           t.text_excerpt, NULL
+    FROM (
+        SELECT *, row_number() OVER (
+            PARTITION BY session ORDER BY seq NULLS LAST, ts, id
+        ) AS rn
+        FROM turn, params p
+        WHERE session IS NOT NULL AND role = 'user' AND message_kind = 'task'
+          AND (p.cutoff IS NULL OR ts > p.cutoff)
+    ) t
+    WHERE t.rn = 1
+
+    UNION ALL
+    -- hook invocations with a real intervention -> policy_decision.
+    SELECT h.session, h.ts, 'policy_decision', 'policy_backed',
+           NULL, h.tool_call, NULL, NULL,
+           NULL, h.id, NULL,
+           'hook_command_invocation', h.id,
+           coalesce(h.hook_name, 'hook') || ': ' || coalesce(h.effect, '?'),
+           json_merge_patch(json_merge_patch(json_merge_patch('{}',
+               json_object('effect', h.effect)),
+               json_object('hook_name', h.hook_name)),
+               json_object('provider_status', h.provider_status))
+    FROM hook_command_invocation h, params p
+    WHERE h.session IS NOT NULL
+      AND h.effect IN ('blocked', 'injected_context', 'modified_input', 'notified')
+      AND (p.cutoff IS NULL OR h.ts > p.cutoff)
+
+    UNION ALL
+    -- session checkout -> repo_state. dirty is NOT read (git writes it
+    -- always-false, #578 review).
+    SELECT s.id, s.started_at, 'repo_state', 'derived',
+           NULL, NULL, NULL, NULL,
+           NULL, NULL, s.checkout,
+           'checkout', s.checkout,
+           coalesce(c.repository, 'repo')
+               || CASE WHEN c.branch IS NOT NULL THEN ' @ ' || c.branch ELSE '' END
+               || CASE WHEN c.head_sha IS NOT NULL THEN ' · ' || substr(c.head_sha, 1, 7) ELSE '' END,
+           json_merge_patch(json_merge_patch(json_merge_patch('{}',
+               json_object('repository', c.repository)),
+               json_object('branch', c.branch)),
+               json_object('head_sha', c.head_sha))
+    FROM session s
+    JOIN checkout c ON c.id = s.checkout
+    CROSS JOIN params p
+    WHERE s.checkout IS NOT NULL AND (p.cutoff IS NULL OR s.started_at > p.cutoff)
+)
+SELECT
+    md5(src.session || chr(31) || src.source_table || chr(31) || src.source_id) AS id,
+    src.session,
+    lin.root AS root_session,
+    lin.parent AS parent_session,
+    src.ts,
+    coalesce(sess.source, 'unknown') AS provider,
+    src.kind, src.backing,
+    src.turn, src.tool_call, NULL AS agent_event, src.compaction, src.plan_snapshot,
+    src.command_outcome, src.hook_invocation, NULL AS artifact, NULL AS file,
+    src.checkout, NULL AS "commit",
+    src.source_table, src.source_id, src.summary,
+    NULL AS content_hash, NULL AS input_hash, NULL AS output_hash,
+    src.attrs
+FROM src
+LEFT JOIN session sess ON sess.id = src.session
+LEFT JOIN lineage lin ON lin.child = src.session
+-- Defensive: a duplicate id inside one INSERT is a DuckDB error, not an upsert.
+QUALIFY row_number() OVER (PARTITION BY md5(src.session || chr(31) || src.source_table || chr(31) || src.source_id) ORDER BY src.ts) = 1
+ON CONFLICT (id) DO UPDATE SET
+    session = excluded.session, root_session = excluded.root_session,
+    parent_session = excluded.parent_session, ts = excluded.ts,
+    provider = excluded.provider, kind = excluded.kind, backing = excluded.backing,
+    turn = excluded.turn, tool_call = excluded.tool_call, agent_event = excluded.agent_event,
+    compaction = excluded.compaction, plan_snapshot = excluded.plan_snapshot,
+    command_outcome = excluded.command_outcome, hook_invocation = excluded.hook_invocation,
+    artifact = excluded.artifact, file = excluded.file, checkout = excluded.checkout,
+    "commit" = excluded."commit", source_table = excluded.source_table,
+    source_id = excluded.source_id, summary = excluded.summary,
+    content_hash = excluded.content_hash, input_hash = excluded.input_hash,
+    output_hash = excluded.output_hash, attrs = excluded.attrs

--- a/apps/axctl/src/ingest/models/run-evidence-models.ts
+++ b/apps/axctl/src/ingest/models/run-evidence-models.ts
@@ -1,0 +1,139 @@
+/**
+ * The run-evidence SQL models + their cutover (#888).
+ *
+ * Default implementation of the `run-evidence` stage. The TS builders in
+ * derive-run-evidence.ts stay in the tree as the shadow implementation
+ * (`AX_RUN_EVIDENCE_IMPL=ts`) for one release; the parity test diffs the two
+ * on the natural key.
+ *
+ * CUTOVER: the models' id scheme (md5 of natural keys) differs from the TS
+ * era's Bun.hash-based keys - legitimate because the cache is REBUILDABLE and
+ * nothing joins on id shape, but the two schemes must never coexist. A
+ * version marker (sentinel watermark row, the established non-file pattern)
+ * records which model version built the tables; on mismatch this module
+ *   1. backfills `command_outcome.check_family` for pre-stamp history
+ *      (rejoining tool_call for command_text, the TS classifier as the single
+ *      source of truth),
+ *   2. wipes run_evidence_ref + run_evidence_event,
+ *   3. runs both models UNWINDOWED once,
+ *   4. stamps the marker.
+ * Subsequent runs execute the models with the ingest since-window only.
+ */
+import { Effect, Schema } from "effect";
+import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { watermarkRow, WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
+import { stableDigest } from "@ax/lib/ids";
+import { checkFamilyFromCommand } from "../check-family.ts";
+import { parseModelHeader, runSqlModel, type SqlModel } from "./runner.ts";
+import RUN_EVIDENCE_EVENT_SQL from "./run-evidence-event.sql" with { type: "text" };
+import RUN_EVIDENCE_REF_SQL from "./run-evidence-ref.sql" with { type: "text" };
+
+export const RUN_EVIDENCE_EVENT_MODEL: SqlModel = { name: "run_evidence_event", sql: RUN_EVIDENCE_EVENT_SQL };
+export const RUN_EVIDENCE_REF_MODEL: SqlModel = { name: "run_evidence_ref", sql: RUN_EVIDENCE_REF_SQL };
+
+/** Ordered: refs recompute event ids, so events land first. */
+export const RUN_EVIDENCE_MODELS: readonly SqlModel[] = [RUN_EVIDENCE_EVENT_MODEL, RUN_EVIDENCE_REF_MODEL];
+
+/** Changes whenever either model's SQL changes -> one full re-derive. */
+export const runEvidenceModelVersion = (): string =>
+    stableDigest(`run-evidence-models-v1${RUN_EVIDENCE_EVENT_SQL}${RUN_EVIDENCE_REF_SQL}`);
+
+const MARKER_SOURCE_KIND = "run_evidence_model";
+const MARKER_PATH = "__run_evidence_model__";
+
+const storedModelVersion = (write: CacheWriteService): Effect.Effect<string | null, CacheWriteError> =>
+    Effect.gen(function* () {
+        const rows = yield* write.rows(
+            Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+            `SELECT sha FROM ${WATERMARK_TABLE} WHERE source_kind = ? AND path = ?`,
+            [MARKER_SOURCE_KIND, MARKER_PATH],
+        );
+        return rows[0]?.sha ?? null;
+    });
+
+/**
+ * Stamp `check_family` onto pre-stamp `command_outcome` history. The outcomes
+ * stage stamps every row it writes from here on; this covers rows written
+ * before the column existed, rejoining tool_call for the text-first input.
+ * The TS classifier remains the single source of truth - SQL never
+ * re-implements it (two token-position parsers WILL drift).
+ */
+export const backfillCheckFamily = (write: CacheWriteService): Effect.Effect<number, CacheWriteError> =>
+    Effect.gen(function* () {
+        const rows = yield* write.rows(
+            Schema.Struct({
+                id: Schema.String,
+                command_text: Schema.NullOr(Schema.String),
+                command_norm: Schema.NullOr(Schema.String),
+            }),
+            `SELECT co.id, tc.command_text, co.command_norm
+             FROM command_outcome co
+             LEFT JOIN tool_call tc ON tc.id = co.tool_call
+             WHERE co.check_family IS NULL`,
+        );
+        const byFamily = new Map<string, string[]>();
+        for (const row of rows) {
+            const family = checkFamilyFromCommand(row.command_text) ?? checkFamilyFromCommand(row.command_norm);
+            if (family === null) continue;
+            const list = byFamily.get(family);
+            if (list) list.push(row.id);
+            else byFamily.set(family, [row.id]);
+        }
+        let updated = 0;
+        for (const [family, ids] of byFamily) {
+            for (let start = 0; start < ids.length; start += 500) {
+                const batch = ids.slice(start, start + 500);
+                const placeholders = batch.map(() => "?").join(", ");
+                updated += yield* write.exec(
+                    `UPDATE command_outcome SET check_family = ? WHERE id IN (${placeholders})`,
+                    [family, ...batch],
+                );
+            }
+        }
+        return updated;
+    });
+
+export interface RunEvidenceModelStats {
+    readonly written: number;
+    readonly refsWritten: number;
+    /** True when this run performed the one-time version cutover. */
+    readonly rebuilt: boolean;
+    /** check_family rows stamped by the cutover backfill (0 on ordinary runs). */
+    readonly backfilled: number;
+}
+
+export const runRunEvidenceModels = (
+    write: CacheWriteService,
+    sinceDays: number | undefined,
+): Effect.Effect<RunEvidenceModelStats, CacheWriteError> =>
+    Effect.gen(function* () {
+        const version = runEvidenceModelVersion();
+        const stored = yield* storedModelVersion(write);
+        const rebuild = stored !== version;
+        let backfilled = 0;
+        if (rebuild) {
+            backfilled = yield* backfillCheckFamily(write);
+            // Order matters: refs point at events, wipe refs first.
+            yield* write.exec("DELETE FROM run_evidence_ref");
+            yield* write.exec("DELETE FROM run_evidence_event");
+        }
+        const window = rebuild ? undefined : sinceDays;
+        const written = yield* runSqlModel(write, RUN_EVIDENCE_EVENT_MODEL, window);
+        const refsWritten = yield* runSqlModel(write, RUN_EVIDENCE_REF_MODEL, window);
+        if (rebuild) {
+            yield* write.put(
+                WATERMARK_TABLE,
+                watermarkRow(MARKER_SOURCE_KIND, MARKER_PATH, { sha: version }),
+            );
+        }
+        return { written, refsWritten, rebuilt: rebuild, backfilled };
+    });
+
+// Header contracts are enforced at import time: a malformed model file fails
+// the FIRST test or run that loads this module, not silently at 3am.
+for (const model of RUN_EVIDENCE_MODELS) {
+    const header = parseModelHeader(model.sql);
+    if (header.model !== model.name) {
+        throw new Error(`model file header says "${header.model}" but is registered as "${model.name}"`);
+    }
+}

--- a/apps/axctl/src/ingest/models/run-evidence-parity.test.ts
+++ b/apps/axctl/src/ingest/models/run-evidence-parity.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The Phase 3 shadow contract (#888): the SQL models must produce the SAME
+ * ledger as the TS builders, row-for-row on the natural key
+ * (session, source_table, source_id) - over a fixture that exercises every
+ * derived kind, the lineage walk, the objective pick, the edited bridge, and
+ * the check_family backfill.
+ *
+ * Ids and path_hash are compared by PRESENCE/SHAPE, not value: the model uses
+ * md5 where TS used Bun.hash (documented rebuildable-cache freedom; the
+ * version cutover wipes TS-era rows so the schemes never coexist).
+ */
+import { describe, expect } from "bun:test";
+import { Effect, Schema } from "effect";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { deriveRunEvidence } from "../derive-run-evidence.ts";
+import { runRunEvidenceModels } from "./run-evidence-models.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("run evidence parity", { requireFts: true });
+
+// Recent, so a 30-day-window model run genuinely re-upserts the fixture rows
+// (an old fixed date would fall outside the window and prove nothing).
+const TS0 = new Date(Date.now() - 24 * 3600 * 1000);
+const at = (min: number) => new Date(TS0.getTime() + min * 60_000);
+
+/** Seed a store that exercises every branch of both implementations. */
+const seedFixture = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        // Sessions: a top-level claude session, a codex session, and a
+        // spawned chain top -> mid -> leaf for the lineage walk.
+        yield* write.putMany("session", [
+            { id: "top", source: "claude", started_at: at(0), checkout: "chk1" },
+            { id: "mid", source: "claude", started_at: at(1), checkout: null },
+            { id: "leaf", source: "claude", started_at: at(2), checkout: null },
+            { id: "codex-s", source: "codex", started_at: at(0), checkout: null },
+        ]);
+        yield* write.put("checkout", {
+            id: "chk1", repository: "repo1", path: "/tmp/repo1", branch: "main", head_sha: "abcdef1234567890",
+        });
+        yield* write.putMany("spawned", [
+            { id: "sp1", in_id: "top", out_id: "mid", ts: at(1) },
+            { id: "sp2", in_id: "mid", out_id: "leaf", ts: at(2) },
+        ]);
+
+        // Tool calls: plain, erroring, an edit pair (one single-edit turn, one
+        // ambiguous double-edit turn), and the check the outcomes stamp covers.
+        yield* write.putMany("tool_call", [
+            { id: "tc1", session: "top", turn: "t-tool1", name: "Bash", ts: at(3), has_error: false, command_norm: "rg foo", command_text: "rg foo src/" },
+            { id: "tc2", session: "codex-s", turn: "t-tool2", name: "exec_command", ts: at(4), has_error: true, command_norm: "bun test", command_text: "bun test" },
+            { id: "tc-edit1", session: "top", turn: "t-edit-single", name: "Edit", ts: at(5), has_error: false, command_norm: null, command_text: null },
+            { id: "tc-edit2a", session: "top", turn: "t-edit-double", name: "Edit", ts: at(6), has_error: false, command_norm: null, command_text: null },
+            { id: "tc-edit2b", session: "top", turn: "t-edit-double", name: "Write", ts: at(6), has_error: false, command_norm: null, command_text: null },
+            // On the spawn-chain LEAF, so its event must carry parent=mid,
+            // root=top - the lineage walk is load-bearing in this fixture.
+            { id: "tc-leaf", session: "leaf", turn: null, name: "Read", ts: at(4), has_error: false, command_norm: null, command_text: null },
+        ]);
+
+        // Command outcomes: a stamped check, an UNSTAMPED legacy check (the
+        // backfill must classify it from tool_call.command_text), and a plain
+        // success that must never become a verification.
+        yield* write.putMany("command_outcome", [
+            { id: "co1", session: "top", tool_call: "tc1", kind: "success", status: "ok", command_norm: "bunx tsc --noEmit", check_family: "typecheck", ts: at(7) },
+            { id: "co2", session: "codex-s", tool_call: "tc2", kind: "expected_feedback", status: "error", command_norm: "bun test", check_family: null, ts: at(8) },
+            { id: "co3", session: "top", tool_call: null, kind: "success", status: "ok", command_norm: "ls -la", check_family: null, ts: at(9) },
+        ]);
+
+        // Compactions: one with a summary (boundary + derived_summary), one
+        // without (boundary only). tokens_before is BIGINT in the DDL.
+        yield* write.putMany("compaction", [
+            { id: "cmp1", session: "top", harness: "claude", ts: at(10), trigger: "auto", strategy: "summarize", source_confidence: "explicit", summary: "compacted the history", tokens_before: 123_456 },
+            { id: "cmp2", session: "codex-s", harness: "codex", ts: at(11), trigger: null, strategy: "truncate", source_confidence: "explicit", summary: null, tokens_before: null },
+        ]);
+
+        yield* write.put("plan_snapshot", { id: "ps1", session: "top", ts: at(12), summary: "3 todos, 1 in progress", source: "claude_task", items: "[]" });
+
+        // Task turns: two per session; only the EARLIEST (min seq) is the
+        // objective. A non-task turn must not qualify.
+        yield* write.putMany("turn", [
+            { id: "t-obj1", session: "top", seq: 2, role: "user", message_kind: "task", ts: at(2), text_excerpt: "fix the flaky test" },
+            { id: "t-obj2", session: "top", seq: 5, role: "user", message_kind: "task", ts: at(3), text_excerpt: "second ask" },
+            { id: "t-ctx", session: "top", seq: 1, role: "user", message_kind: "context", ts: at(1), text_excerpt: "system noise" },
+            { id: "t-obj-codex", session: "codex-s", seq: 1, role: "user", message_kind: "task", ts: at(1), text_excerpt: "port the parser" },
+            { id: "t-edit-single", session: "top", seq: 7, role: "assistant", message_kind: "work", ts: at(5), text_excerpt: null },
+            { id: "t-edit-double", session: "top", seq: 8, role: "assistant", message_kind: "work", ts: at(6), text_excerpt: null },
+            { id: "t-tool1", session: "top", seq: 6, role: "assistant", message_kind: "work", ts: at(3), text_excerpt: null },
+            { id: "t-tool2", session: "codex-s", seq: 2, role: "assistant", message_kind: "work", ts: at(4), text_excerpt: null },
+        ]);
+
+        // Hook invocations: one real intervention, one pass-through (excluded).
+        yield* write.putMany("hook_command_invocation", [
+            { id: "h1", session: "top", tool_call: "tc1", hook_event: "harness-hook-1", ts: at(13), harness: "claude", event_name: "PreToolUse", hook_name: "enforce-worktree", command: "bun dispatch.ts", command_hash: "hash1", effect: "blocked", provider_status: "success" },
+            { id: "h2", session: "top", tool_call: null, hook_event: "harness-hook-2", ts: at(14), harness: "claude", event_name: "PreToolUse", hook_name: "quiet-hook", command: "bun dispatch.ts", command_hash: "hash2", effect: "none", provider_status: "success" },
+        ]);
+
+        // File evidence edges + the edited bridge (single-edit anchors,
+        // double-edit is dropped).
+        yield* write.putMany("file", [
+            { id: "f1", path: "src/a.ts" },
+            { id: "f2", path: "src/b.ts" },
+        ]);
+        yield* write.put("read_file", { id: "rf1", in_id: "tc1", out_id: "f1", ts: at(3), path_seen: "src/a.ts" });
+        yield* write.put("searched_file", { id: "sf1", in_id: "tc1", out_id: "f2", ts: at(3), path_seen: "src/b.ts" });
+        yield* write.putMany("edited", [
+            { id: "ed1", in_id: "t-edit-single", out_id: "f1", ts: at(5), path_seen: "src/a.ts", tool: "Edit" },
+            { id: "ed2", in_id: "t-edit-double", out_id: "f2", ts: at(6), path_seen: "src/b.ts", tool: "Edit" },
+        ]);
+    });
+
+interface EventSnap {
+    readonly kind: string;
+    readonly backing: string;
+    readonly provider: string;
+    readonly root: string | null;
+    readonly parent: string | null;
+    readonly ts: string;
+    readonly links: Record<string, string | null>;
+    readonly summary: string | null;
+    readonly attrs: unknown;
+}
+
+const snapshotEvents = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const rows = yield* write.rows(
+            Schema.Struct({
+                session: Schema.String, source_table: Schema.String, source_id: Schema.String,
+                kind: Schema.String, backing: Schema.String, provider: Schema.String,
+                root_session: Schema.NullOr(Schema.String), parent_session: Schema.NullOr(Schema.String),
+                ts: Schema.String, turn: Schema.NullOr(Schema.String), tool_call: Schema.NullOr(Schema.String),
+                compaction: Schema.NullOr(Schema.String), plan_snapshot: Schema.NullOr(Schema.String),
+                command_outcome: Schema.NullOr(Schema.String), hook_invocation: Schema.NullOr(Schema.String),
+                checkout: Schema.NullOr(Schema.String), summary: Schema.NullOr(Schema.String),
+                attrs: Schema.NullOr(Schema.String),
+            }),
+            `SELECT session, source_table, source_id, kind, backing, provider, root_session, parent_session,
+                    CAST(ts AS VARCHAR) AS ts, turn, tool_call, compaction, plan_snapshot, command_outcome,
+                    hook_invocation, checkout, summary, attrs
+             FROM run_evidence_event`,
+        );
+        const map = new Map<string, EventSnap>();
+        for (const r of rows) {
+            map.set(`${r.session}|${r.source_table}|${r.source_id}`, {
+                kind: r.kind, backing: r.backing, provider: r.provider,
+                root: r.root_session, parent: r.parent_session, ts: r.ts,
+                links: {
+                    turn: r.turn, tool_call: r.tool_call, compaction: r.compaction,
+                    plan_snapshot: r.plan_snapshot, command_outcome: r.command_outcome,
+                    hook_invocation: r.hook_invocation, checkout: r.checkout,
+                },
+                summary: r.summary,
+                attrs: r.attrs === null ? null : JSON.parse(r.attrs),
+            });
+        }
+        return map;
+    });
+
+const snapshotRefs = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const rows = yield* write.rows(
+            Schema.Struct({
+                session: Schema.String, source_table: Schema.String, source_id: Schema.String,
+                ref_kind: Schema.String, target_table: Schema.NullOr(Schema.String),
+                target_id: Schema.NullOr(Schema.String), has_path_hash: Schema.Boolean,
+                privacy_level: Schema.String, attrs: Schema.NullOr(Schema.String),
+            }),
+            `SELECT e.session, e.source_table, e.source_id, r.ref_kind, r.target_table, r.target_id,
+                    r.path_hash IS NOT NULL AS has_path_hash, r.privacy_level, r.attrs
+             FROM run_evidence_ref r JOIN run_evidence_event e ON e.id = r."event"`,
+        );
+        return new Set(rows.map((r) => JSON.stringify({
+            event: `${r.session}|${r.source_table}|${r.source_id}`,
+            refKind: r.ref_kind, targetTable: r.target_table, targetId: r.target_id,
+            hasPathHash: r.has_path_hash, privacy: r.privacy_level,
+            attrs: r.attrs === null ? null : JSON.parse(r.attrs),
+        })));
+    });
+
+describe("run-evidence SQL model parity vs the TS builders", () => {
+    dtest("row-for-row equal on the natural key, refs included", async () => {
+        let tsEvents!: Map<string, EventSnap>;
+        let sqlEvents!: Map<string, EventSnap>;
+        let tsRefs!: Set<string>;
+        let sqlRefs!: Set<string>;
+        let modelStats: unknown;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-rev-parity-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* seedFixture(write);
+
+                // Pass 1: the TS shadow implementation.
+                yield* deriveRunEvidence(write, undefined);
+                tsEvents = yield* snapshotEvents(write);
+                tsRefs = yield* snapshotRefs(write);
+
+                // Pass 2: the SQL models, via the version cutover (fresh store
+                // has no marker -> backfills check_family, wipes, full-derives).
+                modelStats = yield* runRunEvidenceModels(write, undefined);
+                sqlEvents = yield* snapshotEvents(write);
+                sqlRefs = yield* snapshotRefs(write);
+            }),
+        ));
+
+        // The cutover ran: co2 was unstamped and needed the backfill.
+        expect(modelStats).toMatchObject({ rebuilt: true });
+        expect((modelStats as { backfilled: number }).backfilled).toBeGreaterThanOrEqual(1);
+
+        // Same natural-key set.
+        const tsKeys = [...tsEvents.keys()].sort();
+        const sqlKeys = [...sqlEvents.keys()].sort();
+        expect(sqlKeys).toEqual(tsKeys);
+
+        // Same row content per key.
+        for (const key of tsKeys) {
+            expect({ key, ...sqlEvents.get(key)! }).toEqual({ key, ...tsEvents.get(key)! });
+        }
+
+        // Refs: same set on (event natural key, kind, target, attrs).
+        expect([...sqlRefs].sort()).toEqual([...tsRefs].sort());
+
+        // Sanity on coverage: every derived kind is present in the fixture run.
+        const kinds = new Set([...tsEvents.values()].map((e) => e.kind));
+        expect([...kinds].sort()).toEqual([
+            "boundary", "derived_summary", "objective", "policy_decision",
+            "repo_state", "task_state", "tool_observation", "verification",
+        ]);
+        // The double-edit turn's ref was dropped; the single-edit anchored.
+        const editRefs = [...tsRefs].filter((r) => (JSON.parse(r).attrs as { access?: string })?.access === "write");
+        expect(editRefs).toHaveLength(1);
+    });
+
+    dtest("second model run is windowed (no cutover) and idempotent", async () => {
+        let first: unknown;
+        let second: unknown;
+        let countAfter = -1;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-rev-idem-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* seedFixture(write);
+                first = yield* runRunEvidenceModels(write, undefined);
+                const eventsAfterFirst = yield* write.rows(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT count(*)::INTEGER AS n FROM run_evidence_event",
+                );
+                second = yield* runRunEvidenceModels(write, 30);
+                const eventsAfterSecond = yield* write.rows(
+                    Schema.Struct({ n: Schema.Number }),
+                    "SELECT count(*)::INTEGER AS n FROM run_evidence_event",
+                );
+                expect(eventsAfterSecond[0]!.n).toBe(eventsAfterFirst[0]!.n);
+                countAfter = eventsAfterSecond[0]!.n;
+            }),
+        ));
+        expect(first).toMatchObject({ rebuilt: true });
+        expect(second).toMatchObject({ rebuilt: false });
+        expect(countAfter).toBeGreaterThan(0);
+    });
+});

--- a/apps/axctl/src/ingest/models/run-evidence-ref.sql
+++ b/apps/axctl/src/ingest/models/run-evidence-ref.sql
@@ -1,0 +1,99 @@
+-- model: run_evidence_ref
+-- inputs: tool_call, read_file, searched_file, edited, turn
+-- rebuild: incremental
+--
+-- File refs off run-evidence tool_observation events (#578 slices 4+5),
+-- derived inside DuckDB (#888). Mirrors buildRunEvidenceRefs:
+--  * read_file / searched_file (RELATION tool_call -> file) anchor to the
+--    tool_call's tool_observation event directly;
+--  * edited (RELATION turn -> file) bridges to the turn's edit tool_call ONLY
+--    when the turn has exactly ONE edit call - ambiguous multi-edit turns are
+--    dropped rather than mis-attributed.
+--
+-- DELIBERATE DIFFERENCES from the TS builders (rebuildable-cache freedoms,
+-- same cutover wipe as run-evidence-event.sql):
+--  * event key + ref id are md5 over <US>-separated natural keys;
+--  * path_hash = md5(path_seen) (was stableDigest - privacy pointer only,
+--    nothing joins on its shape).
+--
+-- The edit-tool name list below MUST equal EDIT_TOOL_NAMES
+-- (@ax/lib/shared/tool-classes) lowercased - pinned by models.test.ts.
+INSERT INTO run_evidence_ref (
+    id, "event", session, ts, ref_kind, target_table, target_id,
+    path_hash, uri_hash, content_hash, privacy_level, attrs
+)
+WITH
+params AS (
+    SELECT CASE
+        WHEN getvariable('since_days') IS NULL THEN NULL
+        ELSE CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(getvariable('since_days') AS INTEGER) * INTERVAL '1 day')
+    END AS cutoff
+),
+-- Turns with exactly ONE edit tool_call: the unambiguous edited-bridge anchor.
+single_edit_call AS (
+    SELECT tc.turn, min(tc.id) AS tool_call
+    FROM tool_call tc, params p
+    WHERE tc.turn IS NOT NULL
+      AND lower(tc.name) IN ('edit', 'write', 'multiedit', 'notebookedit', 'apply_patch', 'edit_file', 'apply_diff')
+      AND (p.cutoff IS NULL OR tc.ts > p.cutoff)
+    GROUP BY tc.turn
+    HAVING count(*) = 1
+),
+src AS (
+    -- read_file -> access 'read'
+    SELECT tc.session AS session, e.in_id AS tool_call, e.out_id AS file,
+           e.ts AS ts, e.path_seen AS path_seen,
+           json_object('access', 'read') AS attrs
+    FROM read_file e
+    JOIN tool_call tc ON tc.id = e.in_id
+    CROSS JOIN params p
+    WHERE e.ts IS NOT NULL AND (p.cutoff IS NULL OR e.ts > p.cutoff)
+
+    UNION ALL
+    -- searched_file -> access 'search'
+    SELECT tc.session, e.in_id, e.out_id, e.ts, e.path_seen,
+           json_object('access', 'search')
+    FROM searched_file e
+    JOIN tool_call tc ON tc.id = e.in_id
+    CROSS JOIN params p
+    WHERE e.ts IS NOT NULL AND (p.cutoff IS NULL OR e.ts > p.cutoff)
+
+    UNION ALL
+    -- edited (turn -> file), bridged to the turn's single edit tool_call.
+    SELECT t.session, sec.tool_call, e.out_id, e.ts, e.path_seen,
+           json_merge_patch(json_merge_patch('{}', json_object('access', 'write')), json_object('tool', e.tool))
+    FROM edited e
+    JOIN turn t ON t.id = e.in_id
+    JOIN single_edit_call sec ON sec.turn = e.in_id
+    CROSS JOIN params p
+    WHERE e.ts IS NOT NULL AND (p.cutoff IS NULL OR e.ts > p.cutoff)
+),
+shaped AS (
+    SELECT
+        md5(session || chr(31) || 'tool_call' || chr(31) || tool_call) AS event_id,
+        session, ts,
+        'file' AS ref_kind, 'file' AS target_table, file AS target_id,
+        CASE WHEN path_seen IS NOT NULL THEN md5(path_seen) END AS path_hash,
+        attrs
+    FROM src
+    WHERE session IS NOT NULL AND tool_call IS NOT NULL AND file IS NOT NULL
+)
+SELECT
+    md5(event_id || chr(31) || ref_kind || chr(31) || target_table || chr(31)
+        || target_id || chr(31) || coalesce(path_hash, '')) AS id,
+    event_id AS "event", session, ts, ref_kind, target_table, target_id,
+    path_hash, NULL AS uri_hash, NULL AS content_hash,
+    'ref_only' AS privacy_level, attrs
+FROM shaped
+-- One ref row per distinct pointer: the same (event, file, path) read twice in
+-- a window collapses, keeping the earliest ts (deterministic).
+QUALIFY row_number() OVER (
+    PARTITION BY event_id, ref_kind, target_table, target_id, coalesce(path_hash, '')
+    ORDER BY ts, attrs
+) = 1
+ON CONFLICT (id) DO UPDATE SET
+    "event" = excluded."event", session = excluded.session, ts = excluded.ts,
+    ref_kind = excluded.ref_kind, target_table = excluded.target_table,
+    target_id = excluded.target_id, path_hash = excluded.path_hash,
+    uri_hash = excluded.uri_hash, content_hash = excluded.content_hash,
+    privacy_level = excluded.privacy_level, attrs = excluded.attrs

--- a/apps/axctl/src/ingest/models/runner.ts
+++ b/apps/axctl/src/ingest/models/runner.ts
@@ -1,0 +1,78 @@
+/**
+ * SQL model runner v1 (#888, v3 Phase 3).
+ *
+ * A MODEL is one .sql file that derives one table INSIDE DuckDB - the whole
+ * read -> transform -> write round trip that a TS derive stage used to make,
+ * collapsed into a single INSERT ... SELECT ... ON CONFLICT statement the
+ * engine executes without rows ever crossing the JS boundary.
+ *
+ * Contract per file (parsed + validated by models.test.ts):
+ *   -- model: <target table>
+ *   -- inputs: <comma-separated source tables>     (validated against the DDL)
+ *   -- rebuild: incremental | full_rebuild         (visible windowing claim)
+ *
+ * ONE statement per file. The since-window travels as a DuckDB variable
+ * (`SET VARIABLE since_days`), never string interpolation into the model; a
+ * model with `rebuild: incremental` MUST read `getvariable('since_days')` and
+ * treat NULL as "no cutoff". Models run through the ordinary write seam
+ * (`write.exec`), so self-time charging, ledger rows, and the derive budget
+ * are exactly what a TS stage gets.
+ *
+ * v1 runs an explicit ordered list per stage; the `inputs` header seeds a
+ * future topological runner once there is more than one dependency chain.
+ */
+import { Effect } from "effect";
+import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+
+export interface SqlModel {
+    /** Target table (== the `-- model:` header). */
+    readonly name: string;
+    /** The full statement, headers included. */
+    readonly sql: string;
+}
+
+export interface ParsedModelHeader {
+    readonly model: string;
+    readonly inputs: readonly string[];
+    readonly rebuild: "incremental" | "full_rebuild";
+}
+
+/** Parse the header contract. Throws on a malformed file - a model that does
+ *  not declare its shape must not run. */
+export const parseModelHeader = (sql: string): ParsedModelHeader => {
+    const model = /^-- model:\s*(\S+)\s*$/m.exec(sql)?.[1];
+    const inputs = /^-- inputs:\s*(.+)$/m.exec(sql)?.[1];
+    const rebuild = /^-- rebuild:\s*(incremental|full_rebuild)\s*$/m.exec(sql)?.[1];
+    if (!model || !inputs || !rebuild) {
+        throw new Error(
+            "SQL model is missing its header contract (-- model: / -- inputs: / -- rebuild:); refusing to run it",
+        );
+    }
+    return {
+        model,
+        inputs: inputs.split(",").map((s) => s.trim()).filter((s) => s.length > 0),
+        rebuild: rebuild as ParsedModelHeader["rebuild"],
+    };
+};
+
+/**
+ * Run one model. `sinceDays` undefined = full derivation (the variable is set
+ * to NULL, and an incremental model's cutoff predicate passes everything).
+ * Returns the statement's changed-row count.
+ */
+export const runSqlModel = (
+    write: CacheWriteService,
+    model: SqlModel,
+    sinceDays: number | undefined,
+): Effect.Effect<number, CacheWriteError> =>
+    Effect.gen(function* () {
+        // The variable is session-scoped on the shared write connection, so it
+        // is ALWAYS set (NULL included) - a stale value from a previous stage
+        // must never leak into this run's window.
+        const since =
+            sinceDays !== undefined && Number.isFinite(sinceDays) && sinceDays > 0
+                ? String(Math.trunc(sinceDays))
+                : "NULL";
+        yield* write.exec(`SET VARIABLE since_days = ${since}`);
+        return yield* write.exec(model.sql);
+    });

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -46,6 +46,10 @@ interface CommandOutcome {
     readonly sessionKey: string | null;
     readonly commandNorm: string | null;
     readonly commandTool: string | null;
+    /** Check family stamped at write time (single source: check-family.ts);
+     *  text-first so a collapsed command_norm cannot hide a check (#471). The
+     *  run-evidence SQL model consumes this column (#888). */
+    readonly checkFamily: string | null;
     readonly kind: CommandOutcomeKind;
     readonly status: string;
     readonly text: string | null;
@@ -106,12 +110,14 @@ export function deriveCommandOutcomes(rows: readonly ToolCallOutcomeRow[]): Comm
         const toolCallKey = recordKeyPart(row.id, "tool_call") ?? (typeof row.id === "string" ? row.id : null);
         const sessionKey = recordKeyPart(row.session, "session") ?? (typeof row.session === "string" ? row.session : null);
         const kind = classifyCommandOutcome(row);
+        const checkFamily = checkFamilyFromCommand(row.command_text) ?? checkFamilyFromCommand(row.command_norm);
         return {
             key: commandOutcomeKey(row, index),
             toolCallKey,
             sessionKey,
             commandNorm: row.command_norm ?? null,
             commandTool: row.name ?? null,
+            checkFamily,
             kind,
             status: kind === "success" ? "ok" : "error",
             text: row.error_text ?? row.output_excerpt ?? row.command_text ?? null,
@@ -191,7 +197,8 @@ export function deriveUserMessageNgrams(rows: readonly UserTurnRow[], sizes: rea
 
 const commandOutcomeRow = (outcome: CommandOutcome) => cacheRow({
     id: outcome.key, tool_call: outcome.toolCallKey, session: outcome.sessionKey,
-    command_norm: outcome.commandNorm, command_tool: outcome.commandTool, kind: outcome.kind,
+    command_norm: outcome.commandNorm, command_tool: outcome.commandTool,
+    check_family: outcome.checkFamily, kind: outcome.kind,
     status: outcome.status, text: outcome.text, labels: jsonParam(outcome.labels),
     metrics: jsonParam(outcome.metrics), ts: tsParam(outcome.ts),
 });

--- a/apps/axctl/src/types/text.d.ts
+++ b/apps/axctl/src/types/text.d.ts
@@ -2,3 +2,8 @@ declare module "*.md" {
     const content: string;
     export default content;
 }
+
+declare module "*.sql" {
+    const content: string;
+    export default content;
+}

--- a/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
+++ b/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
@@ -83,13 +83,46 @@ replay tests.
 - Model runner: `models/*.sql`, `-- inputs:` headers, topo-run inside DuckDB,
   registered as stages in the EXISTING StageRegistry (ledger, progress,
   budget unchanged).
-- Port order by measured self_ms: turn-content-blocks (302.2s) →
-  run-evidence (99.6s) → outcomes (53.6s) = 455s of 628s. Then opportunistic.
+- ~~Port order by measured self_ms: turn-content-blocks (302.2s) →
+  run-evidence (99.6s) → outcomes (53.6s) = 455s of 628s.~~ **Retracted in
+  place (#888), twice over.** (1) turn-content-blocks is a markdown PARSER
+  (content-blocks/parse-markdown.ts) - SQL cannot host it; its self time is
+  statement volume, and its fix is spooled writes, not a port. (2) The self_ms
+  numbers themselves mislead under concurrency: self_ms wraps each call's WALL
+  time, and on the napi engine's shared serialized connection that includes
+  queue-wait behind other stages - measured directly, run-evidence's windowed
+  derive costs ~0.5-0.9s against an idle connection while the ledger charged
+  it 73.6s. The inference failed because self_ms was read as compute when it
+  is an upper bound (its own doc says so). Port order becomes
+  **run-evidence → outcomes** (genuinely relational), and port decisions are
+  justified by SERIALIZED measurements, full-rebuild cost, and statement-count
+  reduction on the shared connection - not ledger self_ms.
 - Contract per port: old TS stage kept behind a flag one release; shadow-run
   both on the real store; row-for-row diff clean; then delete TS.
 - A model without a watermark predicate must declare `full_rebuild` visibly.
 - Trio rides here: #868 cache-bust lens ships as a model (corroborate vs raw
   cache-token deltas; proposal minting per open question below).
+
+**run-evidence DONE (#888).** Model runner v1
+(`apps/axctl/src/ingest/models/runner.ts`: header contract `-- model:` /
+`-- inputs:` / `-- rebuild:`, window via `SET VARIABLE since_days`, executed
+through the ordinary write seam) + `run-evidence-event.sql` /
+`run-evidence-ref.sql` replace the 12-read → JS-map → putMany round trip:
+lineage as `WITH RECURSIVE`, objective as a window function, kind/backing as
+CASE branches, dropUndefined attrs as `json_merge_patch` chains rooted at
+`'{}'` (a `json_object` base KEEPS null keys - found by the parity test).
+`command_outcome.check_family` is stamped at outcomes-write time (TS
+classifier stays the single source; one-time backfill rejoins tool_call for
+command_text) so SQL never re-implements token-position classification.
+Cutover is version-marked (sentinel watermark): wipe + full re-derive swaps
+the id scheme to md5-of-natural-key (Bun.hash is not computable in SQL;
+rebuildable-cache freedom). TS path stays one release behind
+`AX_RUN_EVIDENCE_IMPL=ts`; parity pinned row-for-row on the natural key.
+Receipts on the real 6.8GB store: full derivation 123.0s (TS) → 12.0s
+(model, backfill included) = 10.3x; windowed 1-day runs are sub-second on
+BOTH paths post-napi (the old 73.6s ledger reading was queue-wait, see the
+retraction above); the text-first check_family fix surfaced ~6.9k historical
+verifications norm-only classification missed (#471).
 
 ### Phase 4 — events as the contract
 

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -204,6 +204,9 @@ const V2_ONLY_COLUMNS: Readonly<Record<string, readonly string[]>> = {
     // Native harness attribution + cache forensics (#867) - fields Claude Code
     // started writing ~2026-05, after the Surreal schema froze.
     turn_token_usage: ["attribution_skill", "attribution_agent", "cache_miss_reason_type", "api_error_status"],
+    // Check family stamped at outcomes-write time (#888) so the run-evidence
+    // SQL model never duplicates the TS token-position classifier.
+    command_outcome: ["check_family"],
 };
 
 const POLYMORPHIC_EDGE_EXTRA_COLUMNS: Readonly<Record<string, readonly string[]>> = {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -1159,8 +1159,19 @@ CREATE TABLE IF NOT EXISTS command_outcome (
     text VARCHAR,
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Check family (test|typecheck|lint|eslint|oxlint|build|check) stamped at
+    -- WRITE time by the outcomes stage via `checkFamilyFromCommand` - the TS
+    -- classifier stays the single source of truth, and the run-evidence SQL
+    -- model consumes this column instead of duplicating token-position logic
+    -- in SQL (#888). NULL = not a check. Stamped text-first (command_text,
+    -- falling back to command_norm), which classifies MORE rows than the old
+    -- norm-only read (#471 taxonomy fix).
+    check_family VARCHAR
 );
+-- The ALTER is what reaches an EXISTING database (self-heal replay pattern,
+-- see ingest_stage.self_ms above).
+ALTER TABLE command_outcome ADD COLUMN IF NOT EXISTS check_family VARCHAR;
 CREATE INDEX IF NOT EXISTS command_outcome_kind_ts ON command_outcome(kind, ts);
 CREATE INDEX IF NOT EXISTS command_outcome_session ON command_outcome(session, ts);
 


### PR DESCRIPTION
Closes #888. Phase 3 slice 1 of the v3 plan.

## What

The run-evidence derivation now executes entirely inside DuckDB as two SQL models (`apps/axctl/src/ingest/models/run-evidence-{event,ref}.sql`), run by a v1 model runner (`models/runner.ts`: `-- model:` / `-- inputs:` / `-- rebuild:` header contract, window via `SET VARIABLE since_days`, executed through the ordinary write seam so ledger/self-time/budget are unchanged). The TS builders stay one release behind `AX_RUN_EVIDENCE_IMPL=ts`, with row-for-row parity pinned on the natural key over a fixture covering all eight derived kinds, the lineage walk, the objective pick, the edited bridge, and the backfill.

## Design points

- **No classifier duplication**: `command_outcome` gains a `check_family` column stamped at outcomes-write time (text-first per #471 - and this surfaced ~6.9k historical verifications that norm-only classification missed). The SQL model consumes the column; `check-family.ts` stays the single source of truth. A one-time backfill rejoins `tool_call.command_text` for pre-stamp history.
- **Version-marked cutover**: model ids are md5-of-natural-key (Bun.hash is not computable in SQL; legitimate because the cache is rebuildable and nothing joins on id shape). A sentinel watermark row records the model version; on mismatch the tables are wiped and fully re-derived, so the two id schemes never coexist.
- **SQL semantics traps found by the parity test**: a `json_object` base KEEPS null keys (chains must root at `'{}'` for dropUndefined semantics); bare NULLs in a UNION's first branch type as INTEGER.

## Plan retraction (recorded in the plan doc)

The plan's port order was justified by ledger `self_ms` (turn-content-blocks 302s first). Two corrections, retracted in place: turn-content-blocks is a markdown parser and cannot become SQL (its fix is spooled writes, a separate slice); and `self_ms` is queue-inflated under stage concurrency - measured directly, the windowed run-evidence derive costs ~0.5-0.9s against an idle connection, not 73.6s. The port's real wins are full-rebuild speed and statement-count reduction on the shared connection.

## Receipts (real 6.8GB store)

- Full derivation: **123.0s (TS) → 12.0s (model, backfill included) = 10.3x**.
- Windowed 1-day: sub-second on both paths post-napi (model 0.9s / TS 0.5s).
- Local gates: strict tsc clean, `bun run typecheck` clean, full `bun test` 6124 pass with only the known studio-desktop electron exemptions, `check:timestamp-cast` + `check:raw-numeric-cast` clean, duckdb-parity updated (`check_family` in `V2_ONLY_COLUMNS` with rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)