### PR TITLE
fix: sync-throw guard fail-open + atomic freshness spawn claim

### DIFF
--- a/apps/axctl/src/queries/ingest-staleness.test.ts
+++ b/apps/axctl/src/queries/ingest-staleness.test.ts
@@ -20,12 +20,20 @@ import {
 const withScratchDataDir = async <A>(fn: (dir: string) => Promise<A>): Promise<A> => {
     const dir = mkdtempSync(join(tmpdir(), "ax-freshness-drive-test-"));
     const original = process.env.AX_DATA_DIR;
+    const originalNoAutoIngest = process.env.AX_NO_AUTO_INGEST;
+    const originalAutoIngest = process.env.AX_AUTO_INGEST;
     process.env.AX_DATA_DIR = dir;
+    delete process.env.AX_NO_AUTO_INGEST;
+    delete process.env.AX_AUTO_INGEST;
     try {
         return await fn(dir);
     } finally {
         if (original === undefined) delete process.env.AX_DATA_DIR;
         else process.env.AX_DATA_DIR = original;
+        if (originalNoAutoIngest === undefined) delete process.env.AX_NO_AUTO_INGEST;
+        else process.env.AX_NO_AUTO_INGEST = originalNoAutoIngest;
+        if (originalAutoIngest === undefined) delete process.env.AX_AUTO_INGEST;
+        else process.env.AX_AUTO_INGEST = originalAutoIngest;
         rmSync(dir, { recursive: true, force: true });
     }
 };
@@ -233,6 +241,38 @@ describe("maybeSpawnBackgroundIngest (freshness drive)", () => {
             await runDrive(db, calls);
             await runDrive(db, calls);
             expect(calls).toHaveLength(1);
+        });
+    });
+
+    test("an atomic claim lets only one parallel stale reader spawn", async () => {
+        await withScratchDataDir(async () => {
+            const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000));
+            const calls: number[] = [];
+            const layer = Layer.mergeAll(db, fakeSpawner(calls), PlatformLayer);
+            await Effect.runPromise(
+                Effect.all(Array.from({ length: 20 }, () => maybeSpawnBackgroundIngest), {
+                    concurrency: "unbounded",
+                }).pipe(Effect.provide(layer)),
+            );
+            expect(calls).toHaveLength(1);
+        });
+    });
+
+    test("releases the atomic claim when the spawn fails", async () => {
+        await withScratchDataDir(async () => {
+            const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000));
+            let attempts = 0;
+            const spawner = Layer.succeed(BackgroundIngestSpawner, {
+                spawn: () =>
+                    Effect.sync(() => {
+                        attempts += 1;
+                        if (attempts === 1) throw new Error("spawn failed");
+                    }),
+            });
+            const layer = Layer.mergeAll(db, spawner, PlatformLayer);
+            await Effect.runPromise(maybeSpawnBackgroundIngest.pipe(Effect.provide(layer)));
+            await Effect.runPromise(maybeSpawnBackgroundIngest.pipe(Effect.provide(layer)));
+            expect(attempts).toBe(2);
         });
     });
 

--- a/apps/axctl/src/queries/ingest-staleness.test.ts
+++ b/apps/axctl/src/queries/ingest-staleness.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CacheRead, CacheUnavailableError, type CacheReadService } from "@ax/lib/duckdb/seam";
@@ -255,6 +255,29 @@ describe("maybeSpawnBackgroundIngest (freshness drive)", () => {
                 }).pipe(Effect.provide(layer)),
             );
             expect(calls).toHaveLength(1);
+        });
+    });
+
+    test("reclaims a stale claim left by a dead process", async () => {
+        await withScratchDataDir(async (dir) => {
+            const claimPath = join(dir, "freshness-drive-claim");
+            writeFileSync(claimPath, "99999\n");
+            const old = new Date(Date.now() - 11 * 60 * 1000);
+            utimesSync(claimPath, old, old);
+            const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000));
+            const calls: number[] = [];
+            await runDrive(db, calls);
+            expect(calls).toHaveLength(1);
+        });
+    });
+
+    test("a fresh foreign claim still blocks the spawn", async () => {
+        await withScratchDataDir(async (dir) => {
+            writeFileSync(join(dir, "freshness-drive-claim"), "99999\n");
+            const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000));
+            const calls: number[] = [];
+            await runDrive(db, calls);
+            expect(calls).toHaveLength(0);
         });
     });
 

