### PR TITLE
fix: skill-spar restore, quota/routing time compares, NavLink shell quoting, share truncation, studio 404

### DIFF
--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -51,6 +51,7 @@ import {
     renderSkillSparReport,
     resolveSkillSparTask,
     scoreSkillSpar,
+    verifyAndRestoreSkill,
 } from "../../dojo/skill-spar.ts";
 import { mainRepoRootFromGitCommonDir, resolvePwdCacheRepository } from "../../pwd.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
@@ -589,6 +590,10 @@ const sparScoreCommand = Command.make(
                     );
                     return yield* exitEffect(1);
                 }
+                yield* verifyAndRestoreSkill(
+                    skillBrief,
+                    posixPath.join(dojoSparDir(), `${id}.skill.orig.md`),
+                );
                 const { mainRepoRoot } = yield* resolveRepo;
                 // sinceForChurn: same derivation as the code-delta path (new Date(brief.createdAt))
                 const sinceForChurn = new Date(skillBrief.createdAt);

--- a/apps/axctl/src/dashboard/studio-assets.test.ts
+++ b/apps/axctl/src/dashboard/studio-assets.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { serveStudioAsset, shouldServeSpaFallback } from "./studio-assets.ts";
+
+describe("serveStudioAsset", () => {
+    test("returns null for a missing extensioned asset", async () => {
+        expect(await serveStudioAsset("/missing-runtime.js")).toBeNull();
+        expect(await serveStudioAsset("/missing.css")).toBeNull();
+    });
+
+    test("permits fallback only for extensionless client routes", () => {
+        expect(shouldServeSpaFallback("/sessions/abc")).toBe(true);
+        expect(shouldServeSpaFallback("/missing-runtime.js")).toBe(false);
+        expect(shouldServeSpaFallback("/missing.css")).toBe(false);
+        expect(shouldServeSpaFallback("/assets/missing")).toBe(false);
+    });
+});

--- a/apps/axctl/src/dashboard/studio-assets.ts
+++ b/apps/axctl/src/dashboard/studio-assets.ts
@@ -57,6 +57,13 @@ function fileResponse(filePath: string, urlPath: string): Response {
     });
 }
 
