### PR TITLE
feat(ingest): content-hash watermark - SHA-256 two-tier skip + eager backfill (#900)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,19 @@ or write. Getting it wrong does not error; it returns a wrong answer.
   same-run MUST stay direct - the allowlist + per-table rationale live on
   `INGEST_SPOOL_TABLES` (`apps/axctl/src/ingest/jsonl-work-unit.ts`), pinned by
   test. `session`, `skill`, and `plan_item` are the load-bearing exclusions.
+- **The ingest watermark is two-tier** (#900): file-form marks store
+  `(mtime_ms, size)` PLUS a SHA-256 of the parsed bytes in
+  `ingest_file_state.sha`. Fast tier: stats match -> skip with no read.
+  Durable tier (claude/codex/pi/omp; NOT the append-only otel spool): stats
+  moved -> hash the bytes; identical hash (mtime churn, resync, touch) ->
+  refresh the mark, SKIP the parse - the jsonl work-unit's third outcome
+  beside processed/skipped. SHA-256 and never `stableDigest`/`Bun.hash` (a
+  bun upgrade would invalidate every mark). A one-time per-kind eager
+  backfill (sentinel `__content_hash_backfill__/<kind>`, version
+  `CONTENT_HASH_VERSION`) hashed the existing corpus; it compares stats at
+  WHOLE-ms grain because the walkers store `Date.getTime()` while
+  `Bun.file().stat()` carries fractional ms. Module:
+  `packages/lib/src/duckdb/watermark.ts`.
 - **Decisions** (proposal, verdict, experiment, session_label) go to the SQLite
   sidecar via `Judgment`, never to the cache. A cache rebuild must not lose them.
 - A command declares what it needs in its `RuntimeManifest`

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1516,6 +1516,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
             sourceKind: "codex_session",
             forceEnv: "AX_REDERIVE_CODEX",
             source: "codex",
+            contentHash: true,
             spool,
             ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),

--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Schema } from "effect";
+import { hashFileSha256 } from "@ax/lib/duckdb/watermark";
 import { parseDuckdbColumnDefs } from "@ax/schema/duckdb-ddl";
 import type { CacheWriteError } from "@ax/lib/duckdb/seam";
 import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
@@ -210,5 +211,91 @@ describe("JSONL provider heartbeat", () => {
             }),
         ));
         expect(progressAt).toBeInstanceOf(Date);