--- a/apps/axctl/src/queries/ingest-staleness.ts
+++ b/apps/axctl/src/queries/ingest-staleness.ts
@@ -13,7 +13,7 @@
  * Fail-open: an unreachable DB prints nothing (the command's own error already
  * says that) and a warning never touches stdout, so `--json` stays machine-clean.
  */
-import { Context, Effect, FileSystem, Layer, Schema } from "effect";
+import { Context, Effect, FileSystem, Layer, Option, Schema } from "effect";
 import { homedir } from "node:os";
 import { jsonField } from "@ax/lib/decode";
 import { TimestampColumn } from "@ax/lib/duckdb/columns";
@@ -177,15 +177,30 @@ const writeFreshnessState = (next: FreshnessState): Effect.Effect<void, never, F
             .pipe(orAbsent<void>(undefined));
     });
 
+/** A live claim exists for milliseconds (state read + spawn). A claim file
+ *  older than this survived a hard process death - reclaim it, or the
+ *  freshness drive stays off forever. */
+const FRESHNESS_CLAIM_STALE_MS = 10 * 60 * 1000;
+
 /** Atomically claim the right to spawn. `wx` maps to O_EXCL, so only one
  *  process can pass this point. The caller always removes its claim. */
 const tryClaimFreshnessSpawn = (): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         yield* fs.makeDirectory(dataDir(), { recursive: true }).pipe(orAbsent<void>(undefined));
-        return yield* fs
-            .writeFileString(freshnessClaimPath(), `${process.pid}\n`, { flag: "wx" })
-            .pipe(Effect.as(true), orAbsent(false));
+        const claim = () =>
+            fs
+                .writeFileString(freshnessClaimPath(), `${process.pid}\n`, { flag: "wx" })
+                .pipe(Effect.as(true), orAbsent(false));
+        const claimed = yield* claim();
+        if (claimed) return true;
+        const mtimeMs = yield* fs.stat(freshnessClaimPath()).pipe(
+            Effect.map((info) => Option.match(info.mtime, { onSome: (d) => d.getTime(), onNone: () => Date.now() })),
+            orAbsent(Date.now()),
+        );
+        if (Date.now() - mtimeMs < FRESHNESS_CLAIM_STALE_MS) return false;
+        yield* fs.remove(freshnessClaimPath(), { force: true }).pipe(Effect.ignore);
+        return yield* claim();
     });
 
 const releaseFreshnessSpawnClaim: Effect.Effect<void, never, FileSystem.FileSystem> =

--- a/apps/axctl/src/queries/ingest-staleness.ts
+++ b/apps/axctl/src/queries/ingest-staleness.ts
@@ -133,15 +133,11 @@ export const BackgroundIngestSpawnerLive: Layer.Layer<BackgroundIngestSpawner> =
     {
         spawn: () =>
             Effect.sync(() => {
-                try {
-                    const child = Bun.spawn(
-                        selfInvokeCommand(["ingest", "--since=1", "--progress=off"]),
-                        { stdio: ["ignore", "ignore", "ignore"] },
-                    );
-                    child.unref();
-                } catch {
-                    // best-effort; a spawn failure must not break the caller's command
-                }
+                const child = Bun.spawn(
+                    selfInvokeCommand(["ingest", "--since=1", "--progress=off"]),
+                    { stdio: ["ignore", "ignore", "ignore"] },
+                );
+                child.unref();
             }),
     },
 );
@@ -154,6 +150,7 @@ const freshnessAutoIngestDisabled = (env: NodeJS.ProcessEnv = process.env): bool
 
 const dataDir = (): string => process.env.AX_DATA_DIR ?? posixPath.join(homedir(), ".local", "share", "ax");
 const freshnessStatePath = (): string => posixPath.join(dataDir(), "freshness-drive-state.json");