+/** Client routes have no extension. Missing files must never receive HTML. */
+export const shouldServeSpaFallback = (pathname: string): boolean => {
+    if (pathname.startsWith("/assets/")) return false;
+    const segment = pathname.slice(pathname.lastIndexOf("/") + 1);
+    return !segment.includes(".");
+};
+
 /**
  * Resolve a request pathname to a studio asset Response, or null if this build
  * does not bundle studio (and nothing is on disk). Asset misses under /assets/
@@ -72,7 +79,7 @@ export async function serveStudioAsset(pathname: string): Promise<Response | nul
     if (HAS_EMBED) {
         const hit = STUDIO_EMBED[clean];
         if (hit) return fileResponse(hit, clean);
-        if (!clean.startsWith("/assets/")) {
+        if (shouldServeSpaFallback(clean)) {
             const index = STUDIO_EMBED["/index.html"];
             if (index) return fileResponse(index, "/index.html");
         }
@@ -84,7 +91,7 @@ export async function serveStudioAsset(pathname: string): Promise<Response | nul
     // valid path join (and keeps node:path out - repo gate check:no-node-fs).
     const directPath = DISK_ROOT + clean.slice(1);
     if (await Bun.file(directPath).exists()) return fileResponse(directPath, clean);
-    if (!clean.startsWith("/assets/")) {
+    if (shouldServeSpaFallback(clean)) {
         const indexPath = `${DISK_ROOT}index.html`;
         if (await Bun.file(indexPath).exists()) return fileResponse(indexPath, "/index.html");
     }

--- a/apps/axctl/src/dojo/skill-spar.test.ts
+++ b/apps/axctl/src/dojo/skill-spar.test.ts
@@ -5,6 +5,7 @@ import { makeTestCacheRead, type TestCacheOptions } from "@ax/lib/testing/cache"
 import type { CacheRead } from "@ax/lib/duckdb/seam";
 import type { Judgment } from "@ax/lib/sqlite";
 import { ProcessServiceTest } from "@ax/lib/process";
+import { BunFileSystem } from "@effect/platform-bun";
 import { layerTestFileSystem } from "@ax/lib/testing/test-filesystem";
 import {
     renderSkillSparBrief,
@@ -15,6 +16,7 @@ import {
     renderSkillSparReport,
     type SkillSparBrief,
     type ResolveSkillSparOpts,
+    verifyAndRestoreSkill,
 } from "./skill-spar.ts";
 import type { SparScore, SparMetrics } from "./spar.ts";
 
@@ -171,9 +173,9 @@ describe("renderSkillSparBrief / parseSkillSparBrief round-trip", () => {
         expect(rendered).toContain(`cp "/tmp/ax-new-abc.md"`);
         expect(rendered).toContain(`cp "/tmp/ax-orig-abc.md"`);
         // The two cp sources must differ (arm B must NOT run the original skill).
-        const cpLines = rendered.split("\n").filter((l) => l.trimStart().startsWith("cp "));
-        const sources = cpLines.map((l) => l.split('"')[1]);
-        expect(new Set(sources).size).toBeGreaterThan(1);
+        expect(rendered.indexOf(`cp "/tmp/ax-orig-abc.md"`)).toBeLessThan(
+            rendered.indexOf(`cp "/tmp/ax-new-abc.md"`),
+        );
     });
 
     // DEFECT 3: a task body with its own `## ` subheading must round-trip whole.
@@ -223,6 +225,18 @@ describe("renderSkillSparBrief / parseSkillSparBrief round-trip", () => {
         expect(guardIdx).toBeLessThan(cpIdx);
     });
 
+    test("Arm B command restores the global skill through an EXIT trap", () => {
+        const rendered = renderSkillSparBrief(BASE_BRIEF, {
+            worktreeBAbs: "/tmp/arm-b",
+            snapshotPathAbs: "/tmp/original.md",
+            editedPathAbs: "/tmp/edited.md",
+        });
+        expect(rendered).toContain(
+            `trap 'cp "/tmp/original.md" "/Users/user/.claude/skills/my-skill/SKILL.md"' EXIT;`,
+        );
+        expect(rendered).toContain(`cd "/tmp/arm-b"; claude`);
+    });
+
     // New: editedPath in guard and cp must be the same path as the save-target note
     test("editedPath in guard/cp matches the path given in the save-to note (consistency)", () => {
         const editedPath = "/Users/user/.ax/dojo/spar/my-skill-abc123-2026-06-16.skill.edited.md";
@@ -255,6 +269,32 @@ describe("renderSkillSparBrief / parseSkillSparBrief round-trip", () => {
         const parsed = parseSkillSparBrief(rendered);
         expect(parsed).not.toBeNull();
         expect(parsed!.editedSkill).toBe(brief.editedSkill);
+    });
+});
+
+describe("verifyAndRestoreSkill", () => {
+    test("restores and warns when Arm B leaves the global skill swapped", async () => {
+        const dir = `${process.env.TMPDIR ?? "/tmp"}/ax-spar-restore-${crypto.randomUUID()}`;
+        const skillDir = `${dir}/skill`;
+        const target = `${skillDir}/SKILL.md`;
+        const snapshot = `${dir}/original.md`;
+        await Bun.write(target, "edited", { createPath: true });
+        await Bun.write(snapshot, "original", { createPath: true });
+        const warn = console.warn;
+        const warnings: string[] = [];
+        console.warn = (message?: unknown) => warnings.push(String(message));
+        try {
+            const restored = await Effect.runPromise(
+                verifyAndRestoreSkill({ ...BASE_BRIEF, skillDir }, snapshot).pipe(
+                    Effect.provide(BunFileSystem.layer),
+                ),
+            );
+            expect(restored).toBe(true);
+            expect(await Bun.file(target).text()).toBe("original");
+            expect(warnings[0]).toContain("restored");
+        } finally {
+            console.warn = warn;
+        }
     });
 });
 

--- a/apps/axctl/src/dojo/skill-spar.ts
+++ b/apps/axctl/src/dojo/skill-spar.ts
@@ -159,11 +159,7 @@ export const renderSkillSparBrief = (
         "## Swap commands",
         "",
         "```bash",
-        `# swap-in (activate edited skill for Arm B)`,
-        `test -f ${sh(editedPath)} || { echo "ERROR: edited skill not found at ${editedPath} - write it before swapping (arm B would otherwise run the ORIGINAL skill)"; exit 1; }`,
-        `cp ${sh(editedPath)} ${sh(skillTarget)}`,
-        `# swap-out (restore original after Arm B completes)`,
-        `cp ${sh(snapshotPath)} ${sh(skillTarget)}`,
+        `trap 'cp ${sh(snapshotPath)} ${sh(skillTarget)}' EXIT; test -f ${sh(editedPath)} || { echo "ERROR: edited skill not found at ${editedPath} - write it before swapping (arm B would otherwise run the ORIGINAL skill)"; exit 1; }; cp ${sh(editedPath)} ${sh(skillTarget)}; cd ${sh(worktreeBPath)}; claude`,
         "```",
         "",
         "## Edited skill",
@@ -177,10 +173,8 @@ export const renderSkillSparBrief = (
         `0. Write your edited SKILL.md to \`${editedPath}\` (you can compose it in the "Edited skill" section above, then save it to that path).`,
         `1. Pin both worktrees (see Worktrees above).`,
         `2. **Arm A** - run the task in \`${brief.worktreeA}\` with the original skill (no swap needed).`,
-        `3. **Swap in** - run the swap-in command above (it will fail loudly if the edited file is missing).`,
-        `4. **Arm B** - run the task in \`${brief.worktreeB}\` with the edited skill active.`,
-        `5. **Swap out** - \`cp ${sh(snapshotPath)} ${sh(skillTarget)}\``,
-        `6. Score: \`ax dojo spar-score ${brief.id}\``,
+        `3. **Arm B** - run the single command above. Its EXIT trap restores the original skill on every exit.`,
+        `4. Score: \`ax dojo spar-score ${brief.id}\``,
         "",
         "> **Concurrency caveat**: do not run other Claude sessions while the swap is active - the skill swap is global.",
         "",
@@ -604,6 +598,24 @@ export const scoreSkillSpar = (
         yield* stampSparSession(sessionB).pipe(Effect.catch(() => Effect.void));
 
         return { sessionA, sessionB, a, b, score };
+    });
+
+/** Restore a leaked Arm B swap before spar-score reads any run evidence. */
+export const verifyAndRestoreSkill = (
+    brief: SkillSparBrief,
+    snapshotPath: string,
+) =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const targetPath = `${brief.skillDir}/SKILL.md`;
+        const [live, snapshot] = yield* Effect.all([
+            fs.readFileString(targetPath),
+            fs.readFileString(snapshotPath),
+        ]);
+        if (live === snapshot) return false;
+        yield* fs.writeFileString(targetPath, snapshot);
+        console.warn(`ax dojo spar-score: restored ${targetPath} from ${snapshotPath}`);
+        return true;
     });
 
 // ---------------------------------------------------------------------------

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -15,10 +15,26 @@ import {
     buildSkillsRolesNext,
     buildRolesNext,
     buildImproveProposalsNext,
+    skillRolesLink,
     studioSessionUrl,
     studioSessionLink,
     type StudioDeeplink,
 } from "./next-links.ts";
