### PR TITLE
fix(test): cost-query fixture turns carry full text (red main after #922)

### DIFF
--- a/apps/axctl/src/dashboard/cost-query.test.ts
+++ b/apps/axctl/src/dashboard/cost-query.test.ts
@@ -53,6 +53,8 @@ const TURNS = (w: CacheWriteService) =>
             seq: 1,
             ts: new Date("2026-05-28T00:00:00.000Z"),
             role: "user",
+            // #921: the FTS index reads full `text`; excerpt derives from it on real rows.
+            text: "we discussed provider support for live-traces",
             text_excerpt: "we discussed provider support for live-traces",
         },
         {
@@ -61,6 +63,7 @@ const TURNS = (w: CacheWriteService) =>
             seq: 1,
             ts: new Date("2026-05-27T00:00:00.000Z"),
             role: "user",
+            text: "provider support ticket follow-up",
             text_excerpt: "provider support ticket follow-up",
         },
     ]);
@@ -155,6 +158,7 @@ describe("fetchCostSummary", () => {
                             seq: 1,
                             ts: new Date("2026-05-28T00:00:00.000Z"),
                             role: "user",
+                            text: "livetrace rollout notes",
                             text_excerpt: "livetrace rollout notes",
                         },
                         {
@@ -163,6 +167,7 @@ describe("fetchCostSummary", () => {
                             seq: 1,
                             ts: new Date("2026-05-27T00:00:00.000Z"),
                             role: "user",
+                            text: "unrelated turn about deployment",
                             text_excerpt: "unrelated turn about deployment",
                         },
                     ]);


### PR DESCRIPTION
Fix-forward for red main at 3e89ff1b (CI run 32324025175).

#922 moved the turn FTS target from `text_excerpt` to full `text`. `fetchCostSummary`'s query selector matches sessions through that index (via `TURN_FTS`), and `cost-query.test.ts` fixture rows only set `text_excerpt` — NULL `text` matches nothing, so its four query-selector tests went red. Same fixture repair #922 applied to `loc-query.test.ts`; this suite was missed.

Audited all `requireFts` suites: this is the only remaining one that both queries through the turn index and lacks `text` in its fixtures (the CI failure list agrees — only `fetchCostSummary` failed).

Local: all 8 cost-query tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)