### PR TITLE
perf(publish): clone-based snapshot publish (APFS clonefile) with logical-copy fallback

### DIFF
--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -43,6 +43,7 @@ import { posixPath } from "../shared/path.ts";
 import { stageAndRename } from "../staged-rename.ts";
 import { loadNodeApiOver, type DuckDbNodeApi } from "./binding.ts";
 import { canonicalPath } from "./canonical-path.ts";
+import { cloneFile, statSnapshot, statsEqual, walIsQuiescent } from "./clone-file.ts";
 import { resolveDylibPath } from "./dylib.ts";
 import {
     DuckDbDecodeError,
@@ -575,17 +576,39 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
         Effect.acquireRelease(open(path, options), (conn) => conn.close);
 
     /**
-     * Copy `livePath`'s current contents to `targetPath` via DuckDB's own
-     * `COPY FROM DATABASE ... TO` (which snapshots the live catalog, not
-     * merely the file bytes), landing the copy at a TEMP PATH THAT IS A
-     * SIBLING OF `targetPath` and only then `fs.rename`-ing it into place.
-     * Same directory -> same filesystem -> the rename is atomic (never
-     * `EXDEV`), which is the entire point: a reader that already has
-     * `targetPath` open keeps reading the OLD inode uninterrupted for as long
-     * as it holds that handle, even while this swaps in a new one.
+     * Copy `livePath`'s current contents to `targetPath`, landing the copy
+     * at a TEMP PATH THAT IS A SIBLING OF `targetPath` and only then
+     * `fs.rename`-ing it into place. Same directory -> same filesystem ->
+     * the rename is atomic (never `EXDEV`), which is the entire point: a
+     * reader that already has `targetPath` open keeps reading the OLD inode
+     * uninterrupted for as long as it holds that handle, even while this
+     * swaps in a new one.
      *
-     * The writer connection doing the copy is closed BEFORE the rename
-     * (inside the `Effect.ensuring` guarding the copy - or, with
+     * TWO ways to produce that temp file, tried in this order (#908):
+     *
+     *  1. THE CLONE FAST PATH (`attemptClone` below): after a `CHECKPOINT`,
+     *     clone `livePath` onto the temp path via APFS `clonefile`
+     *     (copy-on-write - near-instant regardless of catalog size,
+     *     `clone-file.ts`). Taken ONLY when every guard in `attemptClone`
+     *     holds; any failure - the env escape hatch, a checkpoint failure, a
+     *     non-empty post-checkpoint WAL, a stat mismatch across the clone
+     *     (torn-copy tripwire), a failed clonefile syscall (non-APFS,
+     *     `EXDEV`, `ENOTSUP`, ...), or a failed sanity-open of the staged
+     *     clone - falls back to path 2 silently (logged at debug), never
+     *     surfacing as a `publishSnapshot` failure by itself.
+     *  2. THE LOGICAL PATH (`copyThrough`, unchanged): DuckDB's own
+     *     `CHECKPOINT` / `ATTACH` / `COPY FROM DATABASE ... TO` / `DETACH`,
+     *     which snapshots the live catalog logically rather than cloning
+     *     file bytes - slower (a full logical copy of the whole catalog) but
+     *     has no filesystem-support requirement, so it is the correctness
+     *     baseline every clone attempt falls back to.
+     *
+     * Both land the SAME temp path inside ONE `stageAndRename` call, so
+     * there is still exactly one atomic rename per publish regardless of
+     * which path produced the file.
+     *
+     * The writer connection doing the (logical) copy is closed BEFORE the
+     * rename (inside the `Effect.ensuring` guarding the copy - or, with
      * `options.from`, simply never closed at all, see below), so the temp
      * file never has an open writer at the moment it becomes the published
      * snapshot. The whole operation is wrapped in an outer `Effect.ensuring`
@@ -686,6 +709,154 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
             );
         };
 
+        /** `AX_SNAPSHOT_CLONE=off` forces the logical path unconditionally -
+         *  read fresh on every call (not memoized), so a test or a runtime
+         *  toggle takes effect on the very next publish. */
+        const cloneDisabledByEnv = (): boolean =>
+            (process.env.AX_SNAPSHOT_CLONE ?? "").trim().toLowerCase() === "off";
+
+        /** Best-effort: only ever called on a path where `cloneFile` already
+         *  wrote something to `tmp` and a LATER guard rejected it, so the
+         *  fallback about to run (`copyThrough` on the SAME `tmp`) doesn't
+         *  `ATTACH` onto a stale, half-trusted clone. Never fails - a removal
+         *  failure here just surfaces naturally as the fallback's own ATTACH
+         *  error against a non-empty path, which is a legible failure either
+         *  way. This is NOT the tmp-cleanup `stageAndRename`'s finalizer
+         *  already owns (that still runs unconditionally on every exit); it
+         *  exists only so the same `tmp` path can be reused a second time
+         *  within THIS one `stage` call. */
+        const clearPartialClone = (tmp: string): Effect.Effect<void> =>
+            fs.remove(tmp, { force: true, recursive: true }).pipe(
+                Effect.catch((err) =>
+                    Effect.logWarning(
+                        `ax duckdb: could not clear the partially-cloned temp file at ${tmp} before falling back to the logical copy: ${err.message}`,
+                    ),
+                ),
+            );
+
+        /**
+         * The #908 clone fast path. Never fails: every guard below reports a
+         * rejection as `{ mode: "copy", reason }` instead of an error, so the
+         * caller can fall back to `copyThrough` on the exact same `tmp`
+         * within the SAME `stageAndRename` call - one atomic rename either
+         * way. Only ever returns `{ mode: "clone" }` once the staged file at
+         * `tmp` has been checkpoint-consistent, byte-cloned without a torn
+         * read, and has itself opened read-only and answered a sanity query.
+         *
+         * Safety protocol (all four must hold):
+         *  (a) `CHECKPOINT` succeeds on the connection that actually owns the
+         *      live database - the writer's own `options.from` when given
+         *      (RULING R14: a second handle on `livePath` cannot be trusted
+         *      to see that writer's commits), else a dedicated open -> checkpoint
+         *      -> CLOSE (closing the writer before cloning is trivially safe -
+         *      nothing has `livePath` open in this process afterward).
+         *  (b) `<livePath>.wal` is absent or 0 bytes immediately after the
+         *      checkpoint - a non-empty WAL means the checkpoint left
+         *      committed data outside the base file the clone is about to
+         *      copy.
+         *  (c) `stat(livePath)` taken immediately before and immediately
+         *      after the clone syscall reports the identical size + mtime -
+         *      the torn-copy tripwire: something else wrote to `livePath`
+         *      while the clone ran, so its contents can no longer be trusted.
+         *  (d) the staged clone at `tmp` opens read-only and answers
+         *      `SELECT count(*) AS n FROM duckdb_tables()` with a positive
+         *      count, closed again before this returns.
+         */
+        const attemptClone = (
+            tmp: string,
+        ): Effect.Effect<{ readonly mode: "clone" } | { readonly mode: "copy"; readonly reason: string }> =>
+            Effect.gen(function* () {
+                if (cloneDisabledByEnv()) {
+                    return { mode: "copy", reason: "AX_SNAPSHOT_CLONE=off" } as const;
+                }
+
+                // (a) CHECKPOINT on the connection that owns the live database.
+                const checkpoint = yield* Effect.result(
+                    options?.from
+                        ? options.from.exec("CHECKPOINT").pipe(Effect.asVoid)
+                        : Effect.acquireUseRelease(
+                              open(livePath, { readOnly: false }),
+                              (conn) => conn.exec("CHECKPOINT").pipe(Effect.asVoid),
+                              (conn) => conn.close,
+                          ),
+                );
+                if (checkpoint._tag === "Failure") {
+                    return {
+                        mode: "copy",
+                        reason: `checkpoint before clone failed: ${checkpoint.failure.message}`,
+                    } as const;
+                }
+
+                // (b) post-checkpoint WAL tripwire.
+                const walQuiescent = yield* walIsQuiescent(fs, livePath);
+                if (!walQuiescent) {
+                    return { mode: "copy", reason: "WAL is non-empty after checkpoint" } as const;
+                }
+
+                // (c) torn-copy tripwire, half one: stat before the clone.
+                const before = yield* Effect.result(statSnapshot(fs, livePath));
+                if (before._tag === "Failure") {
+                    return {
+                        mode: "copy",
+                        reason: `pre-clone stat of the live database failed: ${before.failure.message}`,
+                    } as const;
+                }
+
+                const clone = yield* cloneFile(livePath, tmp);
+                if (!clone.cloneable) {
+                    return { mode: "copy", reason: clone.reason ?? "clonefile syscall failed" } as const;
+                }
+
+                // (c) torn-copy tripwire, half two: stat after the clone.
+                const after = yield* Effect.result(statSnapshot(fs, livePath));
+                if (after._tag === "Failure") {
+                    yield* clearPartialClone(tmp);
+                    return {
+                        mode: "copy",
+                        reason: `post-clone stat of the live database failed: ${after.failure.message}`,
+                    } as const;
+                }
+                if (!statsEqual(before.success, after.success)) {
+                    yield* clearPartialClone(tmp);
+                    return {
+                        mode: "copy",
+                        reason: "torn-copy tripwire: the live database's size/mtime changed during the clone",
+                    } as const;
+                }
+
+                // (d) the staged clone must open read-only and answer a
+                // sanity query before it is trusted as the publish.
+                const verified = yield* Effect.result(
+                    Effect.acquireUseRelease(
+                        open(tmp, { readOnly: true }),
+                        (conn) =>
+                            conn.query("SELECT count(*) AS n FROM duckdb_tables()").pipe(
+                                Effect.map((result) => {
+                                    const n = result.rows[0]?.n;
+                                    return typeof n === "bigint" && n > 0n;
+                                }),
+                            ),
+                        (conn) => conn.close,
+                    ),
+                );
+                if (verified._tag === "Failure") {
+                    yield* clearPartialClone(tmp);
+                    return {
+                        mode: "copy",
+                        reason: `sanity check on the staged clone failed: ${verified.failure.message}`,
+                    } as const;
+                }
+                if (!verified.success) {
+                    yield* clearPartialClone(tmp);
+                    return {
+                        mode: "copy",
+                        reason: "sanity check on the staged clone found no tables",
+                    } as const;
+                }
+
+                return { mode: "clone" } as const;
+            });
+
         const attempt = Effect.gen(function* () {
             // Cross-review P1-6 + P2-4, both checked BEFORE anything is
             // created or opened, and both compared on the CANONICAL path so
@@ -737,32 +908,49 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
                 });
             }
 
