### PR TITLE
fix(models): clear stale derived rows on reparse (cache-bust + objective)

### DIFF
--- a/apps/axctl/src/ingest/models/cache-bust-event-cleanup.sql
+++ b/apps/axctl/src/ingest/models/cache-bust-event-cleanup.sql
@@ -1,0 +1,17 @@
+-- model: cache_bust_event
+-- inputs: turn_token_usage, cache_bust_event
+-- rebuild: incremental
+--
+-- Remove a derived bust when a reparse clears the source reason. This stays a
+-- separate model because the runner permits one statement per model file.
+--
+-- Window: SET VARIABLE since_days (NULL/unset = full derivation).
+-- ICU-less build: the clock MUST be spelled CAST(CURRENT_TIMESTAMP AS TIMESTAMP).
+DELETE FROM cache_bust_event AS cbe
+USING turn_token_usage AS ttu
+WHERE cbe.id = ttu.id
+  AND ttu.cache_miss_reason_type IS NULL
+  AND (
+    getvariable('since_days') IS NULL
+    OR ttu.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(getvariable('since_days') AS INTEGER) * INTERVAL '1 day')
+  )

--- a/apps/axctl/src/ingest/models/cache-bust-models.ts
+++ b/apps/axctl/src/ingest/models/cache-bust-models.ts
@@ -1,7 +1,7 @@
 /**
  * The cache-bust SQL model + its cutover (#868).
  *
- * Sibling of run-evidence-models.ts, one model instead of two and no
+ * Sibling of run-evidence-models.ts, two ordered models and no
  * check_family backfill: `cache_bust_event` is a priced 1:1 projection of the
  * usage rows that carry a cache_miss_reason, so the only cutover work when
  * the model SQL changes is wipe + one unwindowed run (cheap - the busted
@@ -14,15 +14,21 @@ import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { watermarkRow, WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
 import { stableDigest } from "@ax/lib/ids";
 import { parseModelHeader, runSqlModel, type SqlModel } from "./runner.ts";
+import CACHE_BUST_EVENT_CLEANUP_SQL from "./cache-bust-event-cleanup.sql" with { type: "text" };
 import CACHE_BUST_EVENT_SQL from "./cache-bust-event.sql" with { type: "text" };
 
+export const CACHE_BUST_EVENT_CLEANUP_MODEL: SqlModel = {
+    name: "cache_bust_event",
+    sql: CACHE_BUST_EVENT_CLEANUP_SQL,
+};
 export const CACHE_BUST_EVENT_MODEL: SqlModel = { name: "cache_bust_event", sql: CACHE_BUST_EVENT_SQL };
 
-export const CACHE_BUST_MODELS: readonly SqlModel[] = [CACHE_BUST_EVENT_MODEL];
+/** Ordered: remove cleared source rows before the insert/upsert model runs. */
+export const CACHE_BUST_MODELS: readonly SqlModel[] = [CACHE_BUST_EVENT_CLEANUP_MODEL, CACHE_BUST_EVENT_MODEL];
 
 /** Changes whenever the model's SQL changes -> one full re-derive. */
 export const cacheBustModelVersion = (): string =>
-    stableDigest(`cache-bust-models-v1${CACHE_BUST_EVENT_SQL}`);
+    stableDigest(`cache-bust-models-v1${CACHE_BUST_EVENT_CLEANUP_SQL}${CACHE_BUST_EVENT_SQL}`);
 
 const MARKER_SOURCE_KIND = "cache_bust_model";
 const MARKER_PATH = "__cache_bust_model__";
@@ -55,6 +61,7 @@ export const runCacheBustModels = (
             yield* write.exec("DELETE FROM cache_bust_event");
         }
         const window = rebuild ? undefined : sinceDays;
