### PR TITLE
fix(test): make #900 content-tier tests deterministic on Linux CI

### DIFF
--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -225,9 +225,11 @@ describe("content-hash tier (#900) on real files", () => {
         const filePath = `${dir}/one.jsonl`;
         await Bun.write(filePath, `{"kind":"row"}\n`);
         const statA = await statOf(filePath);
-        // Rewrite the SAME bytes so mtime moves while content does not.
-        await Bun.write(filePath, `{"kind":"row"}\n`);
-        const statB = await statOf(filePath);
+        // A touch moves the stats while the bytes stay the same. Model it by
+        // MOVING THE CANDIDATE STATS, not by rewriting the file: back-to-back
+        // writes can land inside one timer tick (they did on Linux CI), and
+        // identical stats make the FAST tier skip before the durable tier runs.
+        const statB = { mtimeMs: statA.mtimeMs + 7, sizeBytes: statA.sizeBytes };
 
         const first: string[] = [];
         const second: string[] = [];
@@ -274,9 +276,13 @@ describe("content-hash tier (#900) on real files", () => {
                     contentHash: true,
                 });
                 // Change the CONTENT between runs, so run 2 hashes new bytes.
+                // Candidate mtime is bumped past run 1's mark by hand: the
+                // rewrite can land inside run 1's timer tick (same size, same
+                // mtime), and then the fast tier would skip run 2 entirely.
                 const statB = yield* Effect.promise(async () => {
                     await Bun.write(filePath, `{"v":2}\n`);
-                    return statOf(filePath);
+                    const stat = await statOf(filePath);
+                    return { mtimeMs: Math.max(stat.mtimeMs, statA.mtimeMs + 7), sizeBytes: stat.sizeBytes };
                 });
                 for (const index of [1, 2]) {
                     results[index] = yield* runJsonlProviderFiles(write, {


### PR DESCRIPTION
Main CI went red on ac50f2f0 (#901): the touched-but-identical content-tier test rewrote the same bytes back-to-back and trusted the filesystem to move mtime between the writes. On Linux CI both writes landed inside one timer tick, the stats matched, and the FAST watermark tier skipped the file before the durable tier ran - `skippedUnchanged: 1` where the test expects `refreshedUnchanged: 1`.

Fix: model the touch by moving the candidate stats by hand instead of rewriting the file. The changed-content test had the same race (equal-size rewrite), so its candidate mtime is also bumped past run 1's mark explicitly.

Test-only change; verified locally against the shipped ICU-less libduckdb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)