+            // Finding 6 (final fix round, pre-#908): `open` then `copyThrough`
+            // used to be two separate `yield*`s, so an interrupt landing
+            // BETWEEN them leaked the write handle on the live database for
+            // the life of the process - `conn.close` was never reached
+            // because `Effect.ensuring` was only attached to the SECOND
+            // yield. `acquireUseRelease` makes acquire+use+release one atomic
+            // unit: acquisition is uninterruptible, and release is guaranteed
+            // to run once acquisition succeeds, however `use` ends - success,
+            // typed failure, defect, or interruption. This closes the writer
+            // BEFORE the rename, on every path, because the whole `stage`
+            // step completes before `stageAndRename` renames.
+            const logicalCopy = (tmp: string) =>
+                options?.from
+                    ? // Caller-owned connection - copy through it directly
+                      // (RULING R14) and never close it, we don't own its
+                      // lifecycle.
+                      copyThrough(options.from, tmp)
+                    : Effect.acquireUseRelease(
+                          open(livePath, { readOnly: false }),
+                          (conn) => copyThrough(conn, tmp),
+                          (conn) => conn.close,
+                      );
+
             yield* stageAndRename<SnapshotPublishError | DuckDbOpenError>(targetPath, {
+                // #908: try the clone fast path first; `attemptClone` never
+                // fails, so a rejection just falls through to the SAME
+                // logical path this stage function ran unconditionally
+                // before - one `stageAndRename` call, one atomic rename,
+                // either way.
                 stage: (tmp) =>
-                    options?.from
-                        ? // Caller-owned connection - copy through it directly
-                          // (RULING R14) and never close it, we don't own its
-                          // lifecycle.
-                          copyThrough(options.from, tmp)
-                        : // Finding 6 (final fix round): `open` then
-                          // `copyThrough` used to be two separate `yield*`s, so
-                          // an interrupt landing BETWEEN them leaked the write
-                          // handle on the live database for the life of the
-                          // process - `conn.close` was never reached because
-                          // `Effect.ensuring` was only attached to the SECOND
-                          // yield. `acquireUseRelease` makes acquire+use+release
-                          // one atomic unit: acquisition is uninterruptible, and
-                          // release is guaranteed to run once acquisition
-                          // succeeds, however `use` ends - success, typed
-                          // failure, defect, or interruption. This closes the
-                          // writer BEFORE the rename, on every path, because the
-                          // whole `stage` step completes before `stageAndRename`
-                          // renames.
-                          Effect.acquireUseRelease(
-                              open(livePath, { readOnly: false }),
-                              (conn) => copyThrough(conn, tmp),
-                              (conn) => conn.close,
-                          ),
+                    Effect.gen(function* () {
+                        const cloned = yield* attemptClone(tmp);
+                        if (cloned.mode === "clone") {
+                            yield* Effect.logDebug(
+                                `ax duckdb: publishSnapshot(${targetPath}) took the clone fast path (APFS clonefile)`,
+                            );
+                            return;
+                        }
+                        yield* Effect.logDebug(
+                            `ax duckdb: publishSnapshot(${targetPath}) took the logical copy path: ${cloned.reason}`,
+                        );
+                        yield* logicalCopy(tmp);
+                    }),
                 onFsError: (step, err) =>
                     new SnapshotPublishError({
                         snapshotPath: targetPath,

--- a/packages/lib/src/duckdb/clone-file.test.ts
+++ b/packages/lib/src/duckdb/clone-file.test.ts
@@ -1,0 +1,122 @@
+/**
+ * DB-free unit tests for the #908 clone primitives (`clone-file.ts`).
+ *
+ * `cloneFile` is exercised directly against the real filesystem - this
+ * suite's whole point is proving the APFS `clonefile` syscall actually
+ * clones on this machine, so it does NOT go through a `DuckDb` layer at all.
+ * `walIsQuiescent` and `statsEqual` cover the two tripwires the brief calls
+ * out as "hard to synthesize reliably" at the `publishSnapshot` integration
+ * level (a non-empty post-checkpoint WAL, a torn copy): unit-testing the
+ * helpers directly here is the documented fallback for that gap.
+ */
+import { describe, expect, test } from "bun:test";
+import { BunFileSystem } from "@effect/platform-bun";
+import { Effect, FileSystem } from "effect";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cloneFile, statsEqual, walIsQuiescent, type FileStatSnapshot } from "./clone-file.ts";
+
+const withTempDir = async (body: (dir: string) => Promise<void>): Promise<void> => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-clone-file-"));
+    try {
+        await body(dir);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+};
+
+const runWithFs = <A>(body: (fs: FileSystem.FileSystem) => Effect.Effect<A, never, FileSystem.FileSystem>): Promise<A> =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            return yield* body(fs);
+        }).pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<A>,
+    );
+
+describe("cloneFile", () => {
+    test("clones a file byte-for-byte via APFS clonefile", async () => {
+        await withTempDir(async (dir) => {
+            const src = join(dir, "src.bin");
+            const dst = join(dir, "dst.bin");
+            const content = "ax-clone-payload-".repeat(500);
+            writeFileSync(src, content);
+
+            const outcome = await Effect.runPromise(cloneFile(src, dst));
+
+            expect(outcome.cloneable).toBe(true);
+            expect(existsSync(dst)).toBe(true);
+            expect(readFileSync(dst, "utf8")).toBe(content);
+        });
+    });
+
+    test("reports a non-cloneable outcome (never throws) when the source is missing", async () => {
+        await withTempDir(async (dir) => {
+            const src = join(dir, "does-not-exist.bin");
+            const dst = join(dir, "dst.bin");
+
+            const outcome = await Effect.runPromise(cloneFile(src, dst));
+
+            expect(outcome.cloneable).toBe(false);
+            expect(outcome.reason).toBeDefined();
+            expect(existsSync(dst)).toBe(false);
+        });
+    });
+});
+
+describe("statsEqual (torn-copy tripwire, pure half)", () => {
+    test("true for identical size + mtime", () => {
+        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
+        const b: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
+        expect(statsEqual(a, b)).toBe(true);
+    });
+
+    test("false when size differs", () => {
+        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
+        const b: FileStatSnapshot = { size: 2048, mtimeMs: 1_700_000_000_000 };
+        expect(statsEqual(a, b)).toBe(false);
+    });
+
+    test("false when mtime differs", () => {
+        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
+        const b: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_001 };
+        expect(statsEqual(a, b)).toBe(false);
+    });
+});
+
+describe("walIsQuiescent (post-checkpoint WAL tripwire)", () => {
+    test("quiescent when the WAL file is absent", async () => {
+        await withTempDir(async (dir) => {
+            const live = join(dir, "live.duckdb");
+            writeFileSync(live, "not a real duckdb file, just needs to exist as a path stem");
+
+            const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
+
+            expect(quiescent).toBe(true);
+        });
+    });
+
+    test("quiescent when the WAL file exists but is empty", async () => {
+        await withTempDir(async (dir) => {
+            const live = join(dir, "live.duckdb");
+            writeFileSync(live, "stem");
+            writeFileSync(`${live}.wal`, "");
+
+            const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
+
+            expect(quiescent).toBe(true);
+        });
+    });
+
+    test("NOT quiescent when the WAL file has bytes - the case a real checkpoint should never leave behind", async () => {
+        await withTempDir(async (dir) => {
+            const live = join(dir, "live.duckdb");
+            writeFileSync(live, "stem");
+            writeFileSync(`${live}.wal`, "uncommitted-wal-bytes");
+
+            const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
+
+            expect(quiescent).toBe(false);
+        });
+    });
+});