+        yield* runSqlModel(write, CACHE_BUST_EVENT_CLEANUP_MODEL, window);
         const written = yield* runSqlModel(write, CACHE_BUST_EVENT_MODEL, window);
         if (rebuild) {
             yield* write.put(

--- a/apps/axctl/src/ingest/models/run-evidence-event.sql
+++ b/apps/axctl/src/ingest/models/run-evidence-event.sql
@@ -52,6 +52,12 @@ lineage AS (
     SELECT child, any_value(parent) AS parent, arg_max(root, depth) AS root
     FROM walk GROUP BY child
 ),
+affected_objective_sessions AS (
+    SELECT DISTINCT t.session
+    FROM turn t, params p
+    WHERE t.session IS NOT NULL AND t.role = 'user' AND t.message_kind = 'task'
+      AND (p.cutoff IS NULL OR t.ts > p.cutoff)
+),
 src AS (
     -- tool_call -> tool_observation (tool_backed). The NULL link columns are
     -- CAST here because UNION type inference reads the FIRST branch: a bare
@@ -127,7 +133,8 @@ src AS (
     WHERE ps.session IS NOT NULL AND (p.cutoff IS NULL OR ps.ts > p.cutoff)
 
     UNION ALL
-    -- earliest `task` user turn per session -> objective (selection, not NLP).
+    -- Earliest `task` user turn per affected session -> objective. Rank ALL
+    -- task turns in each session, including turns before the active window.
     SELECT t.session, t.ts, 'objective', 'derived',
            t.id, NULL, NULL, NULL,
            NULL, NULL, NULL,
@@ -137,9 +144,9 @@ src AS (
         SELECT *, row_number() OVER (
             PARTITION BY session ORDER BY seq NULLS LAST, ts, id
         ) AS rn
-        FROM turn, params p
-        WHERE session IS NOT NULL AND role = 'user' AND message_kind = 'task'
-          AND (p.cutoff IS NULL OR ts > p.cutoff)
+        FROM turn
+        WHERE session IN (SELECT session FROM affected_objective_sessions)
+          AND role = 'user' AND message_kind = 'task'
     ) t
     WHERE t.rn = 1
 

--- a/apps/axctl/src/ingest/models/run-evidence-models.ts
+++ b/apps/axctl/src/ingest/models/run-evidence-models.ts
@@ -26,17 +26,28 @@ import { stableDigest } from "@ax/lib/ids";
 import { checkFamilyFromCommand } from "../check-family.ts";
 import { parseModelHeader, runSqlModel, type SqlModel } from "./runner.ts";
 import RUN_EVIDENCE_EVENT_SQL from "./run-evidence-event.sql" with { type: "text" };
+import RUN_EVIDENCE_OBJECTIVE_CLEANUP_SQL from "./run-evidence-objective-cleanup.sql" with { type: "text" };
 import RUN_EVIDENCE_REF_SQL from "./run-evidence-ref.sql" with { type: "text" };
 
+export const RUN_EVIDENCE_OBJECTIVE_CLEANUP_MODEL: SqlModel = {
+    name: "run_evidence_event",
+    sql: RUN_EVIDENCE_OBJECTIVE_CLEANUP_SQL,
+};
 export const RUN_EVIDENCE_EVENT_MODEL: SqlModel = { name: "run_evidence_event", sql: RUN_EVIDENCE_EVENT_SQL };
 export const RUN_EVIDENCE_REF_MODEL: SqlModel = { name: "run_evidence_ref", sql: RUN_EVIDENCE_REF_SQL };
 
-/** Ordered: refs recompute event ids, so events land first. */
-export const RUN_EVIDENCE_MODELS: readonly SqlModel[] = [RUN_EVIDENCE_EVENT_MODEL, RUN_EVIDENCE_REF_MODEL];
+/** Ordered: clear affected objectives, replace events, then recompute refs. */
+export const RUN_EVIDENCE_MODELS: readonly SqlModel[] = [
+    RUN_EVIDENCE_OBJECTIVE_CLEANUP_MODEL,
+    RUN_EVIDENCE_EVENT_MODEL,
+    RUN_EVIDENCE_REF_MODEL,
+];
 
 /** Changes whenever either model's SQL changes -> one full re-derive. */
 export const runEvidenceModelVersion = (): string =>
-    stableDigest(`run-evidence-models-v1${RUN_EVIDENCE_EVENT_SQL}${RUN_EVIDENCE_REF_SQL}`);
+    stableDigest(
+        `run-evidence-models-v1${RUN_EVIDENCE_OBJECTIVE_CLEANUP_SQL}${RUN_EVIDENCE_EVENT_SQL}${RUN_EVIDENCE_REF_SQL}`,
+    );
 
 const MARKER_SOURCE_KIND = "run_evidence_model";
 const MARKER_PATH = "__run_evidence_model__";
@@ -118,6 +129,7 @@ export const runRunEvidenceModels = (
             yield* write.exec("DELETE FROM run_evidence_event");
         }
         const window = rebuild ? undefined : sinceDays;
+        yield* runSqlModel(write, RUN_EVIDENCE_OBJECTIVE_CLEANUP_MODEL, window);
         const written = yield* runSqlModel(write, RUN_EVIDENCE_EVENT_MODEL, window);
         const refsWritten = yield* runSqlModel(write, RUN_EVIDENCE_REF_MODEL, window);
         if (rebuild) {

--- a/apps/axctl/src/ingest/models/run-evidence-objective-cleanup.sql
+++ b/apps/axctl/src/ingest/models/run-evidence-objective-cleanup.sql
@@ -1,0 +1,24 @@
+-- model: run_evidence_event
+-- inputs: turn, run_evidence_event
+-- rebuild: incremental
+--
+-- Replace the objective for each session with a task turn in the active
+-- window. The event model then selects that session's earliest task turn from
+-- all history. This stays separate because one model file has one statement.
+--
+-- Window: SET VARIABLE since_days (NULL/unset = full derivation).
+-- ICU-less build: the clock MUST be spelled CAST(CURRENT_TIMESTAMP AS TIMESTAMP).
+DELETE FROM run_evidence_event AS ree
+USING (
+    SELECT DISTINCT t.session
+    FROM turn AS t
+    WHERE t.session IS NOT NULL
+      AND t.role = 'user'
+      AND t.message_kind = 'task'
+      AND (
+        getvariable('since_days') IS NULL
+        OR t.ts > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(getvariable('since_days') AS INTEGER) * INTERVAL '1 day')
+      )
+) AS affected
+WHERE ree.session = affected.session
+  AND ree.kind = 'objective'

--- a/apps/axctl/src/ingest/models/run-evidence-parity.test.ts
+++ b/apps/axctl/src/ingest/models/run-evidence-parity.test.ts
@@ -252,4 +252,50 @@ describe("run-evidence SQL model parity vs the TS builders", () => {
         expect(second).toMatchObject({ rebuilt: false });
         expect(countAfter).toBeGreaterThan(0);
     });
+
+    dtest("keeps the original objective when a recent task affects an old session", async () => {
+        let objectives: ReadonlyArray<{ source_id: string; summary: string | null }> = [];
+        await runWithPlatform(publishCacheFixture(tempDir("ax-rev-objective-window-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                const oldTs = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+                const recentTs = new Date(Date.now() - 2 * 3600 * 1000);
+                yield* write.put("session", {
+                    id: "objective-window-session",
+                    source: "claude",
+                    started_at: oldTs,
+                    checkout: null,
+                });
+                yield* write.put("turn", {
+                    id: "t-old",
+                    session: "objective-window-session",
+                    seq: 1,
+                    role: "user",
+                    message_kind: "task",
+                    ts: oldTs,
+                    text_excerpt: "original objective",
+                });
+                yield* runRunEvidenceModels(write, undefined);
+
+                yield* write.put("turn", {
+                    id: "t-new",
+                    session: "objective-window-session",
+                    seq: 2,
+                    role: "user",
+                    message_kind: "task",
+                    ts: recentTs,
+                    text_excerpt: "follow-up task",
+                });
+                yield* runRunEvidenceModels(write, 1);
+                objectives = yield* write.rows(
+                    Schema.Struct({ source_id: Schema.String, summary: Schema.NullOr(Schema.String) }),
+                    `SELECT source_id, summary
+                     FROM run_evidence_event
+                     WHERE session = 'objective-window-session' AND kind = 'objective'
+                     ORDER BY source_id`,
+                );
+            }),
+        ));
+
+        expect(objectives).toEqual([{ source_id: "t-old", summary: "original objective" }]);
+    });
 });

--- a/apps/axctl/src/queries/cache-bust.duckdb.test.ts
+++ b/apps/axctl/src/queries/cache-bust.duckdb.test.ts
@@ -13,7 +13,7 @@
  *     same SQL is windowed + idempotent (same row count, no duplicates).
  */
 import { describe, expect } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { CacheRead, type CacheWriteService } from "@ax/lib/duckdb/seam";
 import { publishCacheFixture, readFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
@@ -109,6 +109,40 @@ const seedFixture = (write: CacheWriteService) =>
     });
 
 describe("cache-bust model + fetchCacheBustCost over a published snapshot", () => {
+    dtest("removes a recent bust when reparse clears its cache miss reason", async () => {
+        let before = -1;
+        let after = -1;
+        await runWithPlatform(
+            publishCacheFixture(tempDir("cache-bust-cleared-reason"), dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* write.put("turn_token_usage", usageRow({
+                        id: "ttu:cleared", session: SESSION_A, seq: 1, ts: hoursAgo(2), source: "claude",
+                        cacheCreationTokens: 100_000n, cacheCreationUsd: 2,
+                        cacheMiss: "cold",
+                    }));
+                    yield* runCacheBustModels(write, 1);
+                    const beforeRows = yield* write.rows(
+                        Schema.Struct({ n: Schema.Number }),
+                        "SELECT count(*)::INTEGER AS n FROM cache_bust_event WHERE id = 'ttu:cleared'",
+                    );
+                    before = beforeRows[0]!.n;
+
+                    yield* write.exec(
+                        "UPDATE turn_token_usage SET cache_miss_reason_type = NULL WHERE id = 'ttu:cleared'",
+                    );
+                    yield* runCacheBustModels(write, 1);
+                    const afterRows = yield* write.rows(
+                        Schema.Struct({ n: Schema.Number }),
+                        "SELECT count(*)::INTEGER AS n FROM cache_bust_event WHERE id = 'ttu:cleared'",
+                    );
+                    after = afterRows[0]!.n;
+                }),
+            ),
+        );
+
+        expect({ before, after }).toEqual({ before: 1, after: 0 });
+    });
+
     dtest("derives priced busts and rolls them up with a filtering window", async () => {
         const dir = tempDir("cache-bust-cost");
         let first: CacheBustModelStats | undefined;


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-models-sql.

- #928: the cache-bust model only inserts rows whose `cache_miss_reason_type` is set, so a reparse that CLEARS the reason left the derived bust row in the ledger. A new ordered cleanup model (`cache-bust-event-cleanup.sql`) deletes windowed rows whose source usage row now carries a null reason.
- #929: the incremental run-evidence window ranked "earliest task turn" inside the window only, so a recent task turn in an old session minted a second, wrong objective row. A cleanup model removes objectives for sessions with a windowed task turn, and the event model now ranks ALL task turns for exactly those sessions.

Both version digests include the cleanup SQL, so the version-marked cutover re-derives once on the next ingest. Runner order pinned: cleanup -> insert (-> refs).

Gates: parity + duckdb model suites 15/15 re-run at gate, tsc clean, both cast checks clean.

Fixes #928
Fixes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)