+    });
+});
+
+describe("content-hash tier (#900) on real files", () => {
+    const statOf = async (path: string) => {
+        const stat = await Bun.file(path).stat();
+        return { mtimeMs: stat.mtimeMs, sizeBytes: stat.size };
+    };
+
+    dtest("a touched-but-identical file refreshes its mark and skips the parse", async () => {
+        const dir = tempDir("ax-jsonl-content-");
+        const filePath = `${dir}/one.jsonl`;
+        await Bun.write(filePath, `{"kind":"row"}\n`);
+        const statA = await statOf(filePath);
+        // Rewrite the SAME bytes so mtime moves while content does not.
+        await Bun.write(filePath, `{"kind":"row"}\n`);
+        const statB = await statOf(filePath);
+
+        const first: string[] = [];
+        const second: string[] = [];
+        let firstResult: unknown;
+        let secondResult: unknown;
+        let storedSha: string | null = null;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-jsonl-content-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                firstResult = yield* runJsonlProviderFiles(write, {
+                    ...options([candidate(filePath, statA.mtimeMs, statA.sizeBytes)], first),
+                    contentHash: true,
+                });
+                secondResult = yield* runJsonlProviderFiles(write, {
+                    ...options([candidate(filePath, statB.mtimeMs, statB.sizeBytes)], second),
+                    contentHash: true,
+                });
+                storedSha = (yield* write.rows(Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+                    "SELECT sha FROM ingest_file_state WHERE path = ?", [filePath]))[0]!.sha;
+            }),
+        ));
+        expect(firstResult).toMatchObject({ files: 1, skippedUnchanged: 0, refreshedUnchanged: 0 });
+        // The refresh: no parse (processFile never ran), the mark advanced.
+        expect(secondResult).toMatchObject({ files: 0, skippedUnchanged: 0, refreshedUnchanged: 1 });
+        expect(first).toEqual([filePath]);
+        expect(second).toEqual([]);
+        // Verify by transformation: the stored sha IS the file's SHA-256.
+        const expected = await Effect.runPromise(hashFileSha256(filePath));
+        expect(storedSha as string | null).toBe(expected);
+    });
+
+    dtest("changed content parses and stamps the fresh sha; third run fast-skips", async () => {
+        const dir = tempDir("ax-jsonl-content2-");
+        const filePath = `${dir}/two.jsonl`;
+        await Bun.write(filePath, `{"v":1}\n`);
+        const statA = await statOf(filePath);
+
+        const runs: string[][] = [[], [], []];
+        const results: unknown[] = [];
+        let storedSha: string | null = null;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-jsonl-content2-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                results[0] = yield* runJsonlProviderFiles(write, {
+                    ...options([candidate(filePath, statA.mtimeMs, statA.sizeBytes)], runs[0]!),
+                    contentHash: true,
+                });
+                // Change the CONTENT between runs, so run 2 hashes new bytes.
+                const statB = yield* Effect.promise(async () => {
+                    await Bun.write(filePath, `{"v":2}\n`);
+                    return statOf(filePath);
+                });
+                for (const index of [1, 2]) {
+                    results[index] = yield* runJsonlProviderFiles(write, {
+                        ...options([candidate(filePath, statB.mtimeMs, statB.sizeBytes)], runs[index]!),
+                        contentHash: true,
+                    });
+                }
+                storedSha = (yield* write.rows(Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+                    "SELECT sha FROM ingest_file_state WHERE path = ?", [filePath]))[0]!.sha;
+            }),
+        ));
+        expect(results[0]).toMatchObject({ files: 1, refreshedUnchanged: 0 });
+        // Genuinely changed: parsed, not refreshed.
+        expect(results[1]).toMatchObject({ files: 1, skippedUnchanged: 0, refreshedUnchanged: 0 });
+        // Unchanged stats: the FAST tier skips - no read, no hash.
+        expect(results[2]).toMatchObject({ files: 0, skippedUnchanged: 1, refreshedUnchanged: 0 });
+        expect(runs[1]).toEqual([filePath]);
+        expect(runs[2]).toEqual([]);
+        const expected = await Effect.runPromise(hashFileSha256(filePath));
+        expect(storedSha as string | null).toBe(expected);
     });
 });

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -25,7 +25,7 @@
 
 import { Effect } from "effect";
 import type { DbError } from "@ax/lib/errors";