--- a/packages/lib/src/duckdb/clone-file.ts
+++ b/packages/lib/src/duckdb/clone-file.ts
@@ -1,0 +1,101 @@
+/**
+ * The clone-based snapshot publish fast path (#908): primitives for cloning
+ * the live DuckDB file via APFS `clonefile` (copy-on-write) instead of the
+ * logical `COPY FROM DATABASE`, plus the pure/effect guard helpers that
+ * `publishSnapshot` (`client.ts`) runs the clone attempt through before it
+ * trusts the result.
+ *
+ * RULING R6: runtime modules under `packages/lib/src/` may not import
+ * `node:fs`/`node:path` (`check:no-node-fs`) - Effect's `FileSystem` service
+ * is the replacement. This file is the ONE deliberate exception, registered
+ * in `scripts/check-no-node-fs.ts`'s `EXCLUDED_FILES`: `copyFileSync`'s
+ * `COPYFILE_FICLONE_FORCE` flag has no equivalent on `FileSystem` (it exposes
+ * no clone flag at all), and FORCE (not the softer `COPYFILE_FICLONE`, which
+ * silently falls back to a byte copy on failure) is load-bearing - a silent
+ * byte-copy substitution would defeat the entire point of the fast path
+ * without anyone noticing. Every use of the node import is wrapped in
+ * `Effect.try` and never escapes this module as an untyped throw.
+ */
+import { copyFileSync, constants } from "node:fs";
+import { Effect, FileSystem, Option } from "effect";
+import type { PlatformError } from "effect/PlatformError";
+import { orAbsent } from "../shared/fs-error.ts";
+
+/** Outcome of one `cloneFile` attempt. Never throws/fails - a failed clone
+ *  (non-APFS filesystem, cross-device `EXDEV`, unsupported `ENOTSUP`, or any
+ *  other native error) is reported as data so the caller can fall back to the
+ *  logical copy path. */
+export interface CloneOutcome {
+    readonly cloneable: boolean;
+    readonly reason?: string;
+}
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Attempt an APFS `clonefile` (copy-on-write) of `src` to `dst` via
+ * `COPYFILE_FICLONE_FORCE`. FORCE, not the plain `COPYFILE_FICLONE`: the
+ * force flag makes the call FAIL when a true clone isn't possible rather
+ * than silently degrading to a byte-for-byte copy, so a non-clone result is
+ * always visible to the caller as `{ cloneable: false }` and never mistaken
+ * for the fast path having run.
+ *
+ * `dst` must not already exist (or must be safely overwritable) - this
+ * function does not check; callers stage into a fresh temp path.
+ */
+export const cloneFile = (src: string, dst: string): Effect.Effect<CloneOutcome> =>
+    Effect.try({
+        try: () => {
+            copyFileSync(src, dst, constants.COPYFILE_FICLONE_FORCE);
+        },
+        catch: (err) => errorMessage(err),
+    }).pipe(
+        Effect.as({ cloneable: true } as const),
+        Effect.catch((reason) => Effect.succeed({ cloneable: false, reason } as const)),
+    );
+
+/** The two stat fields the torn-copy tripwire compares. */
+export interface FileStatSnapshot {
+    readonly size: number;
+    readonly mtimeMs: number;
+}
+
+/**
+ * Torn-copy tripwire, pure half: `true` iff two stat snapshots of the SAME
+ * path, taken immediately before and immediately after the clone, describe
+ * the same file - i.e. nothing else wrote to it while the clone ran. Split
+ * out from the effectful stat call so this comparison is unit-testable
+ * without touching a filesystem.
+ */
+export const statsEqual = (a: FileStatSnapshot, b: FileStatSnapshot): boolean =>
+    a.size === b.size && a.mtimeMs === b.mtimeMs;
+
+/** Torn-copy tripwire, effectful half: take a `{ size, mtimeMs }` snapshot of
+ *  `path`. Fails (typed `PlatformError`) exactly when `fs.stat` fails -
+ *  callers decide what a stat failure means for their fallback logic. */
+export const statSnapshot = (
+    fs: FileSystem.FileSystem,
+    path: string,
+): Effect.Effect<FileStatSnapshot, PlatformError> =>
+    fs.stat(path).pipe(
+        Effect.map((info) => ({
+            size: Number(info.size),
+            mtimeMs: Option.match(info.mtime, { onNone: () => 0, onSome: (d) => d.getTime() }),
+        })),
+    );
+
+/**
+ * Post-checkpoint tripwire: `true` iff `<livePath>.wal` is absent or exactly
+ * 0 bytes. A non-empty WAL after `CHECKPOINT` means the checkpoint did not
+ * fully flush committed data out of the WAL and into the base file - cloning
+ * the base file alone would silently miss it, so this must hold before the
+ * clone is trusted. Never fails: a stat error (including the WAL vanishing
+ * between the exists-check and the stat, a benign race with DuckDB's own WAL
+ * lifecycle) is treated as "absent" -> quiescent, matching how the rest of
+ * this codebase treats an optional-file probe (`orAbsent`).
+ */
+export const walIsQuiescent = (fs: FileSystem.FileSystem, livePath: string): Effect.Effect<boolean> =>
+    fs.stat(`${livePath}.wal`).pipe(
+        Effect.map((info) => Number(info.size) === 0),
+        orAbsent(true),
+    );

