### PR TITLE
docs(watermark): align comments with #955's imported-only sha set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,8 @@ from the projection - not nulled - so import's column-intersection upsert
 UPDATE` over exactly that set; NOT the spool) can never clobber local
 enrichment. Import also writes `__imported__/<kind>/<sha>` watermark marks
 (`importedMarkPath` + `FileWatermark.knownContentSha` - the jsonl work-unit
-refresh-skips a NEW path whose bytes carry a known sha), then triggers the
+refresh-skips a NEW path whose bytes carry an IMPORTED sha; since #955 only
+`__imported__/` marks feed that set, never ordinary file marks), then triggers the
 contract-driven re-derive (stages whose declared writes are all
 derive/enrich/bookkeep) over `--since=ceil(now - min(started_at))` through the
 exported `cmdIngest`. Catalogs never ride (dangling edges knit later by stable

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -232,9 +232,12 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                         const known =
                             contentSha !== null &&
                             (stored === contentSha ||
-                                // Same bytes under a NEW path (#902): moved file,
-                                // resynced dir, or a `segment import` sentinel
+                                // Same bytes under a NEW path (#902): a
+                                // `segment import` sentinel (__imported__/...)
                                 // attesting the content was loaded already.
+                                // Since #955 only imported marks feed this set -
+                                // an ordinary moved/resynced file matches by its
+                                // own stored (path, sha) mark instead.
                                 (stored === null && wm.knownContentSha(contentSha)));
                         if (known) {
                             refreshedUnchanged += 1;


### PR DESCRIPTION
Promised follow-up to external PR #955: the jsonl-work-unit comment still described the known-sha set as covering moved/resynced files, and the CLAUDE.md segment paragraph said "a known sha". Since #955 only `__imported__/` marks feed `knownContentSha`; ordinary moved files match their own (path, sha) mark. Comment + doc text only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)