### PR TITLE
fix(cost): turn-grain routing-impact window + partial-pricing rollups

### DIFF
--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -88,6 +88,8 @@ describe("fetchCostModels", () => {
         const { layer, captured } = makeTestCacheRead({ routes: { "FROM session_token_usage": [] } });
         await runWithCache(layer, fetchCostModels({ sinceDays: 14 }));
         expect(captured[0]).toContain("GROUP BY model");
+        expect(captured[0]).toContain("count(estimated_cost_usd) AS priced_rows");
+        expect(captured[0]).toContain("estimated_cost_usd IS NULL) AS unpriced_rows");
         expect(captured[0]).toContain("ORDER BY cost_usd DESC");
     });
 });
@@ -99,6 +101,44 @@ describe("fetchCostModels", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetchCostModels - #696 unpriced/recompute semantics", () => {
+    test("recomputes a partially priced model group instead of trusting its nonzero sum", async () => {
+        const dbRows = [
+            { model: "custom-model-x", sessions: 2, priced_rows: 1, unpriced_rows: 1,
+              prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1 },
+        ];
+        const agentModelRows = [
+            {
+                name: "custom-model-x", provider: "test",
+                input_per_million_usd: 2, output_per_million_usd: 10,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: null,
+                input_above_200k_per_million_usd: null, output_above_200k_per_million_usd: null,
+                cache_creation_above_200k_per_million_usd: null, cache_read_above_200k_per_million_usd: null,
+                fast_multiplier: 1, context_window: null, pricing_source: "litellm",
+            },
+        ];
+        const { layer } = makeTestCacheRead({
+            routes: { "FROM session_token_usage": dbRows, "FROM agent_model": agentModelRows },
+        });
+        const result = await runWithCache(layer, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 2, unpriced: false });
+    });
+
+    test("flags a partially priced model group when no catalog rate exists", async () => {
+        const dbRows = [
+            { model: "unknown-model", sessions: 2, priced_rows: 1, unpriced_rows: 1,
+              prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1 },
+        ];
+        const { layer } = makeTestCacheRead({
+            routes: { "FROM session_token_usage": dbRows, "FROM agent_model": [] },
+        });
+        const result = await runWithCache(layer, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 1, unpriced: true });
+    });
+
     test("never masks a real nonzero stored cost, even for a model absent from the built-in catalog", async () => {
         // "db-only-model" is priced ONLY via a DB agent_model refresh (litellm/
         // models.dev), never in BUILTIN_MODEL_PRICING_CATALOG. The old
@@ -355,6 +395,8 @@ describe("fetchCostSplit", () => {
         });
         await runWithCache(layer, fetchCostSplit({ sinceDays: 14 }));
         expect(captured[0]).toContain("GROUP BY source, model");
+        expect(captured[0]).toContain("count(estimated_cost_usd) AS priced_rows");
+        expect(captured[0]).toContain("estimated_cost_usd IS NULL) AS unpriced_rows");
     });
 });
 
