### PR TITLE
fix(segment): transactional import + full-history re-derive on null start times

### DIFF
--- a/apps/axctl/src/segment/import.ts
+++ b/apps/axctl/src/segment/import.ts
@@ -19,7 +19,7 @@
  * `ceil(now - min(started_at))` - there is no session-scoped derive mode, so
  * the window is deliberately WIDE and its cost is the known post-#888 cost.
  */
-import { Data, Effect, Schema } from "effect";
+import { Data, Effect, Exit, Schema } from "effect";
 import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 import { hashFileSha256, importedMarkPath, WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
@@ -156,63 +156,91 @@ export const runSegmentImport = (
     plan: SegmentImportPlan,
 ): Effect.Effect<SegmentImportResult, SegmentImportError> =>
     Effect.gen(function* () {
-        for (const table of plan.tables) {
-            yield* loadTable(write, table).pipe(
+        const imported = yield* Effect.acquireUseRelease(
+            write.exec("BEGIN TRANSACTION").pipe(
                 Effect.mapError(
-                    (error) => new SegmentImportError({ message: `loading ${table.table}: ${String(error)}` }),
+                    (error) =>
+                        new SegmentImportError({ message: `starting import transaction: ${String(error)}` }),
                 ),
-            );
-        }
+            ),
+            () =>
+                Effect.gen(function* () {
+                    for (const table of plan.tables) {
+                        yield* loadTable(write, table).pipe(
+                            Effect.mapError(
+                                (error) => new SegmentImportError({ message: `loading ${table.table}: ${String(error)}` }),
+                            ),
+                        );
+                    }
 
-        // Watermark handshake: one `__imported__/<kind>/<sha>` mark per source
-        // file. Idempotent (PK is (source_kind, path)-derived).
-        let marksWritten = 0;
-        for (const source of plan.manifest.source_files) {
-            yield* write
-                .put(
-                    WATERMARK_TABLE,
-                    watermarkRow(source.source_kind, importedMarkPath(source.source_kind, source.sha), {
-                        sha: source.sha,
-                        size: source.size,
-                    }),
-                )
-                .pipe(
+                    // Watermark handshake: one `__imported__/<kind>/<sha>` mark per source
+                    // file. Idempotent (PK is (source_kind, path)-derived).
+                    let marksWritten = 0;
+                    for (const source of plan.manifest.source_files) {
+                        yield* write
+                            .put(
+                                WATERMARK_TABLE,
+                                watermarkRow(source.source_kind, importedMarkPath(source.source_kind, source.sha), {
+                                    sha: source.sha,
+                                    size: source.size,
+                                }),
+                            )
+                            .pipe(
+                                Effect.mapError(
+                                    (error) => new SegmentImportError({ message: `writing imported mark: ${String(error)}` }),
+                                ),
+                            );
+                        marksWritten += 1;
+                    }
+
+                    // The wide re-derive window, from the segment's own session file (the
+                    // local table may hold older sessions that would widen it for free).
+                    const OldestRow = Schema.Struct({ oldest: Schema.NullOr(Schema.String) });
+                    const sessionPlan = plan.tables.find((table) => table.table === "session");
+                    let rederiveSinceDays: number | null = null;
+                    if (sessionPlan !== undefined) {
+                        const rows = yield* write
+                            .rows(
+                                OldestRow,
+                                `SELECT CAST(min(started_at) AS VARCHAR) AS oldest
+                                 FROM read_ndjson('${sqlPath(sessionPlan.filePath)}', columns={started_at: 'TIMESTAMP'})`,
+                            )
+                            .pipe(
+                                Effect.mapError(
+                                    (error) => new SegmentImportError({ message: `reading oldest session: ${String(error)}` }),
+                                ),
+                            );
+                        const oldest = rows[0]?.oldest ?? null;
+                        if (oldest === null) {
+                            rederiveSinceDays = Math.max(1, Math.ceil(Date.now() / 86_400_000));
+                        } else {
+                            const ms = Date.now() - new Date(`${oldest.replace(" ", "T")}Z`).getTime();
+                            rederiveSinceDays = Math.max(1, Math.ceil(ms / 86_400_000));
+                        }
+                    }
+
+                    return { marksWritten, rederiveSinceDays };
+                }),
+            (_, exit) => {
+                const succeeded = Exit.isSuccess(exit);
+                const finish = (succeeded ? write.exec("COMMIT") : write.exec("ROLLBACK")).pipe(
+                    Effect.asVoid,
                     Effect.mapError(
-                        (error) => new SegmentImportError({ message: `writing imported mark: ${String(error)}` }),
+                        (error) =>
+                            new SegmentImportError({
+                                message: `${succeeded ? "committing" : "rolling back"} import transaction: ${String(error)}`,
+                            }),
                     ),
                 );
-            marksWritten += 1;
-        }
-
-        // The wide re-derive window, from the segment's own session file (the
-        // local table may hold older sessions that would widen it for free).
-        const OldestRow = Schema.Struct({ oldest: Schema.NullOr(Schema.String) });
-        const sessionPlan = plan.tables.find((table) => table.table === "session");
-        let rederiveSinceDays: number | null = null;
-        if (sessionPlan !== undefined) {
-            const rows = yield* write
-                .rows(
-                    OldestRow,
-                    `SELECT CAST(min(started_at) AS VARCHAR) AS oldest
-                     FROM read_ndjson('${sqlPath(sessionPlan.filePath)}', columns={started_at: 'TIMESTAMP'})`,
-                )
-                .pipe(
-                    Effect.mapError(
-                        (error) => new SegmentImportError({ message: `reading oldest session: ${String(error)}` }),
-                    ),
-                );
-            const oldest = rows[0]?.oldest ?? null;
-            if (oldest !== null) {
-                const ms = Date.now() - new Date(`${oldest.replace(" ", "T")}Z`).getTime();
-                rederiveSinceDays = Math.max(1, Math.ceil(ms / 86_400_000));
-            }
-        }
+                return succeeded ? finish : finish.pipe(Effect.ignore);
+            },
+        );
 
         return {
             sessions: plan.manifest.scope.sessions.length,
             tables: plan.tables,
-            marksWritten,
-            rederiveSinceDays,
+            marksWritten: imported.marksWritten,
+            rederiveSinceDays: imported.rederiveSinceDays,
             rederiveStages: rederiveStageKeys(),
         };
     });

--- a/apps/axctl/src/segment/roundtrip.duckdb.test.ts
+++ b/apps/axctl/src/segment/roundtrip.duckdb.test.ts
@@ -13,12 +13,19 @@ import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { CacheRead, type CacheWriteService } from "@ax/lib/duckdb/seam";
 import { runSegmentExport } from "./export.ts";
 import { planSegmentImport, runSegmentImport, type SegmentImportResult } from "./import.ts";
+import { ddlHash } from "./contract.ts";
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("segment round-trip", { requireFts: true });
 
 const T0 = new Date("2026-08-01T10:00:00.000Z");
 const RAW_FILE = "/machines/a/transcripts/seg-s1.jsonl";
 const SOURCE_SHA = "a".repeat(64);
+
+const sha256 = async (path: string): Promise<string> => {
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(await Bun.file(path).arrayBuffer());
+    return hasher.digest("hex");
+};
 
 const seedStoreA = (write: CacheWriteService) =>
     Effect.gen(function* () {
@@ -176,5 +183,106 @@ describe("segment export -> import round-trip on the shipped dylib", () => {
         await Bun.write(`${outDir}/turn.ndjson`, `{"id":"evil"}\n`);
         const tampered = await Effect.runPromise(planSegmentImport(outDir).pipe(Effect.flip));
         expect(String(tampered)).toContain("turn.ndjson does not match");
+    });
+
+    dtest("sessions without a start time use a full-history re-derive window", async () => {
+        const outDir = tempDir("ax-segment-null-time-");
+        const fixtureA = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-segment-null-time-a-"), dylibPath, (write) =>
+                write.put("session", {
+                    id: "null-time-session",
+                    source: "claude",
+                    started_at: null,
+                }),
+            ),
+        );
+        await readThroughFixture(
+            fixtureA,
+            dylibPath,
+            runSegmentExport({ sessions: ["null-time-session"], outDir, axVersion: "0.0.0-test" }),
+        );
+
+        let imported: SegmentImportResult | null = null;
+        await runWithPlatform(
+            publishCacheFixture(tempDir("ax-segment-null-time-b-"), dylibPath, (write) =>
+                Effect.gen(function* () {
+                    const plan = yield* planSegmentImport(outDir);
+                    imported = yield* runSegmentImport(write, plan);
+                }),
+            ),
+        );
+
+        expect(imported).not.toBeNull();
+        expect(imported!.rederiveStages.length).toBeGreaterThan(0);
+        expect(imported!.rederiveSinceDays).not.toBeNull();
+        expect(imported!.rederiveSinceDays).toBeGreaterThan(20_000);
+    });
+
+    dtest("a failed table load rolls back all earlier tables", async () => {
+        const segmentDir = tempDir("ax-segment-rollback-");
+        const sessionFile = `${segmentDir}/session.ndjson`;
+        const turnFile = `${segmentDir}/turn.ndjson`;
+        await Bun.write(
+            sessionFile,
+            `${JSON.stringify({
+                id: "partly-imported",
+                source: "claude",
+                started_at: "2026-08-01T00:00:00.000Z",
+            })}\n`,
+        );
+        await Bun.write(
+            turnFile,
+            `${JSON.stringify({
+                id: "bad-turn",
+                session: "partly-imported",
+                seq: "not-a-bigint",
+                ts: "2026-08-01T00:00:00.000Z",
+                role: "user",
+            })}\n`,
+        );
+        await Bun.write(
+            `${segmentDir}/manifest.json`,
+            `${JSON.stringify({
+                segment_version: 1,
+                created_at: "2026-08-21T00:00:00.000Z",
+                ax_version: "0.0.0-test",
+                ddl_hash: ddlHash(),
+                scope: { kind: "sessions", sessions: ["partly-imported"], since_days: null },
+                tables: [
+                    {
+                        table: "session",
+                        rows: 1,
+                        sha256: await sha256(sessionFile),
+                        columns: ["id", "source", "started_at"],
+                    },
+                    {
+                        table: "turn",
+                        rows: 1,
+                        sha256: await sha256(turnFile),
+                        columns: ["id", "session", "seq", "ts", "role"],
+                    },
+                ],
+                source_files: [],
+                notes: { cost_columns: "test", enrichment_stripped: true },
+            }, null, 2)}\n`,
+        );
+
+        const fixture = await runWithPlatform(
+            publishCacheFixture(tempDir("ax-segment-rollback-target-"), dylibPath, (write) =>
+                Effect.gen(function* () {
+                    const plan = yield* planSegmentImport(segmentDir);
+                    const failure = yield* runSegmentImport(write, plan).pipe(Effect.flip);
+                    expect(String(failure)).toContain("loading turn");
+
+                    const Count = Schema.Struct({ n: Schema.Number });
+                    const rows = yield* write.rows(
+                        Count,
+                        "SELECT CAST(count(*) AS DOUBLE) AS n FROM session WHERE id = 'partly-imported'",
+                    );
+                    expect(rows[0]?.n).toBe(0);
+                }),
+            ),
+        );
+        expect(fixture.snapshotPath).toBeTruthy();
     });
 });


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-segment.

- #986: sessions with null `started_at` made `min()` null, leaving `rederiveSinceDays` null so the CLI skipped ALL derive stages. A null minimum now falls back to a full-history window (days-since-epoch), matching the "wide by design" re-derive intent.
- #987: table loads ran as separate statements with no transaction, so a mid-load failure left earlier tables' rows in the live store for a later ingest to publish (dangling). All table loads + watermark marks now run inside one `acquireUseRelease` transaction (BEGIN -> load -> COMMIT on success / ROLLBACK on any failure or defect).

Noted follow-up (pane): a `transaction` helper on CacheWriteService would generalize this for other multi-statement cache writes.

Gates: segment suites 10/10 (both red->green), tsc clean, both cast checks clean.

Fixes #986
Fixes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)