+const freshnessClaimPath = (): string => posixPath.join(dataDir(), "freshness-drive-claim");
 
 interface FreshnessState {
     readonly lastSpawnAtMs?: number;
@@ -178,6 +175,23 @@ const writeFreshnessState = (next: FreshnessState): Effect.Effect<void, never, F
         yield* fs
             .writeFileString(freshnessStatePath(), `${prettyPrint(next)}\n`)
             .pipe(orAbsent<void>(undefined));
+    });
+
+/** Atomically claim the right to spawn. `wx` maps to O_EXCL, so only one
+ *  process can pass this point. The caller always removes its claim. */
+const tryClaimFreshnessSpawn = (): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(dataDir(), { recursive: true }).pipe(orAbsent<void>(undefined));
+        return yield* fs
+            .writeFileString(freshnessClaimPath(), `${process.pid}\n`, { flag: "wx" })
+            .pipe(Effect.as(true), orAbsent(false));
+    });
+
+const releaseFreshnessSpawnClaim: Effect.Effect<void, never, FileSystem.FileSystem> =
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(freshnessClaimPath(), { force: true }).pipe(Effect.ignore);
     });
 
 /**
@@ -210,9 +224,27 @@ export const maybeSpawnBackgroundIngest: Effect.Effect<
         return;
     }
 
-    const spawner = yield* BackgroundIngestSpawner;
-    yield* spawner.spawn();
-    yield* writeFreshnessState({ ...state, lastSpawnAtMs: nowMs });
+    const claimed = yield* tryClaimFreshnessSpawn();
+    if (!claimed) return;
+
+    yield* Effect.gen(function* () {
+        // Another process can finish between our first state read and this
+        // claim. Recheck while the exclusive claim is held.
+        const claimedState = yield* readFreshnessState();
+        if (
+            !shouldSpawnBackgroundIngest({
+                lastSpawnAtMs: claimedState.lastSpawnAtMs ?? null,
+                nowMs,
+                debounceMs: FRESHNESS_SPAWN_DEBOUNCE_MS,
+            })
+        ) {
+            return;
+        }
+
+        const spawner = yield* BackgroundIngestSpawner;
+        yield* spawner.spawn();
+        yield* writeFreshnessState({ ...claimedState, lastSpawnAtMs: nowMs });
+    }).pipe(Effect.ensuring(releaseFreshnessSpawnClaim));
 }).pipe(
     Effect.timeoutOption(PROBE_TIMEOUT_MS),
     // Same "never fails" contract as warnIfIngestStale - a defect (EPIPE, a

--- a/packages/hooks-sdk/src/dispatch.test.ts
+++ b/packages/hooks-sdk/src/dispatch.test.ts
@@ -76,6 +76,23 @@ describe("dispatchEvent", () => {
     expect(out.stdout).toContain("still here");
   });
 
+  test("a synchronous guard throw fails open without suppressing a later block", async () => {
+    const exploding = defineHook({
+      name: "sync-boom",
+      events: ["PreToolUse"],
+      matcher: { tools: ["Edit"] },
+      run: () => {
+        throw new Error("sync boom");
+      },
+    });
+    const out = await run(claudeEdit, [
+      exploding,
+      fixed("blocker", ["Edit"], Verdict.block("must block")),
+    ]);
+    expect(out.exitCode).toBe(2);
+    expect(out.stderr).toBe("must block");
+  });
+
   test("encodes per harness: codex advise is a no-op exit 0", async () => {
     const codexEdit = JSON.stringify({
       hook_event_name: "PreToolUse",

--- a/packages/hooks-sdk/src/dispatch.ts
+++ b/packages/hooks-sdk/src/dispatch.ts
@@ -44,8 +44,7 @@ export const dispatchEvent = (
     const verdicts: Verdict[] = [];
     for (const guard of guards) {
       if (!matches(guard, event)) continue;
-      const verdict = yield* guard
-        .run(event)
+      const verdict = yield* Effect.suspend(() => guard.run(event))
         .pipe(Effect.catchDefect(() => Effect.succeed(Verdict.allow)));
       verdicts.push(verdict);
     }


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-runtime-guards.

- #946: `dispatchEvent` yielded `guard.run(event)` directly, so a guard that threw SYNCHRONOUSLY escaped the `catchDefect` fail-open boundary and aborted the whole dispatch - every later blocking guard was silently disabled. `Effect.suspend` now routes the sync throw into the same defect handler.
- #947: two concurrent stale readers could both pass the debounce check and both fork a background ingest. The spawn now runs under an exclusive `wx` (O_EXCL) claim file with a state re-check while the claim is held; the claim is released via `Effect.ensuring`, including on spawn failure.
- Gate addition (orchestrator): a claim file left by a hard-killed process (SIGKILL/power loss - `ensuring` cannot run) would have disabled the freshness drive forever. A claim older than 10 minutes is reclaimed; a fresh foreign claim still blocks. Both paths pinned by tests.

Gates: staleness + dispatch suites 29/29, tsc clean (advisory messages only), both cast checks clean.

Fixes #946
Fixes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)