@@ -364,6 +406,36 @@ describe("fetchCostSplit", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetchCostSplit - #696 unpriced/recompute semantics", () => {
+    test("recomputes a partially priced split cell and updates totals", async () => {
+        const dbRows = [
+            { source: "claude", model: "custom-model-x", sessions: 2,
+              priced_rows: 1, unpriced_rows: 1, prompt_tokens: 1_000_000,
+              completion_tokens: 0, cache_read_tokens: 0, cache_create_tokens: 0,
+              cost_usd: 1 },
+        ];
+        const agentModelRows = [
+            {
+                name: "custom-model-x", provider: "test",
+                input_per_million_usd: 2, output_per_million_usd: 10,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: null,
+                input_above_200k_per_million_usd: null, output_above_200k_per_million_usd: null,
+                cache_creation_above_200k_per_million_usd: null, cache_read_above_200k_per_million_usd: null,
+                fast_multiplier: 1, context_window: null, pricing_source: "litellm",
+            },
+        ];
+        const { layer } = makeTestCacheRead({
+            routes: {
+                "FROM session_token_usage": dbRows,
+                "FROM agent_model": agentModelRows,
+                "FROM has_content": [],
+            },
+        });
+        const result = await runWithCache(layer, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 2, unpriced: false });
+        expect(result.totals.cost_usd).toBeCloseTo(2);
+    });
+
     test("never masks a real nonzero stored cost cell absent from the built-in catalog", async () => {
         const dbRows = [
             { source: "codex", model: "db-only-model", sessions: 1,

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -29,6 +29,8 @@ const nnum = Schema.NullOr(NumberFromBigIntColumn);
 const CostModelsAggRow = Schema.Struct({
     model: Schema.NullOr(Schema.String),
     sessions: NumberFromBigIntColumn,
+    priced_rows: Schema.NullOr(NumberFromBigIntColumn),
+    unpriced_rows: Schema.NullOr(NumberFromBigIntColumn),
     prompt_tokens: nnum,
     completion_tokens: nnum,
     cache_read_tokens: nnum,
@@ -40,6 +42,8 @@ const CostSplitAggRow = Schema.Struct({
     source: Schema.String,
     model: Schema.NullOr(Schema.String),
     sessions: NumberFromBigIntColumn,
+    priced_rows: Schema.NullOr(NumberFromBigIntColumn),
+    unpriced_rows: Schema.NullOr(NumberFromBigIntColumn),
     prompt_tokens: nnum,
     completion_tokens: nnum,
     cache_read_tokens: nnum,
@@ -80,25 +84,26 @@ const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
  * row that already carries a stored cost - `derive-cost-backfill.ts`).
  *
  * Resolution order:
- * 1. A stored cost > 0 is real money - never mask it, never recompute it.
+ * 1. A fully priced stored cost > 0 is real money - never mask or recompute it.
  * 2. Zero tokens is a genuine zero-usage row (including the "(unattributed)"
  *    sentinel) - show $0, not UNPRICED.
- * 3. Stored cost === 0 with real tokens and a catalog rate: recompute from
- *    the row's own token split at query time (self-healing without an
- *    ingest re-run).
- * 4. Stored cost === 0 with real tokens and NO catalog rate: genuinely
- *    unpriced - render UNPRICED rather than a silent $0.
+ * 3. A zero-cost or partly priced group with a catalog rate is recomputed from
+ *    its token split at query time.
+ * 4. A zero-cost or partly priced group without a catalog rate is flagged
+ *    UNPRICED. A partial stored sum remains visible.
  */
 const EMPTY_PRICING_CATALOG: ReadonlyMap<string, ModelPricing> = new Map();
 
 /**
- * True when any row carries a stored zero cost with real tokens - the only
- * shape `resolveRowCost` needs a catalog for. Keeps the catalog DB round-trip
- * out of the common all-priced path (and out of every positional-mock caller
- * that never exercises recompute, e.g. buildProfile).
+ * True when any row needs price resolution. This includes zero-cost rows and
+ * groups with incomplete price coverage. Keeps the catalog DB round-trip out
+ * of the common fully priced path.
  */
 interface PriceableTotals {
     readonly cost_usd: number | null;
+    readonly sessions?: number;
+    readonly priced_rows?: number | null;
+    readonly unpriced_rows?: number | null;
     readonly prompt_tokens: number | null;
     readonly completion_tokens: number | null;
     readonly cache_read_tokens: number | null;
@@ -107,7 +112,9 @@ interface PriceableTotals {
 
 const rowsNeedPricing = (rows: ReadonlyArray<PriceableTotals>): boolean =>
     rows.some((row) =>
-        (row.cost_usd ?? 0) === 0
+        ((row.unpriced_rows ?? 0) > 0
+            || (row.priced_rows != null && row.sessions !== undefined && row.priced_rows !== row.sessions)
+            || (row.cost_usd ?? 0) === 0)
         && (row.prompt_tokens ?? 0) + (row.completion_tokens ?? 0)
             + (row.cache_read_tokens ?? 0) + (row.cache_create_tokens ?? 0) > 0,
     );
@@ -120,11 +127,16 @@ function resolveRowCost(
         readonly cacheReadTokens: number;
         readonly cacheCreateTokens: number;
         readonly costUsd: number;
+        readonly rowCount: number;
+        readonly pricedRows: number;
+        readonly unpricedRows: number;
     },
     catalog: ReadonlyMap<string, ModelPricing>,
 ): { readonly cost_usd: number; readonly unpriced: boolean } {
-    if (input.costUsd > 0) {
-        return { cost_usd: input.costUsd, unpriced: false };
+    const storedCost = Number.isFinite(input.costUsd) ? input.costUsd : 0;
+    const incompletePricing = input.unpricedRows > 0 || input.pricedRows !== input.rowCount;
+    if (storedCost > 0 && !incompletePricing) {
+        return { cost_usd: storedCost, unpriced: false };
     }
     const totalTokens = input.promptTokens + input.completionTokens + input.cacheReadTokens + input.cacheCreateTokens;
     if (totalTokens === 0) {
@@ -133,7 +145,7 @@ function resolveRowCost(
     const modelKey = normalizeModelName(input.model);
     const pricing = pricingForModel(modelKey, catalog);
     if (!pricing) {
-        return { cost_usd: 0, unpriced: true };
+        return { cost_usd: storedCost, unpriced: true };
     }
     const estimate = estimateCost({
         modelKey,
@@ -185,6 +197,8 @@ export const fetchCostModels = Effect.fn("queries.fetchCostModels")(
             `SELECT
     model,
     count(*) AS sessions,
+    count(estimated_cost_usd) AS priced_rows,
+    count(*) FILTER (WHERE estimated_cost_usd IS NULL) AS unpriced_rows,
     coalesce(sum(prompt_tokens), 0) AS prompt_tokens,
     coalesce(sum(completion_tokens), 0) AS completion_tokens,
     coalesce(sum(cache_read_input_tokens), 0) AS cache_read_tokens,
@@ -220,6 +234,9 @@ ORDER BY cost_usd DESC;`,
                 cacheReadTokens,
                 cacheCreateTokens,
                 costUsd: row.cost_usd ?? 0,
+                rowCount: row.sessions,
+                pricedRows: row.priced_rows ?? row.sessions,
+                unpricedRows: row.unpriced_rows ?? 0,
             }, catalog);
             return {
                 model,
@@ -362,6 +379,8 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
     source,
     model,
     count(*) AS sessions,
+    count(estimated_cost_usd) AS priced_rows,
+    count(*) FILTER (WHERE estimated_cost_usd IS NULL) AS unpriced_rows,
     coalesce(sum(prompt_tokens), 0) AS prompt_tokens,
     coalesce(sum(completion_tokens), 0) AS completion_tokens,
     coalesce(sum(cache_read_input_tokens), 0) AS cache_read_tokens,
@@ -379,6 +398,8 @@ ORDER BY cost_usd DESC;`,
             origin: "main" | "subagent";
             model: string;
             sessions: number;
+            priced_rows: number;
+            unpriced_rows: number;
             prompt_tokens: number;
             completion_tokens: number;
             cache_read_tokens: number;
@@ -397,10 +418,14 @@ ORDER BY cost_usd DESC;`,
             const cacheRead = row.cache_read_tokens ?? 0;
             const cacheCreate = row.cache_create_tokens ?? 0;
             const cost = row.cost_usd ?? 0;
+            const pricedRows = row.priced_rows ?? sessions;
+            const unpricedRows = row.unpriced_rows ?? 0;
 
             const existing = cellMap.get(key);
             if (existing) {
                 existing.sessions += sessions;
+                existing.priced_rows += pricedRows;
+                existing.unpriced_rows += unpricedRows;
                 existing.prompt_tokens += prompt;
                 existing.completion_tokens += completion;
                 existing.cache_read_tokens += cacheRead;
@@ -411,6 +436,8 @@ ORDER BY cost_usd DESC;`,
                     origin,
                     model,
                     sessions,
+                    priced_rows: pricedRows,
+                    unpriced_rows: unpricedRows,
                     prompt_tokens: prompt,
                     completion_tokens: completion,
                     cache_read_tokens: cacheRead,
@@ -437,8 +464,12 @@ ORDER BY cost_usd DESC;`,
                 cacheReadTokens: cell.cache_read_tokens,
                 cacheCreateTokens: cell.cache_create_tokens,
                 costUsd: cell.cost_usd,
+                rowCount: cell.sessions,
+                pricedRows: cell.priced_rows,
+                unpricedRows: cell.unpriced_rows,
             }, catalog);
-            return { ...cell, cost_usd: resolved.cost_usd, unpriced: resolved.unpriced };
+            const { priced_rows: _pricedRows, unpriced_rows: _unpricedRows, ...publicCell } = cell;
+            return { ...publicCell, cost_usd: resolved.cost_usd, unpriced: resolved.unpriced };
         });
 
         const totalCost = priced.reduce((sum, c) => sum + c.cost_usd, 0);

--- a/apps/axctl/src/routing-impact/io.test.ts
+++ b/apps/axctl/src/routing-impact/io.test.ts
@@ -17,7 +17,7 @@ const { dylibPath, dtest, tempDir } = await duckdbTestSetup("routing impact io",
 
 const at = (iso: string) => new Date(iso);
 
-/** Two sessions' cost and four assistant turns, spread over three days. */
+/** Two session totals, two turn costs, and four turns, spread over three days. */
 const fixture = () =>
     runWithPlatform(
         publishCacheFixture(tempDir("ax-routing-io-"), dylibPath, (w) =>
@@ -33,7 +33,7 @@ const fixture = () =>
                         source: "claude",
                         estimated_tokens: 100n,
                         transcript_bytes: 10n,
-                        estimated_cost_usd: 1.5,
+                        estimated_cost_usd: 100,
                         ts: at("2026-08-01T12:00:00.000Z"),
                     },
                     {
@@ -42,7 +42,7 @@ const fixture = () =>
                         source: "claude",
                         estimated_tokens: 200n,
                         transcript_bytes: 20n,
-                        estimated_cost_usd: 2.25,
+                        estimated_cost_usd: 200,
                         ts: at("2026-08-03T12:00:00.000Z"),
                     },
                 ]);
@@ -51,6 +51,32 @@ const fixture = () =>
                     { id: "t2", session: "s1", seq: 2n, role: "user", ts: at("2026-08-01T12:01:00.000Z") },
                     { id: "t3", session: "s2", seq: 1n, role: "assistant", ts: at("2026-08-03T12:00:00.000Z") },
                     { id: "t4", session: "s2", seq: 2n, role: "assistant", ts: at("2026-08-05T12:00:00.000Z") },
+                ]);
+                yield* w.putMany("turn_token_usage", [
+                    {
+                        id: "tu1",
+                        session: "s1",
+                        turn: "t1",
+                        seq: 1n,
+                        source: "claude",
+                        estimated_tokens: 100n,
+                        estimated_cost_usd: 1.5,
+                        usage_source: "transcript",
+                        usage_quality: "exact",
+                        ts: at("2026-08-01T12:00:00.000Z"),
+                    },
+                    {
+                        id: "tu2",
+                        session: "s2",
+                        turn: "t3",
+                        seq: 1n,
+                        source: "claude",
+                        estimated_tokens: 200n,
+                        estimated_cost_usd: 2.25,
+                        usage_source: "transcript",
+                        usage_quality: "exact",
+                        ts: at("2026-08-03T12:00:00.000Z"),
+                    },
                 ]);
             }),
         ),
@@ -64,7 +90,7 @@ const metricsOver = (snapshotPath: string, startIso: string, endIso: string) =>
     );
 
 describe("fetchWindowMetrics", () => {
-    dtest("sums cost and counts ASSISTANT turns inside the window", async () => {
+    dtest("sums turn-time cost and counts ASSISTANT turns inside the window", async () => {
         const f = await fixture();
         const metrics = await metricsOver(
             f.snapshotPath,

--- a/apps/axctl/src/routing-impact/io.ts
+++ b/apps/axctl/src/routing-impact/io.ts
@@ -67,7 +67,7 @@ export const fetchWindowMetrics = (
         const cost = yield* cacheFirst(
             CostRow,
             {
-                sql: "SELECT sum(estimated_cost_usd) AS c FROM session_token_usage WHERE ts > ? AND ts <= ?",
+                sql: "SELECT sum(estimated_cost_usd) AS c FROM turn_token_usage WHERE ts > ? AND ts <= ?",
                 params: window,
             },
             "routing impact cost",


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-cost-reads.

- #940: `fetchWindowMetrics` summed `session_token_usage` by session timestamp, so a long session overlapping a routing-impact block attributed its ENTIRE cost to the block (~9x observed). The read now sums `turn_token_usage` by per-turn timestamp.
- #944: cost rollups trusted any stored group sum > 0, so a group with SOME unpriced rows reported a silent partial total. The aggregates now carry `priced_rows`/`unpriced_rows` per group; incomplete coverage recomputes the group from its token split when a catalog rate exists, and flags UNPRICED (keeping the partial sum visible) when none does. Internal counters are stripped from the public cell shape.

Gates: cost-analytics + routing-impact suites 34/34 re-run at gate, tsc clean, both cast checks clean.

Fixes #940
Fixes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)