### PR TITLE
fix(spool): repair unpaired UTF-16 surrogates instead of failing the whole load (#906)

### DIFF
--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -292,6 +292,11 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
             // here with the same rationale (silent sanitising is the failure
             // class the seam refuses).
             const totals = opts.spool.totals();
+            if (totals.illFormedValues > 0) {
+                yield* Effect.logWarning(
+                    `ax cache: spool repaired ${totals.illFormedValues} text value(s) with an unpaired UTF-16 surrogate for ${opts.source} - DuckDB's read_ndjson rejects lone surrogates, so each was replaced with U+FFFD (#906).`,
+                );
+            }
             if (totals.nulValues > 0) {
                 yield* Effect.logWarning(
                     `ax cache: spool stripped NUL bytes (U+0000) from ${totals.nulValues} text value(s) for ${opts.source} - a DuckDB VARCHAR cannot carry U+0000; the rest of each value was stored intact.`,

--- a/packages/lib/src/duckdb/spool.test.ts
+++ b/packages/lib/src/duckdb/spool.test.ts
@@ -205,6 +205,23 @@ describe("makeTableSpool", () => {
         );
     });
 
+    dtest("repairs an unpaired UTF-16 surrogate instead of failing the whole load (#906)", async () => {
+        const dir = tempDir("spool-surrogate");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                // A truncated emoji: a lone high surrogate. JSON.stringify
+                // emits it as a bare \ud83d escape, which read_ndjson rejects
+                // as "no low surrogate" - killing the batch on a cold backfill.
+                spool.append("tool", [{ id: "tool:surrogate", name: "cut\uD83Dend", provider: "codex" }]);
+                yield* spool.flush(write);
+                expect(spool.totals().illFormedValues).toBe(1);
+                const got = yield* write.raw("SELECT name FROM tool WHERE id = 'tool:surrogate'");
+                // The lone half became U+FFFD; the rest of the value is intact.
+                expect(got.rows[0]!["name"]).toBe("cut�end");
+            }),
+        );
+    });
+
     dtest("flush unlinks its spool files", async () => {
         const dir = tempDir("spool-unlink");
         await asIngestRun(dir, (write, spool, spoolDir) =>

--- a/packages/lib/src/duckdb/spool.ts
+++ b/packages/lib/src/duckdb/spool.ts
@@ -80,6 +80,9 @@ export interface SpoolTotals {
     readonly statements: number;
     /** Text values that carried a U+0000 and were scrubbed. */
     readonly nulValues: number;
+    /** Text values with an unpaired UTF-16 surrogate, made well-formed
+     *  (lone half -> U+FFFD). See {@link encodeValue} for why. */
+    readonly illFormedValues: number;
 }
 
 export interface SpoolFlushOutcome {
@@ -120,6 +123,7 @@ const encodeValue = (
     column: string,
     value: DuckDbParam,
     onNul: () => void,
+    onIllFormed: () => void,
 ): string | number | boolean | null => {
     if (value === null || value === undefined) return null;
     if (typeof value === "boolean" || typeof value === "number") return value;
@@ -135,11 +139,23 @@ const encodeValue = (
         return value.toString();
     }
     if (value instanceof Date) return value.toISOString();
-    if (value.includes("\u0000")) {
-        onNul();
-        return value.replaceAll("\u0000", "");
+    let text = value;
+    if (!text.isWellFormed()) {
+        // An unpaired UTF-16 surrogate (a truncated emoji half in a transcript,
+        // #906). JSON.stringify would serialize it as a lone `\ud???` escape -
+        // legal ECMA-404 text, but DuckDB's read_ndjson enforces strict UTF-8
+        // and rejects the WHOLE file ("no low surrogate"), failing the stage.
+        // The bind path tolerates the same value, so a fresh-store cold
+        // backfill was the only run that hit it. Scrub to U+FFFD, counted -
+        // silent sanitising is the failure class the seam refuses.
+        onIllFormed();
+        text = text.toWellFormed();
     }
-    return value;
+    if (text.includes("\u0000")) {
+        onNul();
+        return text.replaceAll("\u0000", "");
+    }
+    return text;
 };
 
 interface SpoolBuffer {
@@ -188,6 +204,7 @@ export const makeTableSpool = (options: TableSpoolOptions): TableSpool => {
     let totalRows = 0;
     let totalStatements = 0;
     let nulValues = 0;
+    let illFormedValues = 0;
     let flushSeq = 0;
 
     const append: TableSpool["append"] = (table, rows) => {
@@ -254,6 +271,8 @@ export const makeTableSpool = (options: TableSpoolOptions): TableSpool => {
             for (const column of buffer.columns) {
                 out[column] = encodeValue(table, column, row[column], () => {
                     nulValues += 1;
+                }, () => {
+                    illFormedValues += 1;
                 });
             }
             buffer.lines.set(id, JSON.stringify(out));
@@ -332,7 +351,7 @@ export const makeTableSpool = (options: TableSpoolOptions): TableSpool => {
             return n;
         },
         flush,
-        totals: () => ({ rows: totalRows, statements: totalStatements, nulValues }),
+        totals: () => ({ rows: totalRows, statements: totalStatements, nulValues, illFormedValues }),
     };
 };
 


### PR DESCRIPTION
Closes #906.

A timed cold full backfill (fresh store, 5.6 GB corpus) died in the codex stage: a transcript carries an unpaired UTF-16 surrogate (a truncated emoji half), `JSON.stringify` serializes it as a lone `\ud???` escape - legal ECMA-404 text - and DuckDB's `read_ndjson` enforces strict UTF-8, rejecting the WHOLE spool file with `no low surrogate in string`. A flush failure fails the stage by design, so every fresh install loses the batch. Warm stores never see it: those files predate the spool (#886) and went through bound parameters, which tolerate the value.

Fix, mirroring the seam's NUL scrub: `encodeValue` passes text through `String.prototype.isWellFormed()` / `toWellFormed()` (lone half → U+FFFD), counts each repair in `SpoolTotals.illFormedValues`, and the jsonl work-unit surfaces the count in an end-of-run warning - sanitising silently is the failure class the seam refuses.

Verification:
- Test pins the round trip on a real store: `"cut\uD83Dend"` lands as `cut�end`, counter reads 1.
- Live repro: cold codex-only ingest into a fresh store over all 3,184 files now completes; the spool reported **9 repaired surrogate values** (plus 14 NUL scrubs) across the corpus - this recurs on every fresh install without the fix.
- Full suite at the known 4-fail/4-error studio-desktop electron baseline; strict tsc + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)