--- a/packages/lib/src/duckdb/snapshot.test.ts
+++ b/packages/lib/src/duckdb/snapshot.test.ts
@@ -352,60 +352,74 @@ describe("publishSnapshot options.from (RULING R14)", () => {
                 const live = join(dir, "live.duckdb");
                 const snap = join(dir, "snapshot.duckdb");
 
-                const rw = yield* db.open(live);
-                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
-                for (let i = 0; i < 3000; i++) {
-                    yield* rw.exec(`INSERT INTO t VALUES (${i}, '${"x".repeat(2000)}')`);
+                // #908: this case specifically exercises the LOGICAL copy
+                // path's ATTACH/DETACH robustness under a mid-`COPY FROM
+                // DATABASE` OOM failure - a filesystem clonefile never touches
+                // DuckDB's `memory_limit`, so the clone fast path would just
+                // succeed here and the whole scenario below would be moot.
+                // Forcing the logical path is what keeps this test exercising
+                // what its name says it exercises.
+                const previousClone = process.env.AX_SNAPSHOT_CLONE;
+                process.env.AX_SNAPSHOT_CLONE = "off";
+                try {
+                    const rw = yield* db.open(live);
+                    yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                    for (let i = 0; i < 3000; i++) {
+                        yield* rw.exec(`INSERT INTO t VALUES (${i}, '${"x".repeat(2000)}')`);
+                    }
+                    // Flush normally at full memory, THEN clamp memory_limit so
+                    // the COPY step itself (not CHECKPOINT, which has nothing
+                    // left to flush) runs out of memory - a real, non-fatal
+                    // DuckDB error ("Out of Memory Error: failed to pin block"),
+                    // not the FATAL "database has been invalidated" error a low
+                    // memory_limit produces during an actual checkpoint. This
+                    // leaves `rw` perfectly usable afterward, matching the
+                    // documented hazard exactly: the connection looks fine, only
+                    // `publishSnapshot` through it is broken.
+                    yield* rw.exec("CHECKPOINT");
+                    yield* rw.exec("PRAGMA memory_limit='2MB'");
+
+                    // THE ASSERTION THAT MATTERS: `publishSnapshot` ATTACHes a
+                    // randomly-aliased database on `rw` and must DETACH it again
+                    // on every path, including a mid-copy failure - a leaked
+                    // attachment does NOT collide with any later publish (the
+                    // alias is a fresh `crypto.randomUUID()` per call, so "a
+                    // later publish through the same connection still succeeds"
+                    // proves nothing: it passes even with
+                    // `Effect.ensuring(detach)` deleted entirely). The direct
+                    // check is the attachment count on `rw` itself, via
+                    // `duckdb_databases()`, taken immediately before and after
+                    // the failed publish.
+                    const attachmentCount = () =>
+                        Effect.gen(function* () {
+                            const result = yield* rw.query("SELECT count(*) AS n FROM duckdb_databases()");
+                            return result.rows[0]!.n as bigint;
+                        });
+
+                    const attachmentsBefore = yield* attachmentCount();
+
+                    const first = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
+                    expect(first._tag).toBe("Failure");
+
+                    const attachmentsAfter = yield* attachmentCount();
+                    expect(attachmentsAfter).toBe(attachmentsBefore);
+
+                    // restore normal memory and confirm the connection is
+                    // otherwise completely healthy - the failure was ordinary,
+                    // not fatal.
+                    yield* rw.exec("PRAGMA memory_limit='4GB'");
+                    expect((yield* rw.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3000n);
+
+                    // A subsequent publish through the same connection still
+                    // succeeds too, kept as a secondary end-to-end check.
+                    const second = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
+                    expect(second._tag).toBe("Success");
+
+                    yield* rw.close;
+                } finally {
+                    if (previousClone === undefined) delete process.env.AX_SNAPSHOT_CLONE;
+                    else process.env.AX_SNAPSHOT_CLONE = previousClone;
                 }
-                // Flush normally at full memory, THEN clamp memory_limit so
-                // the COPY step itself (not CHECKPOINT, which has nothing
-                // left to flush) runs out of memory - a real, non-fatal
-                // DuckDB error ("Out of Memory Error: failed to pin block"),
-                // not the FATAL "database has been invalidated" error a low
-                // memory_limit produces during an actual checkpoint. This
-                // leaves `rw` perfectly usable afterward, matching the
-                // documented hazard exactly: the connection looks fine, only
-                // `publishSnapshot` through it is broken.
-                yield* rw.exec("CHECKPOINT");
-                yield* rw.exec("PRAGMA memory_limit='2MB'");
-
-                // THE ASSERTION THAT MATTERS: `publishSnapshot` ATTACHes a
-                // randomly-aliased database on `rw` and must DETACH it again
-                // on every path, including a mid-copy failure - a leaked
-                // attachment does NOT collide with any later publish (the
-                // alias is a fresh `crypto.randomUUID()` per call, so "a
-                // later publish through the same connection still succeeds"
-                // proves nothing: it passes even with
-                // `Effect.ensuring(detach)` deleted entirely). The direct
-                // check is the attachment count on `rw` itself, via
-                // `duckdb_databases()`, taken immediately before and after
-                // the failed publish.
-                const attachmentCount = () =>
-                    Effect.gen(function* () {
-                        const result = yield* rw.query("SELECT count(*) AS n FROM duckdb_databases()");
-                        return result.rows[0]!.n as bigint;
-                    });
-
-                const attachmentsBefore = yield* attachmentCount();
-
-                const first = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
-                expect(first._tag).toBe("Failure");
-
-                const attachmentsAfter = yield* attachmentCount();
-                expect(attachmentsAfter).toBe(attachmentsBefore);
-
-                // restore normal memory and confirm the connection is
-                // otherwise completely healthy - the failure was ordinary,
-                // not fatal.
-                yield* rw.exec("PRAGMA memory_limit='4GB'");
-                expect((yield* rw.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(3000n);
-
-                // A subsequent publish through the same connection still
-                // succeeds too, kept as a secondary end-to-end check.
-                const second = yield* Effect.result(db.publishSnapshot(live, snap, { from: rw }));
-                expect(second._tag).toBe("Success");
-
-                yield* rw.close;
             }),
         ),
         // bun's default 5000ms is a LOCAL number. This case does real DuckDB
@@ -416,5 +430,149 @@ describe("publishSnapshot options.from (RULING R14)", () => {
         // the same case passes locally every time. 30s is generous enough that
         // a failure here means the connection really did stay wedged.
         30_000,
+    );
+});
+
+// #908: the clone fast path. `workDir()` places `live.duckdb` and the
+// staged temp file in the SAME directory (a plain `os.tmpdir()` subdirectory
+// under the repo's root APFS volume in this dev/CI environment), which is
+// exactly what `cloneFile` needs - clonefile only works within one
+// filesystem. These cases run with the default (clone-enabled) settings, so
+// on this machine they exercise the clone path; the WAL-tripwire and
+// torn-copy-tripwire GUARD FUNCTIONS themselves (hard to force through a real
+// checkpoint race) are unit-tested directly in `clone-file.test.ts`
+// (`walIsQuiescent`, `statsEqual`) rather than synthesized here. Per the
+// brief, `publishSnapshot`'s public signature stays `Effect<void, ...>` (no
+// added discriminator), so these assert OBSERVABLE BEHAVIOR - data parity and
+// the reader-holds-old-inode property - not which internal path ran.
+describe("publishSnapshot clone-based fast path (#908)", () => {
+    dtest(
+        "publishes identical data through the clone fast path (options.from)",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'first')");
+                yield* rw.exec("INSERT INTO t VALUES (2, 'second')");
+
+                yield* db.publishSnapshot(live, snap, { from: rw });
+
+                expect(existsSync(snap)).toBe(true);
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+
+                const reader = yield* db.openSnapshot(snap);
+                expect(reader.readOnly).toBe(true);
+                expect((yield* reader.query("SELECT id, note FROM t ORDER BY id")).rows).toEqual([
+                    { id: 1, note: "first" },
+                    { id: 2, note: "second" },
+                ]);
+                yield* reader.close;
+                yield* rw.close;
+            }),
+        ),
+    );
+
+    dtest(
+        "publishes identical data through the clone fast path (no options.from)",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'only')");
+                yield* rw.close;
+
+                yield* db.publishSnapshot(live, snap);
+
+                const reader = yield* db.openSnapshot(snap);
+                expect((yield* reader.query("SELECT note FROM t")).rows).toEqual([{ note: "only" }]);
+                yield* reader.close;
+            }),
+        ),
+    );
+
+    // Pins the SAME reader-isolation property `snapshot.test.ts` already
+    // covers for the logical path, under the clone path this time: a reader
+    // that opened the OLD snapshot before a republish must keep seeing the
+    // OLD data uninterrupted, because the clone lands at a temp sibling and
+    // only the atomic rename swaps it in - identical guarantee, different
+    // mechanism for producing the temp file.
+    dtest(
+        "a reader holding the OLD snapshot keeps reading while a new one is cloned into place",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'v1')");
+                yield* db.publishSnapshot(live, snap, { from: rw });
+
+                const reader = yield* db.openSnapshot(snap);
+                const inodeBefore = statSync(snap).ino;
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+
+                yield* rw.exec("INSERT INTO t VALUES (2, 'v2')");
+                yield* db.publishSnapshot(live, snap, { from: rw });
+
+                // a NEW inode is now published ...
+                expect(statSync(snap).ino).not.toBe(inodeBefore);
+                // ... while the reader holding the OLD handle is unaffected.
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(1n);
+                yield* reader.close;
+
+                const fresh = yield* db.openSnapshot(snap);
+                expect((yield* fresh.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(2n);
+                yield* fresh.close;
+                yield* rw.close;
+            }),
+        ),
+    );
+
+    // AX_SNAPSHOT_CLONE=off is the escape hatch: it must force the logical
+    // path unconditionally, and a publish under it must still succeed with
+    // full data parity - the minimal observable assertion the brief calls
+    // for, since forcing a CLONE failure to prove "off" skipped a working
+    // clone isn't reliably constructible here.
+    dtest(
+        "AX_SNAPSHOT_CLONE=off forces the logical path and still publishes correctly",
+        withDuckDb((db) =>
+            Effect.gen(function* () {
+                const dir = workDir();
+                const live = join(dir, "live.duckdb");
+                const snap = join(dir, "snapshot.duckdb");
+
+                const rw = yield* db.open(live);
+                yield* rw.exec("CREATE TABLE t (id INTEGER, note VARCHAR)");
+                yield* rw.exec("INSERT INTO t VALUES (1, 'off-path')");
+                yield* rw.exec("INSERT INTO t VALUES (2, 'still-works')");
+
+                const previous = process.env.AX_SNAPSHOT_CLONE;
+                process.env.AX_SNAPSHOT_CLONE = "off";
+                try {
+                    yield* db.publishSnapshot(live, snap, { from: rw });
+                } finally {
+                    if (previous === undefined) delete process.env.AX_SNAPSHOT_CLONE;
+                    else process.env.AX_SNAPSHOT_CLONE = previous;
+                }
+
+                expect(existsSync(snap)).toBe(true);
+                expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+
+                const reader = yield* db.openSnapshot(snap);
+                expect((yield* reader.query("SELECT count(*) AS n FROM t")).rows[0]!.n).toBe(2n);
+                yield* reader.close;
+                yield* rw.close;
+            }),
+        ),
     );
 });

