### PR TITLE
fix(queries): otel coverage excludes subagents; recovery median dedupes sessions

### DIFF
--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -306,4 +306,34 @@ describe("recovery latency (lens E)", () => {
         // median of [1000, 3000] = 2000 (s3-no-telemetry absent -> not counted)
         expect(tdd.median_recovery_ms).toBe(2000);
     });
+
+    wtest("counts each recovery session once when it has multiple recovery edges", async () => {
+        const fixture = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-skw-recovery-dedupe-"), dylibPath, (w) =>
+                Effect.gen(function* () {
+                    yield* w.putMany("skill", [SKILL({ id: "sk-tdd", name: "superpowers:tdd" })]);
+                    yield* w.putMany("invoked", [INVOKED("i1", "sk-tdd", "session-a", new Date())]);
+                    yield* w.putMany("turn", [
+                        { id: "turn-a1", session: "session-a", seq: 1, ts: new Date(), role: "assistant" },
+                        { id: "turn-a2", session: "session-a", seq: 2, ts: new Date(), role: "assistant" },
+                        { id: "turn-b", session: "session-b", seq: 1, ts: new Date(), role: "assistant" },
+                    ]);
+                    yield* w.putMany("recovered_by", [
+                        { id: "r1", in_id: "turn-a1", out_id: "sk-tdd", ts: new Date() },
+                        { id: "r2", in_id: "turn-a2", out_id: "sk-tdd", ts: new Date() },
+                        { id: "r3", in_id: "turn-b", out_id: "sk-tdd", ts: new Date() },
+                    ]);
+                    yield* w.putMany("otel_log_event", [
+                        { id: "e1", harness: "claude", event_name: "x", session_id: "session-a", duration_ms: 100, observed_at: new Date() },
+                        { id: "e2", harness: "claude", event_name: "x", session_id: "session-b", duration_ms: 1000, observed_at: new Date() },
+                    ]);
+                }),
+            ),
+        );
+
+        const result = await runWeighted(fixture.snapshotPath);
+        const tdd = result.rows.find((r) => r.skill_name === "superpowers:tdd")!;
+
+        expect(tdd.median_recovery_ms).toBe(550);
+    });
 });

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -291,21 +291,21 @@ export const fetchSkillsWeighted = (
             "skills-weighted.recovery_edges",
         );
 
-        // Build Map<skillId, sessionId[]>
-        const skillToSessions = new Map<string, string[]>();
+        // Build Map<skillId, unique session ids>
+        const skillToSessions = new Map<string, Set<string>>();
         for (const r of recoveryEdges) {
             if (!r.skill || !r.session) continue;
-            const list = skillToSessions.get(r.skill);
-            if (list) {
-                list.push(r.session);
+            const sessions = skillToSessions.get(r.skill);
+            if (sessions) {
+                sessions.add(r.session);
             } else {
-                skillToSessions.set(r.skill, [r.session]);
+                skillToSessions.set(r.skill, new Set([r.session]));
             }
         }
 
         // Collect unique session ids across all recovery skills
         const allRecoverySessions = [...new Set(
-            [...skillToSessions.values()].flat(),
+            [...skillToSessions.values()].flatMap((sessions) => [...sessions]),
         )];
 
         const latencyRows = yield* enrichRowsWithTelemetryLatency(

--- a/apps/axctl/src/queries/otel-rollup.test.ts
+++ b/apps/axctl/src/queries/otel-rollup.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { publishCacheFixture, readThroughFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import {
     FLOWING_MS,
     STALE_MS,
@@ -6,6 +9,7 @@ import {
     buildOtelSessionIdsQuery,
     coveragePct,
     formatAge,
+    fetchOtelRollup,
     healthGlyph,
     otelHealth,
 } from "./otel-rollup.ts";
@@ -13,6 +17,7 @@ import { renderOtelRollup } from "../cli/commands/ax-otel.ts";
 import type { OtelRollupResult } from "./otel-rollup.ts";
 
 const NOW = Date.UTC(2026, 5, 25, 0, 0, 0); // 2026-06-25T00:00:00Z
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("otel-rollup", { requireFts: true });
 
 describe("otelHealth", () => {
     it("is none when never observed", () => {
@@ -91,6 +96,26 @@ describe("buildOtelSessionIdsQuery", () => {
             + " WHERE observed_at > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"
             + " AND session_id IS NOT NULL GROUP BY session_id;",
         );
+    });
+});
+
+describe("fetchOtelRollup", () => {
+    dtest("excludes subagent sessions from the coverage window", async () => {
+        const fixture = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-otel-rollup-"), dylibPath, (w) =>
+                Effect.gen(function* () {
+                    yield* w.putMany("session", [{
+                        id: "019fbf3f-9241-40c3-b699-e1f62e7c5341",
+                        source: "codex-subagent",
+                        started_at: new Date(),
+                    }]);
+                }),
+            ),
+        );
+
+        const result = await readThroughFixture(fixture, dylibPath, fetchOtelRollup({ sinceDays: 14 }));
+
+        expect(result.coverage.window_sessions).toBe(0);
     });
 });
 

--- a/apps/axctl/src/queries/otel-rollup.ts
+++ b/apps/axctl/src/queries/otel-rollup.ts
@@ -196,7 +196,11 @@ export const fetchOtelRollup = Effect.fn("queries.fetchOtelRollup")(
         // strings on the DuckDB cache - bareUuid still normalises defensively.
         const idRows = yield* cacheRows(
             SessionIdRow,
-            { sql: `SELECT id FROM session WHERE started_at > ${daysAgoExpr};`, params: [days] },
+            {
+                sql: `SELECT id FROM session WHERE started_at > ${daysAgoExpr}`
+                    + ` AND source NOT LIKE '%-subagent';`,
+                params: [days],
+            },
             "otel coverage session window",
         );
         const windowUuids = idRows.map((r) => bareUuid(r.id)).filter((u): u is string => u !== null);


### PR DESCRIPTION
Fixes #932
Fixes #933

Fleet fix chunk mbp/fix-query-reads (run map #956). Built by codex (medium), gated by orchestrator: diff review + both suites re-run locally (30 pass / 0 fail), tsc + both cast gates clean.

- otel-rollup.ts: the coverage session window now carries `AND source NOT LIKE '%-subagent'`, matching the documented top-level-only contract and cost-split's origin rule. Regression pins a codex-subagent uuid session out of the denominator.
- skills-weighted.ts: recovery latency dedupes to unique (skill, session) pairs via a Set. Regression pins a double-edge session counting once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)