### PR TITLE
fix(segment): retract the turn-cost-rides pin after #966

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,7 +394,8 @@ refresh-skips a NEW path whose bytes carry a known sha), then triggers the
 contract-driven re-derive (stages whose declared writes are all
 derive/enrich/bookkeep) over `--since=ceil(now - min(started_at))` through the
 exported `cmdIngest`. Catalogs never ride (dangling edges knit later by stable
-ids); cost columns ride as priced by the exporter (manifest note). A segment
+ids); cost columns do NOT ride (enrichment-stripped since #937/#966 - the
+importer's re-derive prices them against the local catalog). A segment
 carries raw turn text - LOCAL artifact, never published, no attribution plug.
 
 ## Workflow extraction commands

--- a/apps/axctl/src/segment/contract.test.ts
+++ b/apps/axctl/src/segment/contract.test.ts
@@ -41,8 +41,11 @@ describe("segment contract (#902)", () => {
         expect(segmentExportColumns("turn")).not.toContain("intent_kind");
         expect(segmentExportColumns("invoked")).not.toContain("was_corrected");
         expect(segmentExportColumns("session_token_usage")).not.toContain("estimated_cost_usd");
-        // Parse-priced turn costs RIDE (accepted divergence, manifest note).
-        expect(segmentExportColumns("turn_token_usage")).toContain("estimated_cost_usd");
+        // RETRACTED (#937/#966): turn costs used to RIDE as parse-priced event
+        // data. The cost backfill now heals turn_token_usage locally, so its
+        // cost columns are ENRICHMENT_COLUMNS and are stripped like the rest -
+        // the importer's re-derive prices them against the LOCAL catalog.
+        expect(segmentExportColumns("turn_token_usage")).not.toContain("estimated_cost_usd");
     });
 
     test("every predicate scopes on __SCOPE__ and substitutes quoted ids", () => {

--- a/apps/axctl/src/segment/export.ts
+++ b/apps/axctl/src/segment/export.ts
@@ -180,7 +180,7 @@ export const runSegmentExport = (
             source_files: sourceFiles,
             notes: {
                 cost_columns:
-                    "estimated_* cost columns were priced by the exporting machine's catalog; divergence accepted",
+                    "estimated_* cost columns do not ride (enrichment-stripped since #937/#966); the importer's re-derive prices them against the local catalog",
                 enrichment_stripped: true,
             },
         };

--- a/apps/axctl/src/segment/roundtrip.duckdb.test.ts
+++ b/apps/axctl/src/segment/roundtrip.duckdb.test.ts
@@ -141,8 +141,10 @@ describe("segment export -> import round-trip on the shipped dylib", () => {
             expect((yield* one(Row, "SELECT intent_kind AS v FROM turn WHERE id = 't1'"))?.v).toBeNull();
             expect((yield* one(Row, "SELECT CAST(was_corrected AS VARCHAR) AS v FROM invoked WHERE id = 'iv1'"))?.v).toBe("false");
             expect((yield* one(Row, "SELECT pricing_source AS v FROM session_token_usage WHERE id = 'stu1'"))?.v).toBeNull();
-            // Parse-priced turn cost RIDES.
-            expect((yield* one(Num, "SELECT estimated_cost_usd AS v FROM turn_token_usage WHERE id = 'ttu1'"))?.v).toBe(0.5);
+            // RETRACTED (#937/#966): turn cost no longer rides - it is an
+            // enrichment column now; the importer's re-derive (cost backfill
+            // covers turn rows) prices it against the LOCAL catalog.
+            expect((yield* one(Num, "SELECT estimated_cost_usd AS v FROM turn_token_usage WHERE id = 'ttu1'"))?.v).toBeNull();
             // TIMESTAMP fidelity through COPY TO JSON -> read_ndjson.
             expect((yield* one(Num, "SELECT CAST(epoch_ms(ts) AS DOUBLE) AS v FROM turn WHERE id = 't1'"))?.v).toBe(T0.getTime());
             // The watermark handshake mark, keyed by content.


### PR DESCRIPTION
Fix-forward for the fleet fix wave: #966 moved `turn_token_usage` cost columns into `ENRICHMENT_COLUMNS` (the cost backfill heals turn rows now), so segment export strips them - and the segment contract + roundtrip tests still pinned the old "parse-priced turn costs RIDE" decision, breaking repo-wide `bun test` on main.

Retracted in place, not silently: the pins now assert the strip and say why the old decision no longer holds; the export manifest note and the CLAUDE.md segment paragraph state that the importer's re-derive prices cost against the LOCAL catalog (the same PR extended the backfill to turn rows, so the loop closes).

Gates: segment suites 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)