--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -56,6 +56,13 @@ const EXCLUDED_FILES: readonly string[] = [
     // Porting it to FileSystem would force every downstream test file that
     // needs a dylib path to build a platform layer just to call it.
     "packages/lib/src/testing/duckdb-dylib.ts",
+    // #908 clone-based snapshot publish: `copyFileSync(src, dst,
+    // COPYFILE_FICLONE_FORCE)` is the APFS clonefile primitive, and
+    // `FileSystem` exposes no clone flag at all - there is no Effect-native
+    // equivalent to port to. Every call is wrapped in `Effect.try` and a
+    // failure never escapes untyped; see the file's own header for why FORCE
+    // (not the softer, silently-degrading `COPYFILE_FICLONE`) is load-bearing.
+    "packages/lib/src/duckdb/clone-file.ts",
 ];
 
 const BANNED_SPECIFIERS = [


### PR DESCRIPTION
Fixes #908

## Summary

`publishSnapshot` (`packages/lib/src/duckdb/client.ts`) ran `CHECKPOINT` /
`ATTACH` / `COPY FROM DATABASE ... TO` / `DETACH` on every publish - a full
logical copy of the ~7GB catalog even when little had changed. This adds a
fast path that clones the live file via APFS `clonefile` (copy-on-write,
near-instant regardless of catalog size) instead, falling back to the
unchanged logical COPY path whenever the clone can't be trusted.

## Mechanism

New module `packages/lib/src/duckdb/clone-file.ts`:
- `cloneFile(src, dst)` - `copyFileSync(src, dst, COPYFILE_FICLONE_FORCE)`
  wrapped in `Effect.try`, reporting `{ cloneable: false, reason }` on any
  failure instead of throwing. **FORCE, not the softer `COPYFILE_FICLONE`**:
  FORCE fails loudly when a true clone isn't possible rather than silently
  degrading to a byte copy, so a non-clone result is never mistaken for the
  fast path having run.
- `walIsQuiescent` / `statSnapshot` / `statsEqual` - the pure/effect guard
  primitives the safety protocol below is built from, split out so they're
  independently unit-testable.

This is the one deliberate exception registered in
`scripts/check-no-node-fs.ts`'s `EXCLUDED_FILES`: `FileSystem` exposes no
clone flag at all, so there's no Effect-native primitive to port to. Every
`node:fs` call is wrapped in `Effect.try` and never escapes this module as an
untyped throw.

## Safety protocol (`attemptClone` in `client.ts`)

The clone publishes ONLY when ALL of these hold; any failure falls back to
the logical COPY path within the SAME `stageAndRename` call (one atomic
rename either way), logged at debug with the reason:

1. **`AX_SNAPSHOT_CLONE=off`** escape hatch, read fresh per call.
2. **CHECKPOINT succeeds on the connection that owns the live database** -
   the writer's own `options.from` when given (RULING R14: a second handle
   on `livePath` can't be trusted to see that writer's commits), else a
   dedicated open -> checkpoint -> CLOSE (closing the writer before cloning
   is trivially safe).
