### PR TITLE
fix(ingest): SHA-256 proposal dedupe signatures + lossless sidecar migration

### DIFF
--- a/apps/axctl/src/cli/retro-plan.ts
+++ b/apps/axctl/src/cli/retro-plan.ts
@@ -29,7 +29,7 @@ import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettyPrint } from "@ax/lib/json";
 import { stableId } from "@ax/lib/stable-id";
 import { fail as sharedFail, parseCsvFlag } from "./commands/shared.ts";
-import { dedupeSig, normalizeTitle } from "../ingest/derive-proposals.ts";
+import { dedupeSig, migrateProposalDedupeSigs, normalizeTitle } from "../ingest/derive-proposals.ts";
 import {
     type InterventionSafetyContract,
     planRetroPlanRegistration,
@@ -214,6 +214,7 @@ export const cmdRetroPlan = (
         const built = buildRetroPlanKeys(parsed);
 
         const judgment = yield* Judgment;
+        yield* migrateProposalDedupeSigs(judgment);
         const hit = yield* findStoredProposal(built.sig);
         if (hit) {
             const existingId = `proposal:${hit.id}`;

--- a/apps/axctl/src/improve/propose.ts
+++ b/apps/axctl/src/improve/propose.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect";
 import { Judgment } from "@ax/lib/sqlite";
 import { stableId } from "@ax/lib/stable-id";
-import { dedupeSig, normalizeTitle } from "../ingest/derive-proposals.ts";
+import { dedupeSig, migrateProposalDedupeSigs, normalizeTitle } from "../ingest/derive-proposals.ts";
 
 /**
  * `ax improve propose` - the agent write-path into the improve loop.
@@ -171,6 +171,7 @@ export const runPropose = Effect.fn("improve.runPropose")(function* (raw: unknow
     }
     const sig = dedupeSig(input.form, normalizeTitle(input.title));
     const judgment = yield* Judgment;
+    yield* migrateProposalDedupeSigs(judgment);
     const id = proposalKey(sig);
     const frequency = input.frequency ?? 1;
     const now = new Date();

--- a/apps/axctl/src/ingest/derive-proposals.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Schema } from "effect";
+import { Judgment, JudgmentLayer } from "@ax/lib/sqlite";
+import { stableId } from "@ax/lib/stable-id";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import {
     buildCacheLensProposalWrites,
     buildGuidanceProposalWrites,
@@ -19,6 +26,7 @@ import {
     IMAGE_CONTEXT_THRESHOLD_MB,
     normalizeTitle,
     parseMetrics,
+    migrateProposalDedupeSigs,
     skillProposalFrequency,
 } from "./derive-proposals.ts";
 import type { HarnessLearningCandidate } from "../project/types.ts";
@@ -37,6 +45,7 @@ describe("derive-proposals helpers", () => {
         expect(a).toBe(b);
         expect(a).not.toBe(c);
         expect(a.startsWith("skill__")).toBe(true);
+        expect(a).toBe("skill__0efefbef285843e6");
     });
 
     test("parseMetrics tolerates string, object, null, undefined", () => {
@@ -52,6 +61,119 @@ describe("derive-proposals helpers", () => {
         expect(skillProposalFrequency({ fix_chain_count: 9 })).toBe(9);
         expect(skillProposalFrequency({ risky_session_count: 1072 })).toBe(0);
         expect(skillProposalFrequency({})).toBe(0);
+    });
+});
+
+describe("proposal dedupe signature migration", () => {
+    const dirs: string[] = [];
+
+    afterEach(() => {
+        for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("re-keys old signatures without losing decisions or sidecar links", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-proposal-dedupe-"));
+        dirs.push(dir);
+        const sidecarPath = join(dir, "judgment.sqlite");
+
+        const rows = await Effect.runPromise(Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            const skillTitle = "Schema  Change Guardrail";
+            const guidanceTitle = "Keep decisions durable";
+            const oldSkillSig = `skill__${Bun.hash(`skill:${normalizeTitle(skillTitle)}`).toString(16).slice(0, 16)}`;
+            const oldGuidanceSig = `guidance__${Bun.hash(`guidance:${normalizeTitle(guidanceTitle)}`).toString(16).slice(0, 16)}`;
+            const oldSkillId = `skill__schema_change_guardrail__${oldSkillSig.slice(-12)}`;
+            const oldGuidanceId = stableId("proposal", [oldGuidanceSig]);
+            yield* judgment.put("proposal", {
+                id: oldSkillId,
+                form: "skill",
+                title: skillTitle,
+                hypothesis: "test",
+                dedupe_sig: oldSkillSig,
+                confidence: "high",
+                status: "rejected",
+                reject_reason: "user decision",
+            });
+            yield* judgment.put("skill_proposal", {
+                id: oldSkillId,
+                proposal: oldSkillId,
+                trigger_pattern: "schema edit",
+                suspected_gap: "no guard",
+                proposed_behavior: "add guard",
+            });
+            yield* judgment.put("proposal", {
+                id: oldGuidanceId,
+                form: "guidance",
+                title: guidanceTitle,
+                hypothesis: "test",
+                dedupe_sig: oldGuidanceSig,
+                confidence: "medium",
+                status: "accepted",
+                origin: "agent",
+                baseline: JSON.stringify({ origin: "agent" }),
+            });
+            yield* judgment.put("guidance_proposal", {
+                id: stableId("guidance_proposal", [oldGuidanceId]),
+                proposal: oldGuidanceId,
+                file_target: "CLAUDE.md",
+                suggested_text: "Keep decisions durable.",
+            });
+            yield* judgment.put("experiment", {
+                id: "experiment-old",
+                proposal: oldGuidanceId,
+                status: "task_emitted",
+            });
+
+            yield* migrateProposalDedupeSigs(judgment);
+            yield* migrateProposalDedupeSigs(judgment);
+
+            return yield* judgment.rows(Schema.Struct({
+                id: Schema.String,
+                dedupe_sig: Schema.String,
+                status: Schema.String,
+                reject_reason: Schema.NullOr(Schema.String),
+                payload_id: Schema.NullOr(Schema.String),
+                payload_proposal: Schema.NullOr(Schema.String),
+                experiment_proposal: Schema.NullOr(Schema.String),
+            }), `
+SELECT p.id, p.dedupe_sig, p.status, p.reject_reason,
+       COALESCE(sp.id, gp.id) AS payload_id,
+       COALESCE(sp.proposal, gp.proposal) AS payload_proposal,
+       e.proposal AS experiment_proposal
+FROM proposal p
+LEFT JOIN skill_proposal sp ON sp.proposal = p.id
+LEFT JOIN guidance_proposal gp ON gp.proposal = p.id
+LEFT JOIN experiment e ON e.proposal = p.id
+ORDER BY p.id`);
+        }).pipe(
+            Effect.scoped,
+            Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+        ));
+
+        const newSkillSig = dedupeSig("skill", normalizeTitle("Schema  Change Guardrail"));
+        const newGuidanceSig = dedupeSig("guidance", normalizeTitle("Keep decisions durable"));
+        const newSkillId = `skill__schema_change_guardrail__${newSkillSig.slice(-12)}`;
+        const newGuidanceId = stableId("proposal", [newGuidanceSig]);
+        expect(rows).toEqual([
+            {
+                id: newGuidanceId,
+                dedupe_sig: newGuidanceSig,
+                status: "accepted",
+                reject_reason: null,
+                payload_id: stableId("guidance_proposal", [newGuidanceId]),
+                payload_proposal: newGuidanceId,
+                experiment_proposal: newGuidanceId,
+            },
+            {
+                id: newSkillId,
+                dedupe_sig: newSkillSig,
+                status: "rejected",
+                reject_reason: "user decision",
+                payload_id: newSkillId,
+                payload_proposal: newSkillId,
+                experiment_proposal: null,
+            },
+        ].sort((a, b) => a.id.localeCompare(b.id)));
     });
 });
 

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -31,10 +31,10 @@
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { cacheRow, jsonParam } from "@ax/lib/duckdb/row";
 import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
-import { Judgment, TextColumn, TimestampColumn, type JudgmentError, type SidecarParam } from "@ax/lib/sqlite";
+import { Judgment, TextColumn, TimestampColumn, type JudgmentError, type JudgmentService, type SidecarParam } from "@ax/lib/sqlite";
 import { judgmentRow } from "../improve/judgment-proposals.ts";
 import { jsonRecordField } from "@ax/lib/decode";
-import { edgeRowId } from "@ax/lib/stable-id";
+import { edgeRowId, stableId } from "@ax/lib/stable-id";
 import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
 import type { HarnessLearningCandidate } from "../project/types.ts";
 import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
@@ -662,8 +662,155 @@ interface SkillCandidateRow {
 export const normalizeTitle = (raw: string): string =>
     raw.toLowerCase().trim().replaceAll(/\s+/g, " ");
 
+const sha256Prefix = (value: string, length = 16): string => {
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(value);
+    return hasher.digest("hex").slice(0, length);
+};
+
 export const dedupeSig = (form: string, normalizedTitle: string): string =>
-    `${form}__${Bun.hash(`${form}:${normalizedTitle}`).toString(16).slice(0, 16)}`;
+    `${form}__${sha256Prefix(`${form}:${normalizedTitle}`)}`;
+
+interface ProposalDedupeMigrationRow {
+    readonly id: string;
+    readonly form: string;
+    readonly title: string;
+    readonly dedupe_sig: string;
+    readonly status: string;
+    readonly origin: string;
+    readonly baseline: string | null;
+}
+
+const decisionRank = (status: string): number => {
+    switch (status) {
+        case "rejected": return 0;
+        case "accepted": return 1;
+        case "superseded": return 2;
+        default: return 3;
+    }
+};
+
+const proposalPayloadTable = (form: string): string | null => {
+    switch (form) {
+        case "skill": return "skill_proposal";
+        case "subagent": return "subagent_proposal";
+        case "hook": return "hook_proposal";
+        case "guidance": return "guidance_proposal";
+        case "automation": return "automation_proposal";
+        default: return null;
+    }
+};
+
+const migratedProposalId = (row: ProposalDedupeMigrationRow, sig: string): string => {
+    const oldSuffix = row.dedupe_sig.slice(-12);
+    if (row.id.endsWith(oldSuffix)) return `${row.id.slice(0, -oldSuffix.length)}${sig.slice(-12)}`;
+    if (row.origin !== "agent") return row.id;
+
+    const baseline = parseMetrics(row.baseline);
+    if (baseline.source === "retro_meta_plan" && typeof baseline.slug === "string") {
+        return stableId("proposal", ["retro_meta", baseline.slug, sig]);
+    }
+    return stableId("proposal", [sig]);
+};
+
+/**
+ * One-time transition from Bun.hash proposal signatures to SHA-256.
+ *
+ * `form` and `title` are the complete signature inputs, so this migration does
+ * not depend on reproducing the Bun version that wrote the old value. Proposal
+ * ids and signature values change together. The same transaction also
+ * changes typed payload ids and all proposal links. It first moves changed ids
+ * to unique temporary values, which makes each update safe under unique indexes.
+ *
+ * A sidecar can already contain logical duplicates if an earlier Bun upgrade
+ * changed Bun.hash. The strongest closed decision receives the canonical SHA
+ * signature. Other rows receive deterministic legacy suffixes. Thus no decision
+ * row or linked row is deleted, while future derivation sees the canonical sig.
+ */
+export const migrateProposalDedupeSigs = (
+    judgment: JudgmentService,
+): Effect.Effect<void, JudgmentError> =>
+    Effect.gen(function* () {
+        const rows = yield* judgment.rows(Schema.Struct({
+            id: TextColumn,
+            form: TextColumn,
+            title: TextColumn,
+            dedupe_sig: TextColumn,
+            status: TextColumn,
+            origin: TextColumn,
+            baseline: Schema.NullOr(TextColumn),
+        }), "SELECT id, form, title, dedupe_sig, status, origin, baseline FROM proposal");
+
+        const groups = new Map<string, ProposalDedupeMigrationRow[]>();
+        for (const row of rows) {
+            const desired = dedupeSig(row.form, normalizeTitle(row.title));
+            const group = groups.get(desired) ?? [];
+            group.push(row);
+            groups.set(desired, group);
+        }
+
+        const targets = new Map<string, { readonly id: string; readonly sig: string }>();
+        for (const [desired, group] of groups) {
+            const ordered = [...group].sort((a, b) =>
+                Number(migratedProposalId(b, desired) === b.id) - Number(migratedProposalId(a, desired) === a.id) ||
+                decisionRank(a.status) - decisionRank(b.status) ||
+                Number(b.dedupe_sig === desired) - Number(a.dedupe_sig === desired) ||
+                a.id.localeCompare(b.id));
+            for (const [index, row] of ordered.entries()) {
+                targets.set(row.id, index === 0
+                    ? { id: migratedProposalId(row, desired), sig: desired }
+                    : { id: row.id, sig: `${desired}__legacy__${sha256Prefix(row.id, 12)}` });
+            }
+        }
+
+        const changed = rows.filter((row) => {
+            const target = targets.get(row.id)!;
+            return target.id !== row.id || target.sig !== row.dedupe_sig;
+        });
+        if (changed.length === 0) return;
+
+        yield* judgment.transaction((transaction) => Effect.gen(function* () {
+            for (const row of changed) {
+                const target = targets.get(row.id)!;
+                if (target.id !== row.id) {
+                    const payloadTable = proposalPayloadTable(row.form);
+                    if (payloadTable !== null) {
+                        yield* transaction.exec(
+                            `UPDATE ${payloadTable} SET id = ? WHERE proposal = ?`,
+                            [`__ax_dedupe_migration_tmp_payload__${row.id}`, row.id],
+                        );
+                    }
+                }
+                yield* transaction.exec(
+                    "UPDATE proposal SET id = ?, dedupe_sig = ? WHERE id = ?",
+                    [`__ax_dedupe_migration_tmp_id__${row.id}`, `__ax_dedupe_migration_tmp_sig__${row.id}`, row.id],
+                );
+            }
+            for (const row of changed) {
+                const target = targets.get(row.id)!;
+                if (target.id !== row.id) {
+                    const payloadTable = proposalPayloadTable(row.form);
+                    if (payloadTable !== null) {
+                        const payloadId = row.origin === "mined"
+                            ? target.id
+                            : stableId(payloadTable, [target.id]);
+                        yield* transaction.exec(
+                            `UPDATE ${payloadTable} SET id = ?, proposal = ? WHERE proposal = ?`,
+                            [payloadId, target.id, row.id],
+                        );
+                    }
+                    yield* transaction.exec(
+                        "UPDATE experiment SET proposal = ? WHERE proposal = ?",
+                        [target.id, row.id],
+                    );
+                }
+                yield* transaction.exec(
+                    "UPDATE proposal SET id = ?, dedupe_sig = ? WHERE id = ?",
+                    [target.id, target.sig, `__ax_dedupe_migration_tmp_id__${row.id}`],
+                );
+            }
+        }));
+    });
 
 export const parseMetrics = (
     raw: Record<string, unknown> | string | null | undefined,
@@ -796,6 +943,7 @@ export const deriveProposals = (
 > =>
     Effect.gen(function* () {
         const judgment = yield* Judgment;
+        yield* migrateProposalDedupeSigs(judgment);
         const [candidates, skills, existingProposals] = yield* Effect.all([
             write.rows(Schema.Struct({
                 id: Schema.String, name: Schema.String, trigger_pattern: Schema.String,

--- a/apps/axctl/src/ingest/derive-retro-proposals.ts
+++ b/apps/axctl/src/ingest/derive-retro-proposals.ts
@@ -36,7 +36,7 @@ import { Judgment, TextColumn, TimestampColumn, type JudgmentError, type Sidecar
 import { judgmentRow } from "../improve/judgment-proposals.ts";
 import { listStoredRetros } from "../queries/judgment-retros.ts";
 import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
-import { dedupeSig, normalizeTitle } from "./derive-proposals.ts";
+import { dedupeSig, migrateProposalDedupeSigs, normalizeTitle } from "./derive-proposals.ts";
 
 export interface DeriveRetroProposalsStats {
     readonly toolFailureProposals: number;
@@ -627,6 +627,7 @@ export const deriveRetroProposals = (
 ): Effect.Effect<DeriveRetroProposalsStats, CacheReadError | JudgmentError, Judgment> =>
     Effect.gen(function* () {
         const judgment = yield* Judgment;
+        yield* migrateProposalDedupeSigs(judgment);
         const sinceDays = opts.sinceDays ?? 30;
         const minSessions = opts.minSessions ?? 2;
         const minRetros = opts.minRetros ?? 2;


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-dedupe-sig.

- #942: proposal dedupe signatures hashed with `Bun.hash`, so any bun upgrade re-keys every signature and the derivation re-mints duplicates of every open proposal. Signatures now use SHA-256 (`Bun.CryptoHasher`), mirroring the watermark rule from #900.
- A one-time idempotent sidecar migration runs before every derivation: recomputes each signature from stored `form` + normalized `title` (no dependence on the old bun version), re-keys proposal ids, typed payload rows, and `experiment` links in ONE transaction, using temporary ids so unique indexes never collide. Pre-existing logical duplicates keep every decision row: the strongest closed decision takes the canonical signature, others get deterministic `__legacy__` suffixes. Nothing is deleted.
- Verified against the sidecar DDL: the only tables referencing `proposal.id` are the five typed payload tables + `experiment`, all covered.

Known residual (accepted): `cites_evidence` edges live in the REBUILDABLE DuckDB cache and keep the old proposal ids for pre-migration agent-origin proposals, so evidence tracing for those specific old rows goes stale. Decisions are untouched; new proposals link correctly.

Gates: proposal + improve + sqlite suites 232/232 re-run at gate, tsc clean, both cast checks clean.

Fixes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)