### PR TITLE
feat(lib): BlobPointer branded type + read cold-storage snapshots back (#891)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
+++ b/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
@@ -176,7 +176,18 @@ ships as its own slice on top of the ledger.
 
 - Freeze `ev_*` tables as the normalized layer; segment export/import =
   remote/sandbox accumulation (parked idea lands free).
-- BlobPointer branded type (pointer-vs-path compile error).
+- BlobPointer branded type (pointer-vs-path compile error). **DONE (#891).**
+  `BlobPointer` is a branded string in `blob-pointer.ts` (`filePointer` mints,
+  `isBlobPointer` narrows, `blobPointerPath` is the one sanctioned pointer →
+  path conversion). Shipping the brand surfaced the bug it exists to prevent,
+  already live: `transcript-locator` probed a pointer hint with
+  `fs.exists(<pointer>)` - a silent no-op - so cold-storage snapshots were
+  NEVER read back and a harness-pruned transcript reported "not found" while
+  its full copy sat in the bucket. The locator now resolves pointer hints
+  against `<dataDir>/buckets` as the LAST fallback (live source and disk
+  search still win - the snapshot is frozen at ingest time), harness derived
+  from the bucket (`codex_artifacts` → codex). Verified on the real store:
+  live-source-wins and pruned-source-resolves both exercised.
 - Watermark keyed by content hash, not absolute path (merge-safe).
 
 ### Phase 5 — learning layer (gated prototype)

--- a/packages/lib/src/blob-pointer.test.ts
+++ b/packages/lib/src/blob-pointer.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The BlobPointer brand (#891): the three sanctioned operations round-trip,
+ * and the structural guard keeps rejecting the shapes that caused the
+ * confusion the brand exists to prevent (absolute filesystem paths).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+    blobPointerBucket,
+    blobPointerPath,
+    filePointer,
+    isBlobPointer,
+} from "./blob-pointer.ts";
+
+describe("blob-pointer", () => {
+    test("filePointer output round-trips through the guard and the accessors", () => {
+        const p = filePointer("transcripts", "abc-123.jsonl");
+        // Widen for the literal comparison - the brand is nominal on purpose.
+        expect(p as string).toBe("transcripts:/abc-123.jsonl");
+        expect(isBlobPointer(p)).toBe(true);
+        expect(blobPointerBucket(p)).toBe("transcripts");
+        expect(blobPointerPath("/data/buckets", p)).toBe("/data/buckets/transcripts/abc-123.jsonl");
+    });
+
+    test("an absolute filesystem path is NOT a pointer", () => {
+        expect(isBlobPointer("/Users/x/.claude/projects/-p/abc.jsonl")).toBe(false);
+        expect(isBlobPointer("/tmp/whatever.jsonl")).toBe(false);
+    });
+
+    test("the guard narrows, so blobPointerPath only accepts guarded strings", () => {
+        const value: string = "codex_artifacts:/r.jsonl";
+        expect(isBlobPointer(value)).toBe(true);
+        if (isBlobPointer(value)) {
+            expect(blobPointerBucket(value)).toBe("codex_artifacts");
+            expect(blobPointerPath("/d", value)).toBe("/d/codex_artifacts/r.jsonl");
+        }
+        // @ts-expect-error - an unguarded string is not a BlobPointer; this
+        // compile error IS the feature (#891).
+        blobPointerPath("/d", value);
+    });
+
+    test("empty and separator-bearing shapes stay rejected", () => {
+        expect(isBlobPointer("")).toBe(false);
+        expect(isBlobPointer("bucket://double")).toBe(false);
+        expect(isBlobPointer("no-separator")).toBe(false);
+    });
+});

--- a/packages/lib/src/blob-pointer.ts
+++ b/packages/lib/src/blob-pointer.ts
@@ -5,8 +5,28 @@
  * of these regardless of which store wrote it. It lives here, not beside any
  * DB client, so comparing two pointer strings never requires importing a
  * database SDK.
+ *
+ * The BRAND (#891, v3 Phase 4): `session.raw_file` legitimately holds either
+ * a pointer OR an absolute filesystem path (claude subagents persist the
+ * source path; codex falls back to it when the snapshot is skipped), and the
+ * two must never be confused - `fs.exists(<pointer>)` is a silent no-op, and
+ * `filePointer(bucket, <absolute path>)` mints a pointer no GC reference set
+ * can match. So a pointer is a BRANDED string: `filePointer` mints it,
+ * `isBlobPointer` narrows to it, and `blobPointerPath` is the ONE sanctioned
+ * pointer -> filesystem-path conversion. A function taking a filesystem path
+ * cannot receive a `BlobPointer` (or vice versa) without one of those three
+ * in the trace.
  */
-export const filePointer = (bucket: string, path: string): string => `${bucket}:/${path}`;
+import { posixPath } from "./shared/path.ts";
+
+declare const BlobPointerBrand: unique symbol;
+
+/** A `"<bucket>:/<name>"` blob pointer. See the module doc for why this is
+ *  branded rather than a plain string. */
+export type BlobPointer = string & { readonly [BlobPointerBrand]: "BlobPointer" };
+
+export const filePointer = (bucket: string, path: string): BlobPointer =>
+    `${bucket}:/${path}` as BlobPointer;
 
 /**
  * Does this string have the shape {@link filePointer} produces?
@@ -17,4 +37,20 @@ export const filePointer = (bucket: string, path: string): string => `${bucket}:
  * filesystem path (`/Users/...`) fails it, which is the case that matters -
  * that is what a parser writes when it stores the source path instead.
  */
-export const isBlobPointer = (value: string): boolean => /^[A-Za-z0-9_-]+:\/[^/]/.test(value);
+export const isBlobPointer = (value: string): value is BlobPointer =>
+    /^[A-Za-z0-9_-]+:\/[^/]/.test(value);
+
+/** The bucket segment of a pointer (`"transcripts:/a.jsonl"` -> `"transcripts"`). */
+export const blobPointerBucket = (pointer: BlobPointer): string =>
+    pointer.slice(0, pointer.indexOf(":/"));
+
+/**
+ * The ONE sanctioned pointer -> filesystem-path conversion: where this
+ * pointer's blob lives under a buckets directory. Pure string math - callers
+ * still have to check the file exists (a pointer can outlive its blob when
+ * GC or the user removed it).
+ */
+export const blobPointerPath = (bucketsDir: string, pointer: BlobPointer): string => {
+    const sep = pointer.indexOf(":/");
+    return posixPath.join(bucketsDir, pointer.slice(0, sep), pointer.slice(sep + 2));
+};

--- a/packages/lib/src/blob-store.test.ts
+++ b/packages/lib/src/blob-store.test.ts
@@ -81,7 +81,7 @@ describe("putBlobFromFile", () => {
             };
         }));
 
-        expect(result.pointer).toBe("transcripts:/abc.jsonl");
+        expect(result.pointer as string | null).toBe("transcripts:/abc.jsonl");
         expect(isBlobPointer(result.pointer ?? "")).toBe(true);
         expect(result.content).toBe("line-1\nline-2\n");
         expect(result.partial).toBe(false);

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -61,6 +61,24 @@ const DEFAULTS = {
  *  route) but must mirror the `AX_INGEST_TIMEOUT_SECONDS` knob's default. */
 export const DEFAULT_INGEST_TIMEOUT_SECONDS = DEFAULTS.ingestTimeoutSeconds;
 
+/** The data dir's DEFAULT shape. `snapshotConfig` uses this as the
+ *  `AX_DATA_DIR` fallback, and `resolveDataDirFromEnv` mirrors it for code
+ *  paths that run without AxConfig - one shape, two readers. */
+export const defaultDataDir = (home: string = HOME): string =>
+    posixPath.join(home, ".local", "share", "ax");
+
+/** `AX_DATA_DIR` else the default, read straight off `process.env` - for code
+ *  paths that run without AxConfig (e.g. the transcript locator resolving a
+ *  blob pointer against `<dataDir>/buckets`). Mirrors `snapshotConfig`'s
+ *  resolution; only a custom `ConfigProvider` (test-only) could diverge, and
+ *  those tests pass an explicit dir instead. */
+export const resolveDataDirFromEnv = (): string => {
+    const fromEnv = process.env.AX_DATA_DIR;
+    if (fromEnv !== undefined) return fromEnv;
+    const home = process.env.HOME;
+    return defaultDataDir(home !== undefined ? home : HOME);
+};
+
 /** Legacy-faithful int knob parsing, byte-identical to the old hand-rolled
  *  env readers: `Number.parseInt(raw, 10)` prefix-parses (`" 5"` -> 5,
  *  `"5abc"` -> 5, `"5.5"` -> 5, `"1e2"` -> 1); a missing var, empty string,
@@ -105,10 +123,7 @@ const stringOr = (name: string, fallback: string): Config.Config<string> =>
 const snapshotConfig: Effect.Effect<AxConfigShape, never, FileSystem.FileSystem> =
     Effect.gen(function* () {
         const home = yield* stringOr("HOME", HOME);
-        const dataDir = yield* stringOr(
-            "AX_DATA_DIR",
-            posixPath.join(home, ".local", "share", "ax"),
-        );
+        const dataDir = yield* stringOr("AX_DATA_DIR", defaultDataDir(home));
         return {
             paths: {
                 home,

--- a/packages/lib/src/transcript-locator.test.ts
+++ b/packages/lib/src/transcript-locator.test.ts
@@ -137,6 +137,52 @@ describe("locateTranscriptOnDisk", () => {
         const stale = join(tmpdir(), `definitely-missing-${bogus}.jsonl`);
         await expect(onDisk(bogus, stale)).rejects.toThrow(/session transcript not found/);
     });
+
+    // #891: a POINTER hint resolves through the buckets dir - the cold-storage
+    // snapshot becomes a real fallback instead of a silent fs.exists no-op.
+    test("a transcripts:/ pointer hint resolves to the bucket snapshot (claude harness)", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "ax-locator-blob-"));
+        tmpRoots.push(dir);
+        const bogus = `ax-test-blob-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const bucketsDir = join(dir, "buckets");
+        await mkdir(join(bucketsDir, "transcripts"), { recursive: true });
+        const blob = join(bucketsDir, "transcripts", `${bogus}.jsonl`);
+        await writeFile(blob, "");
+        const found = await Effect.runPromise(
+            locateTranscriptOnDisk(bogus, `transcripts:/${bogus}.jsonl`, bucketsDir).pipe(
+                Effect.provide(FsLayer),
+            ),
+        );
+        expect(found.path).toBe(blob);
+        expect(found.harness).toBe("claude");
+    });
+
+    test("a codex_artifacts:/ pointer hint resolves with the codex harness", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "ax-locator-blob-cx-"));
+        tmpRoots.push(dir);
+        const bogus = `ax-test-blobcx-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const bucketsDir = join(dir, "buckets");
+        await mkdir(join(bucketsDir, "codex_artifacts"), { recursive: true });
+        const blob = join(bucketsDir, "codex_artifacts", `${bogus}.jsonl`);
+        await writeFile(blob, "");
+        const found = await Effect.runPromise(
+            locateTranscriptOnDisk(bogus, `codex_artifacts:/${bogus}.jsonl`, bucketsDir).pipe(
+                Effect.provide(FsLayer),
+            ),
+        );
+        expect(found.path).toBe(blob);
+        expect(found.harness).toBe("codex");
+    });
+
+    test("a pointer hint whose blob is gone still errors when nothing else matches", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "ax-locator-blob-miss-"));
+        tmpRoots.push(dir);
+        const bogus = `ax-test-blobmiss-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const eff = locateTranscriptOnDisk(bogus, `transcripts:/${bogus}.jsonl`, join(dir, "buckets")).pipe(
+            Effect.provide(FsLayer),
+        );
+        await expect(Effect.runPromise(eff)).rejects.toThrow(/session transcript not found/);
+    });
 });
 
 describe("locateTranscript (with the cache hint)", () => {

--- a/packages/lib/src/transcript-locator.ts
+++ b/packages/lib/src/transcript-locator.ts
@@ -2,15 +2,19 @@
  * TranscriptLocator - given a session id, find its on-disk JSONL transcript
  * and identify the harness (claude vs codex) that produced it.
  *
- * Strategy is CACHE-first, disk-fallback:
+ * Strategy is CACHE-first, disk-fallback, snapshot-last:
  *   1. Read the persisted `raw_file` column off the session row. Synthetic
  *      session ids (e.g. `claude-subagent-<agentId>`) don't match the
  *      filename patterns the disk search scans for, so the hint is the only
  *      way to locate their jsonl.
- *   2. If the hint exists on disk, use it (harness derived from path).
+ *   2. If the hint is a source PATH and exists on disk, use it (harness
+ *      derived from path).
  *   3. Otherwise fall back to filesystem search under `~/.claude/projects/`
  *      then `~/.codex/sessions/`.
- *   4. If nothing matches, throw `TranscriptNotFoundError`.
+ *   4. If the hint is a blob POINTER (see blob-pointer.ts), resolve it
+ *      against `<dataDir>/buckets` - the ingest-time cold-storage snapshot,
+ *      checked LAST because the live source can have grown since.
+ *   5. If nothing matches, throw `TranscriptNotFoundError`.
  *
  * Used by `src/dashboard/session-inspect.ts` and intended as the single
  * source of truth for "where does this session's transcript live?" so future
@@ -21,6 +25,9 @@
 import { homedir } from "node:os";
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { orAbsent } from "@ax/lib/shared/fs-error";
+import { posixPath } from "./shared/path.ts";
+import { blobPointerBucket, blobPointerPath, isBlobPointer } from "./blob-pointer.ts";
+import { resolveDataDirFromEnv } from "./config.ts";
 import { CacheRead } from "./duckdb/seam.ts";
 import { toBareSessionId } from "./shared/session-id.ts";
 
@@ -157,18 +164,43 @@ const resolveRawFileFromCache = (
         }),
     ));
 
-/** Disk-only resolution: try the hint, then claude search, then codex search.
- *  No stored-data dep, so it can be exercised without any read seam. */
+/** Where blob pointers resolve: `<dataDir>/buckets`, from `AX_DATA_DIR` else
+ *  the default - the same tree the ingest snapshot writer targets. */
+const defaultBucketsDir = (): string => posixPath.join(resolveDataDirFromEnv(), "buckets");
+
+/** Which harness's parser reads a SNAPSHOT blob. The bucket is the producer's
+ *  identity (transcripts.ts writes `transcripts`, codex.ts writes
+ *  `codex_artifacts`), so it answers what `harnessFromPath` answers for live
+ *  files - a bucket path never contains `/.codex/sessions/`. */
+const harnessFromBucket = (bucket: string): Harness =>
+    bucket === "codex_artifacts" ? "codex" : "claude";
+
+/** Disk-only resolution: try the hint, then claude search, then codex search,
+ *  then the cold-storage snapshot. No stored-data dep, so it can be exercised
+ *  without any read seam.
+ *
+ *  The `raw_file` hint legitimately holds TWO shapes (see blob-pointer.ts),
+ *  and they slot in at different priorities:
+ *   - an absolute SOURCE PATH (claude subagents; codex when the snapshot was
+ *     skipped) is the live file - it wins outright when it exists;
+ *   - a blob POINTER names the ingest-time snapshot - COLD storage, checked
+ *     LAST, because the live source (found by path hint or search) can have
+ *     grown since the snapshot was taken. Before #891 a pointer hint was
+ *     probed with `fs.exists(<pointer>)` - a silent no-op - so snapshots were
+ *     never read back and a harness-pruned transcript reported "not found"
+ *     while its full copy sat in the bucket. */
 const findOnDisk = (
     sessionId: string,
     rawFileHint: string | null,
+    bucketsDir: string,
 ): Effect.Effect<FoundTranscript, TranscriptNotFoundError, FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        // Hinted path wins when it actually exists on disk - this is how
-        // synthetic session ids (e.g. claude-subagent-<agentId>) resolve to
-        // their real jsonl, since the hint was persisted at ingest time.
-        if (rawFileHint) {
+        const pointerHint = rawFileHint !== null && isBlobPointer(rawFileHint) ? rawFileHint : null;
+        // Hinted source path wins when it actually exists on disk - this is
+        // how synthetic session ids (e.g. claude-subagent-<agentId>) resolve
+        // to their real jsonl, since the hint was persisted at ingest time.
+        if (rawFileHint && pointerHint === null) {
             // OLD: stat(rawFileHint) in try/catch → fall through to search. A
             // probe where any failure means "hint stale, keep searching" -
             // orAbsent.
@@ -181,6 +213,16 @@ const findOnDisk = (
         if (claude) return claude;
         const codex = yield* findCodexJsonl(sessionId);
         if (codex) return codex;
+        if (pointerHint !== null) {
+            const blobPath = blobPointerPath(bucketsDir, pointerHint);
+            const blobExists = yield* fs.exists(blobPath).pipe(orAbsent(false));
+            if (blobExists) {
+                return {
+                    path: blobPath,
+                    harness: harnessFromBucket(blobPointerBucket(pointerHint)),
+                } satisfies FoundTranscript;
+            }
+        }
         return yield* Effect.fail(new TranscriptNotFoundError(sessionId));
     });
 
@@ -198,13 +240,15 @@ export const locateTranscript = (
 > =>
     Effect.gen(function* () {
         const hint = yield* resolveRawFileFromCache(sessionId);
-        return yield* findOnDisk(sessionId, hint);
+        return yield* findOnDisk(sessionId, hint, defaultBucketsDir());
     });
 
 /** Disk-only variant exposed for tests that don't want to spin up a fake
- *  read seam just to exercise the hint + search logic. */
+ *  read seam just to exercise the hint + search logic. `bucketsDir` overrides
+ *  where a pointer hint resolves (default: `<dataDir>/buckets`). */
 export const locateTranscriptOnDisk = (
     sessionId: string,
     rawFileHint: string | null,
+    bucketsDir: string = defaultBucketsDir(),
 ): Effect.Effect<FoundTranscript, TranscriptNotFoundError, FileSystem.FileSystem | Path.Path> =>
-    findOnDisk(sessionId, rawFileHint);
+    findOnDisk(sessionId, rawFileHint, bucketsDir);


### PR DESCRIPTION
Closes #891. v3 Phase 4 slice (plan bullet "BlobPointer branded type (pointer-vs-path compile error)").

## What

`BlobPointer` is now a branded string, and shipping the brand surfaced the bug it exists to prevent - already live in the tree: cold-storage transcript snapshots were **never read back**.

## The live bug

`session.raw_file` legitimately holds two shapes: a blob pointer `transcripts:/<id>.jsonl` (claude top-level, codex) or an absolute source path (claude subagents; codex when the snapshot is skipped). `transcript-locator` probed both with `fs.exists(hint)` - on a pointer that probe is a silent no-op, so the locator always fell through to disk search, and once the harness pruned the source jsonl (the exact scenario blob-store documents the snapshot exists for) `locateTranscript` threw `TranscriptNotFoundError` while a complete copy sat in the bucket.

## How

- `blob-pointer.ts`: `BlobPointer` brand; `filePointer` mints, `isBlobPointer` narrows, `blobPointerPath` is the one sanctioned pointer → path conversion, `blobPointerBucket` names the producer. A pinned `@ts-expect-error` test makes the compile error itself the contract.
- `transcript-locator.ts`: pointer hints resolve against `<dataDir>/buckets` as the **last** fallback - live source path and disk search still win, because the snapshot is frozen at ingest time and the live file can have grown. Harness comes from the bucket (`codex_artifacts` → codex; a bucket path never contains `/.codex/sessions/`).
- `config.ts`: `defaultDataDir` / `resolveDataDirFromEnv` extracted so the locator resolves the buckets dir without requiring `AxConfig` (`ax share`'s locate path deliberately runs on CacheRead + platform layers only).

## Verification

- Real store: a session with both a live source and a snapshot resolves to the live source; a bucket blob with no live source resolves to the snapshot (previously "not found").
- New tests: pointer→bucket resolution (claude + codex buckets), missing-blob still errors, brand round-trip + guard rejections.
- `bunx tsc --noEmit -p tsconfig.json`, `bun run typecheck`, both check gates clean; full `bun test` at the known studio-desktop electron baseline (4 fail + 4 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)