### PR TITLE
fix(lib): harden four DuckDB storage seams

### DIFF
--- a/packages/lib/src/duckdb/clone-file.test.ts
+++ b/packages/lib/src/duckdb/clone-file.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, test } from "bun:test";
 import { BunFileSystem } from "@effect/platform-bun";
 import { Effect, FileSystem } from "effect";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cloneFile, statsEqual, walIsQuiescent, type FileStatSnapshot } from "./clone-file.ts";
@@ -144,6 +144,18 @@ describe("walIsQuiescent (post-checkpoint WAL tripwire)", () => {
             const live = join(dir, "live.duckdb");
             writeFileSync(live, "stem");
             writeFileSync(`${live}.wal`, "uncommitted-wal-bytes");
+
+            const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
+
+            expect(quiescent).toBe(false);
+        });
+    });
+
+    test("NOT quiescent when WAL stat fails for a reason other than NotFound (#950)", async () => {
+        await withTempDir(async (dir) => {
+            const live = join(dir, "live.duckdb");
+            writeFileSync(live, "stem");
+            symlinkSync(`${live}.wal`, `${live}.wal`);
 
             const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
 

--- a/packages/lib/src/duckdb/clone-file.ts
+++ b/packages/lib/src/duckdb/clone-file.ts
@@ -19,7 +19,7 @@
 import { copyFileSync, constants } from "node:fs";
 import { Effect, FileSystem, Option } from "effect";
 import type { PlatformError } from "effect/PlatformError";
-import { orAbsent } from "../shared/fs-error.ts";
+import { skipNotFound } from "../shared/fs-error.ts";
 
 /** Outcome of one `cloneFile` attempt. Never throws/fails - a failed clone
  *  (non-APFS filesystem, cross-device `EXDEV`, unsupported `ENOTSUP`, or any
@@ -91,11 +91,12 @@ export const statSnapshot = (
  * the base file alone would silently miss it, so this must hold before the
  * clone is trusted. Never fails: a stat error (including the WAL vanishing
  * between the exists-check and the stat, a benign race with DuckDB's own WAL
- * lifecycle) is treated as "absent" -> quiescent, matching how the rest of
- * this codebase treats an optional-file probe (`orAbsent`).
+ * lifecycle) is treated as "absent" -> quiescent. Every other stat error is
+ * unsafe, so it returns false and makes publish use the logical copy path.
  */
 export const walIsQuiescent = (fs: FileSystem.FileSystem, livePath: string): Effect.Effect<boolean> =>
     fs.stat(`${livePath}.wal`).pipe(
         Effect.map((info) => Number(info.size) === 0),
-        orAbsent(true),
+        skipNotFound(true),
+        Effect.orElseSucceed(() => false),
     );

--- a/packages/lib/src/duckdb/fts.ts
+++ b/packages/lib/src/duckdb/fts.ts
@@ -45,7 +45,7 @@
  *   4. rebuilds only when the digest moved OR the schema is missing, then
  *      records the new digest. A digest match with a MISSING schema still
  *      rebuilds - the bookkeeping row is not proof the index exists.
- * The digest string is prefixed `v1:` - the formula version. Bumping it forces
+ * The digest string is prefixed with the formula version. Bumping it forces
  * exactly one rebuild fleet-wide the next time this ships, which is the escape
  * hatch if the formula ever needs to change.
  */
@@ -61,10 +61,10 @@ export interface FtsTarget {
 }
 
 /** The digest formula version - bump to force a one-time rebuild of every
- *  target. v2 = the turn target moved from `text_excerpt` to full `text`
- *  (#921); the digest would move on its own (it hashes the new column), but
- *  the explicit bump makes the cutover legible in `fts_index_state`. */
-const FTS_DIGEST_VERSION = "v2";
+ *  target. v3 hashes the id and text as ONE value per row (#948). The prior
+ *  two-argument hash left the aggregate unchanged when text values moved
+ *  between existing ids. */
+const FTS_DIGEST_VERSION = "v3";
 
 /**
  * A per-target content digest computed ENTIRELY in SQL as one VARCHAR. Never
@@ -75,14 +75,15 @@ const FTS_DIGEST_VERSION = "v2";
  * in SQL sidesteps that entirely: this seam only ever sees a string.
  *
  * `bit_xor` is commutative/order-independent, so a row landing via any write
- * path (batch insert, spool flush, single put) produces the same digest -
- * unlike a hash-of-concatenation, which would depend on scan order.
+ * path (batch insert, spool flush, single put) produces the same digest.
+ * Each row hashes one id-delimited-text value, so moving text between ids
+ * changes the row hashes before the aggregate combines them.
  * `COALESCE(bit_xor(...), '0')` covers the empty-table case, where `bit_xor`
  * itself returns NULL.
  */
 export const ftsDigestSql = (target: FtsTarget): string =>
     `SELECT '${FTS_DIGEST_VERSION}:' || count(*)::VARCHAR || ':' || ` +
-    `COALESCE(bit_xor(hash(${target.idColumn}, COALESCE(${target.textColumn}, '')))::VARCHAR, '0') AS digest ` +
+    `COALESCE(bit_xor(hash(${target.idColumn} || chr(31) || COALESCE(${target.textColumn}, '')))::VARCHAR, '0') AS digest ` +
     `FROM "${target.table}"`;
 
 /** Per-target rebuild outcome, returned so a caller (or a test) can observe

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { encodeLockPayload, withIngestLock } from "../ingest-lock.ts";
 import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
 import { TimestampColumn } from "./columns.ts";
-import { buildFtsIndexes, ftsSchemaName, matchBm25Sql, type FtsTarget } from "./fts.ts";
+import { buildFtsIndexes, ftsDigestSql, ftsSchemaName, matchBm25Sql, type FtsTarget } from "./fts.ts";
 import { NUL } from "./nul-strip.ts";
 import {
     CacheRead,
@@ -276,6 +276,39 @@ describe("CacheWrite: the semantics the DDL cannot express", () => {
             // 600 rows crosses the 500-row batch boundary.
             expect(value?.count).toBe(600n);
             expect(value?.ragged._tag).toBe("Failure");
+        });
+    });
+
+    dtest("putMany collapses duplicate ids before chunking with last occurrence wins (#949)", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-putmany-duplicate-ids-");
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        const rows = [
+                            { id: "same-chunk", body: "first" },
+                            { id: "same-chunk", body: "second" },
+                            { id: "chunk-boundary", body: "first" },
+                            ...Array.from({ length: 497 }, (_, i) => ({ id: `unique-${i}`, body: `${i}` })),
+                            { id: "chunk-boundary", body: "second" },
+                        ];
+                        yield* write.putMany("note", rows);
+                        const stored = yield* write.rows(
+                            Schema.Struct({ id: Schema.String, body: Schema.String }),
+                            "SELECT id, body FROM note WHERE id IN ('same-chunk', 'chunk-boundary') ORDER BY id",
+                        );
+                        return { stored, collapsed: write.rowsCollapsed() };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.stored).toEqual([
+                { id: "chunk-boundary", body: "second" },
+                { id: "same-chunk", body: "second" },
+            ]);
+            expect(value?.collapsed).toBe(2);
         });
     });
 
@@ -1001,6 +1034,36 @@ describe("FTS: skip-unchanged rebuild (#909)", () => {
             expect(value?.outcomes).toEqual([{ table: "turn", rebuilt: true }]);
             expect(value?.oldHits).toEqual([]);
             expect(value?.newHits.map((r) => r.id)).toEqual(["t1"]);
+        });
+    });
+
+    dtest("swapping text between existing ids moves the digest (#948)", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-digest-swap-");
+
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.putMany("turn", [
+                            { id: "t1", text_excerpt: "alpha content", ts },
+                            { id: "t2", text_excerpt: "beta content", ts },
+                        ]);
+                        const before = yield* write.raw(ftsDigestSql(TURN_FTS));
+                        yield* write.exec(
+                            `UPDATE turn SET text_excerpt = CASE id
+                                WHEN 't1' THEN 'beta content'
+                                WHEN 't2' THEN 'alpha content'
+                                ELSE text_excerpt END`,
+                        );
+                        const after = yield* write.raw(ftsDigestSql(TURN_FTS));
+                        return { before: before.rows[0]?.digest, after: after.rows[0]?.digest };
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const value = outcome._tag === "completed" ? outcome.value : null;
+            expect(value?.after).not.toBe(value?.before);
         });
     });
 

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -155,6 +155,9 @@ export interface CacheWriteService extends CacheReadService {
      * read them directly.
      */
     readonly nulStripped: () => NulStripTotals;
+    /** Duplicate-id rows removed from `putMany` inputs. The last occurrence
+     *  for each id is the row that the writer keeps. */
+    readonly rowsCollapsed: () => number;
     /** The live database being written (not the snapshot). */
     readonly livePath: string;
 }
@@ -668,6 +671,7 @@ export const withCacheWrite = <A, E, R>(
                     // know it happened.
                     const value = yield* body(write).pipe(
                         Effect.ensuring(reportNulStripped(write, options.livePath)),
+                        Effect.ensuring(reportRowsCollapsed(write, options.livePath)),
                     );
 
                     // Publish LAST and only on success: a failed ingest must
@@ -800,6 +804,17 @@ const reportNulStripped = (write: CacheWriteService, livePath: string): Effect.E
         );
     });
 
+/** Report duplicate-id rows that `putMany` collapsed before it wrote them. */
+const reportRowsCollapsed = (write: CacheWriteService, livePath: string): Effect.Effect<void> =>
+    Effect.suspend(() => {
+        const rows = write.rowsCollapsed();
+        if (rows === 0) return Effect.void;
+        return Effect.logWarning(
+            `ax cache: collapsed ${rows} duplicate-id row(s) before putMany batching while writing ${livePath}; ` +
+                "the last occurrence for each id was kept.",
+        );
+    });
+
 const toPublishError = (
     err: SnapshotPublishError | DuckDbOpenError,
     target: string,
@@ -837,6 +852,7 @@ const writerOver = (
      */
     let nulValues = 0;
     let nulStatements = 0;
+    let collapsedRows = 0;
     const execScrubbed = (
         sql: string,
         params?: ReadonlyArray<DuckDbParam>,
@@ -947,8 +963,13 @@ const writerOver = (
                 }
             }
 
-            for (let start = 0; start < rows.length; start += PUT_BATCH_ROWS) {
-                const batch = rows.slice(start, start + PUT_BATCH_ROWS);
+            const rowsById = new Map<DuckDbParam, Readonly<Record<string, DuckDbParam>>>();
+            for (const row of rows) rowsById.set(row["id"], row);
+            const deduplicated = [...rowsById.values()];
+            collapsedRows += rows.length - deduplicated.length;
+
+            for (let start = 0; start < deduplicated.length; start += PUT_BATCH_ROWS) {
+                const batch = deduplicated.slice(start, start + PUT_BATCH_ROWS);
                 const sql = yield* insertStatement(table, columns, stamped, batch.length);
                 const params = batch.flatMap((row) => columns.map((column) => row[column]));
                 yield* chargeStageSelfTime(execScrubbed(sql, params));
@@ -958,6 +979,7 @@ const writerOver = (
     const put: CacheWriteService["put"] = (table, row) => putMany(table, [row]);
 
     const nulStripped = (): NulStripTotals => ({ values: nulValues, statements: nulStatements });
+    const rowsCollapsed = (): number => collapsedRows;
 
-    return { ...reader, exec, put, putMany, nulStripped, livePath };
+    return { ...reader, exec, put, putMany, nulStripped, rowsCollapsed, livePath };
 };

--- a/packages/lib/src/duckdb/spool.test.ts
+++ b/packages/lib/src/duckdb/spool.test.ts
@@ -131,7 +131,7 @@ describe("makeTableSpool", () => {
         );
     });
 
-    dtest("same id twice in ONE window dedups last-wins (DuckDB rejects in-statement key dups)", async () => {
+    dtest("same id twice in ONE window dedups last-wins", async () => {
         const dir = tempDir("spool-dedup");
         await asIngestRun(dir, (write, spool) =>
             Effect.gen(function* () {
@@ -218,6 +218,23 @@ describe("makeTableSpool", () => {
                 const got = yield* write.raw("SELECT name FROM tool WHERE id = 'tool:surrogate'");
                 // The lone half became U+FFFD; the rest of the value is intact.
                 expect(got.rows[0]!["name"]).toBe("cut�end");
+            }),
+        );
+    });
+
+    dtest("deduplicates on the encoded id with last occurrence wins (#951)", async () => {
+        const dir = tempDir("spool-encoded-id-dedup");
+        await asIngestRun(dir, (write, spool) =>
+            Effect.gen(function* () {
+                spool.append("tool", [
+                    { id: "k\uD800", name: "first", provider: "codex" },
+                    { id: "k\uDC00", name: "second", provider: "codex" },
+                ]);
+                expect(spool.pendingRows()).toBe(1);
+                const outcome = yield* spool.flush(write);
+                expect(outcome.rows).toBe(1);
+                const got = yield* write.raw("SELECT id, name FROM tool");
+                expect(got.rows).toEqual([{ id: "k�", name: "second" }]);
             }),
         );
     });

--- a/packages/lib/src/duckdb/spool.ts
+++ b/packages/lib/src/duckdb/spool.ts
@@ -24,9 +24,9 @@
  *    unspecified - same nondeterminism two interleaved putMany calls had.)
  *  - LAST WRITE WINS PER id. Ingest legitimately re-emits the same row many
  *    times per run (`tool` and `file` on every tool call) and relies on upsert
- *    dedup. DuckDB REJECTS a statement whose source carries two rows with the
- *    same conflict key, so each buffer dedups by id at append - the later row
- *    replaces the earlier one, which is exactly what back-to-back upserts did.
+ *    dedup. DuckDB silently keeps one row when a `read_ndjson` source carries
+ *    duplicate conflict keys, so each buffer dedups by ENCODED id at append.
+ *    The later row replaces the earlier one, matching back-to-back upserts.
  *  - THE `id` INVARIANT + explicit conflict target. `INSERT OR REPLACE` is
  *    unusable on this schema (secondary UNIQUE indexes); the conflict target is
  *    `("id")`, the same statement shape as the seam's.
@@ -267,15 +267,29 @@ export const makeTableSpool = (options: TableSpoolOptions): TableSpool => {
                     message: `spooled row ${i} for ${table} has a non-string id (${typeof id}); every id in this schema is VARCHAR`,
                 });
             }
-            const out: Record<string, unknown> = {};
-            for (const column of buffer.columns) {
-                out[column] = encodeValue(table, column, row[column], () => {
-                    nulValues += 1;
-                }, () => {
-                    illFormedValues += 1;
+            const encodedId = encodeValue(table, "id", id, () => {
+                nulValues += 1;
+            }, () => {
+                illFormedValues += 1;
+            });
+            if (typeof encodedId !== "string") {
+                throw new DuckDbQueryError({
+                    sql: `spool INSERT INTO ${table}`,
+                    message: `spooled row ${i} for ${table} encoded its string id as ${typeof encodedId}`,
                 });
             }
-            buffer.lines.set(id, JSON.stringify(out));
+            const out: Record<string, unknown> = {};
+            for (const column of buffer.columns) {
+                out[column] =
+                    column === "id"
+                        ? encodedId
+                        : encodeValue(table, column, row[column], () => {
+                              nulValues += 1;
+                          }, () => {
+                              illFormedValues += 1;
+                          });
+            }
+            buffer.lines.set(encodedId, JSON.stringify(out));
         }
     };
 


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-storage-seam (high effort).

- #948: the FTS digest hashed `hash(id, text)` per row, which left the XOR aggregate unchanged when text values SWAPPED between existing ids - the index skipped a rebuild it needed. The row hash is now one id-delimited value (`hash(id || chr(31) || text)`), digest version bumped to v3 (one forced rebuild fleet-wide, legible in `fts_index_state`).
- #949: `putMany` sent duplicate-id rows into one INSERT ... ON CONFLICT batch, which DuckDB rejects or silently collapses. The writer now dedups by id before chunking (last occurrence wins, matching back-to-back upserts), counts collapsed rows, and logs a warning at run end via the same `ensuring` seam as the NUL-strip report.
- #950: `walIsQuiescent` treated EVERY WAL stat error as "quiescent", so a permission/IO error could green-light a clone publish over a non-quiescent WAL. Only `NotFound` is benign now; any other stat error returns false and routes publish to the logical copy path.
- #951: the spool deduped buffers by RAW id but wrote the ENCODED id to NDJSON, so two raw ids encoding to one value produced duplicate conflict keys in a single `read_ndjson` load and DuckDB silently dropped a row. Buffers now key on the encoded id, with a guard that encoding kept the id a string.

Gates: full packages/lib/src/duckdb suite 251 tests, 0 fail (1 platform skip) re-run at gate; tsc clean; both cast checks clean.

Fixes #948
Fixes #949
Fixes #950
Fixes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)