3. **Post-checkpoint WAL tripwire**: `<livePath>.wal` is absent or 0 bytes
   immediately after the checkpoint.
4. **Torn-copy tripwire**: `stat(livePath)` (size + mtimeMs) taken
   immediately before and immediately after the clone syscall must match.
5. **Staged-clone sanity check**: the clone at the temp path opens read-only
   and answers `SELECT count(*) AS n FROM duckdb_tables()` with a positive
   count, closed again before it's trusted.

If a clone syscall succeeds but a LATER guard (torn-copy, sanity check)
rejects it, the partially-written temp file is cleared before the fallback
reuses the same temp path (so the logical path's `ATTACH` never opens a
stale, half-trusted file) - this is separate from `stageAndRename`'s own
finalizer, which still owns final temp-file cleanup on every exit path.

`DuckDbService`'s public signature is unchanged - no new required params,
`publishSnapshot` still returns `Effect<void, ...>`.

## Tests (`packages/lib/src/duckdb/`)

- `clone-file.test.ts` (new, DB-free): `cloneFile` exercised directly against
  the real filesystem (proves the syscall clones byte-for-byte on this
  machine, and reports `cloneable: false` on a missing source rather than
  throwing); `statsEqual` pure-equality cases; `walIsQuiescent` against a
  crafted absent / empty / non-empty `.wal` file.
