### PR TITLE
feat(recall): index full turn text (was 500-char excerpt) + match-centered snippets

### DIFF
--- a/apps/axctl/src/dashboard/loc-query.test.ts
+++ b/apps/axctl/src/dashboard/loc-query.test.ts
@@ -86,6 +86,9 @@ const TURNS = (w: CacheWriteService) =>
             seq: 1,
             ts: new Date("2026-05-28T00:00:00.000Z"),
             role: "user",
+            // #921: the FTS target indexes full `text`; excerpt derives from
+            // it on real rows, so the fixture carries both.
+            text: "loc rollup investigation",
             text_excerpt: "loc rollup investigation",
         },
         {
@@ -94,6 +97,7 @@ const TURNS = (w: CacheWriteService) =>
             seq: 1,
             ts: new Date("2026-05-27T00:00:00.000Z"),
             role: "user",
+            text: "unrelated change",
             text_excerpt: "unrelated change",
         },
     ]);

--- a/apps/axctl/src/dashboard/recall.test.ts
+++ b/apps/axctl/src/dashboard/recall.test.ts
@@ -193,6 +193,25 @@ describe("recall: turn source", () => {
         expect(res.hits.map((h) => h.turn_id)).not.toContain("turn:2");
     });
 
+    dtest("finds a phrase PAST the 500-char excerpt bound, and snippets around the match (#921)", async () => {
+        const filler = "the quick brown fox jumps over the lazy dog again and again. ".repeat(12); // ~744 chars
+        const deep = `${filler}zanzibar quokka festival`;
+        const res = await withRecall("ax-recall-deep-", (w) =>
+            Effect.gen(function* () {
+                yield* CORPUS(w);
+                yield* w.putMany("turn", [{
+                    ...turn("turn:deep", "session:a", 9, deep, "2026-08-12T10:00:00.000Z"),
+                    // Mirror the parser: the stored excerpt is the first 500
+                    // chars, so the phrase lives ONLY in the full text.
+                    text_excerpt: deep.slice(0, 500),
+                }]);
+            }), { q: "zanzibar quokka" });
+
+        expect(res.hits.map((h) => h.turn_id)).toEqual(["turn:deep"]);
+        // The snippet centers on the match instead of showing the head excerpt.
+        expect(res.hits[0]?.snippet).toContain("zanzibar quokka");
+    });
+
     dtest("carries the joined session's project, source and cwd onto each hit", async () => {
         const res = await withRecall("ax-recall-join-", CORPUS, { q: "surreal" });
 

--- a/apps/axctl/src/queries/recall.test.ts
+++ b/apps/axctl/src/queries/recall.test.ts
@@ -87,9 +87,12 @@ describe("page and count queries agree about what matches", () => {
         expect(turnCountQuery(ALL_FILTERS).sql.match(/match_bm25/g)).toHaveLength(1);
     });
 
-    test("an unfiltered query binds only the query text (plus pagination)", () => {
-        expect(turnCountQuery(BASE).params).toEqual(["duckdb"]);
-        expect(turnPageQuery(BASE, 0, 50).params).toEqual(["duckdb", 50, 0]);
+    test("an unfiltered query binds the query text four times (3 snippet + 1 score), plus pagination", () => {
+        // #921: the match-centered snippet binds `q` three times (position x2,
+        // substr start) ahead of match_bm25's one - the same subquery serves
+        // page and count, so both carry all four.
+        expect(turnCountQuery(BASE).params).toEqual(["duckdb", "duckdb", "duckdb", "duckdb"]);
+        expect(turnPageQuery(BASE, 0, 50).params).toEqual(["duckdb", "duckdb", "duckdb", "duckdb", 50, 0]);
     });
 
     test("the BM25 score is filtered outside the subquery, not used as a boolean", () => {

--- a/apps/axctl/src/queries/recall.ts
+++ b/apps/axctl/src/queries/recall.ts
@@ -42,10 +42,14 @@ import {
     type Clause,
 } from "@ax/lib/duckdb/clause";
 import { TimestampColumn } from "@ax/lib/duckdb/columns";
-import { matchBm25Sql, type FtsTarget } from "@ax/lib/duckdb/fts";
+import { COMMIT_FTS_TARGET, matchBm25Sql, TURN_FTS_TARGET, type FtsTarget } from "@ax/lib/duckdb/fts";
 
-export const TURN_FTS: FtsTarget = { table: "turn", idColumn: "id", textColumn: "text_excerpt" };
-export const COMMIT_FTS: FtsTarget = { table: "commit", idColumn: "id", textColumn: "message" };
+/** Re-exported FROM the fts module (#921) so the reader can never drift from
+ *  the target `buildFtsIndexes` actually indexes. Turn search covers the FULL
+ *  `turn.text` since #921 (was the 500-char `text_excerpt` - a phrase past
+ *  that bound was silently unfindable). */
+export const TURN_FTS: FtsTarget = TURN_FTS_TARGET;
+export const COMMIT_FTS: FtsTarget = COMMIT_FTS_TARGET;
 
 /** How much of a matched turn/commit/skill body a hit carries. */
 export const SNIPPET_MAX = 240;
@@ -98,7 +102,18 @@ const turnMatchesSql = (where: Clause): string => `
         s.cwd AS cwd,
         t.role AS role,
         t.ts AS ts,
-        t.text_excerpt AS text_excerpt,
+        -- #921: the index covers FULL turn text, so a hit can sit past the
+        -- 500-char excerpt. Show a match-centered window from the full text
+        -- when the literal query string is locatable in it; BM25 also matches
+        -- stemmed/multi-term forms position() cannot find, so fall back to
+        -- the stored head excerpt rather than showing nothing.
+        COALESCE(
+            CASE WHEN position(lower(?) IN lower(t.text)) > 0
+                 THEN substr(t.text, CASE WHEN position(lower(?) IN lower(t.text)) > 120
+                                          THEN position(lower(?) IN lower(t.text)) - 120 ELSE 1 END, 360)
+            END,
+            t.text_excerpt
+        ) AS text_excerpt,
         ${matchBm25Sql(TURN_FTS, "t")} AS score
     FROM turn t
     JOIN session s ON s.id = t.session
@@ -113,7 +128,7 @@ export const turnPageQuery = (filters: TurnFilters, offset: number, limit: numbe
               WHERE score IS NOT NULL
               ORDER BY ts DESC
               LIMIT ? OFFSET ?`,
-        params: [filters.q, ...where.params, limit, offset],
+        params: [filters.q, filters.q, filters.q, filters.q, ...where.params, limit, offset],
     };
 };
 
@@ -121,7 +136,10 @@ export const turnCountQuery = (filters: TurnFilters): Clause => {
     const where = turnWhere(filters);
     return {
         sql: `SELECT count(*) AS total FROM (${turnMatchesSql(where)}) matches WHERE score IS NOT NULL`,
-        params: [filters.q, ...where.params],
+        // Same subquery as the page query, so the same FOUR binds of `q`
+        // (3 snippet + 1 match_bm25) - the optimizer prunes the unused
+        // snippet column, but the placeholders still need their params.
+        params: [filters.q, filters.q, filters.q, filters.q, ...where.params],
     };
 };
 

--- a/packages/lib/src/duckdb/fts.ts
+++ b/packages/lib/src/duckdb/fts.ts
@@ -7,11 +7,16 @@
  * that can live in schema.duckdb.sql; it is a build step that has to run AFTER
  * the rows land, on every ingest, which is what {@link buildFtsIndexes} is.
  *
- * WHAT IS COVERED, and why so little. `turn.text_excerpt` and `commit.message` -
- * that is the whole set, and it is exactly what `ax recall` searches. The Surreal
- * schema also had an ngram FTS index over skill name/description; issue #758
- * dropped it deliberately, because the skill catalogue is small enough that a
- * plain `ILIKE` scan beats an index that cost more to build than the scan it
+ * WHAT IS COVERED, and why so little. `turn.text` (FULL turn text, #921) and
+ * `commit.message` - that is the whole set, and it is exactly what `ax recall`
+ * searches. Turn coverage was `text_excerpt` (the first 500 chars) until #921:
+ * a phrase past the excerpt bound was silently unfindable, and the measured
+ * cost of indexing full text on the real 1.05M-turn store was small (rebuild
+ * 2.2s -> 6.2s, terms 3.2M -> 19.6M rows, no measurable file growth) - with
+ * the #909 skip, a no-op ingest pays none of it. The Surreal schema also had
+ * an ngram FTS index over skill name/description; issue #758 dropped it
+ * deliberately, because the skill catalogue is small enough that a plain
+ * `ILIKE` scan beats an index that cost more to build than the scan it
  * replaced. Content-block search is not carried over either.
  *
  * `LOAD fts`, never `INSTALL fts`. The dylib ax ships links fts statically
@@ -55,8 +60,11 @@ export interface FtsTarget {
     readonly textColumn: string;
 }
 
-/** The digest formula version - bump to force a one-time rebuild of every target. */
-const FTS_DIGEST_VERSION = "v1";
+/** The digest formula version - bump to force a one-time rebuild of every
+ *  target. v2 = the turn target moved from `text_excerpt` to full `text`
+ *  (#921); the digest would move on its own (it hashes the new column), but
+ *  the explicit bump makes the cutover legible in `fts_index_state`. */
+const FTS_DIGEST_VERSION = "v2";
 
 /**
  * A per-target content digest computed ENTIRELY in SQL as one VARCHAR. Never
@@ -84,14 +92,17 @@ export interface FtsBuildOutcome {
     readonly rebuilt: boolean;
 }
 
+/** Full `turn.text` since #921 (was `text_excerpt` - see the module doc).
+ *  Exported by name so readers (`ax recall`, loc-query) reference the SAME
+ *  target the builder indexes instead of re-declaring it and drifting. */
+export const TURN_FTS_TARGET: FtsTarget = { table: "turn", idColumn: "id", textColumn: "text" };
+export const COMMIT_FTS_TARGET: FtsTarget = { table: "commit", idColumn: "id", textColumn: "message" };
+
 /**
  * The WHOLE covered set. Adding to it is a real decision, not a config tweak:
- * every target costs a full index rebuild on every ingest.
+ * every target costs a full index rebuild on every ingest where its digest moves.
  */
-export const FTS_TARGETS: ReadonlyArray<FtsTarget> = [
-    { table: "turn", idColumn: "id", textColumn: "text_excerpt" },
-    { table: "commit", idColumn: "id", textColumn: "message" },
-];
+export const FTS_TARGETS: ReadonlyArray<FtsTarget> = [TURN_FTS_TARGET, COMMIT_FTS_TARGET];
 
 /** The generated index schema for a target - `fts_main_turn`, `fts_main_commit`. */
 export const ftsSchemaName = (target: FtsTarget): string => `fts_main_${target.table}`;


### PR DESCRIPTION
Fixes #921

## Problem

`ax recall` could not find a phrase that sits past the first 500 characters of a turn. The turn FTS target was `text_excerpt` = `text.slice(0, 500)` (transcripts.ts). The failure is silent: the turn is in the store, the phrase is in `turn.text`, and recall returns no match. Found in UAT ("purple pelican" test phrase).

## Change

- **`packages/lib/src/duckdb/fts.ts`**: the turn FTS target moves from `text_excerpt` to full `text`. The targets are now exported by name (`TURN_FTS_TARGET`, `COMMIT_FTS_TARGET`) so readers (`ax recall`, loc-query) reference the SAME target the builder indexes instead of re-declaring it. `FTS_DIGEST_VERSION` bumped `v1` → `v2` so the cutover is legible in `fts_index_state` (one forced rebuild per store on the next ingest; the digest would move anyway since it hashes the new column).
- **`apps/axctl/src/queries/recall.ts`**: turn hits snippet AROUND the match - a position-centered 360-char window over full text, falling back to `text_excerpt` when the exact phrase does not appear verbatim (bm25 can match on stemmed terms). Without this, a deep match would show the unrelated first 500 chars as its snippet. The shared match subquery binds `q` four times (3 snippet + 1 `match_bm25`) in both page and count queries.

## Measured cost (real 1.05M-turn store clone)

- turn index rebuild: 2.2s → 6.2s (one-time per content change; the #909 digest skip means a no-op ingest pays nothing)
- `fts_main_turn` terms: 3.2M → 19.6M rows
- snapshot file size: no measurable growth
- indexed char volume: 33.4M (excerpts) → 193.3M (full text)

## Tests

- New dtest: a phrase planted PAST the 500-char bound is found, and the hit's snippet contains the phrase (`dashboard/recall.test.ts`).
- Param-contract test updated for the four `q` binds (`queries/recall.test.ts`).
- loc-query fixture rows carry full `text` since the index reads it now.

Local gates: 74 tests pass across the 4 touched files; `bunx tsc --noEmit` clean; `check:timestamp-cast` + `check:raw-numeric-cast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)