### PR TITLE
fix: ownership-token freshness claim + serialized SQL-model windows

### DIFF
--- a/apps/axctl/src/ingest/models/models.test.ts
+++ b/apps/axctl/src/ingest/models/models.test.ts
@@ -7,9 +7,10 @@
  * pinned to its source of truth so the two cannot drift silently.
  */
 import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
 import { parseDuckdbTables } from "@ax/schema/duckdb-ddl";
 import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
-import { parseModelHeader } from "./runner.ts";
+import { parseModelHeader, runSqlModel } from "./runner.ts";
 import {
     RUN_EVIDENCE_EVENT_MODEL,
     RUN_EVIDENCE_MODELS,
@@ -59,6 +60,54 @@ describe("model header contract", () => {
                 expect(before).toContain("CAST(");
             }
         }
+    });
+});
+
+describe("SQL model runner", () => {
+    test("each concurrent model observes the since_days value that its caller set", async () => {
+        let markSecondSet!: () => void;
+        let markFirstSet!: () => void;
+        const firstSet = new Promise<void>((resolve) => {
+            markFirstSet = resolve;
+        });
+        const secondSet = new Promise<void>((resolve) => {
+            markSecondSet = resolve;
+        });
+        let sinceDays = "unset";
+        const observed = new Map<string, string>();
+
+        const write = {
+            exec: (sql: string) =>
+                Effect.promise(async () => {
+                    if (sql === "SET VARIABLE since_days = NULL") {
+                        sinceDays = "NULL";
+                        markFirstSet();
+                        await Promise.race([secondSet, Bun.sleep(20)]);
+                        return 0;
+                    }
+                    if (sql === "SET VARIABLE since_days = 1") {
+                        await firstSet;
+                        sinceDays = "1";
+                        markSecondSet();
+                        return 0;
+                    }
+                    observed.set(sql, sinceDays);
+                    return 0;
+                }),
+        };
+
+        await Effect.runPromise(
+            Effect.all(
+                [
+                    runSqlModel(write as never, { name: "rebuild", sql: "REBUILD_MODEL" }, undefined),
+                    runSqlModel(write as never, { name: "windowed", sql: "WINDOWED_MODEL" }, 1),
+                ],
+                { concurrency: "unbounded" },
+            ),
+        );
+
+        expect(observed.get("REBUILD_MODEL")).toBe("NULL");
+        expect(observed.get("WINDOWED_MODEL")).toBe("1");
     });
 });
 

--- a/apps/axctl/src/ingest/models/runner.ts
+++ b/apps/axctl/src/ingest/models/runner.ts
@@ -21,7 +21,7 @@
  * v1 runs an explicit ordered list per stage; the `inputs` header seeds a
  * future topological runner once there is more than one dependency chain.
  */
