### PR TITLE
fix(inspect): page-scoped tool calls + whole-session totals

### DIFF
--- a/apps/axctl/src/dashboard/session-inspect.test.ts
+++ b/apps/axctl/src/dashboard/session-inspect.test.ts
@@ -202,4 +202,90 @@ describe("fetchSessionInspect graph-backed paging", () => {
             [1, "assistant", "done"],
         ]);
     });
+
+    dtest("returns tool calls for a requested turn after the first 4,000 calls", async () => {
+        const fixture = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-session-inspect-tools-"), dylibPath, (w) =>
+                Effect.gen(function* () {
+                    yield* w.put("session", { id: "session-tools", source: "codex" });
+                    yield* w.put("session_health", {
+                        id: "sh-tools",
+                        session: "session-tools",
+                        source: "codex",
+                        turns: 4001,
+                    });
+                    yield* w.put("turn", {
+                        id: "turn-4001",
+                        session: "session-tools",
+                        seq: 4001,
+                        role: "assistant",
+                        ts: new Date("2026-06-09T00:00:01.000Z"),
+                        text: "late tool call",
+                    });
+                    yield* w.putMany("tool_call", Array.from({ length: 4001 }, (_, index) => ({
+                        id: `call-${index + 1}`,
+                        session: "session-tools",
+                        turn: index === 4000 ? "turn-4001" : null,
+                        name: "Read",
+                        ts: new Date("2026-06-09T00:00:01.000Z"),
+                        seq: index + 1,
+                        input_json: JSON.stringify({ file_path: `/tmp/${index + 1}` }),
+                    })));
+                }),
+            ),
+        );
+
+        const payload = await Effect.runPromise(
+            fetchSessionInspect("session-tools", { turnOffset: 4000, turnLimit: 1 }).pipe(
+                Effect.provide(Layer.mergeAll(readFixture(fixture.snapshotPath, dylibPath), BunFsLayer)),
+            ),
+        );
+
+        expect(payload.turns).toHaveLength(1);
+        expect(payload.turns[0]?.tool_calls?.map((call) => call.name)).toEqual(["Read"]);
+    });
+
+    dtest("reports full-session totals when the response contains one turn", async () => {
+        const fixture = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-session-inspect-totals-"), dylibPath, (w) =>
+                Effect.gen(function* () {
+                    yield* w.put("session", { id: "session-totals", source: "codex" });
+                    yield* w.put("session_health", {
+                        id: "sh-totals",
+                        session: "session-totals",
+                        source: "codex",
+                        turns: 2,
+                    });
+                    yield* w.putMany("turn", [
+                        {
+                            id: "totals-turn-1",
+                            session: "session-totals",
+                            seq: 1,
+                            role: "user",
+                            ts: new Date("2026-06-09T00:00:00.000Z"),
+                            text: "12345",
+                        },
+                        {
+                            id: "totals-turn-2",
+                            session: "session-totals",
+                            seq: 2,
+                            role: "assistant",
+                            ts: new Date("2026-06-09T00:00:01.000Z"),
+                            text: "67890",
+                        },
+                    ]);
+                }),
+            ),
+        );
+
+        const payload = await Effect.runPromise(
+            fetchSessionInspect("session-totals", { turnOffset: 0, turnLimit: 1 }).pipe(
+                Effect.provide(Layer.mergeAll(readFixture(fixture.snapshotPath, dylibPath), BunFsLayer)),
+            ),
+        );
+
+        expect(payload.turns).toHaveLength(1);
+        expect(payload.total_chars).toBe(10);
+        expect(payload.totals_by_kind).toEqual({ user_input: 5, assistant_text: 5 });
+    });
 });

