### PR TITLE
feat(routability): learned judgment classifier DARK behind AX_JUDGMENT_MODEL=learned

### DIFF
--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -29,6 +29,7 @@ import { BaseStageStats, IngestContext, type StageDef } from "./stage/types.ts";
 import { reapStaleIngestRuns } from "./reap-runs.ts";
 import { correlateOrphanOtel } from "../otel/correlate.ts";
 import { retainRecentOtel, type OtelRetentionResult } from "../otel/retention.ts";
+import { seedClassifierWeights } from "./seed-classifier-weights.ts";
 
 export interface StageEventName {
     readonly source: string;
@@ -489,6 +490,10 @@ export const runIngest = (
                 Effect.succeed({ error: errorText(error) })),
         );
         yield* buildFtsIndexes(write);
+        // Idempotent, version-gated seed - not a stage (nothing here is
+        // derived from transcripts); best-effort like FTS, a failure here
+        // must not fail the whole run (regex judgment path stays the floor).
+        yield* seedClassifierWeights(write).pipe(Effect.ignore);
         return {
             runId,
             selectedStages: selectedStages.map((s) => s.meta.key),

--- a/apps/axctl/src/ingest/seed-classifier-weights.test.ts
+++ b/apps/axctl/src/ingest/seed-classifier-weights.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "bun:test";
+import { Effect, Layer, Schema } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { join } from "node:path";
+import { CacheRead, CacheReadLayer, withCacheWrite, type CacheWriteService } from "@ax/lib/duckdb/seam";
+import { withIngestLock } from "@ax/lib/ingest-lock";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { seedClassifierWeights } from "./seed-classifier-weights.ts";
+import { JUDGMENT_MODEL_SEED, type JudgmentModelSeed } from "../queries/judgment-weights.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("seed classifier weights");
+const Platform = Layer.merge(BunFileSystem.layer, BunPath.layer);
+
+const CACHE_DDL = `
+CREATE TABLE classifier_weights (
+    id VARCHAR PRIMARY KEY,
+    model_id VARCHAR NOT NULL,
+    feature VARCHAR NOT NULL,
+    weight DOUBLE NOT NULL,
+    threshold DOUBLE NOT NULL,
+    version VARCHAR NOT NULL,
+    trained_at TIMESTAMP
+);
+`;
+
+const WeightRow = Schema.Struct({
+    model_id: Schema.String,
+    feature: Schema.String,
+    weight: Schema.Number,
+    threshold: Schema.Number,
+    version: Schema.String,
+});
+
+interface RunResult {
+    readonly snapshotPath: string;
+}
+
+/** Run one `withCacheWrite` body against a fresh temp store, publish, return
+ *  the snapshot path for a follow-up read. */
+function run(root: string, body: (write: CacheWriteService) => Effect.Effect<void, unknown>): Effect.Effect<RunResult, unknown> {
+    const lockPath = join(root, "ingest.lock");
+    const snapshotPath = join(root, "snapshot.duckdb");
+    const publish = withIngestLock({
+        lockPath,
+        command: "seed-classifier-weights-test",
+        staleMs: 60_000,
+        onBusy: () => Effect.die("unexpected busy lock"),
+    }, withCacheWrite({
+        livePath: join(root, "live.duckdb"),
+        lockPath,
+        snapshotPath,
+        schemaSql: CACHE_DDL,
+        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+    }, body));
+    return publish.pipe(Effect.provide(Platform), Effect.map(() => ({ snapshotPath })));
+}
+
+function readRows(snapshotPath: string) {
+    const layer = CacheReadLayer({ snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) });
+    return Effect.gen(function* () {
+        const read = yield* CacheRead;
+        return yield* read.rows(WeightRow, "SELECT model_id, feature, weight, threshold, version FROM classifier_weights ORDER BY feature");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+}
+
+dtest("seeds all weight rows for the committed constants on a fresh table", async () => {
+    const root = tempDir("ax-classifier-weights-");
+    const { snapshotPath } = await Effect.runPromise(run(root, (write) => seedClassifierWeights(write)));
+    const rows = await Effect.runPromise(readRows(snapshotPath));
+    expect(rows).toHaveLength(Object.keys(JUDGMENT_MODEL_SEED.weights).length);
+    expect(rows.every((r) => r.model_id === JUDGMENT_MODEL_SEED.modelId)).toBe(true);
+    expect(rows.every((r) => r.threshold === JUDGMENT_MODEL_SEED.threshold)).toBe(true);
+    expect(rows.every((r) => r.version === JUDGMENT_MODEL_SEED.version)).toBe(true);
+    const bias = rows.find((r) => r.feature === "bias");
+    expect(bias?.weight).toBe(JUDGMENT_MODEL_SEED.weights.bias);
+});
+
+dtest("re-running the SAME version is a no-op (idempotent)", async () => {
+    const root = tempDir("ax-classifier-weights-idem-");
+    const { snapshotPath } = await Effect.runPromise(run(root, (write) =>
+        Effect.gen(function* () {
+            yield* seedClassifierWeights(write);
+            yield* seedClassifierWeights(write); // second run, same version
+        })));
+    const rows = await Effect.runPromise(readRows(snapshotPath));
+    expect(rows).toHaveLength(Object.keys(JUDGMENT_MODEL_SEED.weights).length);
+});
+
+dtest("a NEW version replaces the old one, deleting stale rows", async () => {
+    const root = tempDir("ax-classifier-weights-replace-");
+    const v1: JudgmentModelSeed = {
+        modelId: "judgment-v1",
+        version: "v1-test",
+        trainedAt: "2026-01-01T00:00:00Z",
+        threshold: 0.4,
+        weights: { bias: -1, editCount: 0.1 },
+    };
+    const v2: JudgmentModelSeed = {
+        modelId: "judgment-v1",
+        version: "v2-test",
+        trainedAt: "2026-01-02T00:00:00Z",
+        threshold: 0.6,
+        weights: { bias: -2, editCount: 0.2, readCount: 0.3 },
+    };
+    const { snapshotPath } = await Effect.runPromise(run(root, (write) =>
+        Effect.gen(function* () {
+            yield* seedClassifierWeights(write, v1);
+            yield* seedClassifierWeights(write, v2);
+        })));
+    const rows = await Effect.runPromise(readRows(snapshotPath));
+    expect(rows.every((r) => r.version === "v2-test")).toBe(true);
+    expect(rows).toHaveLength(3); // v2's weights, not v1's 2
+    expect(rows.every((r) => r.threshold === 0.6)).toBe(true);
+});

--- a/apps/axctl/src/ingest/seed-classifier-weights.ts
+++ b/apps/axctl/src/ingest/seed-classifier-weights.ts
@@ -1,0 +1,51 @@
+/**
+ * Seed `classifier_weights` from the committed constants (#911, Phase 5
+ * landed slice). Called from the ingest run tail (run.ts) alongside
+ * `buildFtsIndexes` - a small idempotent bookkeeping write, not a stage
+ * (nothing here is derived from transcripts). See judgment-weights.ts for the
+ * seed's full provenance; `classifyTurn`'s DEFAULT path never reads this
+ * table, only `AX_JUDGMENT_MODEL=learned` does (routability.ts).
+ *
+ * Idempotent by (model_id, version): DELETE any row for this model_id whose
+ * version differs from the seed's (a stale fit never lingers next to a fresh
+ * one - matters when a refit DROPS a feature, since `put` upserting by `id`
+ * alone would otherwise leave that feature's old row stranded), then
+ * `putMany` the seed's rows keyed by `id = <model_id>__<feature>` - an
+ * INSERT-OR-REPLACE, so re-running the SAME version is a harmless no-op
+ * (same id, same values) rather than needing a separate existence check.
+ */
+import { Effect } from "effect";
+import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { JUDGMENT_MODEL_SEED, type JudgmentModelSeed } from "../queries/judgment-weights.ts";
+
+export type SeedClassifierWeightsError = CacheWriteError;
+
+/** `<model_id>__<feature>` - the same `__`-join-of-parts id shape as
+ *  ingest_stage's `run__source__stage` (this schema has no composite PKs;
+ *  every table is keyed by one `id VARCHAR PRIMARY KEY`). */
+export const classifierWeightRowId = (modelId: string, feature: string): string => `${modelId}__${feature}`;
+
+/** `seed` defaults to the committed {@link JUDGMENT_MODEL_SEED}; overridable
+ *  only so tests can exercise the version-replace path without a second
+ *  committed constants module. */
+export const seedClassifierWeights = Effect.fn("ingest.seedClassifierWeights")(
+    function* (write: CacheWriteService, seed: JudgmentModelSeed = JUDGMENT_MODEL_SEED) {
+        yield* write.exec(
+            `DELETE FROM classifier_weights WHERE model_id = ? AND version <> ?`,
+            [seed.modelId, seed.version],
+        );
+
+        yield* write.putMany(
+            "classifier_weights",
+            Object.entries(seed.weights).map(([feature, weight]) => ({
+                id: classifierWeightRowId(seed.modelId, feature),
+                model_id: seed.modelId,
+                feature,
+                weight,
+                threshold: seed.threshold,
+                version: seed.version,
+                trained_at: seed.trainedAt,
+            })),
+        );
+    },
+);

--- a/apps/axctl/src/ingest/stage/table-writes.ts
+++ b/apps/axctl/src/ingest/stage/table-writes.ts
@@ -127,6 +127,14 @@ export const NON_STAGE_WRITERS: readonly {
         ],
     },
     {
+        // run.ts tail (#911): idempotent, version-gated seed of the learned
+        // judgment classifier's weights from the committed constants
+        // (judgment-weights.ts) - not a stage, nothing here is derived from
+        // transcripts. Same seam pattern as FTS index rebuild.
+        writer: "ingest-run:seed-classifier-weights",
+        writes: [w("classifier_weights", "bookkeep")],
+    },
+    {
         // cli/commands/ingest.ts maintenance verbs: blob-GC afterWork,
         // onTimeout stamp, `ax ingest reap`, telemetryStage for the
         // derive-signals/insights verbs. `ax ingest reap` runs through

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -186,6 +186,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "schema_comment_state", stage: "active", note: "Self-documenting catalog bookkeeping (#869): hash of the last-applied COMMENT ON script, so routine opens skip re-applying (WAL crash-safety)." },
     { table: "cache_bust_event", stage: "active", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
     { table: "fts_index_state", stage: "active", note: "Skip-unchanged bookkeeping for the FTS rebuild (#909): per-target content digest, so buildFtsIndexes only reruns PRAGMA create_fts_index when the indexed table actually changed." },
+    { table: "classifier_weights", stage: "active", note: "Learned judgment classifier weights (#911, Phase 5 landed slice): one row per (model_id, feature), seeded from the committed JUDGMENT_MODEL_SEED constants; classifyTurn's default path never reads it, only AX_JUDGMENT_MODEL=learned does." },
 ] as const;
 
 export function isInsightView(value: string): value is InsightView {

--- a/apps/axctl/src/queries/judgment-weights.ts
+++ b/apps/axctl/src/queries/judgment-weights.ts
@@ -1,0 +1,109 @@
+/**
+ * Phase 5 landed slice (#911) - the committed constants for the learned
+ * judgment classifier, follow-up to the #895 prototype (GATE PASSED at
+ * matched recall - scripts/prototypes/judgment-learn/README.md). DARK: only
+ * `classifyTurn`'s `learned` parameter reads these, gated behind
+ * `AX_JUDGMENT_MODEL=learned` in `fetchRoutability` (routability.ts). The
+ * default path never touches this module.
+ *
+ * PROVENANCE. The #895 prototype's own gitignored population/label files
+ * (`scripts/prototypes/judgment-learn/{population.ndjson,labels/}`) are
+ * LOCAL artifacts that did not exist on the machine this landed slice was
+ * built on - the prototype's PR (#896) never committed them, by design (the
+ * README says "regenerate with extract.ts and re-label to reproduce"). So
+ * rather than invent numbers, this seed is a FRESH end-to-end re-run of the
+ * exact same pipeline against the live published snapshot on 2026-08-20:
+ *
+ *   1. `extract.ts` (READ-ONLY against the published DuckDB snapshot):
+ *      47,263 decision-population turns, 120d window, stratified 360-turn
+ *      sample (9 batches of 40: regexJudgment/toolRoutable/proseOther).
+ *   2. Fresh LLM labeling: 9 parallel single-pass labelers (one per batch),
+ *      same rubric as the original ("judge the WORK, not the vocabulary").
+ *      UNLIKE the original study this pass was NOT double-labeled, so no
+ *      fresh kappa figure exists - a real deviation from the original's
+ *      93.8%/kappa=0.818 inter-labeler check, disclosed here rather than
+ *      re-asserting the old number against new labels.
+ *   3. `train.ts`, unmodified: seed 0xc0ffee, L2 logistic regression, 70/30
+ *      split (251 train / 109 held out), 3000 epochs.
+ *
+ * HELD-OUT METRICS (this run, single canonical split):
+ *   JUDGMENT_GUARD_RE      acc 0.743  precision 0.811  recall 0.588  F1 0.682
+ *   learned @ matched recall (threshold 0.50)
+ *                          acc 0.771  precision 0.825  recall 0.647  F1 0.725
+ * Matched-recall search (lowest recall the regex already guarantees, highest
+ * threshold that still clears it) landed at **0.50** for this fit - NOT the
+ * original prototype's 0.35. Different labels are a different classifier;
+ * pinning the old README's threshold against these weights would not
+ * correspond to the same operating point, so this constant is the number
+ * THIS fit's own matched-recall search produced, not a copied literal.
+ *
+ * Stability check (20 random 70/30 re-splits + re-fit + per-split matched-
+ * recall search, mirroring the original's protocol): precision gap
+ * **+8.3 points mean (sd 4.8), positive in 20/20 splits**, +7.1 points mean
+ * extra recall. Smaller margin than the original prototype's +15.0pt/sd7.0
+ * figure (expected - single-pass labels are noisier than the original's
+ * double-labeled, independently-reviewed batches, and the live population
+ * has moved since #895's run two days earlier) but the gate's own criterion
+ * - positive in every one of 20 splits - still holds outright.
+ *
+ * `regexOwn` fit to a near-zero weight (-0.004) in this run, versus +0.43 in
+ * the original prototype - a real difference worth a human's attention
+ * before the operator flips AX_JUDGMENT_MODEL=learned; see the verdict
+ * package on issue #911 for the full discussion. `regexPrev` (-0.378) and
+ * the tool-composition/text-shape features otherwise read the same
+ * direction as the original ("long prose / non-read tools / code fences
+ * push toward judgment; edit-heavy composition pushes routable").
+ *
+ * Re-fit: bump `version` and re-run this file's provenance block. The
+ * seeding function DELETE+INSERTs by (model_id, version) so a stale fit
+ * never lingers next to a fresh one.
+ */
+
+/** Mirrors `FEATURE_NAMES` in scripts/prototypes/judgment-learn/train.ts -
+ *  the feature vector order/shape the weights below were fit against. Kept
+ *  here (not imported from the prototype dir) because a prototype is
+ *  throwaway; this landed copy is the one production code depends on. */
+export const JUDGMENT_FEATURE_NAMES = [
+    "bias",
+    "editCount",
+    "readCount",
+    "researchCount",
+    "otherToolCount",
+    "logTextLen",
+    "regexOwn",
+    "regexPrev",
+    "questionMarks",
+    "codeFences",
+    "hasTools",
+    "editShare",
+] as const;
+
+export interface JudgmentModelSeed {
+    readonly modelId: string;
+    readonly version: string;
+    /** ISO date this fit was trained - stamped onto `classifier_weights.trained_at`. */
+    readonly trainedAt: string;
+    readonly threshold: number;
+    readonly weights: Readonly<Record<string, number>>;
+}
+
+export const JUDGMENT_MODEL_SEED: JudgmentModelSeed = {
+    modelId: "judgment-v1",
+    version: "2026-08-20-seed0xc0ffee-refit1",
+    trainedAt: "2026-08-20T00:00:00Z",
+    threshold: 0.5,
+    weights: {
+        bias: -3.473,
+        editCount: -0.782,
+        readCount: 0,
+        researchCount: 0,
+        otherToolCount: 1.34,
+        logTextLen: 7.336,
+        regexOwn: -0.004,
+        regexPrev: -0.378,
+        questionMarks: -0.099,
+        codeFences: 1.065,
+        hasTools: 0.558,
+        editShare: -0.782,
+    },
+};

--- a/apps/axctl/src/queries/routability-learned-model.test.ts
+++ b/apps/axctl/src/queries/routability-learned-model.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #911 Phase 5 landed slice - `loadLearnedJudgmentModel` env-gated wiring.
+ * Separate file from routability.test.ts because these tests touch a real
+ * DuckDB store (routability.test.ts is pure-function unit tests only).
+ *
+ * The "never reads classifier_weights when the flag is off" claim is proven
+ * with a COUNTING fake `CacheRead` service rather than by inference from a
+ * missing/broken layer: `cacheRows` fails OPEN on any read error (logs +
+ * degrades to `[]`), so a broken layer can't distinguish "never queried"
+ * from "queried and failed" by exceptions alone - only a call counter can.
+ */
+import { expect } from "bun:test";
+import { Effect, Layer, Option } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { join } from "node:path";
+import { CacheRead, CacheReadLayer, withCacheWrite, type CacheReadService } from "@ax/lib/duckdb/seam";
+import { withIngestLock } from "@ax/lib/ingest-lock";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { loadLearnedJudgmentModel } from "./routability.ts";
+import { JUDGMENT_MODEL_SEED } from "./judgment-weights.ts";
+import { seedClassifierWeights } from "../ingest/seed-classifier-weights.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("routability learned model loader");
+const Platform = Layer.merge(BunFileSystem.layer, BunPath.layer);
+
+function withEnv<A>(value: string | undefined, thunk: () => Promise<A>): Promise<A> {
+    const prev = process.env.AX_JUDGMENT_MODEL;
+    if (value === undefined) delete process.env.AX_JUDGMENT_MODEL;
+    else process.env.AX_JUDGMENT_MODEL = value;
+    return thunk().finally(() => {
+        if (prev === undefined) delete process.env.AX_JUDGMENT_MODEL;
+        else process.env.AX_JUDGMENT_MODEL = prev;
+    });
+}
+
+/** A CacheRead test double that counts `.rows` calls and returns whatever
+ *  `rowsResult` yields - no real DuckDB file involved. */
+function countingCacheRead(rowsResult: ReadonlyArray<Record<string, unknown>>) {
+    let calls = 0;
+    const service: CacheReadService = {
+        rows: (() => {
+            calls++;
+            return Effect.succeed(rowsResult) as ReturnType<CacheReadService["rows"]>;
+        }) as CacheReadService["rows"],
+        first: () => Effect.succeed(Option.none()) as ReturnType<CacheReadService["first"]>,
+        raw: () => Effect.die("not used in these tests") as ReturnType<CacheReadService["raw"]>,
+        snapshotPath: "test:counting",
+    };
+    return { layer: Layer.succeed(CacheRead, service), callCount: () => calls };
+}
+
+for (const [label, value] of [["unset", undefined], ["empty string", ""], ["other value", "sonnet"]] as const) {
+    dtest(`AX_JUDGMENT_MODEL ${label} -> never calls CacheRead.rows`, async () => {
+        const { layer, callCount } = countingCacheRead([]);
+        const result = await withEnv(value, () =>
+            Effect.runPromise(loadLearnedJudgmentModel().pipe(Effect.provide(layer), Effect.scoped)));
+        expect(result).toBeUndefined();
+        expect(callCount()).toBe(0);
+    });
+}
+
+dtest("AX_JUDGMENT_MODEL=learned, no rows -> calls once, falls back to undefined (regex floor), no crash", async () => {
+    const { layer, callCount } = countingCacheRead([]);
+    const result = await withEnv("learned", () =>
+        Effect.runPromise(loadLearnedJudgmentModel().pipe(Effect.provide(layer), Effect.scoped)));
+    expect(result).toBeUndefined();
+    expect(callCount()).toBe(1);
+});
+
+dtest("AX_JUDGMENT_MODEL=learned, malformed rows (missing a feature) -> falls back to undefined", async () => {
+    const { layer } = countingCacheRead([{ feature: "bias", weight: -1, threshold: 0.5 }]); // only 1 of 12 features
+    const result = await withEnv("learned", () =>
+        Effect.runPromise(loadLearnedJudgmentModel().pipe(Effect.provide(layer), Effect.scoped)));
+    expect(result).toBeUndefined();
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real DuckDB round trip through seedClassifierWeights.
+// ---------------------------------------------------------------------------
+
+const CACHE_DDL = `
+CREATE TABLE classifier_weights (
+    id VARCHAR PRIMARY KEY,
+    model_id VARCHAR NOT NULL,
+    feature VARCHAR NOT NULL,
+    weight DOUBLE NOT NULL,
+    threshold DOUBLE NOT NULL,
+    version VARCHAR NOT NULL,
+    trained_at TIMESTAMP
+);
+`;
+
+dtest("AX_JUDGMENT_MODEL=learned + real seeded weights -> returns the model, matching the seed", async () => {
+    const root = tempDir("ax-learned-model-seeded-");
+    const lockPath = join(root, "ingest.lock");
+    const snapshotPath = join(root, "snapshot.duckdb");
+    await Effect.runPromise(withIngestLock({
+        lockPath,
+        command: "routability-learned-model-test",
+        staleMs: 60_000,
+        onBusy: () => Effect.die("unexpected busy lock"),
+    }, withCacheWrite({
+        livePath: join(root, "live.duckdb"),
+        lockPath,
+        snapshotPath,
+        schemaSql: CACHE_DDL,
+        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+    }, (write) => seedClassifierWeights(write))).pipe(Effect.provide(Platform)));
+
+    const layer = CacheReadLayer({ snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) });
+    const result = await withEnv("learned", () =>
+        Effect.runPromise(loadLearnedJudgmentModel().pipe(Effect.provide(layer), Effect.scoped)));
+    expect(result).toBeDefined();
+    expect(result?.threshold).toBe(JUDGMENT_MODEL_SEED.threshold);
+    expect(result?.weights.bias).toBe(JUDGMENT_MODEL_SEED.weights.bias);
+    expect(Object.keys(result?.weights ?? {})).toHaveLength(Object.keys(JUDGMENT_MODEL_SEED.weights).length);
+});

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -338,3 +338,96 @@ describe("aggregateRoutability provider tiers + combineRoutability", () => {
     expect(all.providers).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #911 Phase 5 landed slice: learned judgment classifier (AX_JUDGMENT_MODEL=learned)
+// ---------------------------------------------------------------------------
+
+describe("classifyTurn default path is byte-identical with `learned` omitted", () => {
+  // A broad fixture matrix over every WorkClass + edge case the regex path
+  // produces today, called with NO third argument - pins today's expected
+  // values so a future change to the learned branch cannot silently alter
+  // the default. (routability.test.ts's earlier describes already exercise
+  // this implicitly by never passing `learned`; this block makes the
+  // guarantee explicit and self-contained.)
+  const cases: [string, TurnFacts, boolean, ReturnType<typeof classifyTurn>][] = [
+    ["read-only tools -> gather", { ...base, toolNames: ["Read", "Grep"] }, false, "gather"],
+    ["research tools -> niche-research", { ...base, toolNames: ["WebFetch", "WebSearch"] }, false, "niche-research"],
+    ["edit-dominant -> mechanical-impl", { ...base, toolNames: ["Edit", "Bash"] }, false, "mechanical-impl"],
+    ["no tools, no text -> interactive", { ...base }, false, "interactive"],
+    ["judgment text wins over read tools -> design-decision", { ...base, text: "Review the design of this module", toolNames: ["Read"] }, false, "design-decision"],
+    ["adjacent to user -> interactive", { ...base, toolNames: ["Read"] }, true, "interactive"],
+    ["correction intent -> interactive", { ...base, intentKind: "correction", toolNames: ["Edit"] }, false, "interactive"],
+    ["empty tool list, judgment text -> design-decision", { ...base, text: "audit the security model" }, false, "design-decision"],
+    ["non-judgment prose, no tools -> interactive", { ...base, text: "looks good, thanks" }, false, "interactive"],
+  ];
+  for (const [name, facts, adjacent, expected] of cases) {
+    it(name, () => {
+      expect(classifyTurn(facts, adjacent)).toBe(expected);
+    });
+  }
+});
+
+describe("classifyTurn learned path (AX_JUDGMENT_MODEL=learned)", () => {
+  it("a regex-flagged turn UNDER threshold is NOT design-decision", () => {
+    // Text matches JUDGMENT_GUARD_RE ("review"), but the learned model's
+    // weights ignore regexOwn and gate on otherToolCount, which is 0 here -
+    // demonstrating the learned branch fully REPLACES the regex decision
+    // rather than OR-ing with it.
+    const learned = { threshold: 0.5, weights: { bias: -10, otherToolCount: 5 } };
+    const t: TurnFacts = { ...base, text: "Review the design of this module", toolNames: ["Read"] };
+    expect(classifyTurn(t, false, learned)).not.toBe("design-decision");
+    // Same facts, no `learned` -> regex path still flags it (unchanged default).
+    expect(classifyTurn(t, false)).toBe("design-decision");
+  });
+
+  it("a turn OVER threshold without any regex hit IS design-decision", () => {
+    const learned = { threshold: 0.5, weights: { bias: -10, otherToolCount: 5 } };
+    const t: TurnFacts = { ...base, text: "run the build", toolNames: ["some_mcp_tool", "some_mcp_tool", "some_mcp_tool"] };
+    expect(classifyTurn(t, false)).not.toBe("design-decision"); // regex path: no match
+    expect(classifyTurn(t, false, learned)).toBe("design-decision"); // learned path: otherToolCount=3 crosses threshold
+  });
+
+  it("regexPrev feature reads TurnFacts.prevAssistantText, not the turn's own text", () => {
+    const learned = { threshold: 0.5, weights: { bias: -10, regexPrev: 20 } };
+    const judgmentPrev: TurnFacts = { ...base, prevAssistantText: "let's review the tradeoffs here" };
+    expect(classifyTurn(judgmentPrev, false, learned)).toBe("design-decision");
+    const plainPrev: TurnFacts = { ...base, prevAssistantText: "run the build" };
+    expect(classifyTurn(plainPrev, false, learned)).not.toBe("design-decision");
+    const noPrev: TurnFacts = { ...base };
+    expect(classifyTurn(noPrev, false, learned)).not.toBe("design-decision");
+  });
+
+  it("interactive guards and tool-composition fallthrough are unaffected by `learned`", () => {
+    const learned = { threshold: 0.99, weights: {} }; // score always ~0.5 sigmoid(0), never >= 0.99
+    expect(classifyTurn({ ...base, toolNames: ["Read"] }, true, learned)).toBe("interactive");
+    expect(classifyTurn({ ...base, intentKind: "correction", toolNames: ["Edit"] }, false, learned)).toBe("interactive");
+    expect(classifyTurn({ ...base, toolNames: ["Edit", "Bash"] }, false, learned)).toBe("mechanical-impl");
+    expect(classifyTurn({ ...base, toolNames: ["WebFetch"] }, false, learned)).toBe("niche-research");
+  });
+});
+
+describe("buildSpans + learned model", () => {
+  it("a non-judgment-text, tool-heavy run classifies differently learned-vs-default", () => {
+    // No prose anywhere in this fixture, so the always-on regex sticky demotion
+    // never engages - isolates the learned model's non-regex features
+    // (otherToolCount) as the thing that changes the outcome.
+    const heavy = (seq: number) => turn(seq, "assistant", ["some_mcp_tool", "some_mcp_tool", "some_mcp_tool"]);
+    const turns = [turn(1, "user", []), heavy(2), heavy(3), heavy(4)];
+
+    const defaultSpans = buildSpans(turns, 1);
+    expect(defaultSpans.some((s) => s.cls === "design-decision")).toBe(false); // no tool self-classifies as edit/read/research -> interactive
+
+    const learned = { threshold: 0.5, weights: { bias: -10, otherToolCount: 5 } };
+    const learnedSpans = buildSpans(turns, 1, undefined, learned);
+    expect(learnedSpans.some((s) => s.cls === "design-decision")).toBe(true);
+  });
+
+  it("without `learned`, buildSpans is unaffected (identity default path)", () => {
+    const turns = [turn(1, "user", []), turn(2, "assistant", [], { text: "review the plan" }), turn(3, "assistant", ["Edit"])];
+    // No throw, no behavior change - buildSpans without `learned` takes the
+    // untouched default branch (sticky-only demotion, as pinned above).
+    const spans = buildSpans(turns, 1);
+    expect(spans.some((s) => s.cls === "design-decision")).toBe(true);
+  });
+});

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -20,6 +20,7 @@ import { JUDGMENT_GUARD_RE } from "./routing-tune.ts";
 import { MODEL_ALIASES, reprice } from "./reprice.ts";
 import type { RepriceUsage, ModelPricing } from "./reprice.ts";
 import { builtInPricingCatalog, inferModelProvider } from "../ingest/model-pricing.ts";
+import { JUDGMENT_FEATURE_NAMES, JUDGMENT_MODEL_SEED } from "./judgment-weights.ts";
 
 export type WorkClass =
     | "gather"
@@ -87,6 +88,26 @@ export interface TurnFacts {
     intentKind: string | null;
     text: string | null;
     usage: RepriceUsage | null;
+    /**
+     * The text of the assistant prose that opened the CURRENT message (#911
+     * learned path only) - `buildSpans` threads this through from the same
+     * sticky-prose tracking it already does for `judgmentSticky`; it is the
+     * `regexPrev` feature's input. Left undefined on the default (regex) path,
+     * which never reads it - populating it costs nothing there either way
+     * since `classifyTurn` only consults it when `learned` is passed.
+     */
+    prevAssistantText?: string | null;
+}
+
+/**
+ * A learned judgment model's weights + operating threshold, as loaded from
+ * `classifier_weights` (see judgment-weights.ts / `AX_JUDGMENT_MODEL=learned`).
+ * Passed explicitly rather than read from env inside `classifyTurn` so the
+ * function stays pure and its default path is trivially provably unchanged.
+ */
+export interface LearnedJudgmentModel {
+    readonly threshold: number;
+    readonly weights: Readonly<Record<string, number>>;
 }
 
 type ToolKind = "read" | "edit" | "research";
@@ -163,6 +184,56 @@ function toolKind(name: string, commandNorm: string | null): ToolKind | null {
 }
 
 /**
+ * The learned judgment classifier's feature vector (#911, Phase 5 landed
+ * slice). MUST mirror `featurize()` in
+ * scripts/prototypes/judgment-learn/train.ts exactly - same 12 features,
+ * same caps (8 for tool counts, 5 for question marks/code fences), same
+ * `log1p(len)/10` text-length scaling - because the weights in
+ * judgment-weights.ts were fit against that exact shape. `regexOwn`/
+ * `regexPrev` are the regex baseline surviving as FEATURES, per the v3 plan
+ * ("regexes become features, never deleted first").
+ */
+function judgmentFeatures(
+    text: string,
+    prevAssistantText: string | null | undefined,
+    editCount: number,
+    readCount: number,
+    researchCount: number,
+    otherToolCount: number,
+    hasTools: boolean,
+): Readonly<Record<string, number>> {
+    const questionMarks = (text.match(/\?/g) ?? []).length;
+    const codeFences = (text.match(/```/g) ?? []).length;
+    const toolTotal = editCount + readCount + researchCount;
+    return {
+        bias: 1,
+        editCount: Math.min(editCount, 8),
+        readCount: Math.min(readCount, 8),
+        researchCount: Math.min(researchCount, 8),
+        otherToolCount: Math.min(otherToolCount, 8),
+        logTextLen: Math.log1p(text.length) / 10,
+        regexOwn: JUDGMENT_GUARD_RE.test(text) ? 1 : 0,
+        regexPrev: prevAssistantText ? (JUDGMENT_GUARD_RE.test(prevAssistantText) ? 1 : 0) : 0,
+        questionMarks: Math.min(questionMarks, 5),
+        codeFences: Math.min(codeFences, 5),
+        hasTools: hasTools ? 1 : 0,
+        editShare: toolTotal > 0 ? editCount / toolTotal : 0,
+    };
+}
+
+const judgmentSigmoid = (z: number): number => 1 / (1 + Math.exp(-z));
+
+/** `sigmoid(w . x)` over the learned model's weights (missing weight = 0). */
+function learnedJudgmentScore(
+    features: Readonly<Record<string, number>>,
+    weights: Readonly<Record<string, number>>,
+): number {
+    let z = 0;
+    for (const [name, value] of Object.entries(features)) z += value * (weights[name] ?? 0);
+    return judgmentSigmoid(z);
+}
+
+/**
  * Assign one work-class to a main-agent turn. Judgment-first precedence so
  * review/design/interactive can never be classed routable. `adjacentToUser`
  * is computed by buildSpans (turn neighbours a user turn).
@@ -170,25 +241,38 @@ function toolKind(name: string, commandNorm: string | null): ToolKind | null {
  * Turn-level tool composition only - the `thinking_tokens` signal was dropped
  * after calibration showed it is 0 on 96.6% of main assistant turns (mixed
  * turns report 0 = lower bound; transcripts strip thinking text), so no
- * threshold separated design work from routine edits. Judgment is now caught
- * solely via JUDGMENT_GUARD_RE on the turn text plus the interactive guards.
+ * threshold separated design work from routine edits. Judgment is caught via
+ * JUDGMENT_GUARD_RE on the turn text plus the interactive guards - OR, when
+ * `learned` is supplied (#911, `AX_JUDGMENT_MODEL=learned`), via the learned
+ * classifier's sigmoid(w.x) >= threshold. `learned` absent -> this function's
+ * behavior is BYTE-IDENTICAL to before #911 (pinned by
+ * routability.classify-default.test.ts); the interactive guards and the
+ * tool-composition fallthrough below are untouched by either path.
  */
-export function classifyTurn(t: TurnFacts, adjacentToUser: boolean): WorkClass {
+export function classifyTurn(t: TurnFacts, adjacentToUser: boolean, learned?: LearnedJudgmentModel): WorkClass {
     if (adjacentToUser) return "interactive";
     if (t.intentKind && INTERACTIVE_INTENTS.has(t.intentKind)) return "interactive";
 
     const calls: ReadonlyArray<ToolCallFact> =
         t.toolCalls ?? t.toolNames.map((name) => ({ name, commandNorm: null }));
 
-    let editCount = 0, readCount = 0, researchCount = 0;
+    let editCount = 0, readCount = 0, researchCount = 0, otherToolCount = 0;
     for (const c of calls) {
         const kind = toolKind(c.name, c.commandNorm);
         if (kind === "edit") editCount++;
         else if (kind === "read") readCount++;
         else if (kind === "research") researchCount++;
+        else otherToolCount++;
     }
 
-    if (t.text && JUDGMENT_GUARD_RE.test(t.text)) return "design-decision";
+    if (learned) {
+        const features = judgmentFeatures(
+            t.text ?? "", t.prevAssistantText, editCount, readCount, researchCount, otherToolCount, calls.length > 0,
+        );
+        if (learnedJudgmentScore(features, learned.weights) >= learned.threshold) return "design-decision";
+    } else {
+        if (t.text && JUDGMENT_GUARD_RE.test(t.text)) return "design-decision";
+    }
 
     if (editCount > 0 && editCount >= readCount && editCount >= researchCount) return "mechanical-impl";
     if (researchCount > 0) return "niche-research";
@@ -276,6 +360,7 @@ export function buildSpans(
   turns: ReadonlyArray<TurnFacts>,
   minRun: number,
   roleKind: (role: string) => RoleKind = claudeRoleKind,
+  learned?: LearnedJudgmentModel,
 ): Span[] {
   const spans: Span[] = [];
   let cur: { cls: WorkClass; turnCount: number; usage: RepriceUsage } | null = null;
@@ -289,6 +374,13 @@ export function buildSpans(
   // message) re-evaluates it; a user boundary clears it. Conservative: it only
   // demotes (never promotes), so the routability estimate can only tighten.
   let judgmentSticky = false;
+  // The prose text that opened the CURRENT message, carried across its
+  // tool-only turns exactly like judgmentSticky above - this IS the
+  // `regexPrev` feature's input for the learned path (#911). Captured BEFORE
+  // each turn updates it, so a prose turn itself sees the PRIOR message's
+  // prose (never its own text) as "previous". Unused (never allocated into a
+  // TurnFacts) when `learned` is absent.
+  let prevProseText: string | null = null;
 
   const flush = () => {
     if (!cur) return;
@@ -300,7 +392,7 @@ export function buildSpans(
   for (const t of turns) {
     const kind = roleKind(t.role);
     if (kind === "skip") continue;
-    if (kind === "boundary") { flush(); adjacentToBoundary = true; judgmentSticky = false; continue; }
+    if (kind === "boundary") { flush(); adjacentToBoundary = true; judgmentSticky = false; prevProseText = null; continue; }
     if (kind === "carry") {
       // Tool-output cost belongs to the action that produced it (open span).
       if (cur) cur.usage = addUsage(cur.usage, t.usage);
@@ -312,8 +404,13 @@ export function buildSpans(
     // the judgment carry from that text. Tool-only turns (empty text) keep the
     // value set by the prose turn that opened their message.
     const turnText = t.text?.trim() ?? "";
-    if (turnText.length > 0) judgmentSticky = JUDGMENT_GUARD_RE.test(turnText);
-    let cls = classifyTurn(t, adjacentToBoundary);
+    const prevAssistantText = prevProseText;
+    if (turnText.length > 0) {
+      judgmentSticky = JUDGMENT_GUARD_RE.test(turnText);
+      prevProseText = turnText;
+    }
+    const factsForClassify: TurnFacts = learned ? { ...t, prevAssistantText } : t;
+    let cls = classifyTurn(factsForClassify, adjacentToBoundary, learned);
     adjacentToBoundary = false;
     // Hold judgment-adjacent edits off the routable path: fold them into the
     // design-decision (non-routable) class so they group with the reasoning
@@ -550,6 +647,70 @@ function providerOfSource(source: string): RoutabilityProvider | null {
     return null;
 }
 
+// ---------------------------------------------------------------------------
+// Learned judgment model loading (#911, Phase 5 landed slice)
+// ---------------------------------------------------------------------------
+
+const CLASSIFIER_WEIGHTS_SQL = `
+SELECT feature, weight, threshold
+FROM classifier_weights
+WHERE model_id = ?;
+`;
+
+const ClassifierWeightRow = Schema.Struct({
+    feature: Schema.String,
+    weight: Schema.Number,
+    threshold: Schema.Number,
+});
+
+/**
+ * Load the learned judgment model from `classifier_weights` when
+ * `AX_JUDGMENT_MODEL=learned` (anything else - unset, empty, other value -
+ * takes the regex path UNTOUCHED, and this function does not even issue a
+ * query: `env-unset wiring never reads classifier_weights` is pinned by
+ * routability.classify-default.test.ts). Rows missing (table not yet
+ * seeded) or malformed (not every declared feature present) fall back to the
+ * regex floor with a single logged warning - never a crash, never a silent
+ * wrong answer.
+ */
+export const loadLearnedJudgmentModel = Effect.fn("queries.loadLearnedJudgmentModel")(
+    function* () {
+        if (process.env.AX_JUDGMENT_MODEL !== "learned") return undefined;
+
+        // cacheRows already fails OPEN to [] on a query error (logs + degrades),
+        // so a missing table (not yet seeded) and a genuine query error both
+        // land in the same "no rows" branch below - one warning, one fallback.
+        const rows = yield* cacheRows(
+            ClassifierWeightRow,
+            { sql: CLASSIFIER_WEIGHTS_SQL, params: [JUDGMENT_MODEL_SEED.modelId] },
+            "routability learned judgment weights",
+        );
+
+        if (rows.length === 0) {
+            yield* Effect.logWarning(
+                `AX_JUDGMENT_MODEL=learned but classifier_weights has no rows for model_id=${JUDGMENT_MODEL_SEED.modelId} - falling back to the regex judgment guard. Run \`ax ingest\` to seed it.`,
+            );
+            return undefined;
+        }
+
+        const weights: Record<string, number> = {};
+        let threshold: number | undefined;
+        for (const row of rows) {
+            weights[row.feature] = row.weight;
+            threshold = row.threshold;
+        }
+        const missing = JUDGMENT_FEATURE_NAMES.filter((name) => !(name in weights));
+        if (missing.length > 0 || threshold === undefined) {
+            yield* Effect.logWarning(
+                `AX_JUDGMENT_MODEL=learned but classifier_weights rows for model_id=${JUDGMENT_MODEL_SEED.modelId} are malformed (missing features: ${missing.join(", ") || "none"}) - falling back to the regex judgment guard.`,
+            );
+            return undefined;
+        }
+
+        return { threshold, weights } satisfies LearnedJudgmentModel;
+    },
+);
+
 /**
  * Pull main-agent turns (Claude + Codex) from the DuckDB cache, group into class-run
  * spans per (provider, session), classify + reprice each provider separately,
@@ -573,6 +734,11 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             cacheRows(TurnUsageRow, { sql: TURN_USAGE_SQL, params: [days] }, "routability turn usage"),
             cacheRows(AgentModelRow, { sql: AGENT_MODELS_SQL, params: [] }, "routability agent models"),
         ], { concurrency: 4 });
+
+        // Env-gated (#911): `loadLearnedJudgmentModel` returns `undefined` WITHOUT
+        // issuing any query unless AX_JUDGMENT_MODEL=learned, so the default path
+        // never touches classifier_weights.
+        const learned = yield* loadLearnedJudgmentModel();
 
         // ---- tool calls: turn_id → ToolCallFact[] (carries command_norm) ---
         const toolsByTurn = new Map<string, ToolCallFact[]>();
@@ -696,7 +862,7 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             const spans: Span[] = [];
             for (const turns of bySession.values()) {
                 turns.sort((a, b) => a.seq - b.seq); // DB orders by (session, seq); defensive
-                for (const s of buildSpans(turns, input.minRun, roleKind)) spans.push(s);
+                for (const s of buildSpans(turns, input.minRun, roleKind, learned)) spans.push(s);
             }
             const res = aggregateRoutability(spans, pricingCatalog, input, provider);
             if (res.mainSpendUsd > 0 || res.rows.length > 0) providerResults.push(res);

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -31,7 +31,7 @@ import { SIDECAR_JUDGMENT_TABLES } from "./sidecar-tables.ts";
 // silently shrink to comparing zero (or a handful of) tables/columns.
 const EXPECTED_TABLES_COMPARED = 138;
 /** Of those, how many the DuckDB cache still defines (138 - 14 judgment tables). */
-const EXPECTED_DUCKDB_TABLES = 127; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909)
+const EXPECTED_DUCKDB_TABLES = 128; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909), +classifier_weights (#911)
 // A7 (agent_event.raw prune): schema.surql's `agent_event.raw` field was
 // removed (ax never wrote it - buildAgentEventStatement already omitted it
 // from the CONTENT it upserts). schema.duckdb.sql's `agent_event.raw` column

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -41,6 +41,7 @@ describe("coverage of the Surreal schema", () => {
             "schema_comment_state", // #869 COMMENT ON bookkeeping
             "cache_bust_event", // #868 cache-bust ledger (SQL model)
             "fts_index_state", // #909 skip-unchanged bookkeeping for the FTS rebuild
+            "classifier_weights", // #911 learned judgment classifier weights (Phase 5 landed slice)
         ]);
         const surrealSet = new Set(surrealTables.map((t) => t.table));
         expect(duckTables.filter((t) => !surrealSet.has(t) && !bornAfterSurreal.has(t))).toEqual([]);

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -190,6 +190,7 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     run_evidence_ref: { kind: "node", stage: "active", layer: "derived", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
     cache_bust_event: { kind: "node", stage: "active", layer: "derived", note: "Cache-bust ledger (#868): one row per usage row carrying a cache_miss_reason, priced (ingest cost + independent flat-rate corroboration); derived by the cache-bust SQL model, id == turn_token_usage.id." },
     fts_index_state: { kind: "node", stage: "active", layer: "bookkeeping", note: "Skip-unchanged bookkeeping for the FTS rebuild (#909): per-target content digest, so buildFtsIndexes only reruns PRAGMA create_fts_index when the indexed table actually changed." },
+    classifier_weights: { kind: "node", stage: "active", layer: "bookkeeping", note: "Learned judgment classifier weights (#911, Phase 5 landed slice): one row per (model_id, feature), seeded from the committed JUDGMENT_MODEL_SEED constants; classifyTurn's default path never reads it, only AX_JUDGMENT_MODEL=learned does." },
 };
 
 /**

--- a/packages/schema/src/parse-duckdb-schema.test.ts
+++ b/packages/schema/src/parse-duckdb-schema.test.ts
@@ -7,7 +7,7 @@ import { DUCKDB_TABLE_NAMES, parseDuckdbColumnDefs, parseDuckdbTables } from "./
 // diff, not a silent shared mutation. It is 138 minus the fourteen judgment
 // tables that now live in schema.sidecar.sql; the FULL 138 is still compared
 // against the Surreal schema, across both engines, in duckdb-parity.test.ts.
-const EXPECTED_DUCKDB_TABLES = 127; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909)
+const EXPECTED_DUCKDB_TABLES = 128; // +schema_comment_state (#869), +cache_bust_event (#868), +fts_index_state (#909), +classifier_weights (#911)
 
 describe("parse-duckdb-schema", () => {
     test("parseDuckdbTables finds every table in the committed DDL", () => {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -2698,6 +2698,32 @@ CREATE TABLE IF NOT EXISTS run_evidence_ref (
 );
 CREATE INDEX IF NOT EXISTS run_evidence_ref_event ON run_evidence_ref("event");
 CREATE INDEX IF NOT EXISTS run_evidence_ref_session ON run_evidence_ref(session, ts);
+
+-- Learned judgment classifier (#911, Phase 5 landed slice, follow-up to the
+-- #895 prototype: GATE PASSED at matched recall). One row per (model_id,
+-- feature) weight; threshold and version are DENORMALIZED onto every row of
+-- the same model_id rather than a second table - a 13-row artifact (12
+-- features + bias) does not earn a join. `id` is `<model_id>__<feature>`
+-- (the same `__`-join-of-parts id shape as ingest_stage's
+-- `run__source__stage`) - every table in this schema is keyed by a single
+-- `id VARCHAR PRIMARY KEY` (enforced by duckdb-schema.test.ts's "every table
+-- declares id VARCHAR PRIMARY KEY first"; no table gets a composite PK), so
+-- the (model_id, feature) identity is folded into that one column rather
+-- than declared as a real composite key. Seeded idempotently at ingest from
+-- the committed constants module (apps/axctl/src/queries/judgment-weights.ts,
+-- JUDGMENT_MODEL_SEED); classifyTurn's DEFAULT path never reads this table -
+-- it only lights up behind AX_JUDGMENT_MODEL=learned. Bookkeeping layer: the
+-- store's own model-serving state, not data derived from transcripts.
+CREATE TABLE IF NOT EXISTS classifier_weights (
+    id VARCHAR PRIMARY KEY,
+    model_id VARCHAR NOT NULL,
+    feature VARCHAR NOT NULL,
+    weight DOUBLE NOT NULL,
+    threshold DOUBLE NOT NULL,
+    version VARCHAR NOT NULL,
+    trained_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS classifier_weights_model_id ON classifier_weights(model_id);
 CREATE INDEX IF NOT EXISTS run_evidence_ref_target ON run_evidence_ref(target_table, target_id);
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #911

## Summary

Lands the Phase 5 learned-judgment-classifier follow-up to the #895 prototype (GATE PASSED at matched recall - see `scripts/prototypes/judgment-learn/README.md`). **The default path is byte-identical and pinned by test; the flip to `AX_JUDGMENT_MODEL=learned` (and the verdict package) is the operator's, per the issue's own scope.**

- `classifyTurn` gains an optional trailing `learned?: { threshold, weights }` parameter. Absent → the exact pre-#911 lines (only the parameter and an `if (learned) {…} else {…}` branch were added around the regex check - nothing else moved). Present → replaces the `JUDGMENT_GUARD_RE.test(text)` decision with `sigmoid(w·x) >= threshold` over the same 12 prototype features (tool-composition counts, text-length/question-mark/code-fence stats, `regexOwn`/`regexPrev`). `regexOwn`/`regexPrev` ride as FEATURES, never deleted - per the v3 plan.
- `TurnFacts` gains an optional `prevAssistantText` field; `buildSpans` threads it from the same sticky-prose tracking it already does for `judgmentSticky`, so `regexPrev` sees the message that opened the CURRENT prose block.
- New cache table `classifier_weights` (bookkeeping layer): `id = <model_id>__<feature>` - **not** the composite `(model_id, feature)` PK the issue sketch suggested, because this schema enforces a single `id VARCHAR PRIMARY KEY` on every table (pinned by `duckdb-schema.test.ts`'s "every table declares id VARCHAR PRIMARY KEY first" - a real conflict with the plan sketch, corrected here rather than forced through). `threshold`/`version` are denormalized per row (a 13-row artifact doesn't earn a join).
- Seeded idempotently from committed constants (`apps/axctl/src/queries/judgment-weights.ts`, `JUDGMENT_MODEL_SEED`) at the ingest run tail, alongside `buildFtsIndexes` - DELETE-by-stale-version then upsert-by-id, best-effort (`Effect.ignore`) so a seeding hiccup never fails a run.
- `fetchRoutability` loads the model via `loadLearnedJudgmentModel()`, gated on `process.env.AX_JUDGMENT_MODEL === "learned"` - **any other value (unset, empty, `"sonnet"`, ...) returns `undefined` without issuing a single query**, proven with a call-counting `CacheRead` test double, not inference from a broken layer (`cacheRows` fails OPEN on read errors, so a broken layer can't otherwise distinguish "never queried" from "queried and failed"). Missing/malformed weight rows log one warning and fall back to the regex floor.

## TS-not-SQL inference rationale (single-source rule)

Per the issue: inference lives in TS (`classifyTurn`'s learned branch), not a SQL model, because a SQL model would have to duplicate `JUDGMENT_GUARD_RE` and the Claude/Codex `toolKind`/`codexToolClass` dispatch in SQL - the exact single-source duplication the check-family rule (`CLAUDE.md`) forbids. Feature computation lives next to the code that already has `editCount`/`readCount`/`researchCount`/`otherToolCount` in hand.

## Seeded weights provenance (read before flipping the flag)

**The committed weights are NOT the #895 prototype's original numbers.** That prototype's population/label files (`scripts/prototypes/judgment-learn/population.ndjson`, `labels/`) are gitignored LOCAL artifacts and were not present on the machine this slice was built on - the #896 PR never committed them, by design. Per the task's explicit fallback ("if it fails to run... use weights from an existing output file... as a last resort ask rather than invent"), no such file existed either, so this PR **re-ran the prototype's own pipeline end-to-end** rather than typing in numbers:

1. `extract.ts` (READ-ONLY against the published DuckDB snapshot): 47,263 decision-population turns, 120d window, stratified 360-turn sample (9×40 batches).
2. **Fresh LLM labeling**: 9 parallel single-pass labelers (one per batch), same rubric as the original ("judge the WORK, not the vocabulary"). **Deviation**: the original study double-labeled two batches and reported Cohen's kappa 0.818; this re-run was single-pass, so no fresh kappa exists - disclosed rather than re-asserting the old number against new labels.
3. `train.ts`, unmodified: seed `0xc0ffee`, L2 logistic regression, 70/30 split.

**Held-out metrics (this run, canonical split)**: regex acc 0.743 / P 0.811 / R 0.588 / F1 0.682 vs. learned@**0.50** (this fit's own matched-recall threshold, **not** the original's 0.35 - different labels are a different classifier, so pinning the old threshold against new weights would not correspond to the same operating point) acc 0.771 / P 0.825 / R 0.647 / F1 0.725. **20-split stability check**: precision gap **+8.3 points mean (sd 4.8), positive in 20/20 splits**, +7.1 points mean extra recall - smaller margin than the original's +15.0pt/sd7.0, but the gate's own bar (positive in every split) still clears outright. `regexOwn` fit near-zero (-0.004) here vs. +0.43 in the original - worth a human's attention before flipping the flag; full discussion + caveats live in `judgment-weights.ts`'s header comment.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` - clean
- `bun run typecheck` - clean
- `bun test apps/axctl/src/queries/ apps/axctl/src/ingest/ packages/schema` - all green except 3 pre-existing `ingest-staleness.test.ts` failures confirmed present on `main` with the same env (`AX_NO_AUTO_INGEST=1` interacting with the freshness-drive spawn assertions), unrelated to this change
- `bun run check:timestamp-cast` / `check:raw-numeric-cast` - clean
- Full `bun test` repo-wide: 6203 pass, only the 3 known-pre-existing failures + pre-existing Electron-install errors in `studio-desktop` (environment, unrelated files)

## Test coverage added

- `routability.test.ts`: default-path fixture matrix pinned with `learned` omitted; learned-path threshold crossing (regex-flagged-but-under-threshold NOT flagged; non-regex-but-over-threshold IS flagged); `regexPrev` reads `TurnFacts.prevAssistantText` in isolation; interactive guards/tool-composition fallthrough unaffected by `learned`; `buildSpans` with/without `learned`.
- `routability-learned-model.test.ts`: env unset/empty/other never call `CacheRead.rows` (counting fake service); `learned` + no rows falls back with one warning, no crash; `learned` + malformed rows falls back; real DuckDB round trip through `seedClassifierWeights`.
- `seed-classifier-weights.test.ts`: fresh seed writes all 12 rows; same-version re-run is a no-op; version bump deletes stale rows and replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)