-import { Effect } from "effect";
+import { Effect, Semaphore } from "effect";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 
 export interface SqlModel {
@@ -36,6 +36,18 @@ export interface ParsedModelHeader {
     readonly inputs: readonly string[];
     readonly rebuild: "incremental" | "full_rebuild";
 }
+
+/** One gate per shared write connection keeps the session variable and its
+ * model statement in one critical section. */
+const modelGates = new WeakMap<CacheWriteService, Semaphore.Semaphore>();
+
+const modelGate = (write: CacheWriteService): Semaphore.Semaphore => {
+    const existing = modelGates.get(write);
+    if (existing !== undefined) return existing;
+    const gate = Semaphore.makeUnsafe(1);
+    modelGates.set(write, gate);
+    return gate;
+};
 
 /** Parse the header contract. Throws on a malformed file - a model that does
  *  not declare its shape must not run. */
@@ -65,14 +77,16 @@ export const runSqlModel = (
     model: SqlModel,
     sinceDays: number | undefined,
 ): Effect.Effect<number, CacheWriteError> =>
-    Effect.gen(function* () {
-        // The variable is session-scoped on the shared write connection, so it
-        // is ALWAYS set (NULL included) - a stale value from a previous stage
-        // must never leak into this run's window.
-        const since =
-            sinceDays !== undefined && Number.isFinite(sinceDays) && sinceDays > 0
-                ? String(Math.trunc(sinceDays))
-                : "NULL";
-        yield* write.exec(`SET VARIABLE since_days = ${since}`);
-        return yield* write.exec(model.sql);
-    });
+    modelGate(write).withPermits(1)(
+        Effect.gen(function* () {
+            // The variable is session-scoped on the shared write connection, so it
+            // is ALWAYS set (NULL included) - a stale value from a previous stage
+            // must never leak into this run's window.
+            const since =
+                sinceDays !== undefined && Number.isFinite(sinceDays) && sinceDays > 0
+                    ? String(Math.trunc(sinceDays))
+                    : "NULL";
+            yield* write.exec(`SET VARIABLE since_days = ${since}`);
+            return yield* write.exec(model.sql);
+        }),
+    );

--- a/apps/axctl/src/queries/ingest-staleness.test.ts
+++ b/apps/axctl/src/queries/ingest-staleness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Effect, FileSystem, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -268,6 +268,102 @@ describe("maybeSpawnBackgroundIngest (freshness drive)", () => {
             const calls: number[] = [];
             await runDrive(db, calls);
             expect(calls).toHaveLength(1);
+        });
+    });
+
+    test("two-process stale-claim interleave does not remove a replacement claim", async () => {
+        await withScratchDataDir(async (dir) => {
+            const claimPath = join(dir, "freshness-drive-claim");
+            writeFileSync(claimPath, "stale-owner\n");
+            const old = new Date(Date.now() - 11 * 60 * 1000);
+            utimesSync(claimPath, old, old);
+
+            let statCount = 0;
+            let readCount = 0;
+            let removeCount = 0;
+            let replacementCreatedResolve!: () => void;
+            let bothStatsResolve!: () => void;
+            let secondSpawnResolve!: () => void;
+            const replacementCreated = new Promise<void>((resolve) => {
+                replacementCreatedResolve = resolve;
+            });
+            const bothStats = new Promise<void>((resolve) => {
+                bothStatsResolve = resolve;
+            });
+            const secondSpawn = new Promise<void>((resolve) => {
+                secondSpawnResolve = resolve;
+            });
+
+            const interleavingFs = Layer.effect(
+                FileSystem.FileSystem,
+                Effect.gen(function* () {
+                    const fs = yield* FileSystem.FileSystem;
+                    return {
+                        ...fs,
+                        readFileString: (path: string, encoding?: string) => {
+                            if (path !== claimPath) return fs.readFileString(path, encoding);
+                            readCount += 1;
+                            if (readCount !== 4) return fs.readFileString(path, encoding);
+                            return Effect.promise(() => replacementCreated).pipe(
+                                Effect.andThen(fs.readFileString(path, encoding)),
+                            );
+                        },
+                        stat: (path: string) => {
+                            if (path !== claimPath) return fs.stat(path);
+                            return Effect.gen(function* () {
+                                const info = yield* fs.stat(path);
+                                statCount += 1;
+                                if (statCount === 2) bothStatsResolve();
+                                yield* Effect.promise(() => bothStats);
+                                return info;
+                            });
+                        },
+                        remove: (
+                            path: string,
+                            options?: Parameters<FileSystem.FileSystem["remove"]>[1],
+                        ) => {
+                            if (path !== claimPath) return fs.remove(path, options);
+                            removeCount += 1;
+                            if (removeCount !== 2) return fs.remove(path, options);
+                            return Effect.promise(() => replacementCreated).pipe(
+                                Effect.andThen(fs.remove(path, options)),
+                            );
+                        },
+                        writeFileString: (
+                            path: string,
+                            data: string,
+                            options?: Parameters<FileSystem.FileSystem["writeFileString"]>[2],
+                        ) =>
+                            fs.writeFileString(path, data, options).pipe(
+                                Effect.tap(() =>
+                                    path === claimPath && options?.flag === "wx"
+                                        ? Effect.sync(replacementCreatedResolve)
+                                        : Effect.void,
+                                ),
+                            ),
+                    };
+                }),
+            ).pipe(Layer.provide(BunFileSystem.layer));
+
+            let spawnCount = 0;
+            const spawner = Layer.succeed(BackgroundIngestSpawner, {
+                spawn: () =>
+                    Effect.promise(async () => {
+                        spawnCount += 1;
+                        if (spawnCount === 2) secondSpawnResolve();
+                        else await Promise.race([secondSpawn, Bun.sleep(20)]);
+                    }),
+            });
+            const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000));
+            const layer = Layer.mergeAll(db, spawner, interleavingFs, BunPath.layer);
+
+            await Effect.runPromise(
+                Effect.all([maybeSpawnBackgroundIngest, maybeSpawnBackgroundIngest], {
+                    concurrency: "unbounded",
+                }).pipe(Effect.provide(layer)),
+            );
+
+            expect(spawnCount).toBe(1);
         });
     });
 

--- a/apps/axctl/src/queries/ingest-staleness.ts
+++ b/apps/axctl/src/queries/ingest-staleness.ts
@@ -182,31 +182,49 @@ const writeFreshnessState = (next: FreshnessState): Effect.Effect<void, never, F
  *  freshness drive stays off forever. */
 const FRESHNESS_CLAIM_STALE_MS = 10 * 60 * 1000;
 