-import { fileWatermark, WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
+import { fileWatermark, hashFileSha256, WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { TableSpool } from "@ax/lib/duckdb/spool";
 import type { DuckDbParam } from "@ax/lib/duckdb/types";
@@ -111,6 +111,16 @@ export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate
     /** Per-file concurrency. Defaults to 1 (sequential) to match the providers. */
     readonly concurrency?: number | "unbounded";
     /**
+     * Opt into the SHA-256 content tier (#900). When on: the fast (mtime,size)
+     * skip is unchanged; a file whose stats MOVED is hashed before parsing,
+     * and an identical hash (mtime churn, resync, touch) refreshes the mark
+     * and SKIPS the parse - the third outcome beside processed/skipped.
+     * Genuinely-changed files carry their fresh hash into the committed mark.
+     * The transcript providers set it; the append-only otel spool leaves it
+     * off (its files never revert, so hashing them buys nothing).
+     */
+    readonly contentHash?: boolean;
+    /**
      * The stage's NDJSON spool, when its writes route through `withTableSpool`.
      * The work-unit then owns the flush cadence AND defers every watermark to
      * the flush that lands its rows: marks are snapshotted BEFORE the spool
@@ -136,6 +146,9 @@ export interface JsonlWorkUnitResult {
     readonly files: number;
     /** Candidates skipped because their (mtime,size) matched the watermark. */
     readonly skippedUnchanged: number;
+    /** Candidates whose stats moved but whose CONTENT hash matched the stored
+     *  mark (#900): mark refreshed, parse skipped. 0 with `contentHash` off. */
+    readonly refreshedUnchanged: number;
     /** The failure collector (count() / failures) for the provider's stats. */
     readonly failures: FileFailureCollector;
 }
@@ -145,7 +158,11 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
     opts: RunJsonlProviderFilesOptions<E, R, C>,
 ): Effect.Effect<JsonlWorkUnitResult, DbError | CacheWriteError, R> =>
     Effect.gen(function* () {
-        const wm = yield* fileWatermark(write, { sourceKind: opts.sourceKind, forceEnv: opts.forceEnv });
+        const wm = yield* fileWatermark(write, {
+            sourceKind: opts.sourceKind,
+            forceEnv: opts.forceEnv,
+            ...(opts.contentHash === true ? { contentHash: true } : {}),
+        });
         const failures = makeFileFailureCollector({
             source: opts.source,
             ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
@@ -154,6 +171,7 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
         let files = 0;
         let activeFiles = 0;
         let skippedUnchanged = 0;
+        let refreshedUnchanged = 0;
         const loop: JsonlWorkUnitLoop = {
             get activeFiles() {
                 return activeFiles;
@@ -200,6 +218,25 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                         skippedUnchanged += 1;
                         return;
                     }
+                    // Durable tier (#900): stats moved, so hash the bytes
+                    // BEFORE parsing - the hash then describes bytes no newer
+                    // than what the parse reads, so a mid-parse append can
+                    // only cause one redundant reparse, never a skipped one.
+                    // Identical content (mtime churn, resync, touch) refreshes
+                    // the mark and skips the parse: the rows are already in
+                    // the store from the run that stamped this sha.
+                    let contentSha: string | null = null;
+                    if (opts.contentHash === true) {
+                        contentSha = yield* hashFileSha256(candidate.path);
+                        const stored = wm.storedSha(candidate.path);
+                        if (contentSha !== null && stored !== null && contentSha === stored) {
+                            refreshedUnchanged += 1;
+                            // Direct commit even in spool mode: a refresh has
+                            // no spooled rows to wait for.
+                            yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes, contentSha);
+                            return;
+                        }
+                    }
                     activeFiles += 1;
                     yield* failures.isolate(
                         candidate.path,
@@ -214,9 +251,9 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                             // "succeed" includes the flush, so the mark is
                             // deferred to the flush cycle instead.
                             if (opts.spool !== undefined) {
-                                pendingMarks.push(wm.row(candidate.path, candidate.mtimeMs, candidate.sizeBytes));
+                                pendingMarks.push(wm.row(candidate.path, candidate.mtimeMs, candidate.sizeBytes, contentSha));
                             } else {
-                                yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
+                                yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes, contentSha);
                             }
                             if (opts.runId !== undefined && shouldHeartbeatIngestRun(completedFiles)) {
                                 // Courtesy signal only: a transient heartbeat
@@ -256,5 +293,5 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
         }
 
         yield* failures.report;
-        return { files, skippedUnchanged, failures };
+        return { files, skippedUnchanged, refreshedUnchanged, failures };
     });

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -782,6 +782,7 @@ const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.i
             sourceKind: desc.sourceKind,
             forceEnv: desc.forceEnv,
             source: desc.provider,
+            contentHash: true,
             ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             processFile: (file) => Effect.gen(function* () {
                 // OLD: `Bun.file(path).text()` under `Effect.promise` - a read

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1866,6 +1866,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             sourceKind: "claude_transcript",
             forceEnv: "AX_REDERIVE_CLAUDE",
             source: "claude",
+            contentHash: true,
             spool,
             ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),

--- a/packages/lib/src/duckdb/watermark.test.ts
+++ b/packages/lib/src/duckdb/watermark.test.ts
@@ -14,7 +14,10 @@ import { runWithPlatform } from "../testing/cache-fixture.ts";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { withCacheWrite, type CacheWriteService } from "./seam.ts";
 import {
+    CONTENT_HASH_VERSION,
+    contentHashSentinelPath,
     fileWatermark,
+    hashFileSha256,
     watermarkRow,
     watermarkRowId,
     WATERMARK_TABLE,
@@ -280,5 +283,82 @@ describe("fileWatermark", () => {
         );
 
         expect(outcome._tag).toBe("Failure");
+    });
+});
+
+describe("content-hash backfill (#900)", () => {
+    const statOf = async (path: string) => {
+        const stat = await Bun.file(path).stat();
+        return { mtimeMs: stat.mtimeMs, size: stat.size };
+    };
+
+    dtest("hashes only files whose current stats still equal their mark; sentinel arms once", async () => {
+        const dir = tempDir("ax-wm-backfill-");
+        const fileA = `${dir}/a.jsonl`;
+        const fileB = `${dir}/b.jsonl`;
+        const fileC = `${dir}/c.jsonl`;
+        await Bun.write(fileA, "alpha\n");
+        await Bun.write(fileB, "beta\n");
+        await Bun.write(fileC, "gamma\n");
+        const statA = await statOf(fileA);
+        const statB = await statOf(fileB);
+        const statC = await statOf(fileC);
+
+        // Run 1: pre-#900 marks - no content tier, sha stays NULL. Marks are
+        // committed at WHOLE-ms grain, exactly as the walkers do
+        // (`stats.mtime.getTime()`), while `Bun.file().stat()` carries
+        // fractional ms - the backfill must match at the walker's grain (the
+        // strict-compare bug skipped 3,181 of 3,185 codex marks on the real
+        // store).
+        await asIngestRun(dir, (write) =>
+            Effect.gen(function* () {
+                const wm = yield* fileWatermark(write, SOURCE);
+                yield* wm.commit(fileA, Math.floor(statA.mtimeMs), statA.size);
+                yield* wm.commit(fileB, Math.floor(statB.mtimeMs), statB.size);
+                yield* wm.commit(fileC, Math.floor(statC.mtimeMs), statC.size);
+            }),
+        );
+
+        // B's bytes move after its mark; C vanishes. Only A still matches.
+        await Bun.write(fileB, "beta CHANGED\n");
+        await Bun.file(fileC).delete();
+
+        const expectedShaA = await Effect.runPromise(hashFileSha256(fileA));
+
+        // Run 2: the content tier arms and backfills.
+        let stored: readonly { path: string; sha: string | null }[] = [];
+        let storedShaA: string | null = null;
+        await asIngestRun(dir, (write) =>
+            Effect.gen(function* () {
+                const wm = yield* fileWatermark(write, { ...SOURCE, contentHash: true });
+                storedShaA = wm.storedSha(fileA);
+                stored = yield* write.rows(
+                    Schema.Struct({ path: Schema.String, sha: Schema.NullOr(Schema.String) }),
+                    `SELECT path, sha FROM ${WATERMARK_TABLE} ORDER BY path`,
+                );
+            }),
+        );
+        const byPath = new Map(stored.map((row) => [row.path, row.sha]));
+        expect(byPath.get(fileA)).toBe(expectedShaA);
+        expect(storedShaA as string | null).toBe(expectedShaA);
+        expect(byPath.get(fileB)).toBeNull(); // moved since its mark: hash would lie
+        expect(byPath.get(fileC)).toBeNull(); // file gone: cannot fast-skip again anyway
+        expect(byPath.get(contentHashSentinelPath(SOURCE.sourceKind))).toBe(CONTENT_HASH_VERSION);
+
+        // Run 3: sentinel matches - the backfill must NOT run again. Observable:
+        // A's bytes change on disk, but its stored sha stays the run-2 value.
+        await Bun.write(fileA, "alpha CHANGED\n");
+        let shaAfterThird: string | null = null;
+        await asIngestRun(dir, (write) =>
+            Effect.gen(function* () {
+                yield* fileWatermark(write, { ...SOURCE, contentHash: true });
+                shaAfterThird = (yield* write.rows(
+                    Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+                    `SELECT sha FROM ${WATERMARK_TABLE} WHERE path = ?`,
+                    [fileA],
+                ))[0]!.sha;
+            }),
+        );
+        expect(shaAfterThird as string | null).toBe(expectedShaA);
     });
 });

--- a/packages/lib/src/duckdb/watermark.ts
+++ b/packages/lib/src/duckdb/watermark.ts
@@ -34,6 +34,25 @@
  * writes succeed, so a run that dies mid-file re-processes it next time. That
  * ordering belongs to the caller - this module owns the read and the row, never
  * the loop.
+ *
+ * THE CONTENT-HASH TIER (#900, Phase 4 piece 3). File-form marks can opt into
+ * a second, durable change check: `contentHash: true` stores a SHA-256 of the
+ * file's bytes in the previously-NULL `sha` column. The fast tier is
+ * unchanged - (mtime,size) match still skips with no read. When (mtime,size)
+ * MOVED, the caller hashes the bytes and compares against `storedSha`: equal
+ * means mtime churn / resync / touch, so the caller refreshes the mark and
+ * skips the parse (the jsonl work-unit's third outcome). SHA-256 and NOT
+ * `stableDigest`/`Bun.hash`, deliberately: a stored cross-run hash on a
+ * version-unstable 64-bit hash would silently invalidate every mark on a bun
+ * upgrade. The one-time eager backfill (operator decision on #893, measured
+ * 5.9s over the 5.63 GB corpus) hashes each already-marked file whose CURRENT
+ * (mtime,size) still equals its mark - only then does the hash describe the
+ * bytes that were actually parsed; a file that moved since its mark keeps a
+ * NULL sha and re-parses normally. A per-kind sentinel row versioned by
+ * {@link CONTENT_HASH_VERSION} makes the backfill run once per kind.
+ *
+ * RULING R6: runtime module under `packages/lib/src/` - `node:fs`/`node:path`
+ * are banned (`check:no-node-fs`); file access goes through `Bun.file`.
  */
 import { Effect, Schema } from "effect";
 import { stableId } from "../stable-id.ts";
@@ -95,14 +114,41 @@ export const watermarkRow = (
         since_days: numParam(fields.sinceDays),
     });
 
+/** Version tag stored in the per-kind backfill sentinel's `sha`. Bump it to
+ *  re-run the backfill (e.g. on an algorithm change). */
+export const CONTENT_HASH_VERSION = "sha256-v1";
+
+/** Sentinel path for the per-kind content-hash backfill marker. Embeds the
+ *  kind because the DDL keeps ONE global `UNIQUE (path)` - two kinds writing
+ *  the same sentinel path would be a constraint violation, not two rows. */
+export const contentHashSentinelPath = (sourceKind: string): string =>
+    `__content_hash_backfill__/${sourceKind}`;
+
+/** SHA-256 of a file's bytes, hex. Fail-open: any read error yields null and
+ *  the caller falls back to parsing (worst case = the pre-#900 behavior). */
+export const hashFileSha256 = (path: string): Effect.Effect<string | null> =>
+    Effect.promise(async () => {
+        try {
+            const bytes = await Bun.file(path).arrayBuffer();
+            const hasher = new Bun.CryptoHasher("sha256");
+            hasher.update(bytes);
+            return hasher.digest("hex");
+        } catch {
+            return null;
+        }
+    });
+
 export interface FileWatermark {
     /** true => the on-disk (mtime,size) matches the stored mark => skip. */
     unchanged(path: string, mtimeMs: number, size: number): boolean;
+    /** The stored content hash for the durable tier, or null when the mark
+     *  has none (legacy row, hash failure, or `contentHash` off). */
+    storedSha(path: string): string | null;
     /** Write the mark. Call only AFTER the file's own writes succeed. */
-    commit(path: string, mtimeMs: number, size: number): Effect.Effect<void, CacheWriteError>;
+    commit(path: string, mtimeMs: number, size: number, sha?: string | null): Effect.Effect<void, CacheWriteError>;
     /** The same row {@link commit} would write, for a stage that batches its
      *  marks into one `putMany` with the rest of its writes. */
-    row(path: string, mtimeMs: number, size: number): Record<string, DuckDbParam>;
+    row(path: string, mtimeMs: number, size: number, sha?: string | null): Record<string, DuckDbParam>;
 }
 
 export interface FileWatermarkConfig {
@@ -110,13 +156,21 @@ export interface FileWatermarkConfig {
     readonly sourceKind: string;
     /** Env var whose value "1" forces a full re-derive, e.g. "AX_REDERIVE_CLAUDE". */
     readonly forceEnv: string;
+    /** Opt into the SHA-256 content tier (#900): loads stored shas for
+     *  {@link FileWatermark.storedSha} and runs the one-time eager backfill
+     *  for this kind. File-form callers that want resync resilience set it;
+     *  append-only kinds (the otel spool) and non-file kinds leave it off. */
+    readonly contentHash?: boolean;
 }
 
 const MarkRow = Schema.Struct({
     path: Schema.String,
     mtime_ms: Schema.NullOr(Schema.Number),
     size: Schema.NullOr(Schema.Number),
+    sha: Schema.NullOr(Schema.String),
 });
+
+const SentinelRow = Schema.Struct({ sha: Schema.NullOr(Schema.String) });
 
 /**
  * Load this source kind's marks in ONE indexed read and hand back the value
@@ -136,31 +190,97 @@ const MarkRow = Schema.Struct({
 export const fileWatermark = (
     write: CacheWriteService,
     cfg: FileWatermarkConfig,
-): Effect.Effect<FileWatermark, CacheReadError> =>
+): Effect.Effect<FileWatermark, CacheReadError | CacheWriteError> =>
     Effect.gen(function* () {
-        const marks = new Map<string, { readonly mtimeMs: number; readonly size: number }>();
+        const marks = new Map<string, { readonly mtimeMs: number; readonly size: number; sha: string | null }>();
+        const forced = process.env[cfg.forceEnv] === "1";
 
-        if (process.env[cfg.forceEnv] !== "1") {
-            const rows = yield* write.rows(
-                MarkRow,
-                `SELECT path, mtime_ms, size FROM ${WATERMARK_TABLE} WHERE source_kind = ?`,
-                [cfg.sourceKind],
+        const loadRows = write.rows(
+            MarkRow,
+            `SELECT path, mtime_ms, size, sha FROM ${WATERMARK_TABLE} WHERE source_kind = ?`,
+            [cfg.sourceKind],
+        );
+        let rows = forced && cfg.contentHash !== true ? [] : yield* loadRows;
+
+        // The one-time eager content-hash backfill (#900). Only files whose
+        // CURRENT (mtime,size) still equals the stored mark are hashed - for
+        // those the bytes on disk ARE the bytes that were parsed. A file that
+        // moved since its mark keeps sha NULL and re-parses normally, stamping
+        // its sha then. Runs once per kind, re-armed by a version bump.
+        if (cfg.contentHash === true) {
+            const sentinelPath = contentHashSentinelPath(cfg.sourceKind);
+            const sentinel = yield* write.rows(
+                SentinelRow,
+                `SELECT sha FROM ${WATERMARK_TABLE} WHERE path = ?`,
+                [sentinelPath],
             );
-            for (const row of rows) {
-                if (row.mtime_ms === null || row.size === null) continue;
-                marks.set(row.path, { mtimeMs: row.mtime_ms, size: row.size });
+            if (sentinel[0]?.sha !== CONTENT_HASH_VERSION) {
+                const updated: Array<Record<string, DuckDbParam>> = [];
+                const patched: MarkRowT[] = [];
+                for (const mark of rows) {
+                    if (mark.path.startsWith("__content_hash_backfill__/")) {
+                        patched.push(mark);
+                        continue;
+                    }
+                    if (mark.mtime_ms === null || mark.size === null) {
+                        patched.push(mark);
+                        continue;
+                    }
+                    const stat = yield* Effect.promise(async () => {
+                        try {
+                            return await Bun.file(mark.path).stat();
+                        } catch {
+                            return null;
+                        }
+                    });
+                    // Whole-ms grain, deliberately: the walkers store
+                    // `stats.mtime.getTime()` (integer ms) while
+                    // `Bun.file().stat().mtimeMs` carries fractional ms, so a
+                    // strict compare would skip nearly every mark.
+                    if (
+                        stat === null
+                        || Math.floor(stat.mtimeMs) !== Math.floor(mark.mtime_ms)
+                        || stat.size !== mark.size
+                    ) {
+                        patched.push(mark);
+                        continue;
+                    }
+                    const sha = yield* hashFileSha256(mark.path);
+                    if (sha === null) {
+                        patched.push(mark);
+                        continue;
+                    }
+                    updated.push(watermarkRow(cfg.sourceKind, mark.path, { mtimeMs: mark.mtime_ms, size: mark.size, sha }));
+                    patched.push({ ...mark, sha });
+                }
+                if (updated.length > 0) yield* write.putMany(WATERMARK_TABLE, updated);
+                yield* write.put(
+                    WATERMARK_TABLE,
+                    watermarkRow(cfg.sourceKind, sentinelPath, { sha: CONTENT_HASH_VERSION }),
+                );
+                rows = patched;
             }
         }
 
-        const row = (path: string, mtimeMs: number, size: number) =>
-            watermarkRow(cfg.sourceKind, path, { mtimeMs, size });
+        if (!forced) {
+            for (const row of rows) {
+                if (row.mtime_ms === null || row.size === null) continue;
+                marks.set(row.path, { mtimeMs: row.mtime_ms, size: row.size, sha: row.sha });
+            }
+        }
+
+        const row = (path: string, mtimeMs: number, size: number, sha?: string | null) =>
+            watermarkRow(cfg.sourceKind, path, { mtimeMs, size, sha: sha ?? null });
 
         return {
             unchanged: (path, mtimeMs, size) => {
                 const mark = marks.get(path);
                 return mark !== undefined && mark.mtimeMs === mtimeMs && mark.size === size;
             },
-            commit: (path, mtimeMs, size) => write.put(WATERMARK_TABLE, row(path, mtimeMs, size)),
+            storedSha: (path) => marks.get(path)?.sha ?? null,
+            commit: (path, mtimeMs, size, sha) => write.put(WATERMARK_TABLE, row(path, mtimeMs, size, sha)),
             row,
         } satisfies FileWatermark;
     });
+
+type MarkRowT = typeof MarkRow.Type;

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -2445,12 +2445,17 @@ CREATE TABLE IF NOT EXISTS ingest_file_state (
     source_kind VARCHAR NOT NULL,       -- e.g. "claude_transcript" | "git_repo"
     mtime_ms DOUBLE,
     size DOUBLE,
-    sha VARCHAR,  -- git HEAD watermark
+    sha VARCHAR,  -- git HEAD watermark; for file-form marks (#900) a SHA-256 of the parsed bytes (durable content tier)
     since_days DOUBLE,  -- git history window walked
     ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS ingest_file_state_path_uq ON ingest_file_state(path);
 CREATE INDEX IF NOT EXISTS ingest_file_state_source ON ingest_file_state(source_kind);
+-- #900 (Phase 4 piece 3): content-addressed mark lookup. Unused by the
+-- two-tier skip itself (that reads per-kind rows into a Map); it exists for
+-- the slice-3 hash-indexed handshake - recognizing a file that lands at a NEW
+-- path (segment import, resync) by its content hash before parsing it.
+CREATE INDEX IF NOT EXISTS ingest_file_state_kind_sha ON ingest_file_state(source_kind, sha);
 
 -- ---------------------------------------------------------------------------
 -- OTLP telemetry tables (2026-06-15)


### PR DESCRIPTION
Phase 4 slice 2 of the #893 spec (operator sign-off on the issue; slice 1 = #899). Closes #900.

## What

- **SHA-256 content tier on file-form watermarks**, stored in the existing `ingest_file_state.sha` column. SHA-256 and never `stableDigest`/`Bun.hash` [R#12] - a bun upgrade must not invalidate every mark.
- **Two-tier check** in the jsonl work-unit: `(mtime,size)` match -> skip with no read (hot path byte-identical to before). Stats moved -> hash the bytes **before** parsing (the hash then never describes newer bytes than the parse read, so a mid-parse append can only cost one redundant reparse, never a skipped one); an identical hash (mtime churn, resync, touch) refreshes the mark and **skips the parse** - the third work-unit outcome, `refreshedUnchanged` [R#13]. Enabled for claude/codex/pi/omp; the append-only otel spool deliberately stays off.
- **Eager one-time backfill** (operator decision on #893, measured 5.9s over 4,743 files / 5.63 GB): per-kind version-marked sentinel (`__content_hash_backfill__/<kind>` under the global UNIQUE(path), version `sha256-v1`). Only files whose CURRENT `(mtime,size)` still equals their mark are hashed - only for those does the hash describe the bytes that were parsed; drifted or missing files keep NULL `sha` and stamp it at their next parse.
- **`(source_kind, sha)` DDL index** - unused by the skip itself; it exists for the slice-3 hash-indexed handshake (recognizing a file that lands at a NEW path).

## The bug the live run caught

The walkers store `stats.mtime.getTime()` (whole ms) while `Bun.file().stat().mtimeMs` carries fractional ms. The backfill's first strict compare skipped 3,181 of 3,185 codex marks on the real store. Fixed to whole-ms grain, pinned by a walker-faithful test that commits marks at integer ms.

## Verification

- Unit: refresh-skip round trip on real files (mark advances, `processFile` never runs, stored sha == recomputed SHA-256 - verified by transformation, not eyeball); changed-content run parses and restamps; third run fast-skips; backfill hashes exactly the stats-matching file, leaves drifted/missing NULL, arms once (re-arm observable only via version bump).
- Live, real store: backfill covered **3,185/3,185 codex, 61/61 pi, 2/2 omp, 261/294 claude** (33 drifted since marking - correct); a `touch`ed codex file re-ran the codex stage in **98ms with `sessionsIngested: 0`** - mark refreshed, no reparse.
- `bunx tsc --noEmit` + `bun run typecheck` clean; full `bun test` 6170 pass with only the known studio-desktop baseline (4 fail + 4 errors); `check:timestamp-cast` + `check:raw-numeric-cast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)