### PR TITLE
fix(ingest): normalized session upsert no longer nulls columns it does not own (#898)

### DIFF
--- a/apps/axctl/src/ingest/normalized/transcripts.test.ts
+++ b/apps/axctl/src/ingest/normalized/transcripts.test.ts
@@ -68,3 +68,31 @@ describe("normalized transcript persistence on real DuckDB", () => {
         expect(row).toEqual({ id: "catalog-id", scope: "user", content_hash: "real" });
     });
 });
+
+describe("normalized session upsert does not clobber columns it does not own (#898)", () => {
+    dtest("reasoning_effort / repository / checkout survive a re-upsert of the same session", async () => {
+        let row: unknown;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-normalized-own-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                // What the effort stamp + git enrichment wrote before the batch.
+                yield* write.put("session", {
+                    id: "session-e", source: "claude", started_at: at,
+                    reasoning_effort: "high", repository: "repo:x", checkout: "checkout:y",
+                });
+                yield* writeNormalizedTranscriptBatch(write, {
+                    ...emptyBatch(),
+                    providers: [{ name: "claude", displayName: "Claude Code" }],
+                    sessions: [{ id: "session-e", provider: "claude", startedAt: at }],
+                });
+                row = (yield* write.rows(Schema.Struct({
+                    reasoning_effort: Schema.NullOr(Schema.String),
+                    repository: Schema.NullOr(Schema.String),
+                    checkout: Schema.NullOr(Schema.String),
+                }), "SELECT reasoning_effort, repository, checkout FROM session WHERE id = 'session-e'"))[0];
+            }),
+        ));
+        expect(row).toMatchObject({
+            reasoning_effort: "high", repository: "repo:x", checkout: "checkout:y",
+        });
+    });
+});

--- a/apps/axctl/src/ingest/normalized/transcripts.ts
+++ b/apps/axctl/src/ingest/normalized/transcripts.ts
@@ -149,19 +149,22 @@ export const upsertNormalizedSessions = (
     write: CacheWriteService,
     sessions: readonly NormalizedSessionWrite[],
 ): Effect.Effect<void, CacheWriteError> =>
+    // Columns this writer does not own are OMITTED, not nulled: `putMany`
+    // compiles to `ON CONFLICT ("id") DO UPDATE SET <every supplied column>`,
+    // so a hardcoded null here overwrote what its owner just wrote (#898 -
+    // `reasoning_effort` from the claude effort stamp, nulled every run;
+    // `repository`/`checkout` from the git stage, wiped by a
+    // `--stages=claude` reparse until git re-ran).
     write.putMany("session", sessions.map((session) => cacheRow({
         id: session.id,
         project: session.project ?? null,
         cwd: session.cwd ?? null,
         model: session.model ?? null,
-        reasoning_effort: null,
         source: session.provider,
         started_at: tsParam(session.startedAt),
         ended_at: tsParam(session.endedAt),
         raw_file: session.rawFile ?? session.sourcePath ?? null,
         labels: jsonParam(session.labels),
-        repository: null,
-        checkout: null,
         workspace: null,
     })));
 


### PR DESCRIPTION
Closes #898.

`upsertNormalizedSessions` hardcoded `reasoning_effort: null, repository: null, checkout: null`, and `putMany` compiles to `ON CONFLICT ("id") DO UPDATE SET <every supplied column>` - so the claude effort stamp written moments earlier in the same stage was deterministically nulled on every run (empirically: 0/293 claude sessions carried an effort vs 1372/1420 codex, which survives only because its direct session write lands after the batch). A `--stages=claude` reparse also wiped git's `repository`/`checkout` enrichment until the git stage happened to re-run.

Fix: the normalized writer now OMITS the three columns it does not own, exactly the "one writer per column" direction the #893 event-layer contract encodes (`session.reasoning_effort`/`repository`/`checkout` are `ENRICHMENT_COLUMNS`). A new row still gets the DDL's NULL default; an existing row keeps what the owning writer stamped.

Regression test: seed a session with all three set, run `writeNormalizedTranscriptBatch` over the same id, assert they survive. Full `apps/axctl/src/ingest` suite (1,095 tests) + strict tsc green. Existing claude history backfills on the next `ax ingest` run that reparses those sessions (or `--reparse=claude`); no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)