### PR TITLE
fix(hooks): matcher/timeout in install identity + advise-tap fail-open + ledger rotation

### DIFF
--- a/apps/axctl/src/advice/advice-stage.test.ts
+++ b/apps/axctl/src/advice/advice-stage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Effect, Schema } from "effect";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { ingestAdviceLog } from "./advice-stage.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("advice stage", { requireFts: true });
+
+const ledgerRow = (sessionId: string, ts: string): string =>
+  JSON.stringify({
+    ts,
+    session_id: sessionId,
+    tool: "Agent",
+    description: `dispatch ${sessionId}`,
+    injected: null,
+    verdict: "allow",
+  }) + "\n";
+
+describe("advice stage", () => {
+  dtest("returns zero when the ledger directory does not exist", async () => {
+    const home = tempDir("ax-advice-missing-");
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+    let rows = -1;
+    try {
+      await runWithPlatform(
+        publishCacheFixture(tempDir("ax-advice-empty-cache-"), dylibPath, (write) =>
+          Effect.gen(function* () {
+            rows = yield* ingestAdviceLog(write, new Date(0));
+          }),
+        ),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+    expect(rows).toBe(0);
+  });
+
+  dtest("ingests rotated segments once and keeps one watermark per file", async () => {
+    const home = tempDir("ax-advice-home-");
+    const hooksDir = join(home, ".ax", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const segment = join(hooksDir, "advise-log.2026-08-20T00-00-00-000Z-123.jsonl");
+    const live = join(hooksDir, "advise-log.jsonl");
+    writeFileSync(segment, ledgerRow("segment-session", "2026-08-20T00:00:00.000Z"));
+    writeFileSync(live, ledgerRow("live-session", "2026-08-21T00:00:00.000Z"));
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+    let first = -1;
+    let second = -1;
+    let adviceRows = -1;
+    let markPaths: string[] = [];
+    try {
+      await runWithPlatform(
+        publishCacheFixture(tempDir("ax-advice-cache-"), dylibPath, (write) =>
+          Effect.gen(function* () {
+            first = yield* ingestAdviceLog(write, new Date(0));
+            second = yield* ingestAdviceLog(write, new Date(0));
+            adviceRows = (yield* write.rows(
+              Schema.Struct({ count: Schema.Number }),
+              "SELECT count(*)::INTEGER AS count FROM advice",
+            ))[0]!.count;
+            markPaths = (yield* write.rows(
+              Schema.Struct({ path: Schema.String }),
+              "SELECT path FROM ingest_file_state WHERE source_kind = 'advice_log' ORDER BY path",
+            )).map((row) => row.path).filter((path) => !path.startsWith("__"));
+          }),
+        ),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+
+    expect({ first, second, adviceRows }).toEqual({ first: 2, second: 0, adviceRows: 2 });
+    expect(new Set(markPaths)).toEqual(new Set([segment, live]));
+  });
+});

--- a/apps/axctl/src/advice/advice-stage.ts
+++ b/apps/axctl/src/advice/advice-stage.ts
@@ -1,42 +1,75 @@
 import { Cause, Effect, Schema } from "effect";
 import { cacheRow } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import type { DbError } from "@ax/lib/errors";
+import { dirname, join } from "node:path";
 import { BaseStageStats, type IngestContext, StageMeta } from "../ingest/stage/types.ts";
 import type { StageDef } from "../ingest/stage/registry.ts";
+import { runJsonlProviderFiles } from "../ingest/jsonl-work-unit.ts";
+import type { JsonlFileCandidate } from "../ingest/walk-jsonl.ts";
 import { parseAdviceLog, adviceRowKey } from "./model.ts";
 
-/** The append-only advice ledger the tap writes; survives re-ingest (not truncated). */
+const ADVICE_LOG_SOURCE_KIND = "advice_log";
+
+/** The live advice ledger the tap writes. Older rows move to dated segments. */
 export const defaultAdviceLogPath = (): string => `${process.env.HOME}/.ax/hooks/advise-log.jsonl`;
 
+const adviceLogCandidates = (): Effect.Effect<JsonlFileCandidate[]> =>
+  Effect.promise(async () => {
+    const live = defaultAdviceLogPath();
+    const dir = dirname(live);
+    const glob = new Bun.Glob("advise-log*.jsonl");
+    const candidates: JsonlFileCandidate[] = [];
+    try {
+      for await (const name of glob.scan({ cwd: dir, onlyFiles: true })) {
+        const path = join(dir, name);
+        try {
+          const stat = await Bun.file(path).stat();
+          candidates.push({ path, mtimeMs: stat.mtimeMs, sizeBytes: stat.size });
+        } catch {}
+      }
+    } catch {}
+    return candidates.sort((a, b) => a.path.localeCompare(b.path));
+  });
+
 /**
- * Read the advice ledger, keep rows at/after `since`, and idempotently UPSERT
- * them (stable id from session+ts+description). Returns the count written.
- * since-aware so a windowed `ax ingest --since=N` only touches recent rows; the
- * file is NEVER truncated, so history survives.
+ * Read the live ledger and its immutable dated segments. Keep rows at/after
+ * `since`, and idempotently UPSERT them. Returns the count written. Each file
+ * has a two-tier content watermark, so unchanged segments require no read.
  */
 export const ingestAdviceLog = (
   write: CacheWriteService,
   since: Date,
-): Effect.Effect<number, CacheWriteError> =>
+): Effect.Effect<number, CacheWriteError | DbError> =>
   Effect.gen(function* () {
-    const path = defaultAdviceLogPath();
-    const text = yield* Effect.promise(async () => {
-      const f = Bun.file(path);
-      return (await f.exists()) ? await f.text() : "";
+    const candidates = yield* adviceLogCandidates();
+    let written = 0;
+    yield* runJsonlProviderFiles(write, {
+      candidates,
+      sourceKind: ADVICE_LOG_SOURCE_KIND,
+      forceEnv: "AX_REDERIVE_ADVICE",
+      source: "advice",
+      contentHash: true,
+      processFile: (candidate) => Effect.gen(function* () {
+        const text = yield* Effect.promise(() => Bun.file(candidate.path).text());
+        const rows = parseAdviceLog(text).filter((r) => r.ts.getTime() >= since.getTime());
+        if (rows.length > 0) {
+          yield* write.putMany("advice", rows.map((r) => cacheRow({
+            id: adviceRowKey(r),
+            ts: r.ts,
+            session: r.sessionId ?? null,
+            tool: r.tool ?? null,
+            description: r.description ?? null,
+            verdict: r.verdict,
+            advice_text: r.adviceText ?? null,
+            suggested_model: r.suggestedModel ?? null,
+          })));
+          written += rows.length;
+        }
+        return true;
+      }),
     });
-    const rows = parseAdviceLog(text).filter((r) => r.ts.getTime() >= since.getTime());
-    if (rows.length === 0) return 0;
-    yield* write.putMany("advice", rows.map((r) => cacheRow({
-      id: adviceRowKey(r),
-      ts: r.ts,
-      session: r.sessionId ?? null,
-      tool: r.tool ?? null,
-      description: r.description ?? null,
-      verdict: r.verdict,
-      advice_text: r.adviceText ?? null,
-      suggested_model: r.suggestedModel ?? null,
-    })));
-    return rows.length;
+    return written;
   });
 
 export const AdviceKey = Schema.Literal("advice");
@@ -49,7 +82,15 @@ export class AdviceStats extends BaseStageStats.extend<AdviceStats>("AdviceStats
 export const adviceStage: StageDef<AdviceStats, never, CacheWriteError> = {
   // Tagged derive for pipeline placement, but it is an external-ledger
   // LOADER (parse) over ~/.ax/hooks/advise-log.jsonl (#893).
-  meta: StageMeta.make({ key: "advice", deps: [], tags: ["derive"], writes: [{ table: "advice", mode: "parse" }] }),
+  meta: StageMeta.make({
+    key: "advice",
+    deps: [],
+    tags: ["derive"],
+    writes: [
+      { table: "advice", mode: "parse" },
+      { table: "ingest_file_state", mode: "bookkeep" },
+    ],
+  }),
   run: (ctx: IngestContext, write) =>
     Effect.gen(function* () {
       const t0 = Date.now();

--- a/apps/axctl/src/advice/advise-tap.test.ts
+++ b/apps/axctl/src/advice/advise-tap.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const tempDirs: string[] = [];
+const makeTempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "ax-advise-tap-"));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const tap = fileURLToPath(new URL("./advise-tap.ts", import.meta.url));
+
+describe("advise tap", () => {
+  test("preserves target output and blocking exit when the ledger write fails", async () => {
+    const home = makeTempDir();
+    const target = join(home, "blocking-hook.ts");
+    writeFileSync(target, 'process.stderr.write("BLOCKED by target\\n"); process.exit(2);\n');
+
+    const proc = Bun.spawn(["bun", tap, target], {
+      env: { ...process.env, HOME: home },
+      stdin: Buffer.from(JSON.stringify({ session_id: "s", tool_name: "Agent" })),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect({ exitCode, stdout, stderr }).toEqual({
+      exitCode: 2,
+      stdout: "",
+      stderr: "BLOCKED by target\n",
+    });
+  });
+
+  test("rotates a full ledger before it appends to the live file", async () => {
+    const home = makeTempDir();
+    const hooksDir = join(home, ".ax", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const log = join(hooksDir, "advise-log.jsonl");
+    const fullSize = 10 * 1024 * 1024;
+    writeFileSync(log, "x".repeat(fullSize));
+    const target = join(home, "allow-hook.ts");
+    writeFileSync(target, "process.exit(0);\n");
+
+    const proc = Bun.spawn(["bun", tap, target], {
+      env: { ...process.env, HOME: home },
+      stdin: Buffer.from(JSON.stringify({ session_id: "s", tool_name: "Agent" })),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    expect(await proc.exited).toBe(0);
+
+    const segments = readdirSync(hooksDir).filter((name) => /^advise-log\..+\.jsonl$/.test(name));
+    expect(segments).toHaveLength(1);
+    expect(statSync(join(hooksDir, segments[0]!)).size).toBe(fullSize);
+    expect(statSync(log).size).toBeLessThan(fullSize);
+    expect(JSON.parse(readFileSync(log, "utf8"))).toMatchObject({ session_id: "s" });
+  });
+});

--- a/apps/axctl/src/advice/advise-tap.ts
+++ b/apps/axctl/src/advice/advise-tap.ts
@@ -14,11 +14,12 @@
 //
 // Wire it by pointing the hook command at this file with the real hook as arg:
 //   bun ~/.ax/hooks/advise-tap.ts ~/.ax/hooks/route-dispatch.js
-import { appendFileSync } from "node:fs";
+import { appendFileSync, renameSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const LOG = join(homedir(), ".ax/hooks/advise-log.jsonl");
+const MAX_LOG_BYTES = 10 * 1024 * 1024;
 const target = process.argv[2];
 if (!target) {
   process.stderr.write("advise-tap: missing target hook path (argv[2])\n");
@@ -47,21 +48,31 @@ try {
   advice = JSON.parse(out)?.hookSpecificOutput?.additionalContext ?? null;
 } catch {}
 
-// One ledger row per fire. `ts` stamped by the OS (hooks may run in cron).
-appendFileSync(
-  LOG,
-  JSON.stringify({
-    ts: new Date().toISOString(),
-    session_id: sessionId,
-    tool: toolName,
-    description: (toolInput as { description?: string })?.description ?? null,
-    injected: advice, // the additionalContext the model received (null = allow)
-    verdict: advice ? "advise" : "allow",
-    raw_stdout: out.trim() || null,
-  }) + "\n",
-);
-
 // Transparent pass-through: the model still gets exactly what the hook emitted.
 if (err) process.stderr.write(err);
 if (out) process.stdout.write(out);
+
+// One ledger row per fire. Recording is best-effort and cannot replace the
+// target hook result.
+try {
+  if (statSync(LOG).size >= MAX_LOG_BYTES) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    renameSync(LOG, join(homedir(), `.ax/hooks/advise-log.${stamp}-${process.pid}.jsonl`));
+  }
+} catch {}
+try {
+  appendFileSync(
+    LOG,
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      session_id: sessionId,
+      tool: toolName,
+      description: (toolInput as { description?: string })?.description ?? null,
+      injected: advice, // the additionalContext the model received (null = allow)
+      verdict: advice ? "advise" : "allow",
+      raw_stdout: out.trim() || null,
+    }) + "\n",
+  );
+} catch {}
+
 process.exit(exitCode === 2 ? 2 : 0);

--- a/apps/axctl/src/hooks/sdk-install.test.ts
+++ b/apps/axctl/src/hooks/sdk-install.test.ts
@@ -189,7 +189,14 @@ describe("filterAlreadyInstalled", () => {
     test("skips an entry whose (provider, scope, event, command) already exists", () => {
         const plan = [entry("claude", "PreToolUse", "bun /abs/g.ts")];
         const existing = [
-            { provider: "claude", scope: "global", event: "PreToolUse", command: "bun /abs/g.ts" },
+            {
+                provider: "claude",
+                scope: "global",
+                event: "PreToolUse",
+                matcher: null,
+                command: "bun /abs/g.ts",
+                timeout: 10,
+            },
         ];
         const out = filterAlreadyInstalled(plan, existing, "global");
         expect(out[0]!.skipped).toBe(true);
@@ -198,10 +205,43 @@ describe("filterAlreadyInstalled", () => {
     test("matches even when the existing command carries an ax marker", () => {
         const plan = [entry("claude", "PreToolUse", "bun /abs/g.ts")];
         const existing = [
-            { provider: "claude", scope: "global", event: "PreToolUse", command: "bun /abs/g.ts # ax:abc12345" },
+            {
+                provider: "claude",
+                scope: "global",
+                event: "PreToolUse",
+                matcher: null,
+                command: "bun /abs/g.ts # ax:abc12345",
+                timeout: 10,
+            },
         ];
         const out = filterAlreadyInstalled(plan, existing, "global");
         expect(out[0]!.skipped).toBe(true);
+    });
+
+    test("does not skip an entry when its matcher or timeout changed", () => {
+        const plan = [entry("claude", "PreToolUse", "bun /abs/g.ts")];
+        const cases = [
+            {
+                provider: "claude",
+                scope: "global",
+                event: "PreToolUse",
+                matcher: "Bash",
+                command: "bun /abs/g.ts",
+                timeout: 10,
+            },
+            {
+                provider: "claude",
+                scope: "global",
+                event: "PreToolUse",
+                matcher: null,
+                command: "bun /abs/g.ts",
+                timeout: 5,
+            },
+        ];
+        for (const existing of cases) {
+            const out = filterAlreadyInstalled(plan, [existing], "global");
+            expect(out[0]!.skipped).toBe(false);
+        }
     });
 
     test("does not skip when provider, event, scope, or command differ", () => {
@@ -224,7 +264,14 @@ describe("filterAlreadyInstalled", () => {
             entry("codex", "PreToolUse", "bun /abs/g.ts"),
         ];
         const existing = [
-            { provider: "claude", scope: "global", event: "PreToolUse", command: "bun /abs/g.ts # ax:deadbeef" },
+            {
+                provider: "claude",
+                scope: "global",
+                event: "PreToolUse",
+                matcher: null,
+                command: "bun /abs/g.ts # ax:deadbeef",
+                timeout: 10,
+            },
         ];
         const out = filterAlreadyInstalled(plan, existing, "global");
         expect(out[0]!.skipped).toBe(true);

--- a/apps/axctl/src/hooks/sdk-install.ts
+++ b/apps/axctl/src/hooks/sdk-install.ts
@@ -170,8 +170,10 @@ export interface InstalledHookKey {
     readonly provider: string;
     readonly scope: string;
     readonly event: string;
+    readonly matcher?: string | null | undefined;
     /** as stored on disk - may carry a trailing ` # ax:<id>` marker. */
     readonly command: string;
+    readonly timeout?: number | undefined;
 }
 
 /** Strip a trailing ` # ax:<id>` ownership marker (providers embed one on
@@ -180,7 +182,7 @@ export const stripAxMarker = (command: string): string =>
     command.replace(/\s*#\s*ax:[a-z0-9_-]+\s*$/, "");
 
 export interface InstallResult extends InstallPlanEntry {
-    /** true when an identical (provider, scope, event, command) hook already exists. */
+    /** true when an identical hook already exists. */
     readonly skipped: boolean;
     /** config file written; undefined when skipped. */
     readonly writtenPath?: string | undefined;
@@ -188,20 +190,37 @@ export interface InstallResult extends InstallPlanEntry {
 
 /**
  * Pure: annotate each plan entry with `skipped: true` when a hook with the
- * same (provider, scope, event, command) already exists. Commands are compared
- * marker-stripped, since providers embed ` # ax:<id>` on write.
+ * same provider, scope, event, matcher, command, and timeout already exists.
+ * Commands are compared marker-stripped, since providers embed an ownership marker.
  */
 export const filterAlreadyInstalled = (
     plan: ReadonlyArray<InstallPlanEntry>,
     existing: ReadonlyArray<InstalledHookKey>,
     scope: HookScope,
 ): Array<InstallPlanEntry & { readonly skipped: boolean }> => {
-    const key = (provider: string, sc: string, event: string, command: string): string =>
-        [provider, sc, event, stripAxMarker(command)].join("\u0000");
-    const seen = new Set(existing.map((e) => key(e.provider, e.scope, e.event, e.command)));
+    const key = (
+        provider: string,
+        sc: string,
+        event: string,
+        matcher: string | null | undefined,
+        command: string,
+        timeout: number | undefined,
+    ): string => [provider, sc, event, matcher ?? "", stripAxMarker(command), timeout ?? ""].join("\u0000");
+    const seen = new Set(
+        existing.map((e) => key(e.provider, e.scope, e.event, e.matcher, e.command, e.timeout)),
+    );
     return plan.map((entry) => ({
         ...entry,
-        skipped: seen.has(key(entry.provider, scope, entry.input.event, entry.input.command)),
+        skipped: seen.has(
+            key(
+                entry.provider,
+                scope,
+                entry.input.event,
+                entry.input.matcher,
+                entry.input.command,
+                entry.input.timeout,
+            ),
+        ),
     }));
 };
 


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-hooks-advice.

- #974: `filterAlreadyInstalled` keyed on (provider, scope, event, command), omitting the tool MATCHER, so a dispatcher entry whose matcher union widened was marked already-installed and new guards never fired. The identity key now includes matcher + timeout. For the dispatcher path this composes with `planLegacyRemoval` (which removes the old entry by command), so it replaces cleanly rather than double-firing.
- #975: the advise-tap wrote its ledger BEFORE forwarding the wrapped hook's output, so a ledger error ate the hook's stdout/stderr/exit. Pass-through now happens first; rotation + append are best-effort (try/catch). Exit code 2 (block) is preserved.
- #979: `advise-log.jsonl` grew unbounded. The tap now rotates at 10 MiB into an immutable dated segment; the advice stage ingests the live file + all segments, one two-tier watermark per file (idempotent - a re-ingest reads 0 new rows).

Noted follow-ups (pane): a broader change can replace a stale non-dispatcher ax-owned entry in place; rotated segments remain on disk until the user removes them.

Gates: sdk-install + dispatch-install + advice suites 52/52 (all red->green), tsc clean, both cast checks clean.

Fixes #974
Fixes #975
Fixes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)