- `snapshot.test.ts` (extended): clone-path data parity (`options.from` and
  without), the reader-holding-old-inode property pinned specifically for the
  clone path (mirrors the existing logical-path case), and
  `AX_SNAPSHOT_CLONE=off` forcing the logical path with parity preserved.
- One pre-existing test ("a mid-copy failure on the `from` path still leaves
  the connection usable") now forces `AX_SNAPSHOT_CLONE=off` for its
  duration - its premise (a `PRAGMA memory_limit` clamp forcing `COPY FROM
  DATABASE` to OOM) is specific to the logical path; a filesystem clonefile
  never touches DuckDB's `memory_limit`, so without the override the clone
  fast path would just succeed and the scenario would be moot. This is the
  one existing test that needed a change - it's otherwise unmodified.

## Deviations from the brief

- The non-empty-WAL fallback is unit-tested at the `walIsQuiescent` helper
  level rather than synthesized end-to-end through `publishSnapshot` - the
  brief flagged this as likely necessary ("hard to synthesize reliably...
  cover the tripwire function itself"), and I couldn't reliably force a
  non-empty post-checkpoint WAL through the public API either.
- `publishSnapshot` does not return a `{ mode: "clone" | "copy" }`
  discriminator - per the brief's fallback allowance, tests assert
  observable behavior only (data parity, reader isolation) rather than which
  internal path ran, so the public signature stays exactly as documented in
  `DuckDbService`.

## Gates (run from the worktree root)

- `bunx tsc --noEmit -p tsconfig.json` - clean
- `bun run typecheck` - clean
- `AX_DUCKDB_DYLIB=... AX_DUCKDB_REQUIRE_FTS=1 AX_DATA_DIR=$(mktemp -d) bun test packages/lib/src/duckdb/` - 241 pass, 0 fail
- `bun run check:no-node-fs` / `check:timestamp-cast` / `check:raw-numeric-cast` - all clean

## Pending (orchestrator, per the task brief)

Real-store parity (row-count + per-table content digest vs the logical-copy
baseline, on an APFS clone of the real store, not the store itself) and the
warm `--since=1` before/after benchmark were explicitly out of scope for this
change and are left for the orchestrator to verify.

Generated with [ax](https://github.com/Necmttn/ax)