### PR TITLE
feat(prototypes): Phase 5 learning-layer prototype - gate PASSED at matched recall (#895)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
+++ b/docs/superpowers/plans/2026-08-18-v3-events-and-sql-models-plan.md
@@ -210,6 +210,23 @@ gated on the operator.
 - Ship gate: beats the regex baseline (JUDGMENT_GUARD_RE first) on held-out
   labels, else the regex stays. Regexes become features, never deleted first.
 
+**Prototype run 2026-08-19 (#895): GATE PASSED at matched recall.**
+360 LLM-labeled decision-population turns (labeler agreement kappa 0.818),
+12 cheap features (tool composition, text stats, regex own+prev AS
+features), hand-rolled L2 logistic. The regex is a guard, so the deciding
+comparison is at the guard's operating point: threshold lowered until
+held-out judgment-recall >= the regex's, then compare precision. Over 20
+random 70/30 splits the learned model's precision beats the regex by
+**+15.0 points mean (sd 7.0), positive in 20/20 splits**, while also
+carrying +4.9 points extra recall - i.e. same-or-better safety with about
+a third fewer routable turns wrongly held on the frontier. At the default
+0.5 threshold the model under-flags (recall 0.42 vs 0.71) - the landed
+threshold must be pinned from matched-recall fold data, NOT 0.5. Receipts +
+caveats (LLM labels, regex-stratified sample, n=360):
+scripts/prototypes/judgment-learn/README.md. Landed slice (follow-up):
+grow labels via dojo, k-fold, weights-as-table + SQL-model inference,
+`classifyTurn` consumes the score with the regex as floor fallback.
+
 ## Sequencing + effort (rough)
 
 0: #837 ~0.5d · golden corpus ~1d · #869 ~0.5d

--- a/scripts/prototypes/judgment-learn/.gitignore
+++ b/scripts/prototypes/judgment-learn/.gitignore
@@ -1,0 +1,3 @@
+population.ndjson
+batches/
+labels/

--- a/scripts/prototypes/judgment-learn/README.md
+++ b/scripts/prototypes/judgment-learn/README.md
@@ -1,0 +1,87 @@
+# judgment-learn - Phase 5 learning-layer prototype (#895)
+
+Can a tiny trained model beat `JUDGMENT_GUARD_RE` at deciding whether a
+main-agent turn is judgment work (stay on the frontier model) or routable
+(cheap tier)? The v3 plan's ship gate: **beats the regex baseline on
+held-out labels, else the regex stays. Regexes become features, never
+deleted first.**
+
+## Verdict (2026-08-19): GATE PASSED - at matched recall
+
+The regex is a safety guard, so the deciding comparison is at the guard's
+own operating point: the learned model's threshold lowered until its
+held-out judgment-recall ≥ the regex's, then compare precision (= how much
+routable work is wrongly held on the frontier).
+
+Over **20 random 70/30 splits** of 360 LLM-labeled turns:
+
+- precision gap at matched-or-better recall: **+15.0 points mean (sd 7.0),
+  positive in 20/20 splits** (regex ≈ 0.39–0.55 per split; learned ≈ +0.15)
+- while ALSO carrying **+4.9 points extra recall** on average
+  (matched-recall search lands above the target, never below).
+
+Single canonical split (seed 0xc0ffee, n=109 held out, 24 judgment):
+
+| detector | acc | precision | recall | F1 |
+| --- | --- | --- | --- | --- |
+| `JUDGMENT_GUARD_RE` (own text) | 0.688 | 0.386 | 0.708 | 0.500 |
+| regex + prev-prose carry | 0.670 | 0.370 | 0.708 | 0.486 |
+| learned @0.5 | 0.789 | 0.526 | 0.417 | 0.465 |
+| **learned @0.35 (matched recall)** | **0.780** | **0.500** | **0.750** | **0.600** |
+
+Interpretation: at the default 0.5 threshold the model under-flags (wrong
+direction for a guard). At 0.35 it dominates the regex on BOTH axes: same
+or better safety (recall) with roughly a third fewer false flags - i.e.
+more genuinely-routable spend actually routes.
+
+The learned weights are legible and match intuition: long prose, question
+marks, code fences and non-read tool mixes push toward judgment; edit-heavy
+tool composition pushes routable; `regexOwn` survives as a positive feature
+(+0.43) exactly as the plan predicted ("regexes become features").
+
+## Method
+
+1. `extract.ts` - decision population from the PUBLISHED snapshot: claude
+   MAIN sessions, assistant turns not adjacent to a user turn (the turns
+   `classifyTurn` actually decides on), 120-day window → 45,938 turns.
+   Stratified sample of 360 (120 regex-judgment / 120 tool-routable /
+   120 prose-other) into 9 batches.
+2. LLM labeling - 9 parallel subagents labeled judgment-vs-routable from
+   the turn text + tools + previous assistant prose, instructed to judge
+   the WORK, not the vocabulary. Two batches double-labeled by independent
+   annotators: raw agreement 93.8%, Cohen's kappa 0.818 (strong - the
+   labels are real signal, not labeler noise). Class balance: 26.4%
+   judgment.
+3. `train.ts` - 12 features (tool-composition counts, text stats, regex
+   hits own+prev), hand-rolled L2 logistic regression (3k epochs, CPU
+   seconds), the three detectors evaluated on the SAME held-out set, plus
+   the threshold sweep, matched-recall comparison, and 20-repeat stability
+   check.
+
+Data files (population.ndjson, batches/, labels/) contain raw turn text
+and are gitignored - LOCAL artifacts; re-generate with extract.ts and
+re-label to reproduce.
+
+## Honest caveats
+
+- Labels are LLM-generated (kappa 0.818 against a second LLM instance, not
+  a human). The double-label subset bounds label noise but does not remove
+  shared-model bias.
+- The sample is stratified BY the regex's own decision boundary, so these
+  are not population metrics; both detectors are measured on the same set,
+  so the COMPARISON is fair, but absolute rates will differ in production.
+- n=360 total / ~109 per held-out split; per-split variance is real (sd
+  7.0 points) - the 20/20 positive-splits result is the robust claim.
+- The regex+carry baseline approximates buildSpans' judgmentSticky with
+  prev-assistant-prose only.
+
+## What the landed slice would look like (follow-up, not this issue)
+
+- Grow labels (another few hundred turns via dojo surplus), k-fold, and
+  re-fit; pin the matched-recall threshold from the fold data.
+- Weights-as-table (`agent_model`-style catalog row or a dedicated
+  `classifier_weights` table), inference as a SQL model in the DAG
+  (logistic over these features is one SELECT), versioned by the
+  established sentinel-marker cutover.
+- `classifyTurn` consumes the score with the regex as FLOOR fallback when
+  weights are absent; the regex feature is never deleted.

