### PR TITLE
fix(ingest): restrict cross-path hash reuse to imports

### DIFF
--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -305,6 +305,39 @@ describe("content-hash tier (#900) on real files", () => {
         expect(storedSha as string | null).toBe(expected);
     });
 
+    dtest("a NEW path with bytes matching an ordinary file mark still parses", async () => {
+        const dir = tempDir("ax-jsonl-content-copy-");
+        const firstPath = `${dir}/session-a.jsonl`;
+        const secondPath = `${dir}/session-b.jsonl`;
+        const bytes = `{"kind":"same-bytes"}\n`;
+        await Bun.write(firstPath, bytes);
+        await Bun.write(secondPath, bytes);
+        const firstStat = await statOf(firstPath);
+        const secondStat = await statOf(secondPath);
+
+        const first: string[] = [];
+        const second: string[] = [];
+        let firstResult: unknown;
+        let secondResult: unknown;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-jsonl-content-copy-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                firstResult = yield* runJsonlProviderFiles(write, {
+                    ...options([candidate(firstPath, firstStat.mtimeMs, firstStat.sizeBytes)], first),
+                    contentHash: true,
+                });
+                secondResult = yield* runJsonlProviderFiles(write, {
+                    ...options([candidate(secondPath, secondStat.mtimeMs, secondStat.sizeBytes)], second),
+                    contentHash: true,
+                });
+            }),
+        ));
+
+        expect(firstResult).toMatchObject({ files: 1, refreshedUnchanged: 0 });
+        expect(secondResult).toMatchObject({ files: 1, skippedUnchanged: 0, refreshedUnchanged: 0 });
+        expect(first).toEqual([firstPath]);
+        expect(second).toEqual([secondPath]);
+    });
+
     dtest("an __imported__ sentinel mark makes a NEW path with those bytes refresh-skip; force still parses", async () => {
         const dir = tempDir("ax-jsonl-content3-");
         const filePath = `${dir}/imported.jsonl`;

--- a/packages/lib/src/duckdb/watermark.ts
+++ b/packages/lib/src/duckdb/watermark.ts
@@ -155,10 +155,10 @@ export interface FileWatermark {
     /** The stored content hash for the durable tier, or null when the mark
      *  has none (legacy row, hash failure, or `contentHash` off). */
     storedSha(path: string): string | null;
-    /** true => bytes with this hash were already fully ingested under this
-     *  source kind - by a parse on this machine (any path) or by a segment
-     *  import (#902, `importedMarkPath` marks). The caller may then mark the
-     *  new path and skip the parse. Always false under forceEnv. */
+    /** true => a segment import sentinel (`importedMarkPath`) attests that
+     *  bytes with this hash were already fully ingested. Ordinary file marks
+     *  do not qualify: provider output may depend on the file path, so equal
+     *  bytes at a new path still need parsing. Always false under forceEnv. */
     knownContentSha(sha: string): boolean;
     /** Write the mark. Call only AFTER the file's own writes succeed. */
     commit(path: string, mtimeMs: number, size: number, sha?: string | null): Effect.Effect<void, CacheWriteError>;
@@ -278,15 +278,16 @@ export const fileWatermark = (
             }
         }
 
-        // Content-hash index across ALL of this kind's marks (#902): real file
-        // marks AND `__imported__/` sentinel marks, whose sha attests the
-        // bytes were ingested elsewhere. The backfill-version sentinel is
-        // excluded (its sha is a version tag, not a content hash). Empty under
-        // force, so a forced run reparses everything.
-        const knownShas = new Set<string>();
+        // Cross-path reuse is reserved for `__imported__/` sentinel marks
+        // (#902), whose sha explicitly attests that the bytes were loaded by
+        // `segment import`. A real file mark only proves that exact path was
+        // processed: provider output can derive identity from its path, so a
+        // byte-identical file at a new path must still parse (#927). Empty
+        // under force, so a forced run reparses everything.
+        const importedShas = new Set<string>();
         if (!forced) {
             for (const row of rows) {
-                if (row.sha !== null && !row.path.startsWith("__content_hash_backfill__/")) knownShas.add(row.sha);
+                if (row.sha !== null && row.path.startsWith("__imported__/")) importedShas.add(row.sha);
                 if (isSentinelMarkPath(row.path)) continue;
                 if (row.mtime_ms === null || row.size === null) continue;
                 marks.set(row.path, { mtimeMs: row.mtime_ms, size: row.size, sha: row.sha });
@@ -302,7 +303,7 @@ export const fileWatermark = (
                 return mark !== undefined && mark.mtimeMs === mtimeMs && mark.size === size;
             },
             storedSha: (path) => marks.get(path)?.sha ?? null,
-            knownContentSha: (sha) => knownShas.has(sha),
+            knownContentSha: (sha) => importedShas.has(sha),
             commit: (path, mtimeMs, size, sha) => write.put(WATERMARK_TABLE, row(path, mtimeMs, size, sha)),
             row,
         } satisfies FileWatermark;


### PR DESCRIPTION
## Summary

Restrict cross-path content-hash reuse to `__imported__/` sentinel marks. Ordinary file watermarks now authorize refresh-skips only for the same path, preventing byte-identical copied or renamed Claude transcripts from silently losing path-derived session and project identity.

Closes #927

## Behavior change

Before, a new JSONL path whose bytes matched any previously parsed file could refresh its watermark without parsing. Now, a new path is parsed unless an explicit `segment import` sentinel attests that those bytes were already loaded; same-path touch/resync skips remain unchanged.

## Test plan

- [x] `bun test packages/lib/src/duckdb/watermark.test.ts apps/axctl/src/ingest/jsonl-work-unit.test.ts` (5 pass, 18 platform skips, 0 fail)
- [x] `bun run typecheck`
- [ ] Manual verification: the real-DuckDB cases require ax's statically FTS-enabled libduckdb, which has no official win32/x64 build; Linux CI will run the new regression.

## Release notes

- [x] User-visible change is covered by the Conventional Commit PR title.
- [x] No website changelog entry: this restores intended ingest behavior and belongs in the release PR notes.

## Notes for reviewer

The regression creates two byte-identical files at different paths and asserts both are processed. Existing coverage continues to pin same-path refresh-skips and `__imported__/` sentinel cross-path skips.

`bun run check:no-node-fs` currently reports 13 pre-existing imports outside this change; neither modified file adds a banned import.