### PR TITLE
fix(pricing): per-turn session costs, merged catalog at ingest, honest unpriced totals

### DIFF
--- a/apps/axctl/src/ingest/codex.stage.test.ts
+++ b/apps/axctl/src/ingest/codex.stage.test.ts
@@ -6,7 +6,7 @@ describe("codexStage", () => {
     it("declares the canonical key/deps/tags", () => {
         expect(Schema.decodeUnknownSync(CodexKey)("codex")).toBe("codex");
         expect(codexStage.meta.key).toBe("codex");
-        expect(codexStage.meta.deps).toEqual(["skills", "commands"]);
+        expect(codexStage.meta.deps).toEqual(["skills", "commands", "pricing"]);
         expect(codexStage.meta.tags).toEqual(["ingest"]);
     });
 });

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
 import { agentEventRecordKey } from "./provider-events.ts";
 import { SkillName } from "@ax/lib/brands";
 import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
@@ -6,6 +7,7 @@ import {
     __testCompactCodexToolCall,
     __testExtractCodexJsonlLines,
     __testStreamCodexJsonlLines,
+    __testWriteCodexTokenUsage,
     codexConcurrency,
     codexFlushEvery,
     codexPayloadMaxBytes,
@@ -13,7 +15,8 @@ import {
     shouldSnapshotCodexRaw,
     toCodexNormalizedBatch,
 } from "./codex.ts";
-import { estimateCost, normalizeModelName } from "./model-pricing.ts";
+import { builtInPricingCatalog, estimateCost, normalizeModelName } from "./model-pricing.ts";
+import type { ModelPricing } from "./model-pricing.ts";
 import { codexSourceForThread } from "./source-origin.ts";
 
 const normalizedCodexBatch = (
@@ -507,6 +510,131 @@ describe("Codex transcript extraction", () => {
             usageQuality: "provider_turn",
         });
         expect(extracted?.turnTokenUsages[0]?.usageSource).toBe("codex_token_count.last_token_usage");
+    });
+
+    test("writes merged catalog pricing for an upstream-only Codex model", async () => {
+        const model = "gpt-upstream-only";
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-09T10:00:00.000Z",
+                payload: {
+                    id: "codex-merged-price",
+                    cwd: "/tmp",
+                    model_provider: "openai",
+                    timestamp: "2026-05-09T10:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "turn_context",
+                timestamp: "2026-05-09T10:00:00.500Z",
+                payload: { model },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T10:00:01.000Z",
+                payload: {
+                    type: "message",
+                    role: "assistant",
+                    content: [{ type: "output_text", text: "done" }],
+                },
+            }),
+            JSON.stringify({
+                type: "event_msg",
+                timestamp: "2026-05-09T10:00:02.000Z",
+                payload: {
+                    type: "token_count",
+                    info: {
+                        total_token_usage: { input_tokens: 100_000, output_tokens: 10_000, total_tokens: 110_000 },
+                        last_token_usage: { input_tokens: 100_000, output_tokens: 10_000, total_tokens: 110_000 },
+                    },
+                },
+            }),
+        ]);
+        const catalog = new Map<string, ModelPricing>([[model, {
+            provider: "openai",
+            inputPerMillionUsd: 2,
+            outputPerMillionUsd: 10,
+            cacheCreationPerMillionUsd: 2.5,
+            cacheReadPerMillionUsd: 0.2,
+            fastMultiplier: 1,
+            pricingSource: "litellm",
+        }]]);
+        const written = new Map<string, Record<string, unknown>[]>();
+        const write = {
+            put: (table: string, row: Record<string, unknown>) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), row]);
+            }),
+            putMany: (table: string, rows: Record<string, unknown>[]) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), ...rows]);
+            }),
+        };
+
+        await Effect.runPromise(__testWriteCodexTokenUsage(
+            write as never,
+            extracted!.tokenUsage,
+            extracted!.turnTokenUsages,
+            "codex",
+            catalog,
+        ));
+
+        expect(written.get("turn_token_usage")?.[0]?.estimated_cost_usd as number).toBeCloseTo(0.3, 6);
+        expect(written.get("turn_token_usage")?.[0]?.pricing_source).toBe("litellm");
+    });
+
+    test("prices a mixed-model Codex session from its turn costs", async () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-09T10:00:00.000Z",
+                payload: { id: "codex-mixed-price", cwd: "/tmp", model_provider: "openai" },
+            }),
+            JSON.stringify({ type: "turn_context", payload: { model: "claude-sonnet-4" } }),
+            JSON.stringify({
+                type: "response_item",
+                payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "one" }] },
+            }),
+            JSON.stringify({
+                type: "event_msg",
+                payload: { type: "token_count", info: {
+                    total_token_usage: { input_tokens: 2_000_000, output_tokens: 0, total_tokens: 2_000_000 },
+                    last_token_usage: { input_tokens: 2_000_000, output_tokens: 0, total_tokens: 2_000_000 },
+                } },
+            }),
+            JSON.stringify({ type: "turn_context", payload: { model: "claude-fable-5" } }),
+            JSON.stringify({
+                type: "response_item",
+                payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "two" }] },
+            }),
+            JSON.stringify({
+                type: "event_msg",
+                payload: { type: "token_count", info: {
+                    total_token_usage: { input_tokens: 2_100_000, output_tokens: 0, total_tokens: 2_100_000 },
+                    last_token_usage: { input_tokens: 100_000, output_tokens: 0, total_tokens: 100_000 },
+                } },
+            }),
+        ]);
+        const written = new Map<string, Record<string, unknown>[]>();
+        const write = {
+            put: (table: string, row: Record<string, unknown>) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), row]);
+            }),
+            putMany: (table: string, rows: Record<string, unknown>[]) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), ...rows]);
+            }),
+        };
+
+        await Effect.runPromise(__testWriteCodexTokenUsage(
+            write as never,
+            extracted!.tokenUsage,
+            extracted!.turnTokenUsages,
+            "codex",
+            builtInPricingCatalog(),
+        ));
+
+        const session = written.get("session_token_usage")?.[0];
+        expect(session?.model).toBe("claude-fable-5");
+        expect(session?.estimated_cost_usd).toBe(7);
     });
 
     // Plan 003 fix round 1: `codexTurnTokenUsageFromPayload`'s `first_total`

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -53,7 +53,7 @@ import {
 import { decodeCodexTranscriptLine } from "./line-schemas.ts";
 import { isNotFound } from "@ax/lib/shared/fs-error";
 import { tokenQualityLabels } from "./token-quality.ts";
-import { estimateCost } from "./model-pricing.ts";
+import { estimateCost, loadPricingCatalog, sumCostEstimates, type ModelPricing } from "./model-pricing.ts";
 import { codexSourceForThread } from "./source-origin.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
@@ -351,7 +351,7 @@ function codexTurnTokenUsageFromPayload(
             session: usage.session,
             seq,
             ts: usage.ts,
-            model: usage.model,
+            model: usage.model, // Display attribution only; turn costs own the session price.
             ...metrics,
             usageSource: "codex_token_count.last_token_usage",
             usageQuality: "provider_turn",
@@ -1235,17 +1235,33 @@ const writeCodexTokenUsage = (
     usage: CodexTokenUsage | null,
     turnUsages: readonly CodexTurnTokenUsage[],
     source: "codex" | "codex-subagent",
+    pricingCatalog: ReadonlyMap<string, ModelPricing>,
+    sessionTurnUsages: readonly CodexTurnTokenUsage[] = turnUsages,
 ) => Effect.gen(function* () {
+    const priceTurn = (turnUsage: CodexTurnTokenUsage) => estimateCost({
+        modelKey: turnUsage.model,
+        promptTokens: turnUsage.promptTokens,
+        completionTokens: turnUsage.completionTokens,
+        cacheCreationInputTokens: turnUsage.cacheCreationInputTokens,
+        cacheReadInputTokens: turnUsage.cacheReadInputTokens,
+        estimatedTokens: turnUsage.estimatedTokens,
+        pricingCatalog,
+        ...(isCodexTurnUsageAggregated(turnUsage) ? { aggregated: true } : {}),
+    });
+    const turnCosts = turnUsages.map(priceTurn);
     if (usage !== null) {
-        const cost = estimateCost({
-            modelKey: usage.model,
-            promptTokens: usage.promptTokens,
-            completionTokens: usage.completionTokens,
-            cacheCreationInputTokens: null,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            estimatedTokens: usage.estimatedTokens,
-            aggregated: true,
-        });
+        const cost = sessionTurnUsages.length > 0
+            ? sumCostEstimates(sessionTurnUsages.map(priceTurn))
+            : estimateCost({
+                modelKey: usage.model,
+                promptTokens: usage.promptTokens,
+                completionTokens: usage.completionTokens,
+                cacheCreationInputTokens: null,
+                cacheReadInputTokens: usage.cacheReadInputTokens,
+                estimatedTokens: usage.estimatedTokens,
+                pricingCatalog,
+                aggregated: true,
+            });
         yield* write.put("session_token_usage", cacheRow({
             id: usage.session,
             session: usage.session,
@@ -1283,16 +1299,8 @@ const writeCodexTokenUsage = (
             ts: tsParam(usage.ts),
         }));
     }
-    yield* write.putMany("turn_token_usage", turnUsages.map((usage) => {
-        const cost = estimateCost({
-            modelKey: usage.model,
-            promptTokens: usage.promptTokens,
-            completionTokens: usage.completionTokens,
-            cacheCreationInputTokens: usage.cacheCreationInputTokens,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            estimatedTokens: usage.estimatedTokens,
-            ...(isCodexTurnUsageAggregated(usage) ? { aggregated: true } : {}),
-        });
+    yield* write.putMany("turn_token_usage", turnUsages.map((usage, index) => {
+        const cost = turnCosts[index]!;
         const turn = turnRecordKey(usage.session, usage.seq);
         return cacheRow({
             id: turn,
@@ -1322,6 +1330,8 @@ const writeCodexTokenUsage = (
         });
     }));
 });
+
+export const __testWriteCodexTokenUsage = writeCodexTokenUsage;
 
 export const toCodexNormalizedBatch = (
     batch: MutableCodexExtract,
@@ -1439,6 +1449,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         const cfg = yield* AxConfig;
         const path = yield* Path.Path;
         const spoolFs = yield* FileSystem.FileSystem;
+        const pricingCatalog = (yield* loadPricingCatalog(cfg.paths.dataDir)).catalog;
         // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool; the
         // shadowed `write` routes every write in this stage through it. The
         // per-session agent_event DELETE stays a pass-through exec and fires
@@ -1564,6 +1575,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 let fileInvocations = 0;
                 let fileToolCalls = 0;
                 let filePlanSnapshots = 0;
+                const sessionCostUsages = new Map<number, CodexTurnTokenUsage>();
 
                 const emitProgress = (phase: number) =>
                     opts.onProgress
@@ -1635,11 +1647,16 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                             toCodexNormalizedBatch(batch, payloadMaxBytes),
                             { clearExisting },
                         );
+                        for (const turnUsage of batch.turnTokenUsages) {
+                            sessionCostUsages.set(turnUsage.seq, turnUsage);
+                        }
                         yield* writeCodexTokenUsage(
                             write,
                             batch.tokenUsage,
                             batch.turnTokenUsages,
                             codexSourceForThread(batch.session?.thread_source),
+                            pricingCatalog,
+                            [...sessionCostUsages.values()],
                         );
                         turnCount += batch.turns.length;
                         fileTurns += batch.turns.length;
@@ -1831,7 +1848,7 @@ export class CodexStageStats extends BaseStageStats.extend<CodexStageStats>("Cod
 export const codexStage: StageDef<CodexStageStats, AxConfig | FileSystem.FileSystem | Path.Path, DbError | CacheWriteError> = {
     meta: StageMeta.make({
         key: "codex",
-        deps: ["skills", "commands"],
+        deps: ["skills", "commands", "pricing"],
         tags: ["ingest"],
         writes: [
             ...NORMALIZED_BATCH_WRITES,

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -19,6 +19,7 @@ import {
     writeTokenUsageForSubagents,
 } from "./transcripts.ts";
 import { resolveSkillName } from "@ax/lib/skill-id";
+import { loadPricingCatalog } from "./model-pricing.ts";
 
 interface SubagentManifest {
     readonly agentId: string;
@@ -189,6 +190,7 @@ export const deriveClaudeSubagents = (
     Effect.gen(function* () {
         const cfg = yield* AxConfig;
         const fs = yield* FileSystem.FileSystem;
+        const pricingCatalog = (yield* loadPricingCatalog(cfg.paths.dataDir)).catalog;
         if (opts.onProgress) yield* opts.onProgress({ phase: 1 });
         const manifests = yield* discover(cfg.paths.transcriptsDir);
         if (opts.onProgress) {
@@ -343,7 +345,7 @@ export const deriveClaudeSubagents = (
                 }));
                 if (parentRepository !== null) repositoryInherited += 1;
 
-                yield* writeTokenUsageForSubagents(write, extracted);
+                yield* writeTokenUsageForSubagents(write, extracted, pricingCatalog);
                 yield* upsertTurnsForSubagents(write, extracted.turns);
                 yield* writeToolCallStatementsForSubagents(write, extracted.toolCalls);
                 yield* writeToolFileEvidenceForSubagents(write, extracted.toolCalls);

--- a/apps/axctl/src/ingest/derive-cost-backfill.test.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.test.ts
@@ -23,6 +23,25 @@ const usage = (id: string, model: string | null, values: Record<string, unknown>
     ...values,
 });
 
+const turnUsage = (id: string, model: string | null, values: Record<string, unknown> = {}) => ({
+    id,
+    session: "s1",
+    turn: id,
+    seq: 1,
+    source: "claude",
+    model,
+    prompt_tokens: 1_000_000,
+    completion_tokens: 100_000,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    estimated_tokens: 1_100_000,
+    estimated_cost_usd: null,
+    pricing_source: null,
+    usage_source: "test",
+    usage_quality: "provider_turn",
+    ...values,
+});
+
 describe("deriveCostBackfill on real DuckDB", () => {
     dtest("prices estimated tokens and preserves the pricing source", async () => {
         let stats: unknown;
@@ -56,6 +75,35 @@ describe("deriveCostBackfill on real DuckDB", () => {
             }),
         ));
         expect(cost).toBe(30);
+    });
+
+    dtest("heals null costs on turn token usage rows", async () => {
+        let stats: unknown;
+        let row: unknown;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-turn-cost-backfill-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* write.put("turn_token_usage", turnUsage("turn-1", "claude-opus-4-5"));
+                stats = yield* deriveCostBackfill(write);
+                row = (yield* write.rows(Schema.Struct({
+                    cost: Schema.Number,
+                    inputCost: Schema.Number,
+                    outputCost: Schema.Number,
+                    source: Schema.String,
+                }), `SELECT estimated_cost_usd AS cost,
+                    estimated_input_cost_usd AS inputCost,
+                    estimated_output_cost_usd AS outputCost,
+                    pricing_source AS source
+                    FROM turn_token_usage WHERE id = ?`, ["turn-1"]))[0];
+            }),
+        ));
+
+        expect(stats).toEqual({ scanned: 1, backfilled: 1, unpriced: 0 });
+        expect(row).toEqual({
+            cost: 7.5,
+            inputCost: 5,
+            outputCost: 2.5,
+            source: `estimated:${MODEL_PRICING_SOURCE}`,
+        });
     });
 
     dtest("leaves unknown models null and becomes idempotent", async () => {

--- a/apps/axctl/src/ingest/derive-cost-backfill.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.ts
@@ -1,6 +1,6 @@
 /**
- * Derive-time cost backfill for `session_token_usage` rows that were never
- * priced at ingest (review must-fix on #175).
+ * Derive-time cost backfill for session and turn token usage rows that were
+ * never priced at ingest (review must-fix on #175 and #937).
  *
  * The read-time estimator (`metrics/cost-estimate.ts`) fixed only the 3
  * surfaces that call `fillEstimatedCost`; every other reader (dashboard cost
@@ -22,19 +22,20 @@
  *   `estimated:` are also skipped in JS, defensively). Re-pricing after a
  *   catalog change is intentionally NOT done here - delete the stored
  *   `estimated:` costs to force a recompute.
- * - Bounded: one indexed-or-full select over session_token_usage (one row per
- *   session, ~thousands) with a hard row cap; UPDATEs by primary record id in
- *   chunks. No edge derefs (hang safety).
+ * - Bounded: direct selects over both usage tables share one hard row cap.
+ *   UPDATEs use primary record ids. No edge derefs exist on this path.
  */
 import { Effect, Schema } from "effect";
 import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import {
+    ESTIMATED_PRICING_PREFIX,
     fillEstimatedCost,
     isEstimatedPricingSource,
     loadPricingCatalogForModels,
 } from "../metrics/cost-estimate.ts";
 import { numOrNull, numOrZero, strOrNull } from "../metrics/util.ts";
+import { estimateCost, normalizeModelName } from "./model-pricing.ts";
 
 export interface CostBackfillStats {
     /** Null-cost rows scanned this run. */
@@ -48,6 +49,7 @@ export interface CostBackfillStats {
 /** Hard cap on rows per run (one row per session - generous headroom; residual
  *  rows heal on the next derive run, which the daemon triggers per ingest). */
 const MAX_ROWS_PER_RUN = 20_000;
+const MIN_TURN_ROWS_PER_RUN = MAX_ROWS_PER_RUN / 2;
 
 const UsageRow = Schema.Struct({
     id: Schema.String,
@@ -69,14 +71,29 @@ export const deriveCostBackfill = (
     write: CacheWriteService,
 ): Effect.Effect<CostBackfillStats, CacheWriteError> =>
     Effect.gen(function* () {
-        const rows = yield* write.rows(
+        const turnRows = yield* write.rows(
             UsageRow,
             `SELECT id, model, prompt_tokens, completion_tokens,`
             + ` cache_creation_input_tokens, cache_read_input_tokens, estimated_tokens,`
             + ` estimated_cost_usd, pricing_source`
-            + ` FROM session_token_usage WHERE estimated_cost_usd IS NULL LIMIT ?`,
-            [MAX_ROWS_PER_RUN],
+            + ` FROM turn_token_usage WHERE estimated_cost_usd IS NULL LIMIT ?`,
+            [MIN_TURN_ROWS_PER_RUN],
         );
+        const sessionLimit = MAX_ROWS_PER_RUN - turnRows.length;
+        const sessionRows = sessionLimit === 0
+            ? []
+            : yield* write.rows(
+                UsageRow,
+                `SELECT id, model, prompt_tokens, completion_tokens,`
+                + ` cache_creation_input_tokens, cache_read_input_tokens, estimated_tokens,`
+                + ` estimated_cost_usd, pricing_source`
+                + ` FROM session_token_usage WHERE estimated_cost_usd IS NULL LIMIT ?`,
+                [sessionLimit],
+            );
+        const rows = [
+            ...sessionRows.map((row) => ({ ...row, table: "session_token_usage" as const })),
+            ...turnRows.map((row) => ({ ...row, table: "turn_token_usage" as const })),
+        ];
         if (rows.length === 0) return { scanned: 0, backfilled: 0, unpriced: 0 };
 
         const catalog = yield* loadPricingCatalogForModels(write, rows.map((r) => strOrNull(r.model)));
@@ -91,7 +108,7 @@ export const deriveCostBackfill = (
             // an already-estimated row (idempotency: catalog drift must not make
             // every derive run rewrite the whole table).
             if (storedCost !== null || isEstimatedPricingSource(storedSource)) continue;
-            const filled = fillEstimatedCost({
+            const usage = {
                 model: strOrNull(row.model),
                 prompt_tokens: numOrNull(row.prompt_tokens),
                 completion_tokens: numOrNull(row.completion_tokens),
@@ -100,7 +117,40 @@ export const deriveCostBackfill = (
                 estimated_tokens: numOrZero(row.estimated_tokens),
                 estimated_cost_usd: null,
                 pricing_source: storedSource,
-            }, catalog);
+            };
+            if (row.table === "turn_token_usage") {
+                const cost = estimateCost({
+                    modelKey: normalizeModelName(usage.model),
+                    promptTokens: usage.prompt_tokens,
+                    completionTokens: usage.completion_tokens,
+                    cacheCreationInputTokens: usage.cache_creation_input_tokens,
+                    cacheReadInputTokens: usage.cache_read_input_tokens,
+                    estimatedTokens: usage.estimated_tokens,
+                    pricingCatalog: catalog,
+                });
+                if (cost.totalUsd === null || cost.pricingSource === null) {
+                    unpriced += 1;
+                    continue;
+                }
+                yield* write.exec(
+                    `UPDATE turn_token_usage SET estimated_input_cost_usd = ?,`
+                        + ` estimated_output_cost_usd = ?, estimated_cache_creation_cost_usd = ?,`
+                        + ` estimated_cache_read_cost_usd = ?, estimated_cost_usd = ?, pricing_source = ?`
+                        + ` WHERE id = ? AND estimated_cost_usd IS NULL`,
+                    [
+                        cost.inputUsd,
+                        cost.outputUsd,
+                        cost.cacheCreationUsd,
+                        cost.cacheReadUsd,
+                        cost.totalUsd,
+                        `${ESTIMATED_PRICING_PREFIX}${cost.pricingSource}`,
+                        row.id,
+                    ],
+                );
+                backfilled += 1;
+                continue;
+            }
+            const filled = fillEstimatedCost(usage, catalog);
             if (!filled.estimated || filled.estimatedCostUsd === null || filled.pricingSource === null) {
                 unpriced += 1;
                 continue;

--- a/apps/axctl/src/ingest/derive-metrics.ts
+++ b/apps/axctl/src/ingest/derive-metrics.ts
@@ -228,6 +228,7 @@ export const deriveMetricsStage: StageDef<DeriveMetricsStageStats, never, Ingest
             { table: "session_metrics", mode: "derive" },
             { table: "fragility_cascade", mode: "derive" },
             { table: "session_token_usage", mode: "enrich" }, // cost backfill
+            { table: "turn_token_usage", mode: "enrich" }, // cost backfill
             { table: "commit", mode: "enrich" }, // reverted stamping
             { table: "ingest_file_state", mode: "bookkeep" },
         ],

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -168,6 +168,48 @@ describe("model pricing", () => {
         expect(estimateCost({ ...usage, fastTier: true }).totalUsd).toBeCloseTo(12.5, 6);
     });
 
+    it("applies cache creation defaults to built-in pricing", () => {
+        const pricing = builtInPricingCatalog().get("gpt-5-nano");
+
+        expect(pricing?.cacheCreationPerMillionUsd).toBeCloseTo(0.0625, 6);
+        expect(estimateCost({
+            modelKey: "gpt-5-nano",
+            promptTokens: 500_000,
+            completionTokens: 0,
+            cacheCreationInputTokens: 500_000,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 500_000,
+        }).totalUsd).toBeCloseTo(0.03125, 6);
+    });
+
+    it("returns a null total when used tokens have no price", () => {
+        const catalog = new Map([[
+            "partial-price",
+            {
+                provider: "test",
+                inputPerMillionUsd: 1,
+                outputPerMillionUsd: 2,
+                cacheCreationPerMillionUsd: null,
+                cacheReadPerMillionUsd: 0.1,
+                fastMultiplier: 1,
+                pricingSource: "test",
+            },
+        ]]);
+
+        const cost = estimateCost({
+            modelKey: "partial-price",
+            promptTokens: 500_000,
+            completionTokens: 100_000,
+            cacheCreationInputTokens: 500_000,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 600_000,
+            pricingCatalog: catalog,
+        });
+
+        expect(cost.cacheCreationUsd).toBeNull();
+        expect(cost.totalUsd).toBeNull();
+    });
+
     it("prices claude-opus-5 and its dated variants from the built-in catalog", () => {
         const catalog = builtInPricingCatalog();
 
@@ -182,6 +224,22 @@ describe("model pricing", () => {
         }
         // opus-5 must NOT fall through to the opus-4 rule (15/75).
         expect(pricingForModel("claude-opus-5", catalog)?.outputPerMillionUsd).not.toBe(75);
+    });
+
+    it("routes dated and suffixed Opus 4 variants to their specific catalog entries", () => {
+        const catalog = builtInPricingCatalog();
+        const cases = [
+            ["claude-opus-4-5-20251101", "claude-opus-4-5"],
+            ["claude-opus-4-5-thinking", "claude-opus-4-5"],
+            ["claude-opus-4-6-20260201", "claude-opus-4-6"],
+            ["claude-opus-4-7-20260301", "claude-opus-4-7"],
+            ["claude-opus-4-8-20260401", "claude-opus-4-8"],
+            ["claude-opus-4.1-20250401", "claude-opus-4.1"],
+        ] as const;
+
+        for (const [variant, base] of cases) {
+            expect(pricingForModel(variant, catalog)).toEqual(catalog.get(base)!);
+        }
     });
 
     it("routes dated GPT-5.6 tier variants to their own tier, not the gpt-5.5 approximation", () => {

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -38,6 +38,24 @@ export interface CostEstimate {
     readonly pricingSource: string | null;
 }
 
+export const sumCostEstimates = (costs: readonly CostEstimate[]): CostEstimate => {
+    const sumComponent = (values: ReadonlyArray<number | null>): number | null => {
+        const known = values.filter((value): value is number => value !== null);
+        return known.length === 0 ? null : known.reduce((sum, value) => sum + value, 0);
+    };
+    const sources = new Set(costs.flatMap((cost) => cost.pricingSource === null ? [] : [cost.pricingSource]));
+    return {
+        inputUsd: sumComponent(costs.map((cost) => cost.inputUsd)),
+        outputUsd: sumComponent(costs.map((cost) => cost.outputUsd)),
+        cacheCreationUsd: sumComponent(costs.map((cost) => cost.cacheCreationUsd)),
+        cacheReadUsd: sumComponent(costs.map((cost) => cost.cacheReadUsd)),
+        totalUsd: costs.some((cost) => cost.totalUsd === null)
+            ? null
+            : costs.reduce((sum, cost) => sum + cost.totalUsd!, 0),
+        pricingSource: sources.size === 1 ? [...sources][0]! : sources.size > 1 ? "mixed" : null,
+    };
+};
+
 export interface AgentModelPricingRow {
     readonly name?: string | null;
     readonly provider?: string | null;
@@ -80,7 +98,7 @@ const withCacheDefaults = (pricing: ModelPricing): ModelPricing => ({
     cacheReadPerMillionUsd: pricing.cacheReadPerMillionUsd ?? (pricing.inputPerMillionUsd === null ? null : pricing.inputPerMillionUsd * 0.1),
 });
 
-export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing>> = {
+const RAW_BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing>> = {
     "gpt-5": {
         provider: "openai",
         inputPerMillionUsd: 1.25,
@@ -353,6 +371,11 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
     },
 };
 
+export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing>> = Object.fromEntries(
+    Object.entries(RAW_BUILTIN_MODEL_PRICING_CATALOG)
+        .map(([modelKey, pricing]) => [modelKey, withCacheDefaults(pricing)]),
+);
+
 /**
  * Claude Code's placeholder `model` on assistant entries it generated WITHOUT an
  * API call. It is not a model: it must never win a session's model attribution
@@ -508,6 +531,11 @@ export function pricingForModel(
     if (modelKey.startsWith("claude-fable-5")) return catalog.get("claude-fable-5") ?? null;
     if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;
     if (modelKey.startsWith("claude-opus-5")) return catalog.get("claude-opus-5") ?? null;
+    if (modelKey.startsWith("claude-opus-4-5")) return catalog.get("claude-opus-4-5") ?? null;
+    if (modelKey.startsWith("claude-opus-4-6")) return catalog.get("claude-opus-4-6") ?? null;
+    if (modelKey.startsWith("claude-opus-4-7")) return catalog.get("claude-opus-4-7") ?? null;
+    if (modelKey.startsWith("claude-opus-4-8")) return catalog.get("claude-opus-4-8") ?? null;
+    if (modelKey.startsWith("claude-opus-4.1")) return catalog.get("claude-opus-4.1") ?? null;
     if (modelKey.startsWith("claude-opus-4")) return catalog.get("claude-opus-4") ?? null;
     if (modelKey.startsWith("claude-sonnet-5")) return catalog.get("claude-sonnet-5") ?? null;
     if (modelKey.startsWith("claude-sonnet-4")) return catalog.get("claude-sonnet-4") ?? null;
@@ -583,9 +611,15 @@ export function estimateCost(input: {
     const cacheCreationUsd = componentCost(cacheCreationTokens, cacheCreationRate);
     const cacheReadUsd = componentCost(cacheReadTokens, cacheReadRate);
     const tierMultiplier = input.fastTier === true ? pricing.fastMultiplier : 1;
-    const totalUsd = [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
-        .filter((value): value is number => value !== null)
-        .reduce((sum, value) => sum + value, 0) * tierMultiplier;
+    const hasUnpricedTokens = (freshInputTokens > 0 && inputUsd === null)
+        || ((input.completionTokens ?? 0) > 0 && outputUsd === null)
+        || (cacheCreationTokens > 0 && cacheCreationUsd === null)
+        || (cacheReadTokens > 0 && cacheReadUsd === null);
+    const totalUsd = hasUnpricedTokens
+        ? null
+        : [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
+            .filter((value): value is number => value !== null)
+            .reduce((sum, value) => sum + value, 0) * tierMultiplier;
     return {
         inputUsd,
         outputUsd,

--- a/apps/axctl/src/ingest/transcripts.stage.test.ts
+++ b/apps/axctl/src/ingest/transcripts.stage.test.ts
@@ -6,7 +6,7 @@ describe("claudeStage", () => {
     it("declares the canonical key/deps/tags", () => {
         expect(Schema.decodeUnknownSync(ClaudeKey)("claude")).toBe("claude");
         expect(claudeStage.meta.key).toBe("claude");
-        expect(claudeStage.meta.deps).toEqual(["skills", "commands"]);
+        expect(claudeStage.meta.deps).toEqual(["skills", "commands", "pricing"]);
         expect(claudeStage.meta.tags).toEqual(["ingest"]);
     });
 });

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
 import { SkillName } from "@ax/lib/brands";
 import { agentEventRecordKey } from "./provider-events.ts";
 import { fileRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import {
     __testExtractClaudeJsonlLines,
+    __testWriteClaudeTokenUsageRows,
     claudeConcurrency,
     transcriptEditFileRecordKey,
 } from "./transcripts.ts";
-import { estimateCost, normalizeModelName } from "./model-pricing.ts";
+import { builtInPricingCatalog, estimateCost, normalizeModelName } from "./model-pricing.ts";
+import type { ModelPricing } from "./model-pricing.ts";
 
 // Fixture skill names are plain string literals; brand via the schema constructor.
 const sn = (s: string): SkillName => SkillName.make(s);
@@ -1830,6 +1833,105 @@ describe("claude token usage", () => {
         });
         expect(cost.totalUsd).toBe(0.0035);
         expect(first.promptTokens).toBe(1300);
+    });
+
+    test("writes merged catalog pricing for a long-context Claude turn", async () => {
+        const model = "claude-sonnet-4-5-20250929";
+        const extracted = __testExtractClaudeJsonlLines([
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a1",
+                timestamp: "2026-06-01T10:00:01.000Z",
+                sessionId: "cl-merged-price",
+                message: {
+                    role: "assistant",
+                    model,
+                    content: "ok",
+                    usage: {
+                        input_tokens: 300_000,
+                        output_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                    },
+                },
+            }),
+        ], "-tmp", "cl-merged-price");
+        const catalog = new Map<string, ModelPricing>([[model, {
+            provider: "anthropic",
+            inputPerMillionUsd: 3,
+            outputPerMillionUsd: 15,
+            cacheCreationPerMillionUsd: 3.75,
+            cacheReadPerMillionUsd: 0.3,
+            inputAbove200kPerMillionUsd: 7.5,
+            outputAbove200kPerMillionUsd: 22.5,
+            cacheCreationAbove200kPerMillionUsd: 9.375,
+            cacheReadAbove200kPerMillionUsd: 0.6,
+            fastMultiplier: 1,
+            pricingSource: "models.dev",
+        }]]);
+        const written = new Map<string, Record<string, unknown>[]>();
+        const write = {
+            put: (table: string, row: Record<string, unknown>) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), row]);
+            }),
+            putMany: (table: string, rows: Record<string, unknown>[]) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), ...rows]);
+            }),
+        };
+
+        await Effect.runPromise(__testWriteClaudeTokenUsageRows(
+            write as never,
+            extracted!,
+            "claude",
+            catalog,
+        ));
+
+        expect(written.get("turn_token_usage")?.[0]?.estimated_cost_usd).toBe(2.25);
+        expect(written.get("turn_token_usage")?.[0]?.pricing_source).toBe("models.dev");
+    });
+
+    test("prices a mixed-model session from its turn costs", async () => {
+        const lines = [
+            ["a1", "claude-sonnet-4", 2_000_000],
+            ["a2", "claude-fable-5", 100_000],
+        ].map(([uuid, model, input], index) => JSON.stringify({
+            type: "assistant",
+            uuid,
+            timestamp: `2026-06-01T10:00:0${index + 1}.000Z`,
+            sessionId: "cl-mixed-price",
+            message: {
+                role: "assistant",
+                model,
+                content: "ok",
+                usage: {
+                    input_tokens: input,
+                    output_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                },
+            },
+        }));
+        const extracted = __testExtractClaudeJsonlLines(lines, "-tmp", "cl-mixed-price");
+        const written = new Map<string, Record<string, unknown>[]>();
+        const write = {
+            put: (table: string, row: Record<string, unknown>) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), row]);
+            }),
+            putMany: (table: string, rows: Record<string, unknown>[]) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), ...rows]);
+            }),
+        };
+
+        await Effect.runPromise(__testWriteClaudeTokenUsageRows(
+            write as never,
+            extracted!,
+            "claude",
+            builtInPricingCatalog(),
+        ));
+
+        const session = written.get("session_token_usage")?.[0];
+        expect(session?.model).toBe("claude-fable-5");
+        expect(session?.estimated_cost_usd).toBe(7);
     });
 
     test("emits no turn rows when the transcript carries no usage", () => {

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -66,7 +66,15 @@ import { claudeEffortStamp, loadClaudeEffortLevel } from "./claude-effort.ts";
 
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
-import { estimateCost, isSyntheticModel, normalizeModelName } from "./model-pricing.ts";
+import {
+    builtInPricingCatalog,
+    estimateCost,
+    isSyntheticModel,
+    loadPricingCatalog,
+    normalizeModelName,
+    sumCostEstimates,
+    type ModelPricing,
+} from "./model-pricing.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import {
@@ -1593,19 +1601,32 @@ const writeClaudeTokenUsageRows = (
     write: CacheWriteService,
     extracted: FileExtract,
     source: "claude" | "claude-subagent",
+    pricingCatalog: ReadonlyMap<string, ModelPricing>,
 ) => Effect.gen(function* () {
     const usage = extracted.tokenUsage;
+    const turnCosts = extracted.turnTokenUsages.map((turnUsage) => estimateCost({
+        modelKey: normalizeModelName(turnUsage.model),
+        promptTokens: turnUsage.promptTokens,
+        completionTokens: turnUsage.completionTokens,
+        cacheCreationInputTokens: turnUsage.cacheCreationInputTokens,
+        cacheReadInputTokens: turnUsage.cacheReadInputTokens,
+        estimatedTokens: turnUsage.estimatedTokens,
+        pricingCatalog,
+    }));
     if (usage !== null) {
         const modelKey = normalizeModelName(usage.model);
-        const cost = estimateCost({
-            modelKey,
-            promptTokens: usage.promptTokens,
-            completionTokens: usage.completionTokens,
-            cacheCreationInputTokens: usage.cacheCreationInputTokens,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            estimatedTokens: usage.estimatedTokens,
-            aggregated: true,
-        });
+        const cost = turnCosts.length > 0
+            ? sumCostEstimates(turnCosts)
+            : estimateCost({
+                modelKey,
+                promptTokens: usage.promptTokens,
+                completionTokens: usage.completionTokens,
+                cacheCreationInputTokens: usage.cacheCreationInputTokens,
+                cacheReadInputTokens: usage.cacheReadInputTokens,
+                estimatedTokens: usage.estimatedTokens,
+                pricingCatalog,
+                aggregated: true,
+            });
         const burnBuckets = computeBurnBuckets(
             [...extracted.turnTokenUsages].sort((a, b) => a.seq - b.seq).map((t) => t.estimatedTokens),
         );
@@ -1614,7 +1635,7 @@ const writeClaudeTokenUsageRows = (
             session: extracted.session.id,
             source,
             workflow_epoch: null,
-            model: usage.model,
+            model: usage.model, // Display attribution only; turn costs own the session price.
             prompt_tokens: usage.promptTokens,
             completion_tokens: usage.completionTokens,
             cache_creation_input_tokens: usage.cacheCreationInputTokens,
@@ -1636,16 +1657,9 @@ const writeClaudeTokenUsageRows = (
             ts: tsParam(usage.ts),
         }));
     }
-    yield* write.putMany("turn_token_usage", extracted.turnTokenUsages.map((turnUsage) => {
+    yield* write.putMany("turn_token_usage", extracted.turnTokenUsages.map((turnUsage, index) => {
         const modelKey = normalizeModelName(turnUsage.model);
-        const cost = estimateCost({
-            modelKey,
-            promptTokens: turnUsage.promptTokens,
-            completionTokens: turnUsage.completionTokens,
-            cacheCreationInputTokens: turnUsage.cacheCreationInputTokens,
-            cacheReadInputTokens: turnUsage.cacheReadInputTokens,
-            estimatedTokens: turnUsage.estimatedTokens,
-        });
+        const cost = turnCosts[index]!;
         const turn = turnRecordKey(extracted.session.id, turnUsage.seq);
         return cacheRow({
             id: turn,
@@ -1680,8 +1694,13 @@ const writeClaudeTokenUsageRows = (
     }));
 });
 
-const writeClaudeTokenUsage = (write: CacheWriteService, extracted: FileExtract) =>
-    writeClaudeTokenUsageRows(write, extracted, "claude");
+export const __testWriteClaudeTokenUsageRows = writeClaudeTokenUsageRows;
+
+const writeClaudeTokenUsage = (
+    write: CacheWriteService,
+    extracted: FileExtract,
+    pricingCatalog: ReadonlyMap<string, ModelPricing>,
+) => writeClaudeTokenUsageRows(write, extracted, "claude", pricingCatalog);
 
 /**
  * Subagent variant: identical rows, but `source = "claude-subagent"` so
@@ -1689,8 +1708,11 @@ const writeClaudeTokenUsage = (write: CacheWriteService, extracted: FileExtract)
  * dispatched-agent spend. The session-health pass writes the same value from
  * `session.source`; without this the last writer would flip the field.
  */
-export const writeTokenUsageForSubagents = (write: CacheWriteService, extracted: FileExtract) =>
-    writeClaudeTokenUsageRows(write, extracted, "claude-subagent");
+export const writeTokenUsageForSubagents = (
+    write: CacheWriteService,
+    extracted: FileExtract,
+    pricingCatalog: ReadonlyMap<string, ModelPricing> = builtInPricingCatalog(),
+) => writeClaudeTokenUsageRows(write, extracted, "claude-subagent", pricingCatalog);
 
 interface IngestOpts {
     sinceDays: number | undefined;
@@ -1732,6 +1754,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
         const cfg = yield* AxConfig;
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
+        const pricingCatalog = (yield* loadPricingCatalog(cfg.paths.dataDir)).catalog;
         // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool and
         // land as one read_ndjson load per (table, signature) per flush.
         // Everything else - session, skill, watermarks, reads, the per-session
@@ -1917,7 +1940,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 extracted.session.raw_file = pointer;
                 yield* upsertSessions(write, [extracted.session]);
                 sessions += 1;
-                yield* writeClaudeTokenUsage(write, extracted);
+                yield* writeClaudeTokenUsage(write, extracted, pricingCatalog);
                 // Resolve invoked names onto the catalog before writing so the
                 // `invoked` and `concerns` edges land on the real skill row.
                 const resolvedInvocations = extracted.invocations.map((inv) => ({
@@ -2052,7 +2075,7 @@ export class ClaudeStats extends BaseStageStats.extend<ClaudeStats>("ClaudeStats
 export const claudeStage: StageDef<ClaudeStats, AxConfig | FileSystem.FileSystem | Path.Path, DbError | CacheWriteError> = {
     meta: StageMeta.make({
         key: "claude",
-        deps: ["skills", "commands"],
+        deps: ["skills", "commands", "pricing"],
         tags: ["ingest"],
         writes: [
             ...NORMALIZED_BATCH_WRITES,

--- a/packages/schema/src/duckdb-tables.ts
+++ b/packages/schema/src/duckdb-tables.ts
@@ -119,7 +119,7 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
     user_message_ngram: { kind: "node", stage: "active", layer: "derived", note: "Derived user-language n-grams for preference and correction mining." },
     workflow_epoch: { kind: "node", stage: "active", layer: "derived", note: "Derived workflow eras for before/after comparisons." },
     session_token_usage: { kind: "node", stage: "active", layer: "event", note: "Actual or estimated session token/cache usage. LAYER NOTE (#893): event (actuals parsed from transcripts), with two enumerated derived writers - session-health upserts ESTIMATED rows (WRITE_MODE_EXCEPTIONS) and derive-metrics backfills cost columns (ENRICHMENT_COLUMNS)." },
-    turn_token_usage: { kind: "node", stage: "active", layer: "event", note: "Provider-derived per-turn token/cache usage and priced cost estimates." },
+    turn_token_usage: { kind: "node", stage: "active", layer: "event", note: "Provider-derived per-turn token/cache usage. Derive-metrics can backfill its cost columns through ENRICHMENT_COLUMNS." },
     session_health: { kind: "node", stage: "active", layer: "derived", note: "Derived session-level workflow, context, and interruption health." },
     session_metrics: { kind: "node", stage: "active", layer: "derived", note: "Graph-derived per-session metrics (durability, time-to-land, loc)." },
     fragility_cascade: { kind: "node", stage: "active", layer: "derived", note: "Precomputed cross-session fragility-cascade signal edges (origin session -> downstream fixer)." },
@@ -208,8 +208,9 @@ const TABLE_METADATA: Readonly<Record<string, Omit<DuckdbTableSpec, "table">>> =
  *   stamp (currently nulled by a parser bug, #898).
  * - invoked.turn_index/total_turns/is_first - invoked-positions backfill;
  *   invoked.was_corrected - signals correction stamping.
- * - session_token_usage.estimated_cost_usd/pricing_source - derive-metrics
- *   cost backfill (`WHERE estimated_cost_usd IS NULL`).
+ * - session_token_usage.estimated_cost_usd/pricing_source and
+ *   turn_token_usage cost columns - derive-metrics cost backfill
+ *   (`WHERE estimated_cost_usd IS NULL`).
  * - commit.reverted - derive-metrics revert detection.
  * - turn.intent_kind - `ax derive-intents` (CLI-only writer).
  */
@@ -217,6 +218,14 @@ export const ENRICHMENT_COLUMNS: Readonly<Record<string, readonly string[]>> = {
     session: ["project", "repository", "checkout", "cwd", "reasoning_effort"],
     invoked: ["turn_index", "total_turns", "is_first", "was_corrected"],
     session_token_usage: ["estimated_cost_usd", "pricing_source"],
+    turn_token_usage: [
+        "estimated_input_cost_usd",
+        "estimated_output_cost_usd",
+        "estimated_cache_creation_cost_usd",
+        "estimated_cache_read_cost_usd",
+        "estimated_cost_usd",
+        "pricing_source",
+    ],
     commit: ["reverted"],
     turn: ["intent_kind"],
 };


### PR DESCRIPTION
Fleet fix wave (run map #956), chunk fix-pricing-core (high effort).

- #936 (CRITICAL): Claude and Codex session cost was priced from session-total tokens at the session's DISPLAY model - a mixed-model session billed everything at the last model (+30.9% observed live). Session cost is now `sumCostEstimates` over per-turn estimates, each priced at its own turn's model; the `model` column stays display-only attribution.
- #937: Claude and Codex ingest priced against the BUILT-IN catalog only; the merged (built-in-over-upstream) catalog now loads once per stage run (`claude` stage gains a `pricing` dep), and the cost backfill extends to `turn_token_usage` rows under the same shared row cap.
- #938: dated/suffixed Opus 4.x model keys fell through to the generic `claude-opus-4` rate; specific variants now match first.
- #941: `estimateCost` summed only priceable components, so tokens with no rate silently vanished from the total. `totalUsd` is now null when any USED component lacks a rate, and cache-rate defaults apply to the whole built-in catalog.

Gates: pricing/backfill/transcripts/codex/cost-analytics suites 122/122 re-run at gate ON TOP of the merged fix-cost-reads chunk (nullable-total interaction covered), tsc exit 0, both cast checks clean.

Fixes #936
Fixes #937
Fixes #938
Fixes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)