### PR TITLE
fix(ci): exempt golden-corpus harvest/replay from the no-node-fs gate

### DIFF
--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -63,6 +63,16 @@ const EXCLUDED_FILES: readonly string[] = [
     // failure never escapes untyped; see the file's own header for why FORCE
     // (not the softer, silently-degrading `COPYFILE_FICLONE`) is load-bearing.
     "packages/lib/src/duckdb/clone-file.ts",
+    // Golden-corpus dev tool (#876): `bun harvest.ts <provider>` pulls +
+    // sanitizes fixtures on a developer machine, outside the axctl Effect
+    // runtime, and is never bundled into the binary. Plain sync node fs/path
+    // is the correct dependency for a run-once codegen script.
+    "apps/axctl/src/ingest/golden-corpus/harvest.ts",
+    // Golden-corpus replay seam (#876): shared by golden-corpus.test.ts and
+    // harvest.ts, materializes sqlite seeds into temp dbs SYNCHRONOUSLY so
+    // `replay(content)` stays a plain function the test can call without a
+    // platform layer - the same trade the duckdb-dylib.ts exemption makes.
+    "apps/axctl/src/ingest/golden-corpus/replay.ts",
 ];
 
 const BANNED_SPECIFIERS = [


### PR DESCRIPTION
Fix-forward for red main at 1ecf8c49 (CI run 32327638539 - only `check:no-node-fs` failed; `bun test` passed).

#877's `harvest.ts` and `replay.ts` import `node:fs`/`node:path`. Both are legitimately outside the Effect runtime: `harvest.ts` is a run-once dev codegen tool (never bundled), and `replay.ts` is the shared test/harvest seam that materializes sqlite seeds synchronously so `replay(content)` stays a plain function tests can call without a platform layer - the same trade the existing `duckdb-dylib.ts` exemption makes. Added to `EXCLUDED_FILES` with reasons.

Local: `check-no-node-fs: clean (682 files scanned, 0 banned imports)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)