+
+describe("shell-safe commands (#981)", () => {
+    test("quotes hostile dynamic values as one POSIX shell argument", () => {
+        expect(skillRolesLink("review skill; touch /tmp/pwn").cmd).toBe(
+            "ax skills roles 'review skill; touch /tmp/pwn'",
+        );
+        expect(skillRolesLink("review' skill").cmd).toBe(
+            "ax skills roles 'review'\"'\"' skill'",
+        );
+        const links = buildImproveProposalsNext([{ sig: "x; touch /tmp/pwn", title: "x" }]);
+        expect(links.map((link) => link.cmd)).toContain(
+            "ax improve show 'x; touch /tmp/pwn'",
+        );
+    });
+});
 
 const UUID_A = "019e2531-b552-7b53-a029-c780adbb6560";
 const UUID_B = "019e9999-aaaa-7b53-a029-c780adbb6560";
@@ -96,7 +112,7 @@ describe("buildRecallNext", () => {
         expect(hits[0]?.next).toHaveLength(1);
         expect(hits[0]?.next?.[0]?.call?.tool).toBe("session_show");
         expect(hits[0]?.next?.[0]?.call?.arguments).toEqual({ sessionId: UUID_A });
-        expect(hits[0]?.next?.[0]?.cmd).toBe(`ax sessions show ${UUID_A}`);
+        expect(hits[0]?.next?.[0]?.cmd).toBe(`ax sessions show '${UUID_A}'`);
     });
 
     test("top-level next carries resume cmd for claude hit with cwd", () => {
@@ -187,7 +203,7 @@ describe("buildSessionsNext", () => {
     test("non-empty window suggests the churn rollup", () => {
         const { next } = buildSessionsNext([row({})], { project: "/Users/x/proj" });
         const churn = next.find((l) => l.cmd?.includes("sessions churn"));
-        expect(churn?.cmd).toBe('ax sessions churn --project="/Users/x/proj"');
+        expect(churn?.cmd).toBe("ax sessions churn --project='/Users/x/proj'");
     });
 
     test("non-empty window without project suggests bare churn", () => {
@@ -270,7 +286,7 @@ describe("buildSessionShowNext", () => {
             ),
         );
         const expand = next.find((l) => l.call?.arguments.expandAll === true);
-        expect(expand?.cmd).toBe(`ax sessions show ${UUID_A} --all`);
+        expect(expand?.cmd).toBe(`ax sessions show '${UUID_A}' --all`);
     });
 
     test("no overview → empty next", () => {
@@ -429,7 +445,7 @@ describe("buildSkillsRolesNext", () => {
             "tdd",
         );
         expect(next[0]?.call?.tool).toBe("skills_by_role");
-        expect(next[0]?.cmd).toBe("ax skills by-role verifier");
+        expect(next[0]?.cmd).toBe("ax skills by-role 'verifier'");
     });
 });
 

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -49,6 +49,9 @@ export const NEXT_PROTOCOL_HINT =
 // Shared link constructors
 // ---------------------------------------------------------------------------
 
+/** Quote one dynamic value as one POSIX shell argument. */
+const shellArg = (value: string): string => `'${value.replaceAll("'", `'\"'\"'`)}'`;
+
 // ---------------------------------------------------------------------------
 // Studio deeplinks
 // ---------------------------------------------------------------------------
@@ -103,7 +106,7 @@ export const sessionShowLink = (
     return {
         description,
         call: { tool: "session_show", arguments: { sessionId: id } },
-        cmd: `ax sessions show ${id}`,
+        cmd: `ax sessions show ${shellArg(id)}`,
         ui: { priority, group: "read" },
     };
 };
@@ -116,7 +119,7 @@ export const skillRolesLink = (
 ): NavLink => ({
     description,
     call: { tool: "skills_roles", arguments: { skill } },
-    cmd: `ax skills roles ${skill}`,
+    cmd: `ax skills roles ${shellArg(skill)}`,
     ui: { priority, group: "read" },
 });
 
@@ -156,7 +159,7 @@ const sessionsAroundLink = (
     return {
         description,
         call: { tool: "sessions_around", arguments: { date, days } },
-        cmd: `ax sessions around ${date} --days=${days}`,
+        cmd: `ax sessions around ${shellArg(date)} --days=${shellArg(String(days))}`,
         ui: { priority, group: "search" },
     };
 };
@@ -224,7 +227,7 @@ export const buildRecallNext = (
     const broaden: NavLink = {
         description: "Broaden the search to all sources (turns, commits, skills)",
         call: { tool: "recall", arguments: { q: r.q, sources: [...ALL_SOURCES] } },
-        cmd: `ax recall ${JSON.stringify(r.q)} --sources=turn,commit,skill`,
+        cmd: `ax recall ${shellArg(r.q)} --sources=turn,commit,skill`,
         ui: { priority: 4, group: "search" },
     };
     const subsetRequested = opts.requestedSources.length < ALL_SOURCES.length;
@@ -305,7 +308,7 @@ export const buildSessionsNext = (
             description: "Aggregate verification churn (edit vs repair LOC, failed checks) for this scope",
             call: { tool: "sessions_churn", arguments: opts.project ? { project: opts.project } : {} },
             cmd: opts.project
-                ? `ax sessions churn --project="${opts.project}"`
+                ? `ax sessions churn --project=${shellArg(opts.project)}`
                 : "ax sessions churn",
             ui: { priority: 5, group: "read" },
         });
@@ -329,7 +332,7 @@ export const buildSessionsNext = (
                     tool: "sessions_around",
                     arguments: { date: opts.date.slice(0, 10), days: opts.days ?? 3 },
                 },
-                cmd: `ax sessions around ${opts.date.slice(0, 10)} --days=${opts.days ?? 3}`,
+                cmd: `ax sessions around ${shellArg(opts.date.slice(0, 10))} --days=${shellArg(String(opts.days ?? 3))}`,
                 ui: { priority: 8, group: "search" },
             });
         }