+const readFreshnessSpawnClaim = (): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        return yield* fs.readFileString(freshnessClaimPath()).pipe(orAbsent<string | null>(null));
+    });
+
 /** Atomically claim the right to spawn. `wx` maps to O_EXCL, so only one
- *  process can pass this point. The caller always removes its claim. */
-const tryClaimFreshnessSpawn = (): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+ *  process can pass this point. The returned token identifies this claim. */
+const tryClaimFreshnessSpawn = (): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         yield* fs.makeDirectory(dataDir(), { recursive: true }).pipe(orAbsent<void>(undefined));
         const claim = () =>
-            fs
-                .writeFileString(freshnessClaimPath(), `${process.pid}\n`, { flag: "wx" })
-                .pipe(Effect.as(true), orAbsent(false));
+            Effect.suspend(() => {
+                const token = `${process.pid}:${crypto.randomUUID()}\n`;
+                return fs
+                    .writeFileString(freshnessClaimPath(), token, { flag: "wx" })
+                    .pipe(Effect.as<string | null>(token), orAbsent<string | null>(null));
+            });
         const claimed = yield* claim();
-        if (claimed) return true;
+        if (claimed !== null) return claimed;
+        const staleToken = yield* readFreshnessSpawnClaim();
+        if (staleToken === null) return yield* claim();
         const mtimeMs = yield* fs.stat(freshnessClaimPath()).pipe(
             Effect.map((info) => Option.match(info.mtime, { onSome: (d) => d.getTime(), onNone: () => Date.now() })),
             orAbsent(Date.now()),
         );
-        if (Date.now() - mtimeMs < FRESHNESS_CLAIM_STALE_MS) return false;
+        if (Date.now() - mtimeMs < FRESHNESS_CLAIM_STALE_MS) return null;
+        // Another reclaimer can replace the stale file after our stat. Remove
+        // only the exact claim that we classified as stale.
+        const currentToken = yield* readFreshnessSpawnClaim();
+        if (currentToken !== staleToken) return null;
         yield* fs.remove(freshnessClaimPath(), { force: true }).pipe(Effect.ignore);
         return yield* claim();
     });
 
-const releaseFreshnessSpawnClaim: Effect.Effect<void, never, FileSystem.FileSystem> =
+const releaseFreshnessSpawnClaim = (token: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        yield* fs.remove(freshnessClaimPath(), { force: true }).pipe(Effect.ignore);
+        const currentToken = yield* readFreshnessSpawnClaim();
+        if (currentToken === token) {
+            yield* fs.remove(freshnessClaimPath(), { force: true }).pipe(Effect.ignore);
+        }
     });
 
 /**
@@ -239,8 +257,8 @@ export const maybeSpawnBackgroundIngest: Effect.Effect<
         return;
     }
 
-    const claimed = yield* tryClaimFreshnessSpawn();
-    if (!claimed) return;
+    const claimToken = yield* tryClaimFreshnessSpawn();
+    if (claimToken === null) return;
 
     yield* Effect.gen(function* () {
         // Another process can finish between our first state read and this
@@ -259,7 +277,7 @@ export const maybeSpawnBackgroundIngest: Effect.Effect<
         const spawner = yield* BackgroundIngestSpawner;
         yield* spawner.spawn();
         yield* writeFreshnessState({ ...claimedState, lastSpawnAtMs: nowMs });
-    }).pipe(Effect.ensuring(releaseFreshnessSpawnClaim));
+    }).pipe(Effect.ensuring(releaseFreshnessSpawnClaim(claimToken)));
 }).pipe(
     Effect.timeoutOption(PROBE_TIMEOUT_MS),
     // Same "never fails" contract as warnIfIngestStale - a defect (EPIPE, a


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-staleness-models.

- #995 (TOCTOU in the #961 reclaim path): each claim now writes a unique `pid:uuid` token. The stale-reclaim path re-reads the token and removes the file ONLY when it still holds the exact token it classified as stale, so a concurrent reclaimer that already replaced the file makes the loser abort. Release removes only a claim still carrying its own token. The forced two-process interleave test (A replaces the file before B's second read) drives this path red->green.
- #996: `SET VARIABLE since_days` + model exec were separate calls on a shared connection, so a concurrent stage could change the window between them (a rebuild then processed the wrong window and stamped its version marker). A per-write-service Semaphore(1) now serializes each SET+exec pair.

Noted follow-up (pane): a later change can bind the cutoff as a statement parameter and drop the session variable entirely.

Gates: ingest-staleness + models suites 31/31 (both red->green), tsc clean, both cast checks clean.

Fixes #995
Fixes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)