--- a/apps/axctl/src/dashboard/session-inspect.ts
+++ b/apps/axctl/src/dashboard/session-inspect.ts
@@ -408,6 +408,16 @@ const GraphSessionHealthDbRow = Schema.Struct({
 interface GraphSessionHealthRow {
     readonly turns?: number | null;
 }
+const GraphSessionTotalsDbRow = Schema.Struct({
+    total_chars: Schema.Number,
+    user_input: Schema.Number,
+    assistant_text: Schema.Number,
+});
+interface GraphSessionTotalsRow {
+    readonly total_chars: number;
+    readonly user_input: number;
+    readonly assistant_text: number;
+}
 
 /** Resolve the spawning parent of this session (codex spawn_agent / claude
  *  Task). Returns nulls if not a subagent. Defensive: swallows DB errors so
@@ -703,13 +713,18 @@ const GraphTurnToolCallDbRow = Schema.Struct({
  *  just without their tool cards (never crashes the inspector). */
 const resolveGraphTurnToolCalls = (
     sessionId: string,
-): Effect.Effect<ReadonlyMap<number, ToolCallDto[]>, never, CacheRead> =>
-    cacheRows(
+    turnOffset: number,
+    turnLimit: number,
+): Effect.Effect<ReadonlyMap<number, ToolCallDto[]>, never, CacheRead> => {
+    if (turnLimit <= 0) return Effect.succeed(new Map<number, ToolCallDto[]>());
+    const minSeq = turnOffset + 1;
+    const maxSeq = turnOffset + turnLimit;
+    return cacheRows(
         GraphTurnToolCallDbRow,
         {
             sql: `SELECT seq, name, command_norm, command_text, input_json, output_excerpt, has_error
-                  FROM tool_call WHERE session = ? AND seq IS NOT NULL ORDER BY seq ASC LIMIT 4000`,
-            params: [sessionId],
+                  FROM tool_call WHERE session = ? AND seq BETWEEN ? AND ? ORDER BY seq ASC`,
+            params: [sessionId, minSeq, maxSeq],
         },
         "session-inspect.graph_turn_tool_calls",
     ).pipe(
@@ -732,6 +747,7 @@ const resolveGraphTurnToolCalls = (
             return bySeq;
         }),
     );
+};
 
 const resolveGraphSessionHealth = (
     sessionId: string,
@@ -740,6 +756,22 @@ const resolveGraphSessionHealth = (
         GraphSessionHealthDbRow,
         { sql: `SELECT turns FROM session_health WHERE session = ? LIMIT 1`, params: [sessionId] },
         "session-inspect.graph_session_health",
+    );
+
+const resolveGraphSessionTotals = (
+    sessionId: string,
+): Effect.Effect<GraphSessionTotalsRow | null, never, CacheRead> =>
+    cacheFirst(
+        GraphSessionTotalsDbRow,
+        {
+            sql: `SELECT
+                    CAST(COALESCE(SUM(length(COALESCE(text, ''))), 0) AS DOUBLE) AS total_chars,
+                    CAST(COALESCE(SUM(CASE WHEN role = 'assistant' THEN 0 ELSE length(COALESCE(text, '')) END), 0) AS DOUBLE) AS user_input,
+                    CAST(COALESCE(SUM(CASE WHEN role = 'assistant' THEN length(COALESCE(text, '')) ELSE 0 END), 0) AS DOUBLE) AS assistant_text
+                  FROM turn WHERE session = ? AND (text IS NOT NULL OR has_tool_use = true)`,
+            params: [sessionId],
+        },
+        "session-inspect.graph_session_totals",
     );
 
 function codexTurnUsageToDetail(usage: CodexTurnTokenUsage): TurnTokenUsageDetail {
@@ -1045,7 +1077,7 @@ const fetchGraphSessionInspect = (
 ): Effect.Effect<SessionInspectPayload | null, never, CacheRead> =>
     Effect.gen(function* () {
         const turnSourceRefs = turnSourceRefsForWindow(bareSessionId, turnOffset, turnLimit);
-        const [parent, sessionMeta, childrenEdges, allHookFires, tokenUsage, turnTokenUsage, graphTurns, health, turnContent, toolCallsByDbSeq] = yield* Effect.all([
+        const [parent, sessionMeta, childrenEdges, allHookFires, tokenUsage, turnTokenUsage, graphTurns, health, sessionTotals, turnContent, toolCallsByDbSeq] = yield* Effect.all([
             resolveParent(bareSessionId),
             resolveSessionMeta(bareSessionId),
             resolveChildren(bareSessionId),
@@ -1054,8 +1086,9 @@ const fetchGraphSessionInspect = (
             resolveTurnTokenUsageForWindow(bareSessionId, turnOffset, turnLimit),
             resolveGraphTurnWindow(bareSessionId, turnOffset, turnLimit),
             resolveGraphSessionHealth(bareSessionId),
+            resolveGraphSessionTotals(bareSessionId),
             resolveTurnContentForSourceRefs(turnSourceRefs),
-            resolveGraphTurnToolCalls(bareSessionId),
+            resolveGraphTurnToolCalls(bareSessionId, turnOffset, turnLimit),
         ], { concurrency: "unbounded" });
 
         // Subagent run metrics, batched over the resolved child ids. Depends on
@@ -1096,13 +1129,29 @@ const fetchGraphSessionInspect = (
             turns.push(dto);
         }
 
-        const totals = { ...pageTotals };
+        const totals: Partial<Record<InspectSpanKind, number>> = sessionTotals
+            ? {
+                user_input: sessionTotals.user_input,
+                assistant_text: sessionTotals.assistant_text,
+            }
+            : { ...pageTotals };
+        if (sessionTotals) {
+            for (const row of graphTurns) {
+                const text = row.text ?? "";
+                const fallbackKind: InspectSpanKind = row.role === "assistant" ? "assistant_text" : "user_input";
+                totals[fallbackKind] = (totals[fallbackKind] ?? 0) - text.length;
+            }
+            for (const [kind, length] of Object.entries(pageTotals) as [InspectSpanKind, number][]) {
+                totals[kind] = (totals[kind] ?? 0) + length;
+            }
+        }
         if (parent.parent_session) applySubagentTaskTagging(turns, totals);
 
         // Graph rows carry no JSONL to match spawn args against, so child meta
         // is always null here (the JSONL fallback path fills it in).
         const children = buildInspectChildren(childrenEdges, childStats, turns, () => null);
-        const totalChars = Object.values(totals).reduce((sum, value) => sum + Number(value ?? 0), 0);
+        const totalChars = sessionTotals?.total_chars ??
+            Object.values(totals).reduce((sum, value) => sum + Number(value ?? 0), 0);
 
         return assembleInspectPayload({
             sessionId: bareSessionId,


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-session-inspect.

- #934: `resolveGraphTurnToolCalls` read the first 4,000 tool calls of the session, so tool cards vanished on later pages. The query is now scoped to the requested turn window (`seq BETWEEN offset+1 AND offset+limit`), no cap.
- #935: session totals were computed from the current page only. A new aggregate query sums the whole session; the page's precise span totals are reconciled on top (subtract the page's raw role-based estimate, add the exact page totals).

Regression tests red-then-green for both (`undefined` -> tool cards after row 4,000; `5` -> `10` on paginated totals). Gates: suite 12/12 re-run at gate, tsc clean, both cast checks clean.

Fixes #934
Fixes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)