### PR TITLE
perf(fts): skip FTS rebuild when indexed tables are unchanged

### DIFF
--- a/apps/axctl/src/ingest/stage/table-writes.ts
+++ b/apps/axctl/src/ingest/stage/table-writes.ts
@@ -108,6 +108,9 @@ export const NON_STAGE_WRITERS: readonly {
             w("ingest_run", "bookkeep"),
             w("ingest_stage", "bookkeep"),
             w("ingest_event", "bookkeep"),
+            // buildFtsIndexes runs at the ingest tail (ingest/run.ts) - skip-unchanged
+            // bookkeeping for the FTS rebuild (#909).
+            w("fts_index_state", "bookkeep"),
             w("telemetry_of", "derive"),
             w("otel_metric_point", "parse"),
             w("otel_span", "parse"),
@@ -126,13 +129,20 @@ export const NON_STAGE_WRITERS: readonly {
     {
         // cli/commands/ingest.ts maintenance verbs: blob-GC afterWork,
         // onTimeout stamp, `ax ingest reap`, telemetryStage for the
-        // derive-signals/insights verbs.
+        // derive-signals/insights verbs. `ax ingest reap` runs through
+        // `withConfigWrite`, which taps `buildFtsIndexes` after every call (#909).
         writer: "cli:ingest-maintenance",
-        writes: [w("ingest_run", "bookkeep"), w("ingest_stage", "bookkeep"), w("ingest_event", "bookkeep")],
+        writes: [
+            w("ingest_run", "bookkeep"),
+            w("ingest_stage", "bookkeep"),
+            w("ingest_event", "bookkeep"),
+            w("fts_index_state", "bookkeep"),
+        ],
     },
     {
         // `ax ingest --dry-run` calibrates its ETA by running the claude and
         // codex parsers over a capped file set - REAL writes (ingest/dry-run.ts).
+        // Routed through `withConfigWrite`, which taps `buildFtsIndexes` (#909).
         writer: "cli:ingest-dry-run",
         writes: [
             ...NORMALIZED_BATCH_WRITES,
@@ -141,11 +151,13 @@ export const NON_STAGE_WRITERS: readonly {
             w("harness_hook_event", "parse"),
             w("hook_command_invocation", "parse"),
             ...JSONL_WORK_UNIT_WRITES,
+            w("fts_index_state", "bookkeep"),
         ],
     },
     {
         // `ax sessions here|around|near` transcript auto-backfill
-        // (cli/commands/sessions.ts -> ingestTranscripts).
+        // (cli/commands/sessions.ts -> ingestTranscripts). Routed through
+        // `withConfigWrite`, which taps `buildFtsIndexes` (#909).
         writer: "cli:sessions-backfill",
         writes: [
             ...NORMALIZED_BATCH_WRITES,
@@ -154,34 +166,47 @@ export const NON_STAGE_WRITERS: readonly {
             w("harness_hook_event", "parse"),
             w("hook_command_invocation", "parse"),
             ...JSONL_WORK_UNIT_WRITES,
+            w("fts_index_state", "bookkeep"),
         ],
     },
     {
         // `ax derive-intents` (CLI-only, no stage): stamps turn.intent_kind.
+        // Routed through `withConfigWrite`, which taps `buildFtsIndexes` (#909).
         writer: "cli:derive-intents",
-        writes: [w("turn", "enrich")],
+        writes: [w("turn", "enrich"), w("fts_index_state", "bookkeep")],
     },
     {
         // `ax ingest --insights-only` (ingest/claude-insights.ts): imports
         // Claude usage-data facets; placeholder session rows for linkage.
+        // Routed through `withConfigWrite`, which taps `buildFtsIndexes` (#909).
         writer: "cli:ingest-insights",
-        writes: [w("session", "parse"), w("insight", "parse"), w("concerns", "parse"), w("friction_event", "parse")],
+        writes: [
+            w("session", "parse"),
+            w("insight", "parse"),
+            w("concerns", "parse"),
+            w("friction_event", "parse"),
+            w("fts_index_state", "bookkeep"),
+        ],
     },
     {
         // `ax wrapped publish` (dashboard/wrapped-cards.ts): replace-all of
-        // the agent-authored recap cards.
+        // the agent-authored recap cards. Routed through `withConfigWrite`,
+        // which taps `buildFtsIndexes` (#909).
         writer: "cli:wrapped-publish",
-        writes: [w("wrapped_card", "parse")],
+        writes: [w("wrapped_card", "parse"), w("fts_index_state", "bookkeep")],
     },
     {
         // `ax skills reconcile|rm` / `ax agents reconcile|rm` catalog
-        // lifecycle (config-core/reconcile.ts three-pass tombstone).
+        // lifecycle (config-core/reconcile.ts three-pass tombstone). Runs
+        // through `withConfigWrite` in the SAME module that defines it, which
+        // taps `buildFtsIndexes` after every call (#909).
         writer: "cli:catalog-reconcile",
-        writes: [w("skill", "parse"), w("agent_def", "parse")],
+        writes: [w("skill", "parse"), w("agent_def", "parse"), w("fts_index_state", "bookkeep")],
     },
     {
         // Classifier CLI writers: workflow-candidates apply, label-mining
-        // projectReviewed --apply, package-service execution plans.
+        // projectReviewed --apply, package-service execution plans. Routed
+        // through `withConfigWrite`, which taps `buildFtsIndexes` (#909).
         writer: "cli:classifiers",
         writes: [
             w("classifier_graph_node", "derive"),
@@ -189,6 +214,7 @@ export const NON_STAGE_WRITERS: readonly {
             w("classifier_graph_fact", "derive"),
             w("transcript_label_vector", "derive"),
             w("cites_evidence", "derive"),
+            w("fts_index_state", "bookkeep"),
         ],
     },
     {
@@ -196,11 +222,13 @@ export const NON_STAGE_WRITERS: readonly {
         // segment directory (column-intersection loader over the contract's
         // table list) and writes the `__imported__/<kind>/<sha>` watermark
         // handshake marks. The write set IS the segment contract, imported so
-        // the two cannot drift.
+        // the two cannot drift. Routed through `withConfigWrite`, which taps
+        // `buildFtsIndexes` (#909).
         writer: "cli:segment-import",
         writes: [
             ...SEGMENT_TABLES.map((spec) => w(spec.table, "parse")),
             w("ingest_file_state", "bookkeep"),
+            w("fts_index_state", "bookkeep"),
         ],
     },
     {

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -185,6 +185,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "run_evidence_ref", stage: "active", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
     { table: "schema_comment_state", stage: "active", note: "Self-documenting catalog bookkeeping (#869): hash of the last-applied COMMENT ON script, so routine opens skip re-applying (WAL crash-safety)." },
     { table: "cache_bust_event", stage: "active", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
+    { table: "fts_index_state", stage: "active", note: "Skip-unchanged bookkeeping for the FTS rebuild (#909): per-target content digest, so buildFtsIndexes only reruns PRAGMA create_fts_index when the indexed table actually changed." },
 ] as const;
 
 export function isInsightView(value: string): value is InsightView {

--- a/packages/lib/src/duckdb/fts.ts
+++ b/packages/lib/src/duckdb/fts.ts
@@ -21,8 +21,30 @@
  * network. Issuing `INSTALL` would reach for the extension repository - a network
  * call on a load-bearing local path, which is exactly what the static build was
  * built to avoid.
+ *
+ * SKIP-IF-UNCHANGED (#909). A full rebuild is `PRAGMA create_fts_index(...,
+ * overwrite=1)` scanning the WHOLE source table, and it used to run
+ * unconditionally at the tail of every ingest and every `withConfigWrite` call -
+ * a large share of the warm-run tail once `turn` passed a million rows, almost
+ * always for a table that had not changed since the last build. `fts_index_state`
+ * (schema.duckdb.sql) stores one row per target: a content digest computed
+ * ENTIRELY in SQL (never bring the underlying UBIGINT hash through JS - see
+ * {@link ftsDigestSql}) plus when it was last built. Per target, {@link
+ * buildFtsIndexes} now:
+ *   1. computes the current digest;
+ *   2. reads the stored digest;
+ *   3. probes whether `fts_main_<table>` still exists (the fts extension
+ *      materializes it as a real schema, so a prior rebuild can be undone by
+ *      anything that drops it, or never happened on a store that only imported
+ *      the bookkeeping row);
+ *   4. rebuilds only when the digest moved OR the schema is missing, then
+ *      records the new digest. A digest match with a MISSING schema still
+ *      rebuilds - the bookkeeping row is not proof the index exists.
+ * The digest string is prefixed `v1:` - the formula version. Bumping it forces
+ * exactly one rebuild fleet-wide the next time this ships, which is the escape
+ * hatch if the formula ever needs to change.
  */
-import { Effect } from "effect";
+import { Effect, Option, Schema } from "effect";
 import type { CacheWriteError, CacheWriteService } from "./seam.ts";
 
 export interface FtsTarget {
@@ -31,6 +53,35 @@ export interface FtsTarget {
     readonly idColumn: string;
     /** The single text column indexed. */
     readonly textColumn: string;
+}
+
+/** The digest formula version - bump to force a one-time rebuild of every target. */
+const FTS_DIGEST_VERSION = "v1";
+
+/**
+ * A per-target content digest computed ENTIRELY in SQL as one VARCHAR. Never
+ * decode the underlying `bit_xor(hash(...))` (a UBIGINT) in JS - the seam's
+ * `write.raw` applies no column decoder, and a BIGINT arrives as a JS
+ * `bigint` that silently fails a `typeof x === "number"` check (see
+ * CLAUDE.md's raw-numeric-cast trap). Casting the whole expression to VARCHAR
+ * in SQL sidesteps that entirely: this seam only ever sees a string.
+ *
+ * `bit_xor` is commutative/order-independent, so a row landing via any write
+ * path (batch insert, spool flush, single put) produces the same digest -
+ * unlike a hash-of-concatenation, which would depend on scan order.
+ * `COALESCE(bit_xor(...), '0')` covers the empty-table case, where `bit_xor`
+ * itself returns NULL.
+ */
+export const ftsDigestSql = (target: FtsTarget): string =>
+    `SELECT '${FTS_DIGEST_VERSION}:' || count(*)::VARCHAR || ':' || ` +
+    `COALESCE(bit_xor(hash(${target.idColumn}, COALESCE(${target.textColumn}, '')))::VARCHAR, '0') AS digest ` +
+    `FROM "${target.table}"`;
+
+/** Per-target rebuild outcome, returned so a caller (or a test) can observe
+ *  whether a warm no-op run actually skipped the rebuild. */
+export interface FtsBuildOutcome {
+    readonly table: string;
+    readonly rebuilt: boolean;
 }
 
 /**
@@ -58,23 +109,33 @@ export const matchBm25Sql = (target: FtsTarget, alias: string): string =>
     `${ftsSchemaName(target)}.match_bm25(${alias}.${target.idColumn}, ?)`;
 
 /**
- * (Re)build every FTS index. Idempotent: `overwrite = 1` replaces an existing
- * index, so this is safe to run at the end of every ingest, and it MUST run
- * there - the index is a materialized copy, so rows added since the last build
- * are invisible to search until it does.
+ * (Re)build every FTS index THAT NEEDS IT. Idempotent: `overwrite = 1`
+ * replaces an existing index, so this is safe to run at the end of every
+ * ingest, and it MUST run there - the index is a materialized copy, so rows
+ * added since the last build are invisible to search until it does. What
+ * changed in #909 is that a target whose content digest still matches the
+ * stored one, AND whose `fts_main_<table>` schema still exists, is skipped -
+ * see the module doc for the exact rule.
  *
  * The PRAGMA takes its arguments as string literals rather than parameters, so
  * every value here comes from {@link FTS_TARGETS} - a module constant, never
  * caller input. `buildFtsIndexes` accepts a `targets` override for tests only;
  * it validates identifiers rather than trusting them.
+ *
+ * Returns one {@link FtsBuildOutcome} per target, in target order, so a caller
+ * (or a test asserting a warm no-op run genuinely skipped) can observe what
+ * happened without re-deriving it. `LOAD fts` runs at most once, and only when
+ * at least one target actually needs a rebuild - a fully-skipped run touches
+ * the fts extension not at all. Readers (`ax recall`, `match_bm25` callers)
+ * autoload the extension in their OWN connection independently; this LOAD is
+ * only for the `PRAGMA create_fts_index` call below, which is not autoloadable.
  */
 export const buildFtsIndexes = (
     write: CacheWriteService,
     targets: ReadonlyArray<FtsTarget> = FTS_TARGETS,
-): Effect.Effect<void, CacheWriteError> =>
+): Effect.Effect<ReadonlyArray<FtsBuildOutcome>, CacheWriteError> =>
     Effect.gen(function* () {
-        if (targets.length === 0) return;
-        yield* write.exec("LOAD fts");
+        if (targets.length === 0) return [];
         for (const target of targets) {
             for (const name of [target.table, target.idColumn, target.textColumn]) {
                 if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
@@ -83,8 +144,54 @@ export const buildFtsIndexes = (
                     );
                 }
             }
+        }
+
+        const digestSchema = Schema.Struct({ digest: Schema.String });
+        const countSchema = Schema.Struct({ n: Schema.BigInt });
+
+        const decisions: Array<{ readonly target: FtsTarget; readonly digest: string; readonly rebuild: boolean }> =
+            [];
+        for (const target of targets) {
+            const currentRow = yield* write.first(digestSchema, ftsDigestSql(target));
+            const currentDigest = Option.getOrElse(currentRow, () => ({ digest: `${FTS_DIGEST_VERSION}:0:0` })).digest;
+
+            const storedRow = yield* write.first(
+                digestSchema,
+                "SELECT digest FROM fts_index_state WHERE id = ?",
+                [target.table],
+            );
+
+            const schemaRow = yield* write.first(
+                countSchema,
+                "SELECT count(*) AS n FROM information_schema.schemata WHERE schema_name = ?",
+                [ftsSchemaName(target)],
+            );
+            const schemaExists = Number(Option.getOrElse(schemaRow, () => ({ n: 0n })).n) > 0;
+
+            const digestMatches = Option.isSome(storedRow) && storedRow.value.digest === currentDigest;
+            decisions.push({ target, digest: currentDigest, rebuild: !(digestMatches && schemaExists) });
+        }
+
+        if (decisions.some((decision) => decision.rebuild)) {
+            yield* write.exec("LOAD fts");
+        }
+
+        const outcomes: FtsBuildOutcome[] = [];
+        for (const { target, digest, rebuild } of decisions) {
+            if (!rebuild) {
+                yield* Effect.logDebug(`fts: ${target.table} unchanged, skip rebuild`);
+                outcomes.push({ table: target.table, rebuilt: false });
+                continue;
+            }
+            yield* Effect.logInfo(`fts: rebuilding ${target.table}`);
             yield* write.exec(
                 `PRAGMA create_fts_index('${target.table}', '${target.idColumn}', '${target.textColumn}', overwrite = 1)`,
             );
+            yield* write.exec(
+                "INSERT OR REPLACE INTO fts_index_state (id, digest, built_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                [target.table, digest],
+            );
+            outcomes.push({ table: target.table, rebuilt: true });
         }
+        return outcomes;
     });

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { encodeLockPayload, withIngestLock } from "../ingest-lock.ts";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { TimestampColumn } from "./columns.ts";
-import { buildFtsIndexes, matchBm25Sql, type FtsTarget } from "./fts.ts";
+import { buildFtsIndexes, ftsSchemaName, matchBm25Sql, type FtsTarget } from "./fts.ts";
 import { NUL } from "./nul-strip.ts";
 import {
     CacheRead,
@@ -47,6 +47,19 @@ CREATE TABLE IF NOT EXISTS turn (
     id VARCHAR PRIMARY KEY,
     text_excerpt VARCHAR,
     ts TIMESTAMP NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "commit" (
+    id VARCHAR PRIMARY KEY,
+    message VARCHAR,
+    ts TIMESTAMP NOT NULL
+);
+-- Mirrors schema.duckdb.sql's fts_index_state (#909): skip-unchanged
+-- bookkeeping buildFtsIndexes reads/writes on every call, regardless of
+-- which targets are in scope for a given test.
+CREATE TABLE IF NOT EXISTS fts_index_state (
+    id VARCHAR PRIMARY KEY,
+    digest VARCHAR NOT NULL,
+    built_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE TABLE IF NOT EXISTS note (
     id VARCHAR PRIMARY KEY,
@@ -853,6 +866,171 @@ describe("FTS", () => {
             // No hits, no error, and the table is still there.
             expect(outcome._tag).toBe("completed");
             expect(outcome._tag === "completed" ? outcome.value : null).toEqual([]);
+        });
+    });
+});
+
+describe("FTS: skip-unchanged rebuild (#909)", () => {
+    const TURN_FTS: FtsTarget = { table: "turn", idColumn: "id", textColumn: "text_excerpt" };
+    const COMMIT_FTS: FtsTarget = { table: "commit", idColumn: "id", textColumn: "message" };
+    const TARGETS = [TURN_FTS, COMMIT_FTS];
+    const ts = new Date("2026-08-15T10:00:00.000Z");
+
+    const hitIds = (write: CacheWriteService, target: FtsTarget, term: string) =>
+        write.rows(
+            Schema.Struct({ id: Schema.String }),
+            `SELECT t.id AS id FROM "${target.table}" t WHERE ${matchBm25Sql(target, "t")} IS NOT NULL ORDER BY t.id`,
+            [term],
+        );
+
+    dtest("first build on a fresh store rebuilds every target and search works", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-skip-fresh-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("turn", { id: "t1", text_excerpt: "the seam owns semantics", ts });
+                        yield* write.put("commit", { id: "c1", message: "fix semantics bug", ts });
+                        const outcomes = yield* buildFtsIndexes(write, TARGETS);
+                        const digestRows = yield* write.rows(
+                            Schema.Struct({ id: Schema.String }),
+                            "SELECT id FROM fts_index_state ORDER BY id",
+                        );
+                        const turnHits = yield* hitIds(write, TURN_FTS, "semantics");
+                        const commitHits = yield* hitIds(write, COMMIT_FTS, "semantics");
+                        return { outcomes, digestRows, turnHits, commitHits };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.outcomes).toEqual([
+                { table: "turn", rebuilt: true },
+                { table: "commit", rebuilt: true },
+            ]);
+            expect(value?.digestRows.map((r) => r.id)).toEqual(["commit", "turn"]);
+            expect(value?.turnHits.map((r) => r.id)).toEqual(["t1"]);
+            expect(value?.commitHits.map((r) => r.id)).toEqual(["c1"]);
+        });
+    });
+
+    dtest("a second call with no data change skips every target and search still works", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-skip-warm-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("turn", { id: "t1", text_excerpt: "the seam owns semantics", ts });
+                        yield* write.put("commit", { id: "c1", message: "fix semantics bug", ts });
+                        yield* buildFtsIndexes(write, TARGETS);
+                        const outcomes = yield* buildFtsIndexes(write, TARGETS);
+                        const turnHits = yield* hitIds(write, TURN_FTS, "semantics");
+                        return { outcomes, turnHits };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.outcomes).toEqual([
+                { table: "turn", rebuilt: false },
+                { table: "commit", rebuilt: false },
+            ]);
+            expect(value?.turnHits.map((r) => r.id)).toEqual(["t1"]);
+        });
+    });
+
+    dtest("a new row in turn only rebuilds turn - commit stays skipped, new row is findable", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-skip-newrow-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("turn", { id: "t1", text_excerpt: "the seam owns semantics", ts });
+                        yield* write.put("commit", { id: "c1", message: "fix semantics bug", ts });
+                        yield* buildFtsIndexes(write, TARGETS);
+
+                        yield* write.put("turn", { id: "t2", text_excerpt: "a brand new discussion", ts });
+                        const outcomes = yield* buildFtsIndexes(write, TARGETS);
+                        const newRowHits = yield* hitIds(write, TURN_FTS, "brand");
+                        return { outcomes, newRowHits };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.outcomes).toEqual([
+                { table: "turn", rebuilt: true },
+                { table: "commit", rebuilt: false },
+            ]);
+            expect(value?.newRowHits.map((r) => r.id)).toEqual(["t2"]);
+        });
+    });
+
+    dtest("updating an existing row's text moves the digest and rebuilds", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-skip-update-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("turn", { id: "t1", text_excerpt: "the original wording", ts });
+                        yield* buildFtsIndexes(write, [TURN_FTS]);
+
+                        // Same row count, same id - only the text changed. A count-only
+                        // digest would miss this; bit_xor(hash(id, text)) must not.
+                        yield* write.exec("UPDATE turn SET text_excerpt = ? WHERE id = ?", [
+                            "a completely rewritten sentence",
+                            "t1",
+                        ]);
+                        const outcomes = yield* buildFtsIndexes(write, [TURN_FTS]);
+                        const oldHits = yield* hitIds(write, TURN_FTS, "original");
+                        const newHits = yield* hitIds(write, TURN_FTS, "rewritten");
+                        return { outcomes, oldHits, newHits };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.outcomes).toEqual([{ table: "turn", rebuilt: true }]);
+            expect(value?.oldHits).toEqual([]);
+            expect(value?.newHits.map((r) => r.id)).toEqual(["t1"]);
+        });
+    });
+
+    dtest("a matching digest with a missing fts schema still rebuilds", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-skip-missing-schema-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("turn", { id: "t1", text_excerpt: "the seam owns semantics", ts });
+                        yield* buildFtsIndexes(write, [TURN_FTS]);
+
+                        // The digest row still matches, but the materialized fts_main_turn
+                        // schema is gone - a rebuild must happen regardless (fresh store /
+                        // imported bookkeeping case), never trust the digest row alone.
+                        yield* write.exec("LOAD fts");
+                        yield* write.exec(`DROP SCHEMA IF EXISTS ${ftsSchemaName(TURN_FTS)} CASCADE`);
+
+                        const outcomes = yield* buildFtsIndexes(write, [TURN_FTS]);
+                        const hits = yield* hitIds(write, TURN_FTS, "semantics");
+                        return { outcomes, hits };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.outcomes).toEqual([{ table: "turn", rebuilt: true }]);
+            expect(value?.hits.map((r) => r.id)).toEqual(["t1"]);
         });
     });
 });

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -31,7 +31,7 @@ import { SIDECAR_JUDGMENT_TABLES } from "./sidecar-tables.ts";
 // silently shrink to comparing zero (or a handful of) tables/columns.
 const EXPECTED_TABLES_COMPARED = 138;
 /** Of those, how many the DuckDB cache still defines (138 - 14 judgment tables). */
-const EXPECTED_DUCKDB_TABLES = 126; // +schema_comment_state (#869), +cache_bust_event (#868)
+const EXPECTED_DUCKDB_TABLES = 127; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909)
 // A7 (agent_event.raw prune): schema.surql's `agent_event.raw` field was
 // removed (ax never wrote it - buildAgentEventStatement already omitted it
 // from the CONTENT it upserts). schema.duckdb.sql's `agent_event.raw` column

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -40,6 +40,7 @@ describe("coverage of the Surreal schema", () => {
         const bornAfterSurreal = new Set([
             "schema_comment_state", // #869 COMMENT ON bookkeeping
             "cache_bust_event", // #868 cache-bust ledger (SQL model)
+            "fts_index_state", // #909 skip-unchanged bookkeeping for the FTS rebuild
         ]);
         const surrealSet = new Set(surrealTables.map((t) => t.table));
         expect(duckTables.filter((t) => !surrealSet.has(t) && !bornAfterSurreal.has(t))).toEqual([]);

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -189,6 +189,7 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     run_evidence_event: { kind: "node", stage: "active", layer: "derived", note: "Run evidence ledger (#578): normalized claim/observation/verification/boundary events over the graph; backing distinguishes model claim vs tool-backed." },
     run_evidence_ref: { kind: "node", stage: "active", layer: "derived", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
     cache_bust_event: { kind: "node", stage: "active", layer: "derived", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
+    fts_index_state: { kind: "node", stage: "active", layer: "bookkeeping", note: "Skip-unchanged bookkeeping for the FTS rebuild (#909): per-target content digest, so buildFtsIndexes only reruns PRAGMA create_fts_index when the indexed table actually changed." },
 };
 
 /**

--- a/packages/schema/src/parse-duckdb-schema.test.ts
+++ b/packages/schema/src/parse-duckdb-schema.test.ts
@@ -7,7 +7,7 @@ import { DUCKDB_TABLE_NAMES, parseDuckdbColumnDefs, parseDuckdbTables } from "./
 // diff, not a silent shared mutation. It is 138 minus the fourteen judgment
 // tables that now live in schema.sidecar.sql; the FULL 138 is still compared
 // against the Surreal schema, across both engines, in duckdb-parity.test.ts.
-const EXPECTED_DUCKDB_TABLES = 126; // +schema_comment_state (#869), +cache_bust_event (#868)
+const EXPECTED_DUCKDB_TABLES = 127; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909)
 
 describe("parse-duckdb-schema", () => {
     test("parseDuckdbTables finds every table in the committed DDL", () => {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -2699,3 +2699,32 @@ CREATE TABLE IF NOT EXISTS run_evidence_ref (
 CREATE INDEX IF NOT EXISTS run_evidence_ref_event ON run_evidence_ref("event");
 CREATE INDEX IF NOT EXISTS run_evidence_ref_session ON run_evidence_ref(session, ts);
 CREATE INDEX IF NOT EXISTS run_evidence_ref_target ON run_evidence_ref(target_table, target_id);
+
+-- ---------------------------------------------------------------------------
+-- fts_index_state: skip-unchanged bookkeeping for the FTS rebuild (#909)
+-- ---------------------------------------------------------------------------
+-- `buildFtsIndexes` (packages/lib/src/duckdb/fts.ts) reran `PRAGMA
+-- create_fts_index(..., overwrite=1)` over every FTS_TARGETS table on EVERY
+-- ingest + reconcile write, even when nothing indexed had changed - a large
+-- share of the warm-run tail at 1M+ turns. This table stores, per target
+-- table, a cheap content digest computed entirely in SQL:
+--   'v1:' || count(*) || ':' || bit_xor(hash(id, COALESCE(text_col, '')))
+-- ('v1:' is the digest FORMULA version - bump it to force one rebuild across
+-- the fleet). When the stored digest still matches AND the `fts_main_<table>`
+-- schema still exists, the rebuild is skipped entirely; otherwise the index is
+-- rebuilt and the digest row is replaced. A digest match with a MISSING fts
+-- schema still rebuilds (fresh store, or a store where fts_index_state was
+-- imported/restored without the actual index materializing).
+--
+-- `id` (not `table_name`) to keep the repo-wide "every table's PK is `id`"
+-- convention this schema otherwise holds without exception (see
+-- duckdb-schema.test.ts's "every table declares id VARCHAR PRIMARY KEY
+-- first"); the value IS the target table name (e.g. 'turn', 'commit') - the
+-- natural key for this row IS its identity here, same as
+-- schema_comment_state's singleton 'comments' row.
+CREATE TABLE IF NOT EXISTS fts_index_state (
+    -- the target table name, e.g. 'turn' | 'commit'
+    id VARCHAR PRIMARY KEY,
+    digest VARCHAR NOT NULL,
+    built_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
Fixes #909

## What changed

`buildFtsIndexes` (`packages/lib/src/duckdb/fts.ts`) reran `PRAGMA
create_fts_index(..., overwrite=1)` over both FTS targets (`turn.text_excerpt`,
`commit.message`) unconditionally at the end of every `ax ingest` run
(`apps/axctl/src/ingest/run.ts:491`) and every `withConfigWrite` call
(`apps/axctl/src/config-core/reconcile.ts`) — a large share of the warm-run
tail once `turn` passed 1M+ rows, almost always for a table that had not
changed since the last build.

Per target, `buildFtsIndexes` now:

1. Computes a content digest **entirely in SQL** as one VARCHAR:
   `'v1:' || count(*)::VARCHAR || ':' || COALESCE(bit_xor(hash(id, COALESCE(text_col, '')))::VARCHAR, '0')`
   — the `v1:` prefix is the digest formula version, bumped to force a
   one-time rebuild fleet-wide if the formula ever changes. Casting entirely
   to VARCHAR in SQL avoids ever bringing the underlying UBIGINT hash through
   JS (the `write.raw`/raw-numeric-cast trap).
2. Reads the stored digest from the new `fts_index_state` bookkeeping table.
3. Probes whether `fts_main_<table>` still exists as a real DuckDB schema
   (`information_schema.schemata`) — the fts extension materializes it, so a
   digest match alone is not proof the index exists (dropped schema,
   imported/restored bookkeeping row, etc.).
4. Skips the rebuild only when the digest matches **and** the schema exists;
   otherwise rebuilds and replaces the digest row.

`buildFtsIndexes` now returns `ReadonlyArray<{ table, rebuilt }>` (non-breaking
— existing callers already discard the return value) so a warm no-op run is
observable, plus `Effect.logDebug`/`logInfo` lines per target
(`fts: turn unchanged, skip rebuild` / `fts: rebuilding turn`).

`LOAD fts` now runs **at most once per call, only when at least one target
actually needs a rebuild** — a fully-skipped run never touches the fts
extension. Readers (`ax recall`, other `match_bm25` callers) autoload the
extension in their own connection independently (default
`autoload_known_extensions`), so this doesn't affect them.

## Schema

New bookkeeping table `fts_index_state` (`layer: "bookkeeping"`):

```sql
CREATE TABLE IF NOT EXISTS fts_index_state (
    -- the target table name, e.g. 'turn' | 'commit'
    id VARCHAR PRIMARY KEY,
    digest VARCHAR NOT NULL,
    built_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

Registered in `packages/schema/src/duckdb-tables.ts` (`TABLE_METADATA`),
`apps/axctl/src/queries/insights.ts` (`SCHEMA_TABLES`), and
`apps/axctl/src/ingest/stage/table-writes.ts` (`NON_STAGE_WRITERS`, mode
`bookkeep`) — on every writer that reaches `buildFtsIndexes`: `ingest-run`
(direct call in `run.ts`) plus every `withConfigWrite`-routed writer
(`cli:ingest-maintenance`, `cli:ingest-dry-run`, `cli:sessions-backfill`,
`cli:derive-intents`, `cli:ingest-insights`, `cli:wrapped-publish`,
`cli:catalog-reconcile`, `cli:classifiers`, `cli:segment-import`), traced by
grep against every `withConfigWrite` call site.

### One deviation from the brief

The brief's literal DDL used `table_name VARCHAR PRIMARY KEY`. That is the
*only* table in the whole schema whose primary key isn't named `id` — it broke
`duckdb-schema.test.ts`'s "every table declares id VARCHAR PRIMARY KEY first"
invariant (a hard repo-wide convention every other 126 tables hold, including
singleton-keyed tables like `schema_comment_state`, which stores `id =
'comments'`). Renamed the column to `id` (still holding the target table name
as its value, e.g. `'turn'`) to keep that invariant intact rather than carve
out an exception. Also bumped the two `EXPECTED_DUCKDB_TABLES` count constants
(`duckdb-parity.test.ts`, `parse-duckdb-schema.test.ts`: 126 → 127) and added
`fts_index_state` to `duckdb-schema.test.ts`'s `bornAfterSurreal` allowlist
(it has no Surreal-era counterpart, same treatment as `schema_comment_state`
and `cache_bust_event`).

## Tests

Extended `packages/lib/src/duckdb/seam.test.ts`'s existing `FTS` describe
block (no separate `fts.test.ts` existed) with a new `FTS: skip-unchanged
rebuild (#909)` suite:

- fresh store: both targets rebuild, digest rows present, `match_bm25` hits.
- warm no-op: both targets skip, search still works.
- new row in `turn` only: `turn` rebuilds, `commit` stays skipped, new row
  findable.
- `UPDATE` of an existing row's text (same row count): digest moves via
  `bit_xor(hash(id, text))`, rebuild happens, updated text findable, old text
  is not.
- digest row present but `fts_main_turn` schema dropped: rebuilds regardless
  of the digest match.

Also updated `seam.test.ts`'s local minimal test DDL to add `fts_index_state`
(and a `commit` table) since it's a separate hand-rolled schema from
production `schema.duckdb.sql`, and `table-writes.behavior.test.ts` runs
clean unmodified — its before/after digest window closes strictly before
`buildFtsIndexes` runs (confirmed by reading `publishCacheFixture`'s call
order), so the new bookkeeping writes never appear as an "undeclared write"
false positive there.

## Gates run locally (from the worktree)

- `bunx tsc --noEmit -p tsconfig.json` — clean (exit 0, no `error TS`)
- `bun run typecheck` (filtered `rg -v ' (warning|message) TS'`) — clean
- `AX_DUCKDB_DYLIB=... AX_DUCKDB_REQUIRE_FTS=1 AX_DATA_DIR=$(mktemp -d) bun test packages/lib/src/duckdb/ packages/schema apps/axctl/src/ingest/stage/` — 395 pass, 1 skip (pre-existing), 0 fail
- Also ran (extra diligence, not required by the brief):
  `apps/axctl/src/queries/insights.test.ts`,
  `apps/axctl/src/ingest/table-writes.behavior.test.ts`,
  `scripts/check-ci-duckdb.test.ts`,
  `apps/axctl/src/config-core/config-core.test.ts`,
  `apps/axctl/src/dashboard/recall.test.ts` — 149 + 60 pass, 0 fail
- `bun run check:timestamp-cast` — clean (1479 files, 0 uncast arithmetic)
- `bun run check:raw-numeric-cast` — clean (1397 files, 0 bare projections)

Real-store no-op / `ax recall` live verification is **pending orchestrator
checks** per the brief — not run against `~/.local/share/ax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)