@@ -445,7 +448,7 @@ export const buildSessionShowNext = (
         top.push({
             description: `Expand all ${p.session.children.length} subagent children inline`,
             call: { tool: "session_show", arguments: { sessionId: id, expandAll: true } },
-            cmd: `ax sessions show ${id} --all`,
+            cmd: `ax sessions show ${shellArg(id)} --all`,
             ui: { priority: 7, group: "read" },
         });
     }
@@ -465,7 +468,7 @@ const skillsByRoleLink = (
 ): NavLink => ({
     description,
     call: { tool: "skills_by_role", arguments: { role } },
-    cmd: `ax skills by-role ${role}`,
+    cmd: `ax skills by-role ${shellArg(role)}`,
     ui: { priority, group: "read" },
 });
 
@@ -534,7 +537,7 @@ export const buildSkillsRolesNext = (
         top.push({
             description: `Unknown skill "${skill}" - search the skill catalog for the right name`,
             call: { tool: "recall", arguments: { q: skill, sources: ["skill"] } },
-            cmd: `ax recall ${JSON.stringify(skill)} --sources=skill`,
+            cmd: `ax recall ${shellArg(skill)} --sources=skill`,
             ui: { priority: 9, group: "search" },
         });
         return top;
@@ -659,12 +662,12 @@ export const buildImproveProposalsNext = (
     top.push({
         description: `Inspect the evidence trail behind the top proposal ("${first.title.slice(0, 60)}")`,
         call: { tool: "improve_show", arguments: { sigOrId: first.sig } },
-        cmd: `ax improve show ${first.sig}`,
+        cmd: `ax improve show ${shellArg(first.sig)}`,
         ui: { priority: 7, group: "read" },
     });
     top.push({
         description: "Accept the top proposal (emits a .ax/tasks brief; CLI-only, mutating)",
-        cmd: `ax improve accept ${first.sig}`,
+        cmd: `ax improve accept ${shellArg(first.sig)}`,
         ui: { priority: 5, group: "act" },
     });
     return sortNavLinks(top);

--- a/apps/axctl/src/quota/cache.test.ts
+++ b/apps/axctl/src/quota/cache.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { isFresh } from "./cache.ts";
+import type { QuotaSnapshot } from "./schema.ts";
+
+const snapshot = (fetchedAt: string): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: fetchedAt,
+    five_hour: null,
+    seven_day: null,
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    extra_usage: null,
+});
+
+describe("isFresh", () => {
+    test("rejects a future-dated cache entry", () => {
+        const now = Date.parse("2026-08-21T00:00:00.000Z");
+        expect(isFresh(snapshot("2026-08-22T00:00:00.000Z"), now, 60)).toBe(false);
+    });
+});