--- a/scripts/prototypes/judgment-learn/extract.ts
+++ b/scripts/prototypes/judgment-learn/extract.ts
@@ -1,0 +1,169 @@
+/**
+ * Phase 5 prototype (#895), step 1: extract the DECISION POPULATION - the
+ * main-agent claude assistant turns `classifyTurn` actually has to decide on
+ * (not adjacent to a user turn) - with the features a tiny model could use,
+ * from the PUBLISHED snapshot.
+ *
+ * Outputs (into this directory):
+ *   population.ndjson   one row per decision turn: features + text excerpts
+ *   batches/batch-N.json  stratified label batches for the LLM labeler
+ *
+ * Run from the repo root: bun scripts/prototypes/judgment-learn/extract.ts
+ * Pin AX_DUCKDB_SNAPSHOT + AX_NO_AUTO_INGEST=1 for a stable read.
+ */
+import { Effect, Schema } from "effect";
+import { CacheRead, CacheReadLive } from "@ax/lib/duckdb/seam";
+import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
+import { JUDGMENT_GUARD_RE } from "../../../apps/axctl/src/queries/routing-tune.ts";
+
+// Prototype-local copies of routability.ts's private tool sets (a landed
+// version would export them; a prototype does not modify production code).
+const READ_TOOLS = new Set(["Read", "Grep", "Glob", "LS"]);
+const RESEARCH_TOOLS = new Set(["WebFetch", "WebSearch"]);
+const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "Bash"]);
+
+const OUT_DIR = new URL(".", import.meta.url).pathname;
+
+const TurnRow = Schema.Struct({
+    id: Schema.String,
+    session: Schema.String,
+    seq: NumberFromBigIntColumn,
+    text: Schema.NullOr(Schema.String),
+    prev_role: Schema.NullOr(Schema.String),
+    next_role: Schema.NullOr(Schema.String),
+    prev_text: Schema.NullOr(Schema.String),
+});
+
+const ToolRow = Schema.Struct({
+    turn: Schema.String,
+    name: Schema.String,
+    command_norm: Schema.NullOr(Schema.String),
+});
+
+// Decision population: claude MAIN sessions (source = 'claude', not
+// *-subagent), assistant turns whose neighbours are not user turns (those are
+// classed `interactive` before any detector runs). 120-day window keeps the
+// sample recent without starving strata.
+const TURNS_SQL = `
+    WITH ordered AS (
+        SELECT t.id, t.session, CAST(t.seq AS BIGINT) AS seq, t.role, t.text,
+               lag(t.role) OVER w AS prev_role,
+               lead(t.role) OVER w AS next_role,
+               lag(CASE WHEN t.role = 'assistant' THEN t.text END) OVER w AS prev_text
+        FROM turn t
+        JOIN session s ON s.id = t.session
+        WHERE s.source = 'claude'
+          AND t.ts > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '120 days'
+        WINDOW w AS (PARTITION BY t.session ORDER BY t.seq)
+    )
+    SELECT id, session, seq, text, prev_role, next_role, prev_text
+    FROM ordered
+    WHERE role = 'assistant'
+      AND coalesce(prev_role, '') <> 'user'
+      AND coalesce(next_role, '') <> 'user'`;
+
+const TOOLS_SQL = `
+    SELECT tc.turn, tc.name, tc.command_norm
+    FROM tool_call tc
+    JOIN session s ON s.id = tc.session
+    WHERE s.source = 'claude'
+      AND tc.ts > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '121 days'`;
+
+export interface PopRow {
+    readonly id: string;
+    readonly session: string;
+    readonly seq: number;
+    // features
+    readonly editCount: number;
+    readonly readCount: number;
+    readonly researchCount: number;
+    readonly otherToolCount: number;
+    readonly textLen: number;
+    readonly regexOwn: boolean;
+    readonly regexPrev: boolean;
+    readonly questionMarks: number;
+    readonly codeFences: number;
+    // labeler context
+    readonly text: string;
+    readonly prevText: string;
+    readonly toolNames: readonly string[];
+}
+
+const excerpt = (s: string | null, cap: number): string => {
+    if (!s) return "";
+    return s.length <= cap ? s : `${s.slice(0, cap)}…[+${s.length - cap} chars]`;
+};
+
+const main = Effect.gen(function* () {
+    const read = yield* CacheRead;
+    const turns = yield* read.rows(TurnRow, TURNS_SQL);
+    const tools = yield* read.rows(ToolRow, TOOLS_SQL);
+
+    const toolsByTurn = new Map<string, { name: string; norm: string | null }[]>();
+    for (const t of tools) {
+        const list = toolsByTurn.get(t.turn);
+        const entry = { name: t.name, norm: t.command_norm };
+        if (list) list.push(entry);
+        else toolsByTurn.set(t.turn, [entry]);
+    }
+
+    const rows: PopRow[] = turns.map((t) => {
+        const calls = toolsByTurn.get(t.id) ?? [];
+        let edit = 0, readC = 0, research = 0, other = 0;
+        for (const c of calls) {
+            if (EDIT_TOOLS.has(c.name)) edit++;
+            else if (READ_TOOLS.has(c.name)) readC++;
+            else if (RESEARCH_TOOLS.has(c.name)) research++;
+            else other++;
+        }
+        const text = t.text ?? "";
+        return {
+            id: t.id, session: t.session, seq: t.seq,
+            editCount: edit, readCount: readC, researchCount: research, otherToolCount: other,
+            textLen: text.length,
+            regexOwn: JUDGMENT_GUARD_RE.test(text),
+            regexPrev: t.prev_text !== null && JUDGMENT_GUARD_RE.test(t.prev_text),
+            questionMarks: (text.match(/\?/g) ?? []).length,
+            codeFences: (text.match(/```/g) ?? []).length,
+            text: excerpt(t.text, 1200),
+            prevText: excerpt(t.prev_text, 600),
+            toolNames: calls.map((c) => c.name),
+        };
+    });
+
+    yield* Effect.promise(() =>
+        Bun.write(`${OUT_DIR}population.ndjson`, rows.map((r) => JSON.stringify(r)).join("\n") + "\n"));
+
+    // Stratified label sample: the gate is decided on held-out LABELS, so the
+    // sample must cover both sides of the baseline's own decision boundary.
+    const rand = (() => { let s = 0xa5eed; return () => (s = (s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff; })();
+    const shuffle = <T>(a: T[]): T[] => { for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(rand() * (i + 1)); [a[i], a[j]] = [a[j]!, a[i]!]; } return a; };
+    const withText = rows.filter((r) => r.textLen > 0 || r.toolNames.length > 0);
+    const strata: Record<string, PopRow[]> = {
+        regexJudgment: shuffle(withText.filter((r) => r.regexOwn)).slice(0, 120),
+        toolRoutable: shuffle(withText.filter((r) => !r.regexOwn && (r.editCount + r.readCount + r.researchCount) > 0)).slice(0, 120),
+        proseOther: shuffle(withText.filter((r) => !r.regexOwn && (r.editCount + r.readCount + r.researchCount) === 0)).slice(0, 120),
+    };
+    const sample = shuffle(Object.values(strata).flat());
+    const BATCH = 40;
+    const { mkdirSync } = yield* Effect.promise(() => import("node:fs"));
+    mkdirSync(`${OUT_DIR}batches`, { recursive: true });
+    for (let i = 0; i * BATCH < sample.length; i++) {
+        const batch = sample.slice(i * BATCH, (i + 1) * BATCH).map((r) => ({
+            id: r.id,
+            tools: r.toolNames,
+            prev_assistant_text: r.prevText,
+            text: r.text,
+        }));
+        yield* Effect.promise(() =>
+            Bun.write(`${OUT_DIR}batches/batch-${i}.json`, JSON.stringify(batch, null, 1)));
+    }
+    console.log(JSON.stringify({
+        population: rows.length,
+        sample: sample.length,
+        strata: Object.fromEntries(Object.entries(strata).map(([k, v]) => [k, v.length])),
+        batches: Math.ceil(sample.length / BATCH),
+    }));
+});
+
+await Effect.runPromise(main.pipe(Effect.provide(CacheReadLive), Effect.scoped));

--- a/scripts/prototypes/judgment-learn/train.ts
+++ b/scripts/prototypes/judgment-learn/train.ts
@@ -1,0 +1,230 @@
+/**
+ * Phase 5 prototype (#895), step 2: train the tiny model and run the ship
+ * gate. Loads population.ndjson + labels/batch-*.labels.json, trains a
+ * hand-rolled L2 logistic regression on a seeded 70/30 split, and reports
+ * held-out accuracy/precision/recall/F1 for THREE detectors on the SAME
+ * held-out set:
+ *   regex       JUDGMENT_GUARD_RE on the turn's own text (the raw baseline)
+ *   regex+carry regex on own text OR the previous assistant prose (the
+ *               production judgmentSticky semantics, approximated)
+ *   learned     the logistic model (regex features included - "regexes
+ *               become features, never deleted first")
+ * Also reports inter-labeler agreement (raw + Cohen's kappa) over the
+ * double-labeled batches (labels/batch-N.labels-b.json).
+ *
+ * Run: bun scripts/prototypes/judgment-learn/train.ts
+ */
+import { readdirSync } from "node:fs";
+import type { PopRow } from "./extract.ts";
+
+const DIR = new URL(".", import.meta.url).pathname;
+
+interface LabelRow { id: string; label: "judgment" | "routable"; confidence: number }
+
+const popText = await Bun.file(`${DIR}population.ndjson`).text();
+const pop = new Map<string, PopRow>();
+for (const line of popText.split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line) as PopRow;
+    pop.set(row.id, row);
+}
+
+const labelFiles = readdirSync(`${DIR}labels`).filter((f) => /^batch-\d+\.labels\.json$/.test(f));
+const labels = new Map<string, LabelRow>();
+for (const f of labelFiles) {
+    for (const l of (await Bun.file(`${DIR}labels/${f}`).json()) as LabelRow[]) labels.set(l.id, l);
+}
+
+// Inter-labeler agreement over the -b double-labeled batches.
+const bFiles = readdirSync(`${DIR}labels`).filter((f) => /labels-b\.json$/.test(f));
+let agree = 0, total = 0, bothJ = 0, aJ = 0, bJ = 0;
+for (const f of bFiles) {
+    for (const l of (await Bun.file(`${DIR}labels/${f}`).json()) as LabelRow[]) {
+        const a = labels.get(l.id);
+        if (!a) continue;
+        total++;
+        if (a.label === l.label) agree++;
+        if (a.label === "judgment") aJ++;
+        if (l.label === "judgment") bJ++;
+        if (a.label === "judgment" && l.label === "judgment") bothJ++;
+    }
+}
+const po = total > 0 ? agree / total : 0;
+const pe = total > 0 ? (aJ / total) * (bJ / total) + ((total - aJ) / total) * ((total - bJ) / total) : 0;
+const kappa = pe < 1 ? (po - pe) / (1 - pe) : 0;
+
+// Feature vector. Regex hits are FEATURES (the plan: never deleted first).
+const featurize = (r: PopRow): number[] => [
+    1,
+    Math.min(r.editCount, 8),
+    Math.min(r.readCount, 8),
+    Math.min(r.researchCount, 8),
+    Math.min(r.otherToolCount, 8),
+    Math.log1p(r.textLen) / 10,
+    r.regexOwn ? 1 : 0,
+    r.regexPrev ? 1 : 0,
+    Math.min(r.questionMarks, 5),
+    Math.min(r.codeFences, 5),
+    r.toolNames.length > 0 ? 1 : 0,
+    r.editCount + r.readCount + r.researchCount > 0
+        ? r.editCount / (r.editCount + r.readCount + r.researchCount)
+        : 0,
+];
+export const FEATURE_NAMES = [
+    "bias", "editCount", "readCount", "researchCount", "otherToolCount",
+    "logTextLen", "regexOwn", "regexPrev", "questionMarks", "codeFences",
+    "hasTools", "editShare",
+];
+
+interface Example { x: number[]; y: number; row: PopRow }
+const examples: Example[] = [];
+for (const [id, l] of labels) {
+    const row = pop.get(id);
+    if (!row) continue;
+    examples.push({ x: featurize(row), y: l.label === "judgment" ? 1 : 0, row });
+}
+
+// Seeded shuffle -> 70/30 split.
+let seed = 0xc0ffee;
+const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+for (let i = examples.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [examples[i], examples[j]] = [examples[j]!, examples[i]!];
+}
+const cut = Math.floor(examples.length * 0.7);
+const train = examples.slice(0, cut);
+const test = examples.slice(cut);
+
+// L2 logistic regression, full-batch gradient descent. CPU milliseconds.
+const dim = FEATURE_NAMES.length;
+const w = new Array<number>(dim).fill(0);
+const sigmoid = (z: number) => 1 / (1 + Math.exp(-z));
+const dot = (a: number[], b: number[]) => a.reduce((s, v, i) => s + v * b[i]!, 0);
+const L2 = 0.01, LR = 0.5, EPOCHS = 3000;
+for (let e = 0; e < EPOCHS; e++) {
+    const grad = new Array<number>(dim).fill(0);
+    for (const ex of train) {
+        const err = sigmoid(dot(w, ex.x)) - ex.y;
+        for (let i = 0; i < dim; i++) grad[i]! += err * ex.x[i]!;
+    }
+    for (let i = 0; i < dim; i++) {
+        w[i]! -= (LR / train.length) * (grad[i]! + L2 * (i === 0 ? 0 : w[i]!));
+    }
+}
+
+interface Metrics { acc: number; precision: number; recall: number; f1: number; tp: number; fp: number; fn: number; tn: number }
+const evaluate = (predict: (r: PopRow) => boolean, set: Example[]): Metrics => {
+    let tp = 0, fp = 0, fn = 0, tn = 0;
+    for (const ex of set) {
+        const p = predict(ex.row);
+        if (p && ex.y === 1) tp++;
+        else if (p && ex.y === 0) fp++;
+        else if (!p && ex.y === 1) fn++;
+        else tn++;
+    }
+    const precision = tp + fp > 0 ? tp / (tp + fp) : 0;
+    const recall = tp + fn > 0 ? tp / (tp + fn) : 0;
+    return {
+        acc: (tp + tn) / set.length,
+        precision, recall,
+        f1: precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0,
+        tp, fp, fn, tn,
+    };
+};
+
+const learned = (r: PopRow) => sigmoid(dot(w, featurize(r))) >= 0.5;
+const regex = (r: PopRow) => r.regexOwn;
+const regexCarry = (r: PopRow) => r.regexOwn || r.regexPrev;
+
+// One split is thin evidence at n=109. Repeat the whole train+matched-recall
+// comparison over R random 70/30 splits and report the mean/sd of the
+// precision gap at matched recall - the number the gate actually turns on.
+const trainWeights = (set: Example[]): number[] => {
+    const wr = new Array<number>(dim).fill(0);
+    for (let e = 0; e < EPOCHS; e++) {
+        const grad = new Array<number>(dim).fill(0);
+        for (const ex of set) {
+            const err = sigmoid(dot(wr, ex.x)) - ex.y;
+            for (let i = 0; i < dim; i++) grad[i]! += err * ex.x[i]!;
+        }
+        for (let i = 0; i < dim; i++) {
+            wr[i]! -= (LR / set.length) * (grad[i]! + L2 * (i === 0 ? 0 : wr[i]!));
+        }
+    }
+    return wr;
+};
+const repeatedSplits = (repeats: number) => {
+    const gaps: number[] = [];
+    const recalls: number[] = [];
+    for (let rep = 0; rep < repeats; rep++) {
+        const shuffled = [...examples];
+        for (let i = shuffled.length - 1; i > 0; i--) {
+            const j = Math.floor(rand() * (i + 1));
+            [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+        }
+        const c = Math.floor(shuffled.length * 0.7);
+        const tr = shuffled.slice(0, c);
+        const te = shuffled.slice(c);
+        const wr = trainWeights(tr);
+        const target = evaluate((r) => r.regexOwn, te).recall;
+        const regexPrecision = evaluate((r) => r.regexOwn, te).precision;
+        let best: Metrics | null = null;
+        for (let t = 0.95; t >= 0.05; t -= 0.05) {
+            const m = evaluate((r) => sigmoid(dot(wr, featurize(r))) >= t, te);
+            if (m.recall >= target) { best = m; break; }
+        }
+        if (best) { gaps.push(best.precision - regexPrecision); recalls.push(best.recall - target); }
+    }
+    const mean = gaps.reduce((s, v) => s + v, 0) / gaps.length;
+    const sd = Math.sqrt(gaps.reduce((s, v) => s + (v - mean) ** 2, 0) / gaps.length);
+    return {
+        repeats: gaps.length,
+        precisionGapMean: Math.round(mean * 1000) / 1000,
+        precisionGapSd: Math.round(sd * 1000) / 1000,
+        splitsWherePositive: gaps.filter((g) => g > 0).length,
+        meanExtraRecall: Math.round((recalls.reduce((s, v) => s + v, 0) / recalls.length) * 1000) / 1000,
+    };
+};
+
+const round = (m: Metrics) => Object.fromEntries(Object.entries(m).map(([k, v]) => [k, typeof v === "number" ? Math.round(v * 1000) / 1000 : v]));
+
+// The regex is a GUARD: it must over-flag (judgment misrouted to a cheap
+// model is the expensive mistake), so the deciding comparison is not the
+// default 0.5 threshold but the learned model AT THE REGEX'S RECALL: sweep
+// the threshold, find the lowest one whose held-out recall >= the regex's,
+// and compare precision there. Also report the sweep so the tradeoff is
+// visible.
+const sweep = (set: Example[]): { threshold: number; m: Metrics }[] => {
+    const out: { threshold: number; m: Metrics }[] = [];
+    for (let t = 0.05; t <= 0.95; t += 0.05) {
+        const th = Math.round(t * 100) / 100;
+        out.push({ threshold: th, m: evaluate((r) => sigmoid(dot(w, featurize(r))) >= th, set) });
+    }
+    return out;
+};
+
+console.log(JSON.stringify({
+    labeled: examples.length,
+    judgmentShare: Math.round((examples.filter((e) => e.y === 1).length / examples.length) * 1000) / 1000,
+    train: train.length,
+    test: test.length,
+    labelerAgreement: { pairs: total, raw: Math.round(po * 1000) / 1000, kappa: Math.round(kappa * 1000) / 1000 },
+    heldOut: {
+        regex: round(evaluate(regex, test)),
+        regexCarry: round(evaluate(regexCarry, test)),
+        learned: round(evaluate(learned, test)),
+    },
+    heldOutSweep: sweep(test).map((s) => ({ t: s.threshold, ...round(s.m) })),
+    matchedRecall: (() => {
+        const target = evaluate(regex, test).recall;
+        const candidates = sweep(test).filter((s) => s.m.recall >= target);
+        const best = candidates.sort((a, b) => b.threshold - a.threshold)[0];
+        return best ? { regexRecall: Math.round(target * 1000) / 1000, atThreshold: best.threshold, learned: round(best.m) } : null;
+    })(),
+    repeatedMatchedRecall: repeatedSplits(20),
+    trainSet: {
+        regex: round(evaluate(regex, train)),
+        learned: round(evaluate(learned, train)),
+    },
+    weights: Object.fromEntries(FEATURE_NAMES.map((n, i) => [n, Math.round(w[i]! * 1000) / 1000])),
+}, null, 1));


### PR DESCRIPTION
Closes #895 (the prototype; the landed slice is follow-up). Phase 5 of the v3 plan, run end to end with the plan's own ship gate.

## Question

Can a tiny trained model beat `JUDGMENT_GUARD_RE` at deciding judgment-vs-routable for main-agent turns? Gate: beats the regex on held-out labels, else the regex stays.

## Verdict: PASSED — at matched recall

The regex is a safety guard (a judgment turn misrouted to a cheap model is the expensive mistake), so the deciding comparison is at the guard's operating point: lower the model's threshold until held-out judgment-recall ≥ the regex's, then compare precision.

Over **20 random 70/30 splits** of 360 labeled turns: precision gap **+15.0 points mean (sd 7.0), positive in 20/20 splits**, with **+4.9 points extra recall** on average. Same-or-better safety, roughly a third fewer routable turns wrongly held on the frontier model. Canonical split: regex acc 0.688 / P 0.386 / R 0.708 / F1 0.500 → learned@0.35 acc 0.780 / P 0.500 / R 0.750 / F1 0.600.

Two honesty notes the landed slice must carry: at the DEFAULT 0.5 threshold the model under-flags (recall 0.42) — the threshold must be pinned from matched-recall fold data; and `regexOwn` survives as a positive feature (+0.43), exactly the plan's "regexes become features, never deleted first".

## Method

- `extract.ts`: decision population off the published snapshot (claude main assistant turns not adjacent to a user turn — the turns `classifyTurn` actually decides on): 45,938 turns / 120d; stratified 360-turn sample.
- Labels: 9 parallel subagents judging the WORK, not the vocabulary; 2 batches double-labeled independently → raw agreement 93.8%, Cohen's kappa 0.818.
- `train.ts`: 12 cheap features, hand-rolled L2 logistic (CPU seconds), three detectors on the same held-out set + threshold sweep + matched-recall + 20-repeat stability.

Caveats (in the README): LLM-generated labels (kappa vs a second LLM instance, not a human), regex-stratified sample (comparison fair, absolute rates are not population rates), n=360.

## Contents

Prototype code + README under `scripts/prototypes/judgment-learn/` (data files with raw turn text are gitignored, regenerable); plan annotated with the verdict. No production code touched; no tests affected — both typechecks + both check gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)