### PR TITLE
feat(schema): event-layer freeze - layer classification + TableWrite contract + enforcement (#897)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,20 @@ or write. Getting it wrong does not error; it returns a wrong answer.
   (`packages/schema/src/duckdb-tables.ts` or `sidecar-tables.ts`, plus
   `SCHEMA_TABLES` in `apps/axctl/src/queries/insights.ts`). `session_label`
   shipped unregistered for a while precisely because nothing forced it.
+- **The event-layer write contract (#893).** Every cache table carries a
+  `layer` (`event` | `derived` | `bookkeeping`) in `TABLE_METADATA`, and every
+  writer declares its writes: stages via `StageMeta.writes`
+  (`{ table, mode: parse|enrich|derive|bookkeep }`), CLI/orchestration writers
+  in `NON_STAGE_WRITERS` (`apps/axctl/src/ingest/stage/table-writes.ts`).
+  Mode-vs-layer legality is pinned by `stage/table-writes.test.ts` (static)
+  and `table-writes.behavior.test.ts` (fixture runs + per-table content
+  digests - UPDATEs change no row count, so digests, not counts). Derived
+  columns living on event rows are enumerated in `ENRICHMENT_COLUMNS`;
+  derive-writes into event tables are enumerated in `WRITE_MODE_EXCEPTIONS`
+  with a rationale. Growing either list is a design decision, not a fix for a
+  red test. The ingest/derive stage TAG is NOT the layer authority - the
+  `subagents` "derive" stage is a parser, `usage`/`advice` are external-ledger
+  loaders, and `git` (tagged ingest) draws derived `produced` edges.
 - Nested objects → JSON-encoded as a `VARCHAR` column, decoded at the read seam.
 - `CURRENT_TIMESTAMP` is a TIMESTAMPTZ, and the DuckDB build ax ships carries NO
   ICU, so date arithmetic MUST cast it: `CAST(CURRENT_TIMESTAMP AS TIMESTAMP)`.

--- a/apps/axctl/src/advice/advice-stage.ts
+++ b/apps/axctl/src/advice/advice-stage.ts
@@ -47,7 +47,9 @@ export class AdviceStats extends BaseStageStats.extend<AdviceStats>("AdviceStats
 }) {}
 
 export const adviceStage: StageDef<AdviceStats, never, CacheWriteError> = {
-  meta: StageMeta.make({ key: "advice", deps: [], tags: ["derive"] }),
+  // Tagged derive for pipeline placement, but it is an external-ledger
+  // LOADER (parse) over ~/.ax/hooks/advise-log.jsonl (#893).
+  meta: StageMeta.make({ key: "advice", deps: [], tags: ["derive"], writes: [{ table: "advice", mode: "parse" }] }),
   run: (ctx: IngestContext, write) =>
     Effect.gen(function* () {
       const t0 = Date.now();

--- a/apps/axctl/src/digest/digest-stage.ts
+++ b/apps/axctl/src/digest/digest-stage.ts
@@ -20,7 +20,8 @@ export class DigestStats extends BaseStageStats.extend<DigestStats>("DigestStats
  *  full/read-only disk on the digest write logs a warning and yields a zero-item
  *  stats row, never failing the surrounding ingest run. */
 export const digestStage: StageDef<DigestStats, Judgment, CacheWriteError> = {
-  meta: StageMeta.make({ key: "digest", deps: ["proposals", "derive-metrics"], tags: ["derive"] }),
+  // Writes no cache table: the digest lands in ~/.ax/digest.json.
+  meta: StageMeta.make({ key: "digest", deps: ["proposals", "derive-metrics"], tags: ["derive"], writes: [] }),
   run: (_ctx: IngestContext, write: CacheWriteService) =>
     Effect.gen(function* () {
       const t0 = Date.now();

--- a/apps/axctl/src/ingest/agent-def.ts
+++ b/apps/axctl/src/ingest/agent-def.ts
@@ -154,7 +154,7 @@ export const agentDefStage: StageDef<
     FileSystem.FileSystem | Path.Path | AgentSourceRegistry,
     DbError | CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "agent-def", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "agent-def", deps: [], tags: ["ingest"], writes: [{ table: "agent_def", mode: "parse" }] }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/backfill-invoked-positions.ts
+++ b/apps/axctl/src/ingest/backfill-invoked-positions.ts
@@ -123,6 +123,7 @@ export const invokedPositionsStage: StageDef<InvokedPositionsStats, never, Cache
         key: "invoked-positions",
         deps: ["claude", "codex", "subagents"],
         tags: ["derive"],
+        writes: [{ table: "invoked", mode: "enrich" }],
     }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/classifier-results.ts
+++ b/apps/axctl/src/ingest/classifier-results.ts
@@ -240,7 +240,18 @@ export class ClassifierResultsStageStats extends BaseStageStats.extend<Classifie
 }) {}
 
 export const classifierResultsStage: StageDef<ClassifierResultsStageStats, never, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "classifier-results", deps: ["turn-analysis"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "classifier-results",
+        deps: ["turn-analysis"],
+        tags: ["derive"],
+        writes: [
+            { table: "classifier_definition", mode: "derive" },
+            { table: "classifier_run", mode: "derive" },
+            { table: "classifier_result", mode: "derive" },
+            { table: "has_classification", mode: "derive" },
+            { table: "cites_evidence", mode: "derive" },
+        ],
+    }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/claude-config.ts
+++ b/apps/axctl/src/ingest/claude-config.ts
@@ -997,7 +997,7 @@ export const claudeConfigStage: StageDef<
     AxConfig | FileSystem.FileSystem | Path.Path,
     CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "claude-config", deps: ["skills", "commands", "agent-def"], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "claude-config", deps: ["skills", "commands", "agent-def"], tags: ["ingest"], writes: [{ table: "guidance_config_artifact", mode: "parse" }, { table: "guidance_revision", mode: "parse" }] }),
     run: (_ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/claude-sidecars.ts
+++ b/apps/axctl/src/ingest/claude-sidecars.ts
@@ -1040,7 +1040,18 @@ export const claudeSidecarsStage: StageDef<
     AxConfig | FileSystem.FileSystem | Path.Path,
     CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "claude-sidecars", deps: ["claude", "subagents"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "claude-sidecars",
+        deps: ["claude", "subagents"],
+        tags: ["ingest"],
+        writes: [
+            { table: "claude_sidecar_artifact", mode: "parse" },
+            { table: "used_sidecar_artifact", mode: "parse" },
+            { table: "plan", mode: "parse" },
+            { table: "plan_snapshot", mode: "parse" },
+            { table: "plan_item", mode: "parse" },
+        ],
+    }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/closure.ts
+++ b/apps/axctl/src/ingest/closure.ts
@@ -366,7 +366,18 @@ export class ClosureStageStats extends BaseStageStats.extend<ClosureStageStats>(
 }) {}
 
 export const closureStage: StageDef<ClosureStageStats, never, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "closure", deps: ["signals"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "closure",
+        deps: ["signals"],
+        tags: ["derive"],
+        writes: [
+            { table: "commit_classification", mode: "derive" },
+            { table: "later_fixed_by", mode: "derive" },
+            { table: "skill_candidate", mode: "derive" },
+            { table: "suggests_skill", mode: "derive" },
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -7,6 +7,7 @@ import { SkillName } from "@ax/lib/brands";
 import { AxConfig } from "@ax/lib/config";
 import { blobName, putBlobFromFile } from "@ax/lib/blob-store";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
+import { JSONL_WORK_UNIT_WRITES, NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
@@ -1827,7 +1828,17 @@ export class CodexStageStats extends BaseStageStats.extend<CodexStageStats>("Cod
 }) {}
 
 export const codexStage: StageDef<CodexStageStats, AxConfig | FileSystem.FileSystem | Path.Path, DbError | CacheWriteError> = {
-    meta: StageMeta.make({ key: "codex", deps: ["skills", "commands"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "codex",
+        deps: ["skills", "commands"],
+        tags: ["ingest"],
+        writes: [
+            ...NORMALIZED_BATCH_WRITES,
+            { table: "session_token_usage", mode: "parse" },
+            { table: "turn_token_usage", mode: "parse" },
+            ...JSONL_WORK_UNIT_WRITES,
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/commands.ts
+++ b/apps/axctl/src/ingest/commands.ts
@@ -326,7 +326,7 @@ export const commandsStage: StageDef<
     FileSystem.FileSystem | Path.Path,
     CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "commands", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "commands", deps: [], tags: ["ingest"], writes: [{ table: "skill", mode: "parse" }, { table: "skill_revision", mode: "parse" }] }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -21,6 +21,7 @@ import { type NormalizedTranscriptBatch, writeNormalizedTranscriptBatch } from "
 import { providerPlanSignalAvailability } from "./plans.ts";
 import { identityPart, toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
+import { NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import type { StageDef } from "./stage/registry.ts";
 import { boundExcerpt, isRecord, parseJsonRecord, stringField } from "./normalized/toolkit.ts";
 import { makeToolCallWrite } from "./normalized/tool-call-write.ts";
@@ -1154,7 +1155,12 @@ export class CursorStageStats extends BaseStageStats.extend<CursorStageStats>("C
 }) {}
 
 export const cursorStage: StageDef<CursorStageStats, AxConfig | FileSystem.FileSystem | Path.Path, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "cursor", deps: ["skills", "commands"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "cursor",
+        deps: ["skills", "commands"],
+        tags: ["ingest"],
+        writes: [...NORMALIZED_BATCH_WRITES, { table: "ingest_file_state", mode: "bookkeep" }],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/derive-cache-bust.ts
+++ b/apps/axctl/src/ingest/derive-cache-bust.ts
@@ -28,6 +28,10 @@ export const cacheBustStage: StageDef<CacheBustStats, never, CacheWriteError> = 
         key: "cache-bust",
         deps: ["claude", "pricing"],
         tags: ["derive"],
+        writes: [
+            { table: "cache_bust_event", mode: "derive" },
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
     }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -464,7 +464,35 @@ export class SubagentsStats extends BaseStageStats.extend<SubagentsStats>("Subag
 }) {}
 
 export const subagentsStage: StageDef<SubagentsStats, AxConfig | FileSystem.FileSystem | Path.Path, CacheWriteError> = {
-    meta: StageMeta.make({ key: "subagents", deps: ["claude", "codex"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "subagents",
+        // Tagged derive for pipeline placement, but this stage IS A PARSER:
+        // it walks agent-*.jsonl subagent files with a fileWatermark and
+        // writes event rows (#893 - the flagship tags-are-not-the-layer case).
+        deps: ["claude", "codex"],
+        tags: ["derive"],
+        writes: [
+            { table: "session", mode: "parse" },
+            { table: "session", mode: "enrich" }, // parent repo/checkout/cwd backfill
+            { table: "spawned", mode: "parse" },
+            { table: "session_token_usage", mode: "parse" },
+            { table: "turn_token_usage", mode: "parse" },
+            { table: "turn", mode: "parse" },
+            { table: "tool", mode: "parse" },
+            { table: "tool_call", mode: "parse" },
+            { table: "file", mode: "parse" },
+            { table: "edited", mode: "parse" },
+            { table: "read_file", mode: "parse" },
+            { table: "searched_file", mode: "parse" },
+            { table: "skill", mode: "parse" },
+            { table: "invoked", mode: "parse" },
+            { table: "concerns", mode: "parse" },
+            { table: "plan", mode: "parse" },
+            { table: "plan_snapshot", mode: "parse" },
+            { table: "plan_item", mode: "parse" },
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -202,6 +202,10 @@ export const contentTypesStage: StageDef<ContentTypeStats, never, CacheWriteErro
         key: "content-types",
         deps: ["claude", "codex", "pi", "omp", "cursor"],
         tags: ["derive"],
+        writes: [
+            { table: "content_type", mode: "derive" },
+            { table: "has_content", mode: "derive" },
+        ],
     }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/derive-directive-ngrams.ts
+++ b/apps/axctl/src/ingest/derive-directive-ngrams.ts
@@ -71,6 +71,7 @@ export const directiveNgramsStage: StageDef<DirectiveNgramsStats, never, IngestS
         key: "directive-ngrams",
         deps: ["closure"],
         tags: ["derive"],
+        writes: [{ table: "directive_ngram", mode: "derive" }],
     }),
     run: (_ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/derive-loaded-skills.ts
+++ b/apps/axctl/src/ingest/derive-loaded-skills.ts
@@ -172,6 +172,7 @@ export const loadedSkillsStage: StageDef<LoadedSkillsStats, never, CacheWriteErr
         key: "loaded-skills",
         deps: ["skills", "agent-def", "spawned"],
         tags: ["derive"],
+        writes: [{ table: "loaded", mode: "derive" }],
     }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/derive-metrics.ts
+++ b/apps/axctl/src/ingest/derive-metrics.ts
@@ -220,7 +220,18 @@ export class DeriveMetricsStageStats extends BaseStageStats.extend<DeriveMetrics
 }) {}
 
 export const deriveMetricsStage: StageDef<DeriveMetricsStageStats, never, IngestStageError> = {
-    meta: StageMeta.make({ key: "derive-metrics", deps: ["git", "session-health", "spawned"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "derive-metrics",
+        deps: ["git", "session-health", "spawned"],
+        tags: ["derive"],
+        writes: [
+            { table: "session_metrics", mode: "derive" },
+            { table: "fragility_cascade", mode: "derive" },
+            { table: "session_token_usage", mode: "enrich" }, // cost backfill
+            { table: "commit", mode: "enrich" }, // reverted stamping
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/derive-opportunities.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.ts
@@ -519,7 +519,7 @@ export const opportunitiesStage: StageDef<
     Judgment | FileSystem.FileSystem,
     CacheWriteError | CacheReadError | JudgmentError
 > = {
-    meta: StageMeta.make({ key: "opportunities", deps: ["proposals"], tags: ["derive"] }),
+    meta: StageMeta.make({ key: "opportunities", deps: ["proposals"], tags: ["derive"], writes: [{ table: "opportunity", mode: "derive" }] }),
     run: (_ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -763,7 +763,7 @@ export const proposalsStage: StageDef<
     Judgment | ProcessService | FileSystem.FileSystem | Path.Path,
     CacheWriteError | CacheReadError | JudgmentError
 > = {
-    meta: StageMeta.make({ key: "proposals", deps: ["closure"], tags: ["derive"] }),
+    meta: StageMeta.make({ key: "proposals", deps: ["closure"], tags: ["derive"], writes: [{ table: "cites_evidence", mode: "derive" }] }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/derive-retro-proposals.ts
+++ b/apps/axctl/src/ingest/derive-retro-proposals.ts
@@ -741,7 +741,7 @@ export const retroProposalsStage: StageDef<
     Judgment,
     CacheReadError | CacheWriteError | JudgmentError
 > = {
-    meta: StageMeta.make({ key: "retro-proposals", deps: ["proposals"], tags: ["derive", "retro"] }),
+    meta: StageMeta.make({ key: "retro-proposals", deps: ["proposals"], tags: ["derive", "retro"], writes: [{ table: "reviewed", mode: "derive" }] }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -699,6 +699,12 @@ export const runEvidenceStage: StageDef<RunEvidenceStats, never, CacheWriteError
         key: "run-evidence",
         deps: ["claude", "codex", "pi", "omp", "opencode", "cursor", "outcomes", "git", "spawned"],
         tags: ["derive"],
+        writes: [
+            { table: "run_evidence_event", mode: "derive" },
+            { table: "run_evidence_ref", mode: "derive" },
+            { table: "command_outcome", mode: "derive" }, // check_family cutover backfill
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
     }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -319,7 +319,20 @@ export class SignalsStats extends BaseStageStats.extend<SignalsStats>("SignalsSt
 }) {}
 
 export const signalsStage: StageDef<SignalsStats, never, CacheWriteError> = {
-    meta: StageMeta.make({ key: "signals", deps: ["claude", "codex", "pi", "omp", "opencode", "cursor", "subagents", "spawned", "git"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "signals",
+        deps: ["claude", "codex", "pi", "omp", "opencode", "cursor", "subagents", "spawned", "git"],
+        tags: ["derive"],
+        writes: [
+            { table: "corrected_by", mode: "derive" },
+            { table: "proposed", mode: "derive" },
+            { table: "skill_paired", mode: "derive" },
+            { table: "recovered_by", mode: "derive" },
+            { table: "friction_event", mode: "derive" },
+            { table: "diagnostic_event", mode: "derive" },
+            { table: "invoked", mode: "enrich" }, // was_corrected stamping
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/derive-spawned.ts
+++ b/apps/axctl/src/ingest/derive-spawned.ts
@@ -180,7 +180,9 @@ export class SpawnedStats extends BaseStageStats.extend<SpawnedStats>("SpawnedSt
 }) {}
 
 export const spawnedStage: StageDef<SpawnedStats, never, CacheWriteError> = {
-    meta: StageMeta.make({ key: "spawned", deps: ["claude", "codex"], tags: ["derive"] }),
+    // derive-mode write into the event table `spawned` - an enumerated
+    // exception (WRITE_MODE_EXCEPTIONS): the subagents parser also writes it.
+    meta: StageMeta.make({ key: "spawned", deps: ["claude", "codex"], tags: ["derive"], writes: [{ table: "spawned", mode: "derive" }] }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/git.ts
+++ b/apps/axctl/src/ingest/git.ts
@@ -777,7 +777,22 @@ export const gitStage: StageDef<
     FileSystem.FileSystem | Path.Path,
     CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "git", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "git",
+        deps: [],
+        tags: ["ingest"],
+        writes: [
+            { table: "repository", mode: "parse" },
+            { table: "checkout", mode: "parse" },
+            { table: "has_checkout", mode: "parse" },
+            { table: "commit", mode: "parse" },
+            { table: "file", mode: "parse" },
+            { table: "touched", mode: "parse" },
+            { table: "produced", mode: "derive" }, // session->commit correlation
+            { table: "session", mode: "enrich" }, // project/repository/checkout
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     // Unnamed Effect.fn: stack-frame boundary only. The stage runner already
     // wraps each run in a LiveTrace.step span named by the stage key, so a
     // named span here would double-wrap.

--- a/apps/axctl/src/ingest/github-pr-stage.ts
+++ b/apps/axctl/src/ingest/github-pr-stage.ts
@@ -249,7 +249,18 @@ export const ingestGithubPrs = Effect.fn("github-pr.ingest")(
  * Tags: ingest
  */
 export const githubPrStage: StageDef<GithubPrStageStats, never, CacheWriteError> = {
-    meta: StageMeta.make({ key: "github-pr", deps: ["git"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "github-pr",
+        deps: ["git"],
+        tags: ["ingest"],
+        writes: [
+            { table: "pull_request", mode: "parse" },
+            { table: "review_event", mode: "parse" },
+            { table: "check_run", mode: "parse" },
+            { table: "delivery_outcome", mode: "parse" },
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/harness.ts
+++ b/apps/axctl/src/ingest/harness.ts
@@ -88,7 +88,18 @@ export class HarnessStageStats extends BaseStageStats.extend<HarnessStageStats>(
 }) {}
 
 export const harnessStage: StageDef<HarnessStageStats, ProcessService | FileSystem.FileSystem | Path.Path, IngestStageError> = {
-    meta: StageMeta.make({ key: "harness", deps: ["outcomes", "session-health", "closure"], tags: ["derive", "health"] }),
+    meta: StageMeta.make({
+        key: "harness",
+        // Tagged derive/health for pipeline placement, but its writes are
+        // parses: guidance/stack rows restate observed on-disk config (#893).
+        deps: ["outcomes", "session-health", "closure"],
+        tags: ["derive", "health"],
+        writes: [
+            { table: "guidance_source", mode: "parse" },
+            { table: "guidance_revision", mode: "parse" },
+            { table: "stack", mode: "parse" },
+        ],
+    }),
     run: (_ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/hook-fire-spool.ts
+++ b/apps/axctl/src/ingest/hook-fire-spool.ts
@@ -113,7 +113,7 @@ export const hookFireSpoolStage: StageDef<
     FileSystem.FileSystem | Path.Path,
     CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "hook-fire-spool", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "hook-fire-spool", deps: [], tags: ["ingest"], writes: [{ table: "hook_fire", mode: "parse" }] }),
     run: Effect.fn(function* (_ctx: IngestContext, write: CacheWriteService) {
         const started = Date.now();
         const outcome = yield* drainHookFireSpool(write).pipe(

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -836,7 +836,7 @@ export class PricingStageStats extends BaseStageStats.extend<PricingStageStats>(
 }) {}
 
 export const pricingStage: StageDef<PricingStageStats, AxConfig | FileSystem.FileSystem | Path.Path, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "pricing", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "pricing", deps: [], tags: ["ingest"], writes: [{ table: "agent_model", mode: "parse" }, { table: "ingest_file_state", mode: "bookkeep" }] }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -17,6 +17,7 @@ import { agentEventRecordKey, type AgentEventWrite } from "./provider-events.ts"
 import { providerPlanSignalAvailability } from "./plans.ts";
 import { toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
+import { NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
     extractOpenCodeCompaction,
@@ -1273,7 +1274,7 @@ export class OpenCodeStageStats extends BaseStageStats.extend<OpenCodeStageStats
 }) {}
 
 export const opencodeStage: StageDef<OpenCodeStageStats, AxConfig | FileSystem.FileSystem | Path.Path, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "opencode", deps: ["skills", "commands"], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "opencode", deps: ["skills", "commands"], tags: ["ingest"], writes: NORMALIZED_BATCH_WRITES }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -177,7 +177,7 @@ export const otelSpoolStage: StageDef<
     FileSystem.FileSystem | Path.Path,
     DbError | CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"], writes: [{ table: "otel_metric_point", mode: "parse" }, { table: "otel_span", mode: "parse" }, { table: "otel_log_event", mode: "parse" }, { table: "ingest_file_state", mode: "bookkeep" }, { table: "ingest_run", mode: "bookkeep" }] }),
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {
         const t0 = Date.now();
         const result = yield* ingestOtelSpool(write, {

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -277,7 +277,7 @@ export class OutcomesStageStats extends BaseStageStats.extend<OutcomesStageStats
 }) {}
 
 export const outcomesStage: StageDef<OutcomesStageStats, never, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "outcomes", deps: ["signals"], tags: ["derive"] }),
+    meta: StageMeta.make({ key: "outcomes", deps: ["signals"], tags: ["derive"], writes: [{ table: "command_outcome", mode: "derive" }, { table: "user_message_ngram", mode: "derive" }] }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -17,6 +17,7 @@ import { agentEventRecordKey, type AgentEventWrite, type AgentProviderName } fro
 import { providerPlanSignalAvailability } from "./plans.ts";
 import { toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
+import { JSONL_WORK_UNIT_WRITES, NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
     booleanField,
@@ -857,7 +858,16 @@ const makePiLikeStage = (
     desc: PiLikeProvider,
     ingest: ReturnType<typeof makePiLikeIngest>,
 ): StageDef<PiStageStats, AxConfig | FileSystem.FileSystem | Path.Path, DbError | CacheWriteError> => ({
-    meta: StageMeta.make({ key: desc.provider, deps: ["skills", "commands"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: desc.provider,
+        deps: ["skills", "commands"],
+        tags: ["ingest"],
+        writes: [
+            ...NORMALIZED_BATCH_WRITES,
+            { table: "session_token_usage", mode: "parse" },
+            ...JSONL_WORK_UNIT_WRITES,
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/reaction-events.ts
+++ b/apps/axctl/src/ingest/reaction-events.ts
@@ -303,7 +303,7 @@ export class ReactionEventsStageStats extends BaseStageStats.extend<ReactionEven
 }) {}
 
 export const reactionEventsStage: StageDef<ReactionEventsStageStats, never, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "reaction-events", deps: ["turn-analysis"], tags: ["derive"] }),
+    meta: StageMeta.make({ key: "reaction-events", deps: ["turn-analysis"], tags: ["derive"], writes: [{ table: "reaction_event", mode: "derive" }] }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/run.test.ts
+++ b/apps/axctl/src/ingest/run.test.ts
@@ -15,7 +15,7 @@ import { runIngest, stageEventName, withIngestRunFinish } from "./run.ts";
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("ingest run", { requireFts: true });
 
 const stage = (key: string, deps: string[] = [], delay = 0): StageDef => ({
-    meta: StageMeta.make({ key, deps, tags: [key === "outcomes" ? "derive" : "ingest"] }),
+    meta: StageMeta.make({ key, deps, tags: [key === "outcomes" ? "derive" : "ingest"], writes: [] }),
     run: () => Effect.succeed({
         ...BaseStageStats.make({ durationMs: 1, summary: `${key} done` }),
         sessions: key === "skills" ? 3 : 0,

--- a/apps/axctl/src/ingest/session-health.ts
+++ b/apps/axctl/src/ingest/session-health.ts
@@ -477,7 +477,18 @@ export class SessionHealthStageStats extends BaseStageStats.extend<SessionHealth
 }) {}
 
 export const sessionHealthStage: StageDef<SessionHealthStageStats, never, CacheWriteError> = {
-    meta: StageMeta.make({ key: "session-health", deps: ["signals"], tags: ["derive", "health"] }),
+    meta: StageMeta.make({
+        key: "session-health",
+        deps: ["signals"],
+        tags: ["derive", "health"],
+        writes: [
+            { table: "workflow_epoch", mode: "derive" },
+            { table: "session_health", mode: "derive" },
+            // Estimated usage rows upserted into the event table - an
+            // enumerated exception (WRITE_MODE_EXCEPTIONS).
+            { table: "session_token_usage", mode: "derive" },
+        ],
+    }),
     run: (ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -323,7 +323,7 @@ export const skillsStage: StageDef<
     Judgment | FileSystem.FileSystem | Path.Path,
     CacheWriteError | JudgmentError
 > = {
-    meta: StageMeta.make({ key: "skills", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "skills", deps: [], tags: ["ingest"], writes: [{ table: "skill", mode: "parse" }, { table: "skill_revision", mode: "parse" }] }),
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/stage/registry.test.ts
+++ b/apps/axctl/src/ingest/stage/registry.test.ts
@@ -9,7 +9,7 @@ import {
 import { BaseStageStats, StageMeta } from "./types.ts";
 
 const fakeStage: StageDef = {
-    meta: StageMeta.make({ key: "skills", deps: [], tags: ["ingest"] }),
+    meta: StageMeta.make({ key: "skills", deps: [], tags: ["ingest"], writes: [] }),
     run: (_ctx) =>
         Effect.succeed(
             BaseStageStats.make({ durationMs: 0, summary: "noop" }),

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -43,7 +43,7 @@ const outcomeRecorder = () => {
 };
 
 const stage = (key: string, deps: string[]): StageDef => ({
-    meta: StageMeta.make({ key, deps, tags: ["ingest"] }),
+    meta: StageMeta.make({ key, deps, tags: ["ingest"], writes: [] }),
     run: () =>
         Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: key })),
 });
@@ -80,7 +80,7 @@ describe("runPipeline", () => {
     it("propagates a stage error outside the legacy database error channel", async () => {
         const cacheFailure = "cache-read-failed" as const;
         const cacheStage: StageDef<BaseStageStats, never, typeof cacheFailure> = {
-            meta: StageMeta.make({ key: "cache", deps: [], tags: ["derive"] }),
+            meta: StageMeta.make({ key: "cache", deps: [], tags: ["derive"], writes: [] }),
             run: () => Effect.fail(cacheFailure),
         };
         const ctx = IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
@@ -93,7 +93,7 @@ describe("runPipeline", () => {
     it("runs every stage exactly once and respects deps", async () => {
         const order: string[] = [];
         const make = (key: string, deps: string[]): StageDef => ({
-            meta: StageMeta.make({ key, deps, tags: ["ingest"] }),
+            meta: StageMeta.make({ key, deps, tags: ["ingest"], writes: [] }),
             run: () =>
                 Effect.sync(() => {
                     order.push(key);
@@ -152,7 +152,7 @@ describe("runPipeline", () => {
                 deps: string[],
                 gate?: Deferred.Deferred<void, never>,
             ): StageDef => ({
-                meta: StageMeta.make({ key, deps, tags: ["ingest"] }),
+                meta: StageMeta.make({ key, deps, tags: ["ingest"], writes: [] }),
                 run: () =>
                     Effect.gen(function* () {
                         if (gate) yield* Deferred.await(gate);
@@ -236,7 +236,7 @@ describe("annotateStageProgress", () => {
         const ctx = IngestContext.make({ cwd: "/tmp/ax", since: new Date(0), debug: false });
 
         const demo: StageDef = {
-            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"] }),
+            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"], writes: [] }),
             run: () =>
                 annotateStageProgress({
                     currentFile: 2,
@@ -302,7 +302,7 @@ describe("stageFileFailureAnnotator", () => {
         };
 
         const demo: StageDef = {
-            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"] }),
+            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"], writes: [] }),
             run: () =>
                 Effect.gen(function* () {
                     const onFileFailures = yield* stageFileFailureAnnotator;
@@ -351,7 +351,7 @@ describe("stageFileFailureAnnotator", () => {
         const ctx = IngestContext.make({ cwd: "/tmp/ax", since: new Date(0), debug: false });
 
         const demo: StageDef = {
-            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"] }),
+            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"], writes: [] }),
             run: () =>
                 Effect.gen(function* () {
                     const onFileFailures = yield* stageFileFailureAnnotator;
@@ -435,11 +435,11 @@ describe("derive-stage hung detector (#671, demoted by #837)", () => {
         await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const ran: string[] = [];
             const hang: StageDef = {
-                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"], writes: [] }),
                 run: () => Effect.never, // never resolves → watchdog must fire
             };
             const after: StageDef = {
-                meta: StageMeta.make({ key: "after", deps: ["hang"], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "after", deps: ["hang"], tags: ["derive"], writes: [] }),
                 run: () =>
                     Effect.sync(() => {
                         ran.push("after");
@@ -465,7 +465,7 @@ describe("derive-stage hung detector (#671, demoted by #837)", () => {
         await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const rec = outcomeRecorder();
             const hang: StageDef = {
-                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"], writes: [] }),
                 run: () => Effect.never,
             };
             await Effect.runPromise(
@@ -482,7 +482,7 @@ describe("derive-stage hung detector (#671, demoted by #837)", () => {
         await withEnv({ AX_STAGE_HUNG_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const rec = outcomeRecorder();
             const fine: StageDef = {
-                meta: StageMeta.make({ key: "fine", deps: [], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "fine", deps: [], tags: ["derive"], writes: [] }),
                 run: () => Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: "fine" })),
             };
             await Effect.runPromise(
@@ -495,7 +495,7 @@ describe("derive-stage hung detector (#671, demoted by #837)", () => {
     it("still completes when no recorder is supplied (the hook is optional)", async () => {
         await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const hang: StageDef = {
-                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "hang", deps: [], tags: ["derive"], writes: [] }),
                 run: () => Effect.never,
             };
             const results = await Effect.runPromise(
@@ -508,7 +508,7 @@ describe("derive-stage hung detector (#671, demoted by #837)", () => {
     it("does NOT watchdog a non-derive (ingest) stage that runs past the cap", async () => {
         await withEnv({ AX_STAGE_HUNG_SECONDS: "0.05", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const slowIngest: StageDef = {
-                meta: StageMeta.make({ key: "slow", deps: [], tags: ["ingest"] }),
+                meta: StageMeta.make({ key: "slow", deps: [], tags: ["ingest"], writes: [] }),
                 run: () =>
                     Effect.sync(() => BaseStageStats.make({ durationMs: 0, summary: "real" })).pipe(
                         Effect.delay("150 millis"), // 3× the cap, but ingest stages are exempt
@@ -556,7 +556,7 @@ describe("derive self-time budget (#837)", () => {
         tags: ReadonlyArray<"ingest" | "derive">,
         callsMs: ReadonlyArray<number>,
     ): StageDef => ({
-        meta: StageMeta.make({ key, deps: [], tags }),
+        meta: StageMeta.make({ key, deps: [], tags, writes: [] }),
         run: () =>
             Effect.provideService(
                 Effect.forEach(callsMs, (ms) => chargeStageSelfTime(busy(ms))).pipe(
@@ -575,7 +575,7 @@ describe("derive self-time budget (#837)", () => {
             const rec = outcomeRecorder();
             const ran: string[] = [];
             const after: StageDef = {
-                meta: StageMeta.make({ key: "after", deps: ["greedy"], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "after", deps: ["greedy"], tags: ["derive"], writes: [] }),
                 run: () =>
                     Effect.sync(() => {
                         ran.push("after");
@@ -642,7 +642,7 @@ describe("derive self-time budget (#837)", () => {
         // defect keeps crashing the pipeline as before.
         await withEnv({ AX_STAGE_TIMEOUT_SECONDS: "60", AX_INGEST_HEARTBEAT_SECONDS: "0" }, async () => {
             const boom: StageDef = {
-                meta: StageMeta.make({ key: "boom", deps: [], tags: ["derive"] }),
+                meta: StageMeta.make({ key: "boom", deps: [], tags: ["derive"], writes: [] }),
                 run: () => Effect.die(new Error("unrelated defect")),
             };
             const exit = await Effect.runPromiseExit(
@@ -661,7 +661,7 @@ describe("runPipeline derive budget (#697)", () => {
         tags: ReadonlyArray<"ingest" | "derive">,
         run: Effect.Effect<BaseStageStats, never, never>,
     ): StageDef<BaseStageStats, never> => ({
-        meta: StageMeta.make({ key, deps: [], tags }),
+        meta: StageMeta.make({ key, deps: [], tags, writes: [] }),
         run: () => run,
     });
 

--- a/apps/axctl/src/ingest/stage/select.test.ts
+++ b/apps/axctl/src/ingest/stage/select.test.ts
@@ -5,7 +5,7 @@ import { selectByKeys, selectByTag } from "./select.ts";
 import { BaseStageStats, StageMeta, type StageDef } from "./types.ts";
 
 const stage = (key: string, tags: string[], deps: string[] = []): StageDef => ({
-    meta: StageMeta.make({ key, deps, tags: tags as never }),
+    meta: StageMeta.make({ key, deps, tags: tags as never, writes: [] }),
     run: () => Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: key })),
 });
 

--- a/apps/axctl/src/ingest/stage/table-writes.test.ts
+++ b/apps/axctl/src/ingest/stage/table-writes.test.ts
@@ -1,0 +1,111 @@
+// apps/axctl/src/ingest/stage/table-writes.test.ts
+/**
+ * Static half of the event-layer freeze enforcement (#893 slice 1, #897):
+ * every declared TableWrite is checked mode-vs-layer against the manifest.
+ * Deliberately phrased over the WRITE declarations, never over the stage
+ * tags array [R#14] - tags say where a stage runs, not what its writes are.
+ * The behavioral half (fixture runs + content digests) lives in
+ * ../table-writes.behavior.test.ts.
+ */
+import { describe, expect, test } from "bun:test";
+import { DUCKDB_TABLE_LAYERS, ENRICHMENT_COLUMNS } from "@ax/schema/duckdb-tables";
+import { parseDuckdbColumns } from "@ax/schema/parse-duckdb-schema";
+import { ALL_STAGES } from "./registry.ts";
+import { NON_STAGE_WRITERS, WRITE_MODE_EXCEPTIONS } from "./table-writes.ts";
+import type { TableWrite } from "./types.ts";
+
+interface DeclaredWriter {
+    readonly writer: string;
+    readonly writes: readonly TableWrite[];
+}
+
+const ALL_WRITERS: readonly DeclaredWriter[] = [
+    ...ALL_STAGES.map((stage) => ({ writer: `stage:${stage.meta.key}`, writes: stage.meta.writes })),
+    ...NON_STAGE_WRITERS,
+];
+
+const hasException = (writer: string, write: TableWrite): boolean =>
+    WRITE_MODE_EXCEPTIONS.some((e) => e.writer === writer && e.table === write.table && e.mode === write.mode);
+
+describe("event-layer write contract (static)", () => {
+    test("every declared write targets a table the DDL manifest knows", () => {
+        for (const { writer, writes } of ALL_WRITERS) {
+            for (const write of writes) {
+                expect(DUCKDB_TABLE_LAYERS.has(write.table), `${writer} declares unknown table ${write.table}`).toBe(true);
+            }
+        }
+    });
+
+    test("every declared mode is legal for the target table's layer", () => {
+        const violations: string[] = [];
+        for (const { writer, writes } of ALL_WRITERS) {
+            for (const write of writes) {
+                const layer = DUCKDB_TABLE_LAYERS.get(write.table);
+                if (layer === undefined) continue; // covered by the test above
+                const legal = (() => {
+                    switch (write.mode) {
+                        case "parse":
+                            return layer === "event" || hasException(writer, write);
+                        case "enrich":
+                            return layer === "event" && (ENRICHMENT_COLUMNS[write.table]?.length ?? 0) > 0;
+                        case "derive":
+                            return layer === "derived" || hasException(writer, write);
+                        case "bookkeep":
+                            return layer === "bookkeeping";
+                    }
+                })();
+                if (!legal) violations.push(`${writer}: ${write.mode} on ${write.table} (layer ${layer})`);
+            }
+        }
+        expect(violations).toEqual([]);
+    });
+
+    test("every exception is load-bearing - a declared write actually uses it", () => {
+        for (const exception of WRITE_MODE_EXCEPTIONS) {
+            const used = ALL_WRITERS.some(
+                (w) => w.writer === exception.writer
+                    && w.writes.some((write) => write.table === exception.table && write.mode === exception.mode),
+            );
+            expect(used, `stale exception: ${exception.writer} / ${exception.table} / ${exception.mode}`).toBe(true);
+        }
+    });
+
+    test("enrichment columns name real event-table columns", () => {
+        for (const [table, columns] of Object.entries(ENRICHMENT_COLUMNS)) {
+            expect(DUCKDB_TABLE_LAYERS.get(table), `${table} must be an event table to carry enrichment`).toBe("event");
+            expect(columns.length).toBeGreaterThan(0);
+            const ddlColumns = new Set(parseDuckdbColumns(table));
+            for (const column of columns) {
+                expect(ddlColumns.has(column), `${table}.${column} is not a DDL column`).toBe(true);
+            }
+        }
+    });
+
+    test("every enrichment-column table has a declared enrich writer", () => {
+        for (const table of Object.keys(ENRICHMENT_COLUMNS)) {
+            const hasWriter = ALL_WRITERS.some(
+                (w) => w.writes.some((write) => write.table === table && write.mode === "enrich"),
+            );
+            expect(hasWriter, `${table} is enumerated but nothing declares an enrich write on it`).toBe(true);
+        }
+    });
+
+    test("non-stage writer names are unique and do not collide with stage keys", () => {
+        const names = NON_STAGE_WRITERS.map((w) => w.writer);
+        expect(new Set(names).size).toBe(names.length);
+        const stageNames = new Set(ALL_STAGES.map((s) => `stage:${s.meta.key}`));
+        for (const name of names) {
+            expect(stageNames.has(name), `${name} collides with a stage writer id`).toBe(false);
+        }
+    });
+
+    /** Pins the exception list itself: growing it is a design decision made
+     *  in review, not a mechanical fix for a red test. */
+    test("the exception list stays enumerated", () => {
+        expect(WRITE_MODE_EXCEPTIONS.map((e) => `${e.writer}/${e.table}/${e.mode}`).sort()).toEqual([
+            "cli:ingest-insights/friction_event/parse",
+            "stage:session-health/session_token_usage/derive",
+            "stage:spawned/spawned/derive",
+        ]);
+    });
+});

--- a/apps/axctl/src/ingest/stage/table-writes.ts
+++ b/apps/axctl/src/ingest/stage/table-writes.ts
@@ -1,0 +1,199 @@
+// apps/axctl/src/ingest/stage/table-writes.ts
+/**
+ * The event-layer write contract (#893 slice 1, #897).
+ *
+ * Every DuckDB cache writer declares its writes as `TableWrite` rows
+ * ({ table, mode }) - stages on `StageMeta.writes`, everything else in
+ * `NON_STAGE_WRITERS` below. `table-writes.test.ts` checks each declared
+ * mode against the table's `layer` in `@ax/schema/duckdb-tables`:
+ *
+ *   parse    -> event tables only
+ *   enrich   -> event tables with a non-empty ENRICHMENT_COLUMNS entry
+ *   derive   -> derived tables, or an enumerated WRITE_MODE_EXCEPTIONS pair
+ *   bookkeep -> bookkeeping tables only
+ *
+ * The contract binds WRITES, not stage tags - the review round on #893
+ * proved tags do not map onto the layer boundary (the `subagents` stage is
+ * tagged derive but IS a parser; `usage`/`advice` are external-ledger
+ * loaders; `git` is tagged ingest but draws derived `produced` edges).
+ */
+import type { TableWrite } from "./types.ts";
+
+const w = (table: string, mode: TableWrite["mode"]): TableWrite => ({ table, mode });
+
+/**
+ * Tables reachable through `writeNormalizedTranscriptBatch`
+ * (ingest/normalized/transcripts.ts) + the evidence writers it calls. Every
+ * transcript provider shares this set; providers whose batches carry empty
+ * arrays for a family (e.g. opencode's `toolFileEvidence: []`) still declare
+ * the tables - the writer is reached, the row count happens to be zero.
+ */
+export const NORMALIZED_BATCH_WRITES: readonly TableWrite[] = [
+    w("session", "parse"),
+    w("agent_provider", "parse"),
+    w("agent_session", "parse"),
+    w("agent_event", "parse"),
+    w("agent_event_child", "parse"),
+    w("turn", "parse"),
+    w("tool", "parse"),
+    w("tool_call", "parse"),
+    w("file", "parse"),
+    w("edited", "parse"),
+    w("read_file", "parse"),
+    w("searched_file", "parse"),
+    w("skill", "parse"),
+    w("invoked", "parse"),
+    w("concerns", "parse"),
+    w("plan", "parse"),
+    w("plan_snapshot", "parse"),
+    w("plan_item", "parse"),
+    w("compaction", "parse"),
+];
+
+/** Watermark + heartbeat bookkeeping written by the shared jsonl work-unit
+ *  (ingest/jsonl-work-unit.ts). */
+export const JSONL_WORK_UNIT_WRITES: readonly TableWrite[] = [
+    w("ingest_file_state", "bookkeep"),
+    w("ingest_run", "bookkeep"),
+];
+
+/**
+ * Enumerated exceptions to the mode-vs-layer base rules - today's known
+ * cross-writes, legalized EXPLICITLY (#893 [R#3]) instead of smuggled.
+ * Adding a pair here is a design decision, not a fix for a failing test.
+ */
+export const WRITE_MODE_EXCEPTIONS: readonly {
+    readonly writer: string;
+    readonly table: string;
+    readonly mode: TableWrite["mode"];
+    readonly why: string;
+}[] = [
+    {
+        writer: "stage:spawned",
+        table: "spawned",
+        mode: "derive",
+        why: "derive-spawned inserts derived dispatch edges into the event table the subagents parser also writes - no single-writer assumption survives.",
+    },
+    {
+        writer: "stage:session-health",
+        table: "session_token_usage",
+        mode: "derive",
+        why: "session-health upserts ESTIMATED usage rows into the event table, read-modify-write preserving parsed actuals.",
+    },
+    {
+        writer: "cli:ingest-insights",
+        table: "friction_event",
+        mode: "parse",
+        why: "imported Claude usage-data friction lands in the derived table the signals stage wipes on full re-derive (pre-existing).",
+    },
+];
+
+/**
+ * Cache writers that live OUTSIDE the StageDef list (#893 [R#5]). Coarse
+ * grain: one entry per writer module/verb. Sidecar-only writers are not
+ * listed - the contract covers the DuckDB cache.
+ */
+export const NON_STAGE_WRITERS: readonly {
+    readonly writer: string;
+    readonly writes: readonly TableWrite[];
+}[] = [
+    {
+        // run.ts orchestration: run/stage/event telemetry (ingest/telemetry.ts,
+        // reap-runs.ts), the OTLP correlation pass (otel/correlate.ts), OTLP
+        // 30d retention (otel/retention.ts - a lifecycle delete by the same
+        // owner that loads the spool), and the `--reset` wipe-before-reparse.
+        writer: "ingest-run",
+        writes: [
+            w("ingest_run", "bookkeep"),
+            w("ingest_stage", "bookkeep"),
+            w("ingest_event", "bookkeep"),
+            w("telemetry_of", "derive"),
+            w("otel_metric_point", "parse"),
+            w("otel_span", "parse"),
+            w("otel_log_event", "parse"),
+            // --reset deletes: event tables ahead of a reparse...
+            w("invoked", "parse"),
+            w("concerns", "parse"),
+            w("skill", "parse"),
+            // ...and derived tables (always safe to wipe).
+            w("loaded", "derive"),
+            w("proposed", "derive"),
+            w("recovered_by", "derive"),
+            w("skill_paired", "derive"),
+        ],
+    },
+    {
+        // cli/commands/ingest.ts maintenance verbs: blob-GC afterWork,
+        // onTimeout stamp, `ax ingest reap`, telemetryStage for the
+        // derive-signals/insights verbs.
+        writer: "cli:ingest-maintenance",
+        writes: [w("ingest_run", "bookkeep"), w("ingest_stage", "bookkeep"), w("ingest_event", "bookkeep")],
+    },
+    {
+        // `ax ingest --dry-run` calibrates its ETA by running the claude and
+        // codex parsers over a capped file set - REAL writes (ingest/dry-run.ts).
+        writer: "cli:ingest-dry-run",
+        writes: [
+            ...NORMALIZED_BATCH_WRITES,
+            w("session_token_usage", "parse"),
+            w("turn_token_usage", "parse"),
+            w("harness_hook_event", "parse"),
+            w("hook_command_invocation", "parse"),
+            ...JSONL_WORK_UNIT_WRITES,
+        ],
+    },
+    {
+        // `ax sessions here|around|near` transcript auto-backfill
+        // (cli/commands/sessions.ts -> ingestTranscripts).
+        writer: "cli:sessions-backfill",
+        writes: [
+            ...NORMALIZED_BATCH_WRITES,
+            w("session_token_usage", "parse"),
+            w("turn_token_usage", "parse"),
+            w("harness_hook_event", "parse"),
+            w("hook_command_invocation", "parse"),
+            ...JSONL_WORK_UNIT_WRITES,
+        ],
+    },
+    {
+        // `ax derive-intents` (CLI-only, no stage): stamps turn.intent_kind.
+        writer: "cli:derive-intents",
+        writes: [w("turn", "enrich")],
+    },
+    {
+        // `ax ingest --insights-only` (ingest/claude-insights.ts): imports
+        // Claude usage-data facets; placeholder session rows for linkage.
+        writer: "cli:ingest-insights",
+        writes: [w("session", "parse"), w("insight", "parse"), w("concerns", "parse"), w("friction_event", "parse")],
+    },
+    {
+        // `ax wrapped publish` (dashboard/wrapped-cards.ts): replace-all of
+        // the agent-authored recap cards.
+        writer: "cli:wrapped-publish",
+        writes: [w("wrapped_card", "parse")],
+    },
+    {
+        // `ax skills reconcile|rm` / `ax agents reconcile|rm` catalog
+        // lifecycle (config-core/reconcile.ts three-pass tombstone).
+        writer: "cli:catalog-reconcile",
+        writes: [w("skill", "parse"), w("agent_def", "parse")],
+    },
+    {
+        // Classifier CLI writers: workflow-candidates apply, label-mining
+        // projectReviewed --apply, package-service execution plans.
+        writer: "cli:classifiers",
+        writes: [
+            w("classifier_graph_node", "derive"),
+            w("classifier_graph_edge", "derive"),
+            w("classifier_graph_fact", "derive"),
+            w("transcript_label_vector", "derive"),
+            w("cites_evidence", "derive"),
+        ],
+    },
+    {
+        // The seam's own open path (packages/lib/src/duckdb/seam.ts): DDL
+        // replay + COMMENT ON apply hash.
+        writer: "seam:open",
+        writes: [w("schema_comment_state", "bookkeep")],
+    },
+];

--- a/apps/axctl/src/ingest/stage/types.test.ts
+++ b/apps/axctl/src/ingest/stage/types.test.ts
@@ -25,8 +25,10 @@ describe("StageMeta", () => {
             key: "signals",
             deps: ["claude", "codex"],
             tags: ["derive"],
+            writes: [{ table: "corrected_by", mode: "derive" }],
         });
         expect(decoded.key).toBe("signals");
+        expect(decoded.writes[0]?.mode).toBe("derive");
     });
 });
 

--- a/apps/axctl/src/ingest/stage/types.ts
+++ b/apps/axctl/src/ingest/stage/types.ts
@@ -37,13 +37,46 @@ export const sinceDaysFromCtx = (ctx: IngestContext): number | undefined => {
     return days > 0 ? days : undefined;
 };
 
+/**
+ * How a writer touches one DuckDB cache table (#893 Phase 4 event-layer
+ * freeze). The MODE is the contract, checked against the table's `layer` in
+ * `@ax/schema/duckdb-tables` by `table-writes.test.ts`:
+ *
+ * - `parse`     - event rows written from OUTSIDE-WORLD bytes (transcripts,
+ *                 git, catalogs, spools, external ledgers). Legal only on
+ *                 `event`-layer tables. Covers the parser's own lifecycle
+ *                 UPDATEs/DELETEs on that table (reconcile tombstones,
+ *                 scoped replace) - they restate on-disk reality.
+ * - `enrich`    - UPDATE-ing an ENUMERATED set of derived columns on an
+ *                 event table (`ENRICHMENT_COLUMNS`). The named, permanent
+ *                 exception for derived-data-at-rest in event rows.
+ * - `derive`    - writing a `derived`-layer table from event rows (insert,
+ *                 update, or wipe - wiping derived tables is always safe).
+ *                 Also legal on an EVENT table only when the (writer, table)
+ *                 pair is enumerated in `DERIVED_ROW_WRITES_ON_EVENT_TABLES`.
+ * - `bookkeep`  - the store's own state (`bookkeeping` layer): watermarks,
+ *                 run/stage telemetry, sentinel markers.
+ */
+export const TableWriteMode = Schema.Literals(["parse", "enrich", "derive", "bookkeep"]);
+export type TableWriteMode = typeof TableWriteMode.Type;
+
+export const TableWrite = Schema.Struct({
+    table: Schema.String,
+    mode: TableWriteMode,
+});
+export type TableWrite = typeof TableWrite.Type;
+
 /** Declarative metadata for a stage. The `key` field is narrowed per stage at
  *  construction time; deps/tags reference Schema unions defined in
- *  `./registry.ts` and `./tags.ts`. */
+ *  `./registry.ts` and `./tags.ts`. `writes` declares every cache table the
+ *  stage (including its helpers) touches - the event-layer contract binds
+ *  WRITES, not tags (#893): a stage's ingest/derive TAG says where it runs in
+ *  the pipeline, while each TableWrite mode says what KIND of write it is. */
 export class StageMeta extends Schema.Class<StageMeta>("StageMeta")({
     key: Schema.String, // tightened at the registry level to IngestStageKey
     deps: Schema.Array(Schema.String),
     tags: Schema.Array(IngestStageTag),
+    writes: Schema.Array(TableWrite),
 }) {}
 
 /** A stage = metadata + a typed Effect runner. `R` is the union of Effect

--- a/apps/axctl/src/ingest/table-writes.behavior.test.ts
+++ b/apps/axctl/src/ingest/table-writes.behavior.test.ts
@@ -1,0 +1,185 @@
+// apps/axctl/src/ingest/table-writes.behavior.test.ts
+/**
+ * Behavioral half of the event-layer freeze enforcement (#893 slice 1,
+ * #897): run REGISTERED stages against a real temp DuckDB fixture and diff
+ * per-table CONTENT digests before/after. Any table whose digest changed
+ * must be declared in the stage's `meta.writes`.
+ *
+ * The digest is `bit_xor(hash(row))`, not a row count - the known
+ * undeclared-write failure modes are UPDATEs, which change no count [R#4]
+ * (pinned below by the invoked-positions case: count constant, hash moves).
+ *
+ * Coverage is a deliberate SUBSET: six stages whose fixtures are cheap,
+ * chosen to exercise each write mode (parse via the shared normalized batch,
+ * enrich via UPDATE stamping, derive, bookkeep) plus the
+ * session-health-writes-session_token_usage exception. The static test in
+ * stage/table-writes.test.ts covers every declaration; stages without a
+ * fixture here simply have no behavioral witness yet.
+ */
+import { describe, expect } from "bun:test";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { AxConfigTest } from "@ax/lib/config";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { DUCKDB_TABLE_LAYERS } from "@ax/schema/duckdb-tables";
+import { FixturePlatform, publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import type { StageDef } from "./stage/registry.ts";
+import { ALL_STAGES } from "./stage/registry.ts";
+import type { BaseStageStats } from "./stage/types.ts";
+import { IngestContext } from "./stage/types.ts";
+import { piStage } from "./pi.ts";
+import { invokedPositionsStage } from "./backfill-invoked-positions.ts";
+import { outcomesStage } from "./outcomes.ts";
+import { contentTypesStage } from "./derive-content-types.ts";
+import { sessionHealthStage } from "./session-health.ts";
+import { deriveMetricsStage } from "./derive-metrics.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("table-writes behavior", { requireFts: true });
+
+const ctx = IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
+
+type Digest = ReadonlyMap<string, string>;
+
+const digestAllTables = (write: CacheWriteService): Effect.Effect<Digest, unknown> =>
+    Effect.gen(function* () {
+        const digest = new Map<string, string>();
+        for (const table of DUCKDB_TABLE_LAYERS.keys()) {
+            const result = yield* write.raw(
+                `SELECT CAST(count(*) AS DOUBLE) AS n, CAST(coalesce(bit_xor(hash(t)), 0) AS VARCHAR) AS h FROM "${table}" AS t`,
+            );
+            const row = result.rows[0] as { n: number; h: string };
+            digest.set(table, `${row.n}:${row.h}`);
+        }
+        return digest;
+    });
+
+const changedTables = (before: Digest, after: Digest): readonly string[] =>
+    [...after.keys()].filter((table) => before.get(table) !== after.get(table));
+
+/** Run one registered stage inside a fresh fixture store and assert every
+ *  table whose content digest moved is declared in `meta.writes`. */
+const assertStageWrites = (
+    stage: StageDef<BaseStageStats, unknown, unknown>,
+    label: string,
+    seed: (write: CacheWriteService) => Effect.Effect<void, unknown, unknown>,
+    provide: <A, E>(effect: Effect.Effect<A, E, unknown>) => Effect.Effect<A, E, never>,
+): Promise<{ changed: readonly string[]; before: Digest; after: Digest }> => {
+    // Identity, not key equality: the descriptor exercised IS the registered one.
+    expect((ALL_STAGES as readonly unknown[]).includes(stage)).toBe(true);
+    let outcome: { changed: readonly string[]; before: Digest; after: Digest } | undefined;
+    return runWithPlatform(
+        publishCacheFixture(tempDir(`ax-tw-${label}-`), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* provide(seed(write));
+                const before = yield* digestAllTables(write);
+                yield* provide(stage.run(ctx, write));
+                const after = yield* digestAllTables(write);
+                const changed = changedTables(before, after);
+                const declared = new Set(stage.meta.writes.map((w) => w.table));
+                const undeclared = changed.filter((table) => !declared.has(table));
+                expect(undeclared, `${label}: undeclared writes`).toEqual([]);
+                outcome = { changed, before, after };
+            }),
+        ),
+    ).then(() => outcome!);
+};
+
+const provideFixture = (paths: Record<string, string>) =>
+    <A, E>(effect: Effect.Effect<A, E, unknown>): Effect.Effect<A, E, never> =>
+        effect.pipe(Effect.provide(AxConfigTest({ paths })), Effect.provide(FixturePlatform)) as Effect.Effect<A, E, never>;
+
+const provideNone = <A, E>(effect: Effect.Effect<A, E, unknown>): Effect.Effect<A, E, never> =>
+    effect.pipe(Effect.provide(FixturePlatform)) as Effect.Effect<A, E, never>;
+
+const noSeed = (_write: CacheWriteService) => Effect.void;
+
+const piLines = (id: string) => [
+    { type: "session", version: 3, id, timestamp: "2026-06-01T10:00:00Z", cwd: "/repo" },
+    { type: "message", id: `${id}-m1`, parentId: null, timestamp: "2026-06-01T10:00:01Z", message: { role: "user", content: [{ type: "text", text: "hello there" }] } },
+    { type: "message", id: `${id}-m2`, parentId: `${id}-m1`, timestamp: "2026-06-01T10:00:02Z", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+].map((row) => JSON.stringify(row)).join("\n");
+
+describe("event-layer write contract (behavioral)", () => {
+    dtest("pi stage (parse family): every touched table is declared", async () => {
+        const piDir = tempDir("ax-tw-pi-src-");
+        await Bun.write(join(piDir, "one.jsonl"), piLines("pi-tw-1"));
+        const { changed } = await assertStageWrites(piStage, "pi", noSeed, provideFixture({ piDir }));
+        // The fixture must actually exercise the parse path.
+        expect(changed).toContain("session");
+        expect(changed).toContain("turn");
+        expect(changed).toContain("ingest_file_state");
+    }, 60_000);
+
+    dtest("invoked-positions (enrich): UPDATE moves the digest at constant count", async () => {
+        const seed = (write: CacheWriteService) =>
+            Effect.gen(function* () {
+                yield* write.put("session", { id: "s1", source: "claude", started_at: new Date("2026-06-01T10:00:00Z") });
+                yield* write.put("turn", { id: "t1", session: "s1", role: "user", seq: 1, ts: new Date("2026-06-01T10:00:01Z") });
+                yield* write.put("skill", { id: "sk1", name: "demo-skill", scope: "user", dir_path: "/tmp/sk", content_hash: "h1" });
+                yield* write.put("invoked", { id: "inv1", in_id: "t1", out_id: "sk1", session: "s1", ts: new Date("2026-06-01T10:00:01Z") });
+            });
+        const { changed, before, after } = await assertStageWrites(
+            invokedPositionsStage, "invoked-positions", seed, provideNone,
+        );
+        expect(changed).toEqual(["invoked"]);
+        // The [R#4] pin: same row count, different content hash.
+        const [countBefore] = before.get("invoked")!.split(":");
+        const [countAfter] = after.get("invoked")!.split(":");
+        expect(countAfter).toBe(countBefore);
+    }, 60_000);
+
+    dtest("outcomes (derive): every touched table is declared", async () => {
+        const seed = (write: CacheWriteService) =>
+            Effect.gen(function* () {
+                yield* write.put("session", { id: "s1", source: "claude", started_at: new Date("2026-06-01T10:00:00Z") });
+                yield* write.put("tool", { id: "tool-bash", name: "Bash", kind: "cli" });
+                yield* write.put("tool_call", {
+                    id: "tc1", session: "s1", tool: "tool-bash", name: "Bash", seq: 1,
+                    ts: new Date("2026-06-01T10:00:02Z"), command_text: "bun test apps", exit_code: 0,
+                });
+            });
+        const { changed } = await assertStageWrites(outcomesStage, "outcomes", seed, provideNone);
+        expect(changed).toContain("command_outcome");
+    }, 60_000);
+
+    dtest("content-types (derive): every touched table is declared", async () => {
+        const seed = (write: CacheWriteService) =>
+            Effect.gen(function* () {
+                yield* write.put("session", { id: "s1", source: "claude", started_at: new Date("2026-06-01T10:00:00Z") });
+                yield* write.put("tool", { id: "tool-read", name: "Read", kind: "agent" });
+                yield* write.put("tool_call", {
+                    id: "tc1", session: "s1", tool: "tool-read", name: "Read", seq: 1,
+                    ts: new Date("2026-06-01T10:00:02Z"), output_json: JSON.stringify({ text: "file body" }),
+                });
+            });
+        const { changed } = await assertStageWrites(contentTypesStage, "content-types", seed, provideNone);
+        expect(changed).toContain("content_type");
+    }, 60_000);
+
+    dtest("session-health (derive incl. the session_token_usage exception)", async () => {
+        const seed = (write: CacheWriteService) =>
+            Effect.gen(function* () {
+                yield* write.put("session", { id: "s1", source: "claude", started_at: new Date("2026-06-01T10:00:00Z"), ended_at: new Date("2026-06-01T11:00:00Z") });
+                yield* write.put("turn", { id: "t1", session: "s1", role: "user", seq: 1, ts: new Date("2026-06-01T10:00:01Z"), text: "do the thing" });
+                yield* write.put("turn", { id: "t2", session: "s1", role: "assistant", seq: 2, ts: new Date("2026-06-01T10:00:05Z"), text: "done" });
+            });
+        const { changed } = await assertStageWrites(sessionHealthStage, "session-health", seed, provideNone);
+        expect(changed).toContain("session_health");
+    }, 60_000);
+
+    dtest("derive-metrics (derive + enrich cost backfill)", async () => {
+        const seed = (write: CacheWriteService) =>
+            Effect.gen(function* () {
+                yield* write.put("session", { id: "s1", source: "claude", started_at: new Date() });
+                yield* write.put("session_token_usage", {
+                    id: "usage-s1", session: "s1", source: "claude", model: "claude-opus-4-5",
+                    estimated_tokens: 1_000_000, transcript_bytes: 4_000_000,
+                });
+            });
+        const { changed } = await assertStageWrites(deriveMetricsStage, "derive-metrics", seed, provideNone);
+        expect(changed).toContain("session_metrics");
+        // The enrich write: cost backfill UPDATEs the seeded usage row.
+        expect(changed).toContain("session_token_usage");
+    }, 60_000);
+});

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -9,6 +9,7 @@ import { resolveSkillName } from "@ax/lib/skill-id";
 import { skillRowId } from "@ax/lib/stable-id";
 import { blobName, putBlobFromFile } from "@ax/lib/blob-store";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
+import { JSONL_WORK_UNIT_WRITES, NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
@@ -2048,7 +2049,19 @@ export class ClaudeStats extends BaseStageStats.extend<ClaudeStats>("ClaudeStats
 }) {}
 
 export const claudeStage: StageDef<ClaudeStats, AxConfig | FileSystem.FileSystem | Path.Path, DbError | CacheWriteError> = {
-    meta: StageMeta.make({ key: "claude", deps: ["skills", "commands"], tags: ["ingest"] }),
+    meta: StageMeta.make({
+        key: "claude",
+        deps: ["skills", "commands"],
+        tags: ["ingest"],
+        writes: [
+            ...NORMALIZED_BATCH_WRITES,
+            { table: "session_token_usage", mode: "parse" },
+            { table: "turn_token_usage", mode: "parse" },
+            { table: "harness_hook_event", mode: "parse" },
+            { table: "hook_command_invocation", mode: "parse" },
+            ...JSONL_WORK_UNIT_WRITES,
+        ],
+    }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/turn-analysis.ts
+++ b/apps/axctl/src/ingest/turn-analysis.ts
@@ -583,7 +583,17 @@ export class TurnAnalysisStageStats extends BaseStageStats.extend<TurnAnalysisSt
 }) {}
 
 export const turnAnalysisStage: StageDef<TurnAnalysisStageStats, never, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "turn-analysis", deps: ["outcomes"], tags: ["derive"] }),
+    meta: StageMeta.make({
+        key: "turn-analysis",
+        deps: ["outcomes"],
+        tags: ["derive"],
+        writes: [
+            { table: "turn_analysis", mode: "derive" },
+            { table: "semantic_signal", mode: "derive" },
+            { table: "expresses", mode: "derive" },
+            { table: "reacts_to", mode: "derive" },
+        ],
+    }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/turn-content-blocks.ts
+++ b/apps/axctl/src/ingest/turn-content-blocks.ts
@@ -187,6 +187,11 @@ export const turnContentBlocksStage: StageDef<TurnContentBlocksStageStats, never
         key: "turn-content-blocks",
         deps: ["claude", "codex", "pi", "omp", "opencode", "cursor"],
         tags: ["derive"],
+        writes: [
+            { table: "content_document", mode: "derive" },
+            { table: "content_block", mode: "derive" },
+            { table: "content_atom", mode: "derive" },
+        ],
     }),
     run: (ctx: IngestContext, write) =>
         Effect.gen(function* () {

--- a/apps/axctl/src/usage/usage-stage.ts
+++ b/apps/axctl/src/usage/usage-stage.ts
@@ -44,7 +44,10 @@ export class UsageStats extends BaseStageStats.extend<UsageStats>("UsageStats")(
 }) {}
 
 export const usageStage: StageDef<UsageStats, never, CacheWriteError> = {
-  meta: StageMeta.make({ key: "usage", deps: [], tags: ["derive"] }),
+  // Tagged derive for pipeline placement, but it is an external-ledger
+  // LOADER (parse): it drains + truncates the usage log, so these cache rows
+  // are the only durable copy (#893).
+  meta: StageMeta.make({ key: "usage", deps: [], tags: ["derive"], writes: [{ table: "ax_invocation", mode: "parse" }] }),
   run: (_ctx: IngestContext, write) =>
     Effect.gen(function* () {
       const t0 = Date.now();

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -4,6 +4,27 @@
  *  `ax insights schema` view can adopt it in wave 2. Exported, NOT wired. */
 import { DUCKDB_TABLE_NAMES } from "./parse-duckdb-schema.ts";
 
+/**
+ * The event-layer freeze (#893). Every cache table belongs to exactly one
+ * layer, and the layer - not a stage's ingest/derive TAG - is what the write
+ * contract checks against (apps/axctl/src/ingest/stage/table-writes.ts):
+ *
+ * - `event`       - written from OUTSIDE-WORLD bytes: transcripts, git, the
+ *                   skills catalog, the OTLP spool, external ledgers, hook
+ *                   configs, the GitHub API. The source of truth. NOTE the
+ *                   definition is "written from outside bytes", NOT
+ *                   "re-readable from the world": some loaders CONSUME their
+ *                   source (the usage stage truncates its log; OTLP retention
+ *                   prunes), so for those the cache row is the only durable
+ *                   copy - which makes them MORE event-like, not less.
+ * - `derived`     - written by a derive from event-layer (or sidecar) rows,
+ *                   rebuildable with no disk access. Wiping every `derived`
+ *                   table is always safe.
+ * - `bookkeeping` - the store's own state: watermarks, run/stage telemetry,
+ *                   schema-comment state.
+ */
+export type DuckdbTableLayer = "event" | "derived" | "bookkeeping";
+
 export interface DuckdbTableSpec {
     readonly table: string;
     readonly kind: "node" | "edge";
@@ -20,6 +41,10 @@ export interface DuckdbTableSpec {
      * in ./sidecar-tables.ts). Every table in THIS manifest is rebuildable.
      */
     readonly stage: "active" | "conditional" | "staged";
+    /** Event-layer classification (#893) - see {@link DuckdbTableLayer}. For
+     *  `staged` (reserved) tables the layer records intent; nothing writes
+     *  them, so no enforcement rides on it yet. */
+    readonly layer: DuckdbTableLayer;
     readonly note: string;
 }
 
@@ -29,7 +54,7 @@ export interface DuckdbTableSpec {
 // elsewhere would have been a second source of truth for the boundary.
 
 /**
- * Hand-authored editorial metadata (kind/stage/note) keyed by table name -
+ * Hand-authored editorial metadata (kind/stage/layer/note) keyed by table name -
  * real content the DDL itself does not carry, so it stays hand-maintained.
  * The exported `DUCKDB_SCHEMA_TABLES` manifest below is DERIVED from
  * `DUCKDB_TABLE_NAMES` (the parsed DDL), not from this map's own keys, so a
@@ -38,132 +63,160 @@ export interface DuckdbTableSpec {
  * silently drifting until a test happens to catch it.
  */
 const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> = {
-    skill: { kind: "node", stage: "active", note: "Installed skills and slash commands. SEMANTICS (P2-2): ingested_at used Surreal `VALUE time::now()`, not a DEFAULT - the writer must stamp CURRENT_TIMESTAMP on every insert AND update, since DuckDB DEFAULT only fires on an omitted-column insert." },
-    skill_revision: { kind: "node", stage: "active", note: "Append-only skill content-change log (drift over time). SEMANTICS (P2-2): `ts` used Surreal `VALUE time::now()` - the writer must stamp CURRENT_TIMESTAMP on every write, not rely on the DuckDB DEFAULT." },
-    agent_def: { kind: "node", stage: "active", note: "Agent definition files (~/.claude/agents) with reconcile lifecycle. SEMANTICS (P2-2): ingested_at used Surreal `VALUE time::now()` - the writer must stamp CURRENT_TIMESTAMP on every write, not rely on the DuckDB DEFAULT." },
-    session: { kind: "node", stage: "active", note: "Transcript sessions across all 6 harnesses: Claude Code, Codex, Pi, oh-my-pi/OMP, OpenCode, and Cursor." },
-    claude_sidecar_artifact: { kind: "node", stage: "active", note: "Metadata-only Claude project sidecars linked to sessions when safe." },
-    used_sidecar_artifact: { kind: "edge", stage: "active", note: "Tool calls that produced, read, searched, or inspected Claude sidecar artifacts." },
-    agent_provider: { kind: "node", stage: "active", note: "Agent transcript provider identities." },
-    agent_model: { kind: "node", stage: "active", note: "Agent model catalogue with pricing and context metadata." },
-    agent_session: { kind: "node", stage: "active", note: "Provider-native session rows linked to normalized sessions." },
-    agent_event: { kind: "node", stage: "active", note: "Provider-native event stream rows." },
-    turn: { kind: "node", stage: "active", note: "Transcript turns and tool result turns." },
-    file: { kind: "node", stage: "active", note: "Canonical repository-relative files plus legacy file rows." },
-    symbol: { kind: "node", stage: "staged", note: "Reserved symbol mention catalogue for code-context queries." },
-    error_signature: { kind: "node", stage: "staged", note: "Reserved normalized error signatures for recurrence queries." },
-    commit: { kind: "node", stage: "active", note: "Git commits imported from tracked repositories." },
-    repository: { kind: "node", stage: "active", note: "Stable repository identities, preferring normalized remotes." },
-    checkout: { kind: "node", stage: "active", note: "Local checkout/worktree paths for repositories." },
-    workspace: { kind: "node", stage: "staged", note: "Reserved for cross-checkout workspace grouping." },
-    tool: { kind: "node", stage: "active", note: "Normalized CLI, MCP, and agent tool identities." },
-    tool_call: { kind: "node", stage: "active", note: "Tool calls with errors and command fields, from Claude Code, Codex, Pi, OMP, OpenCode, and Cursor." },
-    content_type: { kind: "node", stage: "active", note: "Closed content-type taxonomy for tool outputs." },
-    has_content: { kind: "edge", stage: "active", note: "tool_call -> content_type edge; denormalizes session + bytes." },
-    plan: { kind: "node", stage: "active", note: "Current plan state per session/source." },
-    plan_item: { kind: "node", stage: "active", note: "Latest stable plan items for each plan." },
-    artifact: { kind: "node", stage: "active", note: "Generated reports, dogfood artifacts, and guidance evidence." },
-    content_document: { kind: "node", stage: "active", note: "Parsed document containers for markdown artifacts and plans." },
-    content_block: { kind: "node", stage: "active", note: "Searchable markdown block chunks with source offsets." },
-    content_atom: { kind: "node", stage: "active", note: "Fine-grained parsed document facts and evidence atoms." },
-    mentions_file: { kind: "edge", stage: "active", note: "Content atom to file mention edges." },
-    mentions_commit: { kind: "edge", stage: "active", note: "Content atom to commit mention edges." },
-    mentions_artifact: { kind: "edge", stage: "active", note: "Content atom to artifact mention edges." },
-    plan_snapshot: { kind: "node", stage: "active", note: "Point-in-time TodoWrite/update_plan snapshots." },
-    compaction: { kind: "node", stage: "active", note: "Context-compaction events per harness (summarize/history-replacement/encrypted)." },
-    insight: { kind: "node", stage: "active", note: "Imported Claude usage-data insight facets." },
-    friction_event: { kind: "node", stage: "active", note: "Tool failures, imported insight friction, and derived friction." },
-    turn_analysis: { kind: "node", stage: "active", note: "Per-turn message analysis for sparse user feedback and assistant behavior." },
-    reaction_event: { kind: "node", stage: "active", note: "Context-aware user reaction events built from prior assistant/tool context." },
-    classifier_definition: { kind: "node", stage: "active", note: "Installed classifier definitions and declared label/target contracts." },
-    classifier_run: { kind: "node", stage: "active", note: "Classifier execution runs over transcript event windows." },
-    classifier_result: { kind: "node", stage: "active", note: "Versioned classifier labels attached to turns and other subjects." },
-    classifier_graph_node: { kind: "node", stage: "active", note: "Generic classifier graph nodes projected from package operations." },
-    classifier_graph_edge: { kind: "node", stage: "active", note: "Generic classifier graph edges projected from package operations." },
-    classifier_graph_fact: { kind: "node", stage: "active", note: "Generic classifier graph facts projected from package operations." },
-    transcript_label_vector: { kind: "node", stage: "active", note: "Embedding vectors and nearest-neighbor refs for transcript label candidates." },
-    semantic_signal: { kind: "node", stage: "active", note: "Reusable meanings promoted from analyzed turns." },
-    diagnostic_event: { kind: "node", stage: "active", note: "Derived diagnostics from failed commands and friction." },
-    guidance: { kind: "node", stage: "staged", note: "Persisted behavior controls such as rules, skills, hooks, and commands." },
-    guidance_version: { kind: "node", stage: "staged", note: "Legacy guidance history table kept until migration to guidance_revision." },
-    guidance_source: { kind: "node", stage: "active", note: "Observed repo-local and global storage authorities for Guidance." },
-    guidance_revision: { kind: "node", stage: "active", note: "Content-hashed observed Guidance revisions with evidence strength." },
-    guidance_config_artifact: { kind: "node", stage: "active", note: "Metadata-only inventory of provider guidance/config artifacts." },
-    stack: { kind: "node", stage: "active", note: "Lean technology/platform records for applicability matching." },
-    command_outcome: { kind: "node", stage: "active", note: "Semantic command result classifications." },
-    user_message_ngram: { kind: "node", stage: "active", note: "Derived user-language n-grams for preference and correction mining." },
-    workflow_epoch: { kind: "node", stage: "active", note: "Derived workflow eras for before/after comparisons." },
-    session_token_usage: { kind: "node", stage: "active", note: "Actual or estimated session token/cache usage." },
-    turn_token_usage: { kind: "node", stage: "active", note: "Provider-derived per-turn token/cache usage and priced cost estimates." },
-    session_health: { kind: "node", stage: "active", note: "Derived session-level workflow, context, and interruption health." },
-    session_metrics: { kind: "node", stage: "active", note: "Graph-derived per-session metrics (durability, time-to-land, loc)." },
-    fragility_cascade: { kind: "node", stage: "active", note: "Precomputed cross-session fragility-cascade signal edges (origin session -> downstream fixer)." },
-    commit_classification: { kind: "node", stage: "active", note: "Commit message lifecycle classification." },
-    branch: { kind: "node", stage: "conditional", note: "GitHub branch state for delivery analytics; written by the github-pr stage (apps/axctl/src/ingest/github-pr-stage.ts, in ALL_STAGES) only for repos with a GitHub remote and a working `gh` CLI - silently skipped otherwise." },
-    pull_request: { kind: "node", stage: "conditional", note: "GitHub pull request state for delivery analytics; same gh/GitHub-remote gating as `branch`." },
-    review_event: { kind: "node", stage: "conditional", note: "GitHub review events for delivery analytics; same gh/GitHub-remote gating as `branch`." },
-    check_run: { kind: "node", stage: "conditional", note: "GitHub check runs for delivery analytics; same gh/GitHub-remote gating as `branch`." },
-    delivery_outcome: { kind: "node", stage: "conditional", note: "Session delivery/promotion outcome summaries, written by apps/axctl/src/ingest/github-pr-write.ts under the same gh/GitHub-remote gating as `branch`." },
-    workflow_snapshot: { kind: "node", stage: "active", note: "Precomputed dashboard workflow payload used by /api/workflow." },
-    phase_span: { kind: "node", stage: "staged", note: "Session workflow phase spans and phase-level counters." },
-    skill_candidate: { kind: "node", stage: "active", note: "Evidence-backed candidate skills or guardrails." },
-    schema_comment_state: { kind: "node", stage: "active", note: "Self-documenting catalog bookkeeping (#869): hash of the last-applied COMMENT ON script, so routine opens skip re-applying (WAL crash-safety)." },
-    ingest_run: { kind: "node", stage: "active", note: "Top-level ingest execution telemetry." },
-    ingest_stage: { kind: "node", stage: "active", note: "Per-stage ingest execution telemetry." },
-    ingest_event: { kind: "node", stage: "active", note: "Append-like ingest progress events." },
-    query_sample: { kind: "node", stage: "staged", note: "Reserved query execution samples." },
-    graph_health_check: { kind: "node", stage: "staged", note: "Persisted graph health check rows." },
-    invoked: { kind: "edge", stage: "active", note: "Turn-to-skill invocation edges." },
-    loaded: { kind: "edge", stage: "active", note: "Session-to-skill auto-load activations (subagent skills: frontmatter); separate from invoked." },
-    proposed: { kind: "edge", stage: "active", note: "Skills mentioned but not invoked." },
-    edited: { kind: "edge", stage: "active", note: "Turn-to-file edit edges." },
-    mentioned_file: { kind: "edge", stage: "staged", note: "Reserved turn-to-file mention edges." },
-    mentioned_symbol: { kind: "edge", stage: "staged", note: "Reserved turn-to-symbol mention edges." },
-    mentioned_error: { kind: "edge", stage: "staged", note: "Reserved turn-to-error mention edges." },
-    read_file: { kind: "edge", stage: "active", note: "Tool-call-to-file read evidence edges, written by apps/axctl/src/ingest/evidence-writers.ts." },
-    searched_file: { kind: "edge", stage: "active", note: "Tool-call-to-file search evidence edges, written by apps/axctl/src/ingest/evidence-writers.ts." },
-    corrected_by: { kind: "edge", stage: "active", note: "Assistant turns followed by user correction signals." },
-    expresses: { kind: "edge", stage: "active", note: "Turn-to-semantic-signal evidence edges." },
-    reacts_to: { kind: "edge", stage: "active", note: "User reaction turns linked to the prior assistant turn they approve, reject, or revise." },
-    has_classification: { kind: "edge", stage: "active", note: "Turn-to-classifier-result edges for versioned labels." },
-    produced: { kind: "edge", stage: "active", note: "Session-to-commit edges." },
-    touched: { kind: "edge", stage: "active", note: "Commit-to-file edges with additions/deletions/status." },
-    later_fixed_by: { kind: "edge", stage: "active", note: "Feature commit to later overlapping fix commit relation." },
-    suggests_skill: { kind: "edge", stage: "active", note: "Fix or evidence commit to skill candidate relation." },
-    has_checkout: { kind: "edge", stage: "active", note: "Repository-to-checkout edges." },
-    concerns: { kind: "edge", stage: "active", note: "Generic evidence edges, currently used for tool/skill and insight/session links." },
-    resulted_in: { kind: "edge", stage: "staged", note: "Reserved generic outcome relation." },
-    produced_artifact: { kind: "edge", stage: "staged", note: "Reserved producer-to-artifact relation." },
-    has_artifact: { kind: "edge", stage: "staged", note: "Reserved owner-to-artifact relation." },
-    derived_from: { kind: "edge", stage: "active", note: "Provenance relation for derived guidance and artifacts." },
-    skill_paired: { kind: "edge", stage: "active", note: "Derived skill co-occurrence edges." },
-    recovered_by: { kind: "edge", stage: "active", note: "Derived recovery edges after an error turn." },
-    spawned: { kind: "edge", stage: "active", note: "Parent-to-child delegated session edges." },
-    advice: { kind: "node", stage: "active", note: "Hook advice ledger rows from ~/.ax/hooks/advise-log.jsonl (route-dispatch additionalContext)." },
-    agent_event_child: { kind: "edge", stage: "active", note: "Provider-event parent-child edges." },
-    used_model: { kind: "edge", stage: "active", note: "Session-to-agent-model usage edges." },
-    agent_used_model: { kind: "edge", stage: "active", note: "Provider-session-to-agent-model usage edges." },
-    harness_hook_event: { kind: "node", stage: "active", note: "Native agent harness hook lifecycle events." },
-    hook_command_invocation: { kind: "node", stage: "active", note: "Commands invoked by native harness hooks." },
-    ax_invocation: { kind: "node", stage: "active", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
-    feedback_case_type: { kind: "node", stage: "active", note: "Feedback backtest case definitions." },
-    feedback_case_result: { kind: "node", stage: "active", note: "Feedback backtest results." },
-    hook_fire: { kind: "node", stage: "active", note: "Runtime file-context hook decisions." },
-    directive_ngram: { kind: "node", stage: "active", note: "Per-user n-gram lift table: which user-turn markers predict captured outcomes (directive mining v2, #587)." },
-    cites_evidence: { kind: "edge", stage: "active", note: "Proposal-to-evidence edges." },
-    opportunity: { kind: "edge", stage: "active", note: "Experiment trigger recurrence evidence edges." },
-    reviewed: { kind: "edge", stage: "active", note: "Session-to-retro review edges." },
-    ingest_file_state: { kind: "node", stage: "active", note: "Per-source ingest watermark (mtime/size/sha) for skip-unchanged re-ingest." },
-    otel_metric_point: { kind: "node", stage: "active", note: "Harness OTLP metric data points (cost/token/usage)." },
-    otel_span: { kind: "node", stage: "active", note: "Harness OTLP trace spans from generic OTLP span sources; Codex does NOT populate this table - it emits OTLP logs, not spans (see apps/axctl/src/otel/install-config.ts, [otel] exporter targets /v1/logs)." },
-    otel_log_event: { kind: "node", stage: "active", note: "Harness OTLP log events (codex events incl. token usage)." },
-    harness_tool_event: { kind: "node", stage: "active", note: "Shared tool decision/result projection from transcript, hooks, and OTLP events." },
-    harness_run_context: { kind: "node", stage: "active", note: "Shared run context projection from transcript and OTLP startup events." },
-    wrapped_card: { kind: "node", stage: "active", note: "Agent-authored Wrapped recap cards (ax wrapped publish)." },
-    telemetry_of: { kind: "edge", stage: "active", note: "Edge: session -> otel telemetry row (drawn at ingest)." },
-    run_evidence_event: { kind: "node", stage: "active", note: "Run evidence ledger (#578): normalized claim/observation/verification/boundary events over the graph; backing distinguishes model claim vs tool-backed." },
-    run_evidence_ref: { kind: "node", stage: "active", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
-    cache_bust_event: { kind: "node", stage: "active", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
+    skill: { kind: "node", stage: "active", layer: "event", note: "Installed skills and slash commands. SEMANTICS (P2-2): ingested_at used Surreal `VALUE time::now()`, not a DEFAULT - the writer must stamp CURRENT_TIMESTAMP on every insert AND update, since DuckDB DEFAULT only fires on an omitted-column insert." },
+    skill_revision: { kind: "node", stage: "active", layer: "event", note: "Append-only skill content-change log (drift over time). SEMANTICS (P2-2): `ts` used Surreal `VALUE time::now()` - the writer must stamp CURRENT_TIMESTAMP on every write, not rely on the DuckDB DEFAULT." },
+    agent_def: { kind: "node", stage: "active", layer: "event", note: "Agent definition files (~/.claude/agents) with reconcile lifecycle. SEMANTICS (P2-2): ingested_at used Surreal `VALUE time::now()` - the writer must stamp CURRENT_TIMESTAMP on every write, not rely on the DuckDB DEFAULT." },
+    session: { kind: "node", stage: "active", layer: "event", note: "Transcript sessions across all 6 harnesses: Claude Code, Codex, Pi, oh-my-pi/OMP, OpenCode, and Cursor." },
+    claude_sidecar_artifact: { kind: "node", stage: "active", layer: "event", note: "Metadata-only Claude project sidecars linked to sessions when safe." },
+    used_sidecar_artifact: { kind: "edge", stage: "active", layer: "event", note: "Tool calls that produced, read, searched, or inspected Claude sidecar artifacts." },
+    agent_provider: { kind: "node", stage: "active", layer: "event", note: "Agent transcript provider identities." },
+    agent_model: { kind: "node", stage: "active", layer: "event", note: "Agent model catalogue with pricing and context metadata." },
+    agent_session: { kind: "node", stage: "active", layer: "event", note: "Provider-native session rows linked to normalized sessions." },
+    agent_event: { kind: "node", stage: "active", layer: "event", note: "Provider-native event stream rows." },
+    turn: { kind: "node", stage: "active", layer: "event", note: "Transcript turns and tool result turns." },
+    file: { kind: "node", stage: "active", layer: "event", note: "Canonical repository-relative files plus legacy file rows." },
+    symbol: { kind: "node", stage: "staged", layer: "derived", note: "Reserved symbol mention catalogue for code-context queries." },
+    error_signature: { kind: "node", stage: "staged", layer: "derived", note: "Reserved normalized error signatures for recurrence queries." },
+    commit: { kind: "node", stage: "active", layer: "event", note: "Git commits imported from tracked repositories." },
+    repository: { kind: "node", stage: "active", layer: "event", note: "Stable repository identities, preferring normalized remotes." },
+    checkout: { kind: "node", stage: "active", layer: "event", note: "Local checkout/worktree paths for repositories." },
+    workspace: { kind: "node", stage: "staged", layer: "derived", note: "Reserved for cross-checkout workspace grouping." },
+    tool: { kind: "node", stage: "active", layer: "event", note: "Normalized CLI, MCP, and agent tool identities." },
+    tool_call: { kind: "node", stage: "active", layer: "event", note: "Tool calls with errors and command fields, from Claude Code, Codex, Pi, OMP, OpenCode, and Cursor." },
+    content_type: { kind: "node", stage: "active", layer: "derived", note: "Closed content-type taxonomy for tool outputs." },
+    has_content: { kind: "edge", stage: "active", layer: "derived", note: "tool_call -> content_type edge; denormalizes session + bytes." },
+    plan: { kind: "node", stage: "active", layer: "event", note: "Current plan state per session/source." },
+    plan_item: { kind: "node", stage: "active", layer: "event", note: "Latest stable plan items for each plan." },
+    artifact: { kind: "node", stage: "active", layer: "event", note: "Generated reports, dogfood artifacts, and guidance evidence." },
+    content_document: { kind: "node", stage: "active", layer: "derived", note: "Parsed document containers for markdown artifacts and plans." },
+    content_block: { kind: "node", stage: "active", layer: "derived", note: "Searchable markdown block chunks with source offsets." },
+    content_atom: { kind: "node", stage: "active", layer: "derived", note: "Fine-grained parsed document facts and evidence atoms." },
+    mentions_file: { kind: "edge", stage: "active", layer: "derived", note: "Content atom to file mention edges." },
+    mentions_commit: { kind: "edge", stage: "active", layer: "derived", note: "Content atom to commit mention edges." },
+    mentions_artifact: { kind: "edge", stage: "active", layer: "derived", note: "Content atom to artifact mention edges." },
+    plan_snapshot: { kind: "node", stage: "active", layer: "event", note: "Point-in-time TodoWrite/update_plan snapshots." },
+    compaction: { kind: "node", stage: "active", layer: "event", note: "Context-compaction events per harness (summarize/history-replacement/encrypted)." },
+    insight: { kind: "node", stage: "active", layer: "event", note: "Imported Claude usage-data insight facets." },
+    friction_event: { kind: "node", stage: "active", layer: "derived", note: "Tool failures, imported insight friction, and derived friction. LAYER NOTE (#893): classified derived because the signals stage wipes + re-derives it, but the `ax ingest --insights-only` loader also parses IMPORTED rows into it - an enumerated exception in WRITE_MODE_EXCEPTIONS; a full signals re-derive drops the imported rows (pre-existing behavior)." },
+    turn_analysis: { kind: "node", stage: "active", layer: "derived", note: "Per-turn message analysis for sparse user feedback and assistant behavior." },
+    reaction_event: { kind: "node", stage: "active", layer: "derived", note: "Context-aware user reaction events built from prior assistant/tool context." },
+    classifier_definition: { kind: "node", stage: "active", layer: "derived", note: "Installed classifier definitions and declared label/target contracts." },
+    classifier_run: { kind: "node", stage: "active", layer: "derived", note: "Classifier execution runs over transcript event windows." },
+    classifier_result: { kind: "node", stage: "active", layer: "derived", note: "Versioned classifier labels attached to turns and other subjects." },
+    classifier_graph_node: { kind: "node", stage: "active", layer: "derived", note: "Generic classifier graph nodes projected from package operations." },
+    classifier_graph_edge: { kind: "node", stage: "active", layer: "derived", note: "Generic classifier graph edges projected from package operations." },
+    classifier_graph_fact: { kind: "node", stage: "active", layer: "derived", note: "Generic classifier graph facts projected from package operations." },
+    transcript_label_vector: { kind: "node", stage: "active", layer: "derived", note: "Embedding vectors and nearest-neighbor refs for transcript label candidates." },
+    semantic_signal: { kind: "node", stage: "active", layer: "derived", note: "Reusable meanings promoted from analyzed turns." },
+    diagnostic_event: { kind: "node", stage: "active", layer: "derived", note: "Derived diagnostics from failed commands and friction." },
+    guidance: { kind: "node", stage: "staged", layer: "event", note: "Persisted behavior controls such as rules, skills, hooks, and commands." },
+    guidance_version: { kind: "node", stage: "staged", layer: "event", note: "Legacy guidance history table kept until migration to guidance_revision." },
+    guidance_source: { kind: "node", stage: "active", layer: "event", note: "Observed repo-local and global storage authorities for Guidance." },
+    guidance_revision: { kind: "node", stage: "active", layer: "event", note: "Content-hashed observed Guidance revisions with evidence strength." },
+    guidance_config_artifact: { kind: "node", stage: "active", layer: "event", note: "Metadata-only inventory of provider guidance/config artifacts." },
+    stack: { kind: "node", stage: "active", layer: "event", note: "Lean technology/platform records for applicability matching." },
+    command_outcome: { kind: "node", stage: "active", layer: "derived", note: "Semantic command result classifications." },
+    user_message_ngram: { kind: "node", stage: "active", layer: "derived", note: "Derived user-language n-grams for preference and correction mining." },
+    workflow_epoch: { kind: "node", stage: "active", layer: "derived", note: "Derived workflow eras for before/after comparisons." },
+    session_token_usage: { kind: "node", stage: "active", layer: "event", note: "Actual or estimated session token/cache usage. LAYER NOTE (#893): event (actuals parsed from transcripts), with two enumerated derived writers - session-health upserts ESTIMATED rows (WRITE_MODE_EXCEPTIONS) and derive-metrics backfills cost columns (ENRICHMENT_COLUMNS)." },
+    turn_token_usage: { kind: "node", stage: "active", layer: "event", note: "Provider-derived per-turn token/cache usage and priced cost estimates." },
+    session_health: { kind: "node", stage: "active", layer: "derived", note: "Derived session-level workflow, context, and interruption health." },
+    session_metrics: { kind: "node", stage: "active", layer: "derived", note: "Graph-derived per-session metrics (durability, time-to-land, loc)." },
+    fragility_cascade: { kind: "node", stage: "active", layer: "derived", note: "Precomputed cross-session fragility-cascade signal edges (origin session -> downstream fixer)." },
+    commit_classification: { kind: "node", stage: "active", layer: "derived", note: "Commit message lifecycle classification." },
+    branch: { kind: "node", stage: "conditional", layer: "event", note: "GitHub branch state for delivery analytics; written by the github-pr stage (apps/axctl/src/ingest/github-pr-stage.ts, in ALL_STAGES) only for repos with a GitHub remote and a working `gh` CLI - silently skipped otherwise." },
+    pull_request: { kind: "node", stage: "conditional", layer: "event", note: "GitHub pull request state for delivery analytics; same gh/GitHub-remote gating as `branch`." },
+    review_event: { kind: "node", stage: "conditional", layer: "event", note: "GitHub review events for delivery analytics; same gh/GitHub-remote gating as `branch`." },
+    check_run: { kind: "node", stage: "conditional", layer: "event", note: "GitHub check runs for delivery analytics; same gh/GitHub-remote gating as `branch`." },
+    delivery_outcome: { kind: "node", stage: "conditional", layer: "event", note: "Session delivery/promotion outcome summaries, written by apps/axctl/src/ingest/github-pr-write.ts under the same gh/GitHub-remote gating as `branch`." },
+    workflow_snapshot: { kind: "node", stage: "active", layer: "derived", note: "Precomputed dashboard workflow payload used by /api/workflow." },
+    phase_span: { kind: "node", stage: "staged", layer: "derived", note: "Session workflow phase spans and phase-level counters." },
+    skill_candidate: { kind: "node", stage: "active", layer: "derived", note: "Evidence-backed candidate skills or guardrails." },
+    schema_comment_state: { kind: "node", stage: "active", layer: "bookkeeping", note: "Self-documenting catalog bookkeeping (#869): hash of the last-applied COMMENT ON script, so routine opens skip re-applying (WAL crash-safety)." },
+    ingest_run: { kind: "node", stage: "active", layer: "bookkeeping", note: "Top-level ingest execution telemetry." },
+    ingest_stage: { kind: "node", stage: "active", layer: "bookkeeping", note: "Per-stage ingest execution telemetry." },
+    ingest_event: { kind: "node", stage: "active", layer: "bookkeeping", note: "Append-like ingest progress events." },
+    query_sample: { kind: "node", stage: "staged", layer: "bookkeeping", note: "Reserved query execution samples." },
+    graph_health_check: { kind: "node", stage: "staged", layer: "bookkeeping", note: "Persisted graph health check rows." },
+    invoked: { kind: "edge", stage: "active", layer: "event", note: "Turn-to-skill invocation edges." },
+    loaded: { kind: "edge", stage: "active", layer: "derived", note: "Session-to-skill auto-load activations (subagent skills: frontmatter); separate from invoked." },
+    proposed: { kind: "edge", stage: "active", layer: "derived", note: "Skills mentioned but not invoked." },
+    edited: { kind: "edge", stage: "active", layer: "event", note: "Turn-to-file edit edges." },
+    mentioned_file: { kind: "edge", stage: "staged", layer: "event", note: "Reserved turn-to-file mention edges." },
+    mentioned_symbol: { kind: "edge", stage: "staged", layer: "derived", note: "Reserved turn-to-symbol mention edges." },
+    mentioned_error: { kind: "edge", stage: "staged", layer: "derived", note: "Reserved turn-to-error mention edges." },
+    read_file: { kind: "edge", stage: "active", layer: "event", note: "Tool-call-to-file read evidence edges, written by apps/axctl/src/ingest/evidence-writers.ts." },
+    searched_file: { kind: "edge", stage: "active", layer: "event", note: "Tool-call-to-file search evidence edges, written by apps/axctl/src/ingest/evidence-writers.ts." },
+    corrected_by: { kind: "edge", stage: "active", layer: "derived", note: "Assistant turns followed by user correction signals." },
+    expresses: { kind: "edge", stage: "active", layer: "derived", note: "Turn-to-semantic-signal evidence edges." },
+    reacts_to: { kind: "edge", stage: "active", layer: "derived", note: "User reaction turns linked to the prior assistant turn they approve, reject, or revise." },
+    has_classification: { kind: "edge", stage: "active", layer: "derived", note: "Turn-to-classifier-result edges for versioned labels." },
+    produced: { kind: "edge", stage: "active", layer: "derived", note: "Session-to-commit edges." },
+    touched: { kind: "edge", stage: "active", layer: "event", note: "Commit-to-file edges with additions/deletions/status." },
+    later_fixed_by: { kind: "edge", stage: "active", layer: "derived", note: "Feature commit to later overlapping fix commit relation." },
+    suggests_skill: { kind: "edge", stage: "active", layer: "derived", note: "Fix or evidence commit to skill candidate relation." },
+    has_checkout: { kind: "edge", stage: "active", layer: "event", note: "Repository-to-checkout edges." },
+    concerns: { kind: "edge", stage: "active", layer: "event", note: "Generic evidence edges, currently used for tool/skill and insight/session links." },
+    resulted_in: { kind: "edge", stage: "staged", layer: "derived", note: "Reserved generic outcome relation." },
+    produced_artifact: { kind: "edge", stage: "staged", layer: "derived", note: "Reserved producer-to-artifact relation." },
+    has_artifact: { kind: "edge", stage: "staged", layer: "derived", note: "Reserved owner-to-artifact relation." },
+    derived_from: { kind: "edge", stage: "active", layer: "derived", note: "Provenance relation for derived guidance and artifacts." },
+    skill_paired: { kind: "edge", stage: "active", layer: "derived", note: "Derived skill co-occurrence edges." },
+    recovered_by: { kind: "edge", stage: "active", layer: "derived", note: "Derived recovery edges after an error turn." },
+    spawned: { kind: "edge", stage: "active", layer: "event", note: "Parent-to-child delegated session edges. LAYER NOTE (#893): event (the subagents parser writes it from agent-*.jsonl files); derive-spawned also inserts derived edges - an enumerated exception in WRITE_MODE_EXCEPTIONS." },
+    advice: { kind: "node", stage: "active", layer: "event", note: "Hook advice ledger rows from ~/.ax/hooks/advise-log.jsonl (route-dispatch additionalContext)." },
+    agent_event_child: { kind: "edge", stage: "active", layer: "event", note: "Provider-event parent-child edges." },
+    used_model: { kind: "edge", stage: "active", layer: "event", note: "Session-to-agent-model usage edges." },
+    agent_used_model: { kind: "edge", stage: "active", layer: "event", note: "Provider-session-to-agent-model usage edges." },
+    harness_hook_event: { kind: "node", stage: "active", layer: "event", note: "Native agent harness hook lifecycle events." },
+    hook_command_invocation: { kind: "node", stage: "active", layer: "event", note: "Commands invoked by native harness hooks." },
+    ax_invocation: { kind: "node", stage: "active", layer: "event", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
+    feedback_case_type: { kind: "node", stage: "active", layer: "derived", note: "Feedback backtest case definitions." },
+    feedback_case_result: { kind: "node", stage: "active", layer: "derived", note: "Feedback backtest results." },
+    hook_fire: { kind: "node", stage: "active", layer: "event", note: "Runtime file-context hook decisions." },
+    directive_ngram: { kind: "node", stage: "active", layer: "derived", note: "Per-user n-gram lift table: which user-turn markers predict captured outcomes (directive mining v2, #587)." },
+    cites_evidence: { kind: "edge", stage: "active", layer: "derived", note: "Proposal-to-evidence edges." },
+    opportunity: { kind: "edge", stage: "active", layer: "derived", note: "Experiment trigger recurrence evidence edges." },
+    reviewed: { kind: "edge", stage: "active", layer: "derived", note: "Session-to-retro review edges." },
+    ingest_file_state: { kind: "node", stage: "active", layer: "bookkeeping", note: "Per-source ingest watermark (mtime/size/sha) for skip-unchanged re-ingest." },
+    otel_metric_point: { kind: "node", stage: "active", layer: "event", note: "Harness OTLP metric data points (cost/token/usage)." },
+    otel_span: { kind: "node", stage: "active", layer: "event", note: "Harness OTLP trace spans from generic OTLP span sources; Codex does NOT populate this table - it emits OTLP logs, not spans (see apps/axctl/src/otel/install-config.ts, [otel] exporter targets /v1/logs)." },
+    otel_log_event: { kind: "node", stage: "active", layer: "event", note: "Harness OTLP log events (codex events incl. token usage)." },
+    harness_tool_event: { kind: "node", stage: "active", layer: "derived", note: "Shared tool decision/result projection from transcript, hooks, and OTLP events." },
+    harness_run_context: { kind: "node", stage: "active", layer: "derived", note: "Shared run context projection from transcript and OTLP startup events." },
+    wrapped_card: { kind: "node", stage: "active", layer: "event", note: "Agent-authored Wrapped recap cards (ax wrapped publish)." },
+    telemetry_of: { kind: "edge", stage: "active", layer: "derived", note: "Edge: session -> otel telemetry row (drawn at ingest)." },
+    run_evidence_event: { kind: "node", stage: "active", layer: "derived", note: "Run evidence ledger (#578): normalized claim/observation/verification/boundary events over the graph; backing distinguishes model claim vs tool-backed." },
+    run_evidence_ref: { kind: "node", stage: "active", layer: "derived", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
+    cache_bust_event: { kind: "node", stage: "active", layer: "derived", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
+};
+
+/**
+ * The enumerated enrichment columns (#893): derived data at rest in EVENT
+ * rows. An `enrich`-mode TableWrite is legal only on an event table listed
+ * here, and only these columns may be UPDATEd by it. This legalizes today's
+ * cross-writes EXPLICITLY instead of pretending they do not exist; moving
+ * these columns into derived side-tables is out of Phase 4 scope (operator
+ * decision on #893: permanent named exception).
+ *
+ * Writers, for the record:
+ * - session.project/repository/checkout - git stage correlation;
+ *   session.repository/checkout/cwd - subagents parent backfill (guarded
+ *   `WHERE repository IS NULL`); session.reasoning_effort - claude effort
+ *   stamp (currently nulled by a parser bug, #898).
+ * - invoked.turn_index/total_turns/is_first - invoked-positions backfill;
+ *   invoked.was_corrected - signals correction stamping.
+ * - session_token_usage.estimated_cost_usd/pricing_source - derive-metrics
+ *   cost backfill (`WHERE estimated_cost_usd IS NULL`).
+ * - commit.reverted - derive-metrics revert detection.
+ * - turn.intent_kind - `ax derive-intents` (CLI-only writer).
+ */
+export const ENRICHMENT_COLUMNS: Readonly<Record<string, readonly string[]>> = {
+    session: ["project", "repository", "checkout", "cwd", "reasoning_effort"],
+    invoked: ["turn_index", "total_turns", "is_first", "was_corrected"],
+    session_token_usage: ["estimated_cost_usd", "pricing_source"],
+    commit: ["reverted"],
+    turn: ["intent_kind"],
 };
 
 /** Builds the manifest from `DUCKDB_TABLE_NAMES` (the parsed DDL) joined
@@ -176,7 +229,7 @@ function buildManifest(): readonly DuckdbTableSpec[] {
     if (missingMetadata.length > 0) {
         throw new Error(
             `duckdb-tables.ts: DDL table(s) with no TABLE_METADATA entry: ${missingMetadata.join(", ")}. ` +
-                "Add a { kind, stage, note } entry for each before the manifest can build.",
+                "Add a { kind, stage, layer, note } entry for each before the manifest can build.",
         );
     }
     const staleMetadata = Object.keys(TABLE_METADATA).filter((table) => !DUCKDB_TABLE_NAMES.has(table));
@@ -190,3 +243,8 @@ function buildManifest(): readonly DuckdbTableSpec[] {
 }
 
 export const DUCKDB_SCHEMA_TABLES: readonly DuckdbTableSpec[] = buildManifest();
+
+/** Table -> layer lookup derived from the manifest. */
+export const DUCKDB_TABLE_LAYERS: ReadonlyMap<string, DuckdbTableLayer> = new Map(
+    DUCKDB_SCHEMA_TABLES.map((spec) => [spec.table, spec.layer]),
+);


### PR DESCRIPTION
Phase 4 slice 1 of the #893 spec (operator sign-off recorded on the issue). Closes #897.

## What

The event-layer freeze: the contract binds **writes**, not stage tags.

- **`layer: event | derived | bookkeeping`** on every `TABLE_METADATA` entry (all 126 tables). Required by the type, so a new table cannot ship unclassified; `DUCKDB_TABLE_LAYERS` lookup exported.
- **`StageMeta.writes: TableWrite[]`** (`{ table, mode: parse|enrich|derive|bookkeep }`) required on every stage. All 40 stages declare their writes - 239 declarations, surveyed writer-by-writer with file:line evidence (five parallel survey passes over every stage + helper module). Shared sets (`NORMALIZED_BATCH_WRITES`, `JSONL_WORK_UNIT_WRITES`) keep the provider declarations in one place.
- **`NON_STAGE_WRITERS`** registers every cache writer outside the StageDef list: run.ts orchestration (telemetry, `telemetry_of` correlation, OTLP 30d retention, `--reset`), the CLI writers (`--dry-run` real writes, sessions auto-backfill, derive-intents, insights import, wrapped publish, catalog reconcile, classifier appliers), and the seam open path (`schema_comment_state`).
- **`ENRICHMENT_COLUMNS`** enumerates derived-data-at-rest columns on event tables - the survey found more than the spec listed: `session.project/cwd`, `invoked.was_corrected/is_first`, `session_token_usage.estimated_cost_usd/pricing_source`, `commit.reverted`, `turn.intent_kind`.
- **`WRITE_MODE_EXCEPTIONS`** enumerates the three known cross-writes with rationale (derive-spawned→`spawned`, session-health→`session_token_usage` estimates, insights-import→`friction_event`). The static test pins the list, so growing it is a review decision, not a mechanical fix.

## Enforcement

- **Static** (`stage/table-writes.test.ts`): every declared write checked mode-vs-layer against the manifest - phrased over write declarations, never over tags [R#14]; exceptions must be load-bearing; enrichment columns must exist in the DDL and be event-table columns.
- **Behavioral** (`table-writes.behavior.test.ts`): six registered stages (pi, invoked-positions, outcomes, content-types, session-health, derive-metrics) run against real temp DuckDB fixtures; per-table `bit_xor(hash(row))` **content digests** diffed before/after, changed ⊆ declared. The invoked-positions case pins [R#4]: an UPDATE moves the digest at constant row count. Coverage is a stated subset; the static test covers all declarations.

## Found while surveying

`session.reasoning_effort` on claude sessions is nulled by the normalized-batch upsert in the same run - 0 of 293 claude sessions carry it on the real store while codex retains 1372/1420. Filed as #898 (fix out of scope here); exactly the class of undeclared cross-write this freeze exists to catch.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` + `bun run typecheck`: clean.
- Full `bun test`: 6167 pass; 4 fail + 4 errors = the known studio-desktop electron-env baseline (reproduced in isolation).
- `check:timestamp-cast` + `check:raw-numeric-cast`: clean.
- Digest SQL verified on the shipped ICU-less build: UPDATE at constant count moves the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)