--- a/apps/axctl/src/quota/cache.ts
+++ b/apps/axctl/src/quota/cache.ts
@@ -41,5 +41,6 @@ export const isFresh = (
 ): boolean => {
     const fetchedMs = Date.parse(snapshot.fetched_at);
     if (!Number.isFinite(fetchedMs)) return false;
-    return nowMs - fetchedMs < maxAgeSeconds * 1000;
+    const ageMs = nowMs - fetchedMs;
+    return ageMs >= 0 && ageMs < maxAgeSeconds * 1000;
 };

--- a/apps/axctl/src/routing-impact/compute.test.ts
+++ b/apps/axctl/src/routing-impact/compute.test.ts
@@ -50,6 +50,18 @@ describe("buildImpactReport - single block", () => {
         expect(blocks[0]!.fiveHourPpConsumed).toBeNull();
     });
 
+    test("accepts equal reset instants with different ISO formats", () => {
+        const { blocks } = buildImpactReport([
+            block({
+                arm: "off",
+                fiveHourStart: edge(10, "2026-06-19T20:00:00Z"),
+                fiveHourEnd: edge(20, "2026-06-19T20:00:00.000Z"),
+            }),
+        ]);
+        expect(blocks[0]!.windowReset).toBe(false);
+        expect(blocks[0]!.fiveHourPpConsumed).toBe(10);
+    });
+
     test("null quota edges → no window delta, note emitted", () => {
         const { blocks, notes } = buildImpactReport([
             block({ arm: "off", fiveHourStart: null, fiveHourEnd: null }),

--- a/apps/axctl/src/routing-impact/compute.ts
+++ b/apps/axctl/src/routing-impact/compute.ts
@@ -85,7 +85,8 @@ const round = (n: number, dp = 2): number => {
 
 /** Did the 5h window roll over between the two edges? */
 const didReset = (start: WindowEdge, end: WindowEdge): boolean =>
-    end.resets_at !== start.resets_at || end.utilization < start.utilization;
+    new Date(end.resets_at).getTime() !== new Date(start.resets_at).getTime() ||
+    end.utilization < start.utilization;
 
 const resolveBlock = (b: BlockInput): BlockResult => {
     const durationMin = round(minutesBetween(b.started_at, b.ended_at), 1);

--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -40,6 +40,10 @@ export interface AxSessionShare {
         readonly skills_used: number;
         readonly failures: number;
     };
+    /** Total eligible transcript turns before the export row cap. */
+    readonly total_turns?: number;
+    /** True when `turns` contains only the capped prefix. */
+    readonly truncated?: boolean;
     readonly token_usage?: SessionTokenUsageDetail | null;
     /** v3+: runtime hook-fire decisions (file-context injections etc.), so the
      *  shared inspector can show + jump to them like the live one. */
@@ -184,6 +188,8 @@ export function isAxSessionShare(value: unknown): value is AxSessionShare {
     if (typeof value.session.source !== "string") return false;
     if (!isRecord(value.stats)) return false;
     if (!hasNumericStats(value.stats)) return false;
+    if (value.total_turns !== undefined && typeof value.total_turns !== "number") return false;
+    if (value.truncated !== undefined && typeof value.truncated !== "boolean") return false;
     if (!Array.isArray(value.timeline)) return false;
     if (!Array.isArray(value.files)) return false;
     if (!isRecord(value.graph)) return false;
@@ -221,6 +227,8 @@ export function minimalShareArtifact(input: {
             skills_used: 0,
             failures: 0,
         },
+        total_turns: 0,
+        truncated: false,
         turns: [],
         timeline: [],
         files: [],

--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -146,6 +146,23 @@ describe("attachStructuredToolCalls", () => {
 import { minimalShareArtifact } from "./artifact.ts";
 
 describe("buildShareArtifactFromParts", () => {
+    it("carries honest turn truncation metadata", () => {
+        const artifact = buildShareArtifactFromParts({
+            axVersion: "0.2.0",
+            exportedAt: "2026-08-21T00:00:00.000Z",
+            overview: { id: "abc123", project: null, cwd: null, model: null, source: "codex", started_at: null, ended_at: null },
+            topSkills: [],
+            toolCalls: [],
+            turns: [],
+            totalTurns: 2_001,
+            truncated: true,
+            timeline: [],
+            files: [],
+        });
+        expect(artifact.total_turns).toBe(2_001);
+        expect(artifact.truncated).toBe(true);
+    });
+
     it("builds a V1 artifact from session rows", () => {
         const artifact = buildShareArtifactFromParts({
             axVersion: "0.2.0",

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -44,6 +44,8 @@ export interface ShareArtifactParts {
     readonly toolCalls: ReadonlyArray<SessionToolCall>;
     readonly tokenUsage?: SessionTokenUsageDetail | null;
     readonly turns: ReadonlyArray<ShareTurn>;
+    readonly totalTurns?: number;
+    readonly truncated?: boolean;
     readonly timeline: ReadonlyArray<ShareEvent>;
     /** Segmented highlight timeline (L2 phases + L1 key events), computed at
      *  export time so the static share viewer can render it without a daemon. */
@@ -198,6 +200,8 @@ export function buildShareArtifactFromParts(
             skills_used: parts.topSkills.length,
             failures,
         },
+        total_turns: parts.totalTurns ?? parts.turns.length,
+        truncated: parts.truncated ?? false,
         token_usage: parts.tokenUsage ?? null,
         ...(parts.sessionTimeline ? { session_timeline: parts.sessionTimeline } : {}),
         ...(parts.hookFires && parts.hookFires.length > 0 ? { hook_fires: parts.hookFires } : {}),
@@ -408,7 +412,7 @@ export const exportSessionShare = (
         if (remaining < 0) return null;
 
         const read = yield* CacheRead;
-        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, shareTurns, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, harnessHooksRawUnanchored, turnContent] =
+        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, shareTurnsResult, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, harnessHooksRawUnanchored, turnContent] =
             yield* Effect.all([
                 fetchSessionOverview(read, bareId),
                 fetchSessionTopSkills(read, bareId),
@@ -424,6 +428,8 @@ export const exportSessionShare = (
                 fetchSessionShareHarnessHooks(read, bareId),
                 resolveTurnContent(read, bareId),
             ]);
+
+        const shareTurns = shareTurnsResult.turns;
 
         if (overview === null) return null;
 
@@ -486,6 +492,8 @@ export const exportSessionShare = (
             toolCalls: toolCallsRaw,
             tokenUsage,
             turns,
+            totalTurns: shareTurnsResult.totalTurns,
+            truncated: shareTurnsResult.truncated,
             timeline: timelineRaw,
             sessionTimeline,
             files: filesRaw,

--- a/apps/axctl/src/share/session-share-queries.test.ts
+++ b/apps/axctl/src/share/session-share-queries.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { makeTestCacheRead } from "@ax/lib/testing/cache";
+import { fetchSessionShareTurns } from "./session-share-queries.ts";
+
+describe("fetchSessionShareTurns", () => {
+    test("reports the total and truncation when the 2000-row cap applies", async () => {
+        const rows = Array.from({ length: 2_000 }, (_, index) => ({
+            id: `turn-${index}`,
+            seq: index + 1,
+            ts: "2026-08-01T00:00:00.000Z",
+            role: "user",
+            message_kind: "task",
+            intent_kind: null,
+            text: `turn ${index + 1}`,
+            text_excerpt: null,
+            has_tool_use: false,
+            has_error: false,
+        }));
+        const { service } = makeTestCacheRead({
+            routes: {
+                "COUNT(*) AS total_turns": [{ total_turns: 2_001 }],
+                "FROM turn": rows,
+            },
+        });
+        const result = await Effect.runPromise(fetchSessionShareTurns(service, "share-session"));
+        expect(result.turns).toHaveLength(2_000);
+        expect(result.totalTurns).toBe(2_001);
+        expect(result.truncated).toBe(true);
+    });
+});

--- a/apps/axctl/src/share/session-share-queries.ts
+++ b/apps/axctl/src/share/session-share-queries.ts
@@ -278,10 +278,23 @@ WHERE session = ? AND (message_kind IS NULL OR message_kind NOT IN (${EXCLUDED_M
 ORDER BY seq ASC
 LIMIT 2000`;
 
+const ShareTurnCountRow = Schema.Struct({
+    total_turns: NumberFromBigIntColumn,
+});
+
+const SHARE_TURNS_COUNT_SQL = `
+SELECT COUNT(*) AS total_turns
+FROM turn
+WHERE session = ? AND (message_kind IS NULL OR message_kind NOT IN (${EXCLUDED_MESSAGE_KINDS.map(() => "?").join(", ")}))`;
+
 export const fetchSessionShareTurns = Effect.fn("share.fetchSessionShareTurns")(
     function* (read: CacheReadService, sessionId: string) {
-        const rows = yield* read.rows(ShareTurnRow, SHARE_TURNS_SQL, [sessionId, ...EXCLUDED_MESSAGE_KINDS]);
-        return rows.map((r): ShareTurn => {
+        const params = [sessionId, ...EXCLUDED_MESSAGE_KINDS];
+        const [rows, count] = yield* Effect.all([
+            read.rows(ShareTurnRow, SHARE_TURNS_SQL, params),
+            read.first(ShareTurnCountRow, SHARE_TURNS_COUNT_SQL, params),
+        ]);
+        const turns = rows.map((r): ShareTurn => {
             const text = r.text ?? r.text_excerpt ?? "";
             return {
                 id: r.id,
@@ -296,6 +309,8 @@ export const fetchSessionShareTurns = Effect.fn("share.fetchSessionShareTurns")(
                 has_error: r.has_error,
             };
         });
+        const totalTurns = count._tag === "Some" ? count.value.total_turns : turns.length;
+        return { turns, totalTurns, truncated: totalTurns > turns.length };
     },
 );
 


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-dojo-quota-nav.

- #981 (security): every dynamic value in a NavLink `cmd` now goes through one POSIX single-quote helper (`'"'"'` escape), so a hostile skill/session/role name is one shell argument, not injected commands. Swept all cmd builders in next-links.ts.
- #976: skill-spar Arm B command now wraps in a shell `EXIT` trap that restores the snapshot on any exit; spar-score verifies the live skill against the snapshot and restores+warns on mismatch.
- #977: quota freshness requires `0 <= age < ttl`, so a future-dated cache no longer reads fresh forever.
- #978: routing-impact `didReset` compares reset instants as epoch ms, not raw strings (format drift no longer voids a valid block); the utilization-drop clause stays.
- #982: session share now carries honest `total_turns` + `truncated` fields when the 2,000-row cap applies (the artifact still caps rows; a later change can paginate).
- #985: studio SPA fallback only for extensionless routes; a missing `*.js|.css` or `/assets/*` returns null (404), never the HTML shell.

Noted follow-ups (pane): resume-command cmd values come from a separate module (session-id uuids, low risk); capped share queries could move to cursor pagination.

Gates: all six areas' suites 170/170 (each red->green), tsc clean, both cast checks clean.

Fixes #976
Fixes #977
Fixes #978
Fixes #981
Fixes #982
Fixes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)