### PR TITLE
fix: OTLP optional arrays, community numeric clamps + dedup, widget markers, MCP agent arg, workflow sig

### DIFF
--- a/apps/axctl/src/improve/recommend.ts
+++ b/apps/axctl/src/improve/recommend.ts
@@ -13,7 +13,6 @@ export interface RecommendInput {
     readonly forms?: ReadonlyArray<string>;
     readonly project?: string;
     readonly cwd?: string;
-    readonly agent?: "claude" | "codex";
     readonly sinceDays?: number;
 }
 
@@ -28,14 +27,13 @@ export interface RecommendInput {
 export interface RecommendQueryArgs {
     readonly limit?: number | undefined;
     readonly forms?: ReadonlyArray<string> | undefined;
-    readonly agent?: "claude" | "codex" | undefined;
     readonly sinceDays?: number | undefined;
 }
 
 /**
  * Apply default limit + drop empty optional collections. Transports keep their
  * own limit default (CLI 5, MCP 10) by passing `defaultLimit`; everything else
- * (forms/agent/sinceDays presence rules) is shared semantics.
+ * (forms/sinceDays presence rules) is shared semantics.
  *
  * Note: positivity/integer validation of `limit` and `sinceDays` stays in the
  * transports (CLI `requirePositiveInt` exits 2 with usage wording; MCP zod
@@ -55,7 +53,6 @@ export const normalizeRecommendInput = (
     return {
         limit,
         ...(forms !== undefined ? { forms } : {}),
-        ...(args.agent !== undefined ? { agent: args.agent } : {}),
         ...(args.sinceDays !== undefined ? { sinceDays: args.sinceDays } : {}),
     };
 };

--- a/apps/axctl/src/ingest/derive-proposals.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.test.ts
@@ -175,6 +175,65 @@ ORDER BY p.id`);
             },
         ].sort((a, b) => a.id.localeCompare(b.id)));
     });
+
+    test("removes only unprotected open legacy twins", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-proposal-cleanup-"));
+        dirs.push(dir);
+        const sidecarPath = join(dir, "judgment.sqlite");
+
+        const rows = await Effect.runPromise(Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            const title = "Workflow: plan → test → commit";
+            const sig = dedupeSig("guidance", normalizeTitle(title));
+            const proposal = (id: string, dedupe_sig: string, status: string) => ({
+                id,
+                form: "guidance",
+                title,
+                hypothesis: "test",
+                dedupe_sig,
+                confidence: "medium",
+                status,
+            });
+            yield* judgment.put("proposal", proposal("canonical", sig, "open"));
+            yield* judgment.put("proposal", proposal("delete-me", `${sig}__legacy__delete`, "open"));
+            yield* judgment.put("proposal", proposal("keep-decision", `${sig}__legacy__decision`, "rejected"));
+            yield* judgment.put("proposal", proposal("keep-experiment", `${sig}__legacy__experiment`, "open"));
+            yield* judgment.put("guidance_proposal", {
+                id: "delete-payload",
+                proposal: "delete-me",
+                file_target: "CLAUDE.md",
+                section: "workflows",
+                suggested_text: "plan → test → commit",
+            });
+            yield* judgment.put("experiment", {
+                id: "protected-experiment",
+                proposal: "keep-experiment",
+                status: "task_emitted",
+            });
+
+            yield* migrateProposalDedupeSigs(judgment);
+            yield* migrateProposalDedupeSigs(judgment);
+
+            return yield* judgment.rows(Schema.Struct({
+                id: Schema.String,
+                status: Schema.String,
+                experiment_id: Schema.NullOr(Schema.String),
+            }), `
+SELECT p.id, p.status, e.id AS experiment_id
+FROM proposal p
+LEFT JOIN experiment e ON e.proposal = p.id
+ORDER BY p.id`);
+        }).pipe(
+            Effect.scoped,
+            Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+        ));
+
+        expect(rows.map((row) => row.id)).not.toContain("delete-me");
+        expect(rows.map((row) => row.id)).not.toContain("canonical");
+        expect(rows).toContainEqual({ id: "keep-decision", status: "rejected", experiment_id: null });
+        expect(rows).toContainEqual({ id: "keep-experiment", status: "open", experiment_id: "protected-experiment" });
+        expect(rows).toHaveLength(2);
+    });
 });
 
 describe("deriveSkillProposalRows", () => {
@@ -535,6 +594,7 @@ describe("deriveWorkflowProposalRows", () => {
         expect(rows[0]!.title).toContain("plan");
         expect(rows[0]!.frequency).toBe(5); // support → frequency
         expect(rows[0]!.section).toBe("workflows"); // discriminator
+        expect(rows[0]!.sig).toBe(dedupeSig("guidance", normalizeTitle(rows[0]!.title)));
         // stable sig: same arc → same sig
         const again = deriveWorkflowProposalRows([{ steps: ["plan", "tdd", "review", "commit"], support: 5 }]);
         expect(again.rows[0]!.sig).toBe(rows[0]!.sig);

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -257,7 +257,7 @@ export const deriveWorkflowProposalRows = (
         if (arc.support < minSessions) { skipped += 1; continue; }
         const title = workflowTitle(arc.steps);
         const normTitle = normalizeTitle(title);
-        const sig = dedupeSig("workflow", normTitle);
+        const sig = dedupeSig("guidance", normTitle);
         if (seenSigs.has(sig)) { skipped += 1; continue; }
         seenSigs.add(sig);
 
@@ -679,6 +679,7 @@ interface ProposalDedupeMigrationRow {
     readonly status: string;
     readonly origin: string;
     readonly baseline: string | null;
+    readonly reject_reason: string | null;
 }
 
 const decisionRank = (status: string): number => {
@@ -725,7 +726,9 @@ const migratedProposalId = (row: ProposalDedupeMigrationRow, sig: string): strin
  * A sidecar can already contain logical duplicates if an earlier Bun upgrade
  * changed Bun.hash. The strongest closed decision receives the canonical SHA
  * signature. Other rows receive deterministic legacy suffixes. Thus no decision
- * row or linked row is deleted, while future derivation sees the canonical sig.
+ * row or linked experiment is deleted. Open legacy twins without decisions or
+ * experiments are removed after re-keying, so old workflow duplicates do not
+ * remain in the shortlist. Future derivation sees the canonical signature.
  */
 export const migrateProposalDedupeSigs = (
     judgment: JudgmentService,
@@ -739,7 +742,8 @@ export const migrateProposalDedupeSigs = (
             status: TextColumn,
             origin: TextColumn,
             baseline: Schema.NullOr(TextColumn),
-        }), "SELECT id, form, title, dedupe_sig, status, origin, baseline FROM proposal");
+            reject_reason: Schema.NullOr(TextColumn),
+        }), "SELECT id, form, title, dedupe_sig, status, origin, baseline, reject_reason FROM proposal");
 
         const groups = new Map<string, ProposalDedupeMigrationRow[]>();
         for (const row of rows) {
@@ -767,8 +771,6 @@ export const migrateProposalDedupeSigs = (
             const target = targets.get(row.id)!;
             return target.id !== row.id || target.sig !== row.dedupe_sig;
         });
-        if (changed.length === 0) return;
-
         yield* judgment.transaction((transaction) => Effect.gen(function* () {
             for (const row of changed) {
                 const target = targets.get(row.id)!;
@@ -807,6 +809,28 @@ export const migrateProposalDedupeSigs = (
                 yield* transaction.exec(
                     "UPDATE proposal SET id = ?, dedupe_sig = ? WHERE id = ?",
                     [target.id, target.sig, `__ax_dedupe_migration_tmp_id__${row.id}`],
+                );
+            }
+
+            for (const row of rows) {
+                const target = targets.get(row.id)!;
+                if (!target.sig.includes("__legacy__") || row.status !== "open" || row.reject_reason !== null) {
+                    continue;
+                }
+                const payloadTable = proposalPayloadTable(row.form);
+                if (payloadTable !== null) {
+                    yield* transaction.exec(
+                        `DELETE FROM ${payloadTable}
+                         WHERE proposal = ?
+                           AND NOT EXISTS (SELECT 1 FROM experiment WHERE proposal = ?)`,
+                        [target.id, target.id],
+                    );
+                }
+                yield* transaction.exec(
+                    `DELETE FROM proposal
+                     WHERE id = ? AND status = 'open' AND reject_reason IS NULL
+                       AND NOT EXISTS (SELECT 1 FROM experiment WHERE proposal = ?)`,
+                    [target.id, target.id],
                 );
             }
         }));

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -16,7 +16,7 @@ const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     skills_by_role: ["limit", "role"],
     skills_roles: ["skill"],
     roles: [],
-    improve_recommend: ["agent", "forms", "limit", "sinceDays"],
+    improve_recommend: ["forms", "limit", "sinceDays"],
     improve_show: ["sigOrId"],
     improve_list: ["form", "limit", "status"],
     session_metrics: ["limit", "project", "sinceDays"],

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -429,8 +429,6 @@ const rolesTool: AxMcpTool = defineMcpTool({
     },
 });
 
-const RECOMMEND_AGENTS = ["claude", "codex"] as const;
-
 const improveRecommendTool: AxMcpTool = defineMcpTool({
     name: "improve_recommend",
     runtime: "judgment",
@@ -447,10 +445,6 @@ const improveRecommendTool: AxMcpTool = defineMcpTool({
             .array(z.string())
             .optional()
             .describe("Filter to these proposal forms (e.g. skill, hook, rule)."),
-        agent: z
-            .enum(RECOMMEND_AGENTS)
-            .optional()
-            .describe('Filter to a single agent: "claude" or "codex".'),
         sinceDays: z
             .number()
             .int()
@@ -467,7 +461,6 @@ const improveRecommendTool: AxMcpTool = defineMcpTool({
             {
                 ...(args.limit !== undefined ? { limit: args.limit } : {}),
                 ...(args.forms !== undefined ? { forms: args.forms } : {}),
-                ...(args.agent !== undefined ? { agent: args.agent } : {}),
                 ...(args.sinceDays !== undefined ? { sinceDays: args.sinceDays } : {}),
             },
             10,

--- a/apps/axctl/src/otel/otlp-schema.test.ts
+++ b/apps/axctl/src/otel/otlp-schema.test.ts
@@ -112,4 +112,27 @@ describe("otlp envelope schemas", () => {
         const d = Schema.decodeUnknownSync(LogsPayload)(payload);
         expect(d.resourceLogs[0]?.scopeLogs[0]?.logRecords[0]?.attributes?.[0]?.key).toBe("event.name");
     });
+
+    test("defaults omitted repeated log fields without dropping sibling records", () => {
+        const empty = Schema.decodeUnknownSync(LogsPayload)({});
+        const payload = {
+            resourceLogs: [
+                {},
+                {
+                    resource: {},
+                    scopeLogs: [
+                        {},
+                        { logRecords: [{ observedTimeUnixNano: "1718409600000000000" }] },
+                    ],
+                },
+            ],
+        };
+        const decoded = Schema.decodeUnknownSync(LogsPayload)(payload);
+
+        expect(empty.resourceLogs).toEqual([]);
+        expect(decoded.resourceLogs[0]?.scopeLogs).toEqual([]);
+        expect(decoded.resourceLogs[1]?.resource?.attributes).toEqual([]);
+        expect(decoded.resourceLogs[1]?.scopeLogs[0]?.logRecords).toEqual([]);
+        expect(decoded.resourceLogs[1]?.scopeLogs[1]?.logRecords[0]?.attributes).toEqual([]);
+    });
 });

--- a/apps/axctl/src/otel/otlp-schema.ts
+++ b/apps/axctl/src/otel/otlp-schema.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 /**
  * An OTLP/JSON int64 field, which arrives as EITHER a JSON string or a JSON
@@ -39,6 +39,9 @@ export const KeyValue = Schema.Struct({
 });
 export type KeyValue = Schema.Schema.Type<typeof KeyValue>;
 
+const repeated = <S extends Schema.Top>(item: S) =>
+    Schema.Array(item).pipe(Schema.withDecodingDefaultKey(Effect.succeed([])));
+
 /** Collapse an AnyValue to a JS scalar; intValue parses to number. */
 export const attrValueToScalar = (v: AnyValue | undefined): string | number | boolean | null => {
     if (!v) return null;
@@ -56,13 +59,13 @@ export const attrMap = (kvs: readonly KeyValue[] | undefined): Map<string, strin
     return m;
 };
 
-const Resource = Schema.Struct({ attributes: Schema.optional(Schema.Array(KeyValue)) });
+const Resource = Schema.Struct({ attributes: repeated(KeyValue) });
 
 const NumberDataPoint = Schema.Struct({
     asDouble: Schema.optional(Schema.Number),
     asInt: Schema.optional(OtlpInt64),           // string OR number - see OtlpInt64
     timeUnixNano: Schema.optional(OtlpInt64),
-    attributes: Schema.optional(Schema.Array(KeyValue)),
+    attributes: repeated(KeyValue),
 });
 
 const Metric = Schema.Struct({
@@ -89,7 +92,7 @@ const Span = Schema.Struct({
     parentSpanId: Schema.optional(Schema.String),
     startTimeUnixNano: OtlpInt64,
     endTimeUnixNano: OtlpInt64,
-    attributes: Schema.optional(Schema.Array(KeyValue)),
+    attributes: repeated(KeyValue),
 });
 
 export const TracePayload = Schema.Struct({
@@ -105,15 +108,15 @@ export type TracePayload = Schema.Schema.Type<typeof TracePayload>;
 const LogRecord = Schema.Struct({
     timeUnixNano: Schema.optional(OtlpInt64),
     observedTimeUnixNano: Schema.optional(OtlpInt64),
-    attributes: Schema.optional(Schema.Array(KeyValue)),
+    attributes: repeated(KeyValue),
     body: Schema.optional(Schema.Unknown),
 });
 
 export const LogsPayload = Schema.Struct({
-    resourceLogs: Schema.Array(Schema.Struct({
-        resource: Schema.optional(Schema.Struct({ attributes: Schema.optional(Schema.Array(KeyValue)) })),
-        scopeLogs: Schema.Array(Schema.Struct({
-            logRecords: Schema.Array(LogRecord),
+    resourceLogs: repeated(Schema.Struct({
+        resource: Schema.optional(Schema.Struct({ attributes: repeated(KeyValue) })),
+        scopeLogs: repeated(Schema.Struct({
+            logRecords: repeated(LogRecord),
         })),
     })),
 });

--- a/apps/axctl/src/profile/widget.test.ts
+++ b/apps/axctl/src/profile/widget.test.ts
@@ -85,6 +85,23 @@ describe("replaceProfileWidget", () => {
 
         expect(updated).toBe(`# Necmttn\n\nIntro stays.\n\n${nextBlock}\n`);
     });
+
+    test("refuses nested markers before it can corrupt the README", () => {
+        const readme = [
+            "# profile",
+            PROFILE_WIDGET_START,
+            "old outer content",
+            PROFILE_WIDGET_START,
+            "old inner content",
+            PROFILE_WIDGET_END,
+            "stale outer tail",
+            PROFILE_WIDGET_END,
+        ].join("\n");
+
+        expect(() => replaceProfileWidget(readme, renderProfileWidget(profile))).toThrow(
+            "README must contain exactly one ax START marker and one ax END marker",
+        );
+    });
 });
 
 describe("installOrUpdateProfileWidget", () => {

--- a/apps/axctl/src/profile/widget.ts
+++ b/apps/axctl/src/profile/widget.ts
@@ -115,14 +115,19 @@ export function renderProfileWidget(profile: ProfileV1): string {
     ].join("\n");
 }
 
-const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 export function replaceProfileWidget(readme: string, block: string): string {
-    const existingBlock = new RegExp(
-        `${escapeRegExp(PROFILE_WIDGET_START)}[\\s\\S]*?${escapeRegExp(PROFILE_WIDGET_END)}`,
-    );
-    if (existingBlock.test(readme)) {
-        return readme.replace(existingBlock, block);
+    const startCount = readme.split(PROFILE_WIDGET_START).length - 1;
+    const endCount = readme.split(PROFILE_WIDGET_END).length - 1;
+    if (startCount !== endCount || startCount > 1) {
+        throw new Error("README must contain exactly one ax START marker and one ax END marker, or no ax markers");
+    }
+    if (startCount === 1) {
+        const start = readme.indexOf(PROFILE_WIDGET_START);
+        const end = readme.indexOf(PROFILE_WIDGET_END);
+        if (start > end) {
+            throw new Error("README ax START marker must occur before the ax END marker");
+        }
+        return `${readme.slice(0, start)}${block}${readme.slice(end + PROFILE_WIDGET_END.length)}`;
     }
     if (readme.length === 0) return `${block}\n`;
     const prefix = readme.endsWith("\n") ? readme : `${readme}\n`;

--- a/apps/axctl/src/queries/query-input-contract.test.ts
+++ b/apps/axctl/src/queries/query-input-contract.test.ts
@@ -91,15 +91,10 @@ describe("normalizeRecommendInput", () => {
         ]);
     });
 
-    test("agent/sinceDays are only present when supplied", () => {
+    test("sinceDays is only present when supplied", () => {
         const bare = normalizeRecommendInput({}, 5);
-        expect("agent" in bare).toBe(false);
         expect("sinceDays" in bare).toBe(false);
-        const full = normalizeRecommendInput(
-            { agent: "codex", sinceDays: 14 },
-            5,
-        );
-        expect(full.agent).toBe("codex");
+        const full = normalizeRecommendInput({ sinceDays: 14 }, 5);
         expect(full.sinceDays).toBe(14);
     });
 });

--- a/packages/community-compile/src/compile.test.ts
+++ b/packages/community-compile/src/compile.test.ts
@@ -108,6 +108,63 @@ describe("compileCommunity", () => {
         expect(out.skillStats["simplify"]).toEqual({ users: 1, runs: 5, source: "superpowers" });
     });
 
+    test("drops hostile numeric fields before they can overflow aggregates", async () => {
+        const hostile = (login: string) => profile(login, {
+            stats: {
+                sessions: -1,
+                streak_days: 1e308,
+                tokens: { total: -1 },
+                cost_usd: 1e308,
+                models: [],
+                harnesses: ["claude"],
+            },
+            rig: {
+                skills: [{ name: "poison", source: "local", runs: 1e308 }],
+                hooks: [],
+            },
+            taste: {
+                patterns: [{
+                    category: "workflow",
+                    name: "poison",
+                    summary: "hostile row",
+                    evidence: { sessions: 1e308, confidence: 1 },
+                }],
+            },
+        });
+        const out = await compileCommunity(users, fetcher({
+            g1: hostile("alice"),
+            g2: hostile("bob"),
+        }), { now: "2026-08-21T00:00:00.000Z" });
+
+        expect(out.dropped).toEqual([
+            { login: "alice", reason: "invalid-profile" },
+            { login: "bob", reason: "invalid-profile" },
+        ]);
+        expect(JSON.stringify(out)).not.toContain("\"value\":null");
+        expect(JSON.stringify(out)).not.toContain("\"runs\":null");
+        expect(JSON.stringify(out)).not.toContain("\"sessions\":null");
+    });
+
+    test("counts each hook, harness, and model once per profile", async () => {
+        const out = await compileCommunity(
+            [{ github: "alice", gist_id: "g1", joined: "2026-06-01" }],
+            fetcher({
+                g1: profile("alice", {
+                    stats: {
+                        models: [{ name: "opus" }, { name: "opus" }],
+                        harnesses: ["claude", "claude"],
+                    },
+                    rig: { hooks: ["guard", "guard"] },
+                }),
+            }),
+            { now: "2026-08-21T00:00:00.000Z" },
+        );
+
+        expect(out.hookStats.guard).toEqual({ users: 1 });
+        expect(out.state.harness_mix.claude).toBe(1);
+        expect(out.state.model_share.opus).toBe(1);
+    });
+
     test("plugin-namespaced skill name does not double its source prefix", async () => {
         // Real shape: source="superpowers", name="superpowers:brainstorming"
         // (rig.ts keeps the plugin id inside the name). Identity is "brainstorming".
@@ -130,14 +187,14 @@ describe("compileCommunity", () => {
         expect(out.dropped).toEqual([{ login: "bob", reason: "invalid-profile" }]);
     });
 
-    test("absurd values excluded from boards", async () => {
+    test("out-of-range values are rejected during profile validation", async () => {
         const out = await compileCommunity(users, fetcher({
             g1: profile("alice", { stats: { tokens: { prompt: 0, completion: 0, total: 200e9 } } }),
             g2: profile("bob"),
         }), { now: "2026-06-12T03:00:00Z" });
 
         expect(out.leaderboard.boards.tokens.map((r) => r.login)).toEqual(["bob"]);
-        expect(out.dropped).toEqual([{ login: "alice", reason: "absurd-values" }]);
+        expect(out.dropped).toEqual([{ login: "alice", reason: "invalid-profile" }]);
     });
 
     test("unreachable gist dropped, compile continues", async () => {

--- a/packages/community-compile/src/compile.ts
+++ b/packages/community-compile/src/compile.ts
@@ -141,6 +141,20 @@ function representativeSource(name: string, sources: ReadonlySet<string>): strin
 const sortedRecord = <V>(entries: Array<[string, V]>): Record<string, V> =>
     Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
 
+function assertFiniteNumbers(value: unknown, path = "compiled output"): void {
+    if (typeof value === "number") {
+        if (!Number.isFinite(value)) throw new Error(`non-finite ${path}`);
+        return;
+    }
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => assertFiniteNumbers(item, `${path}[${index}]`));
+        return;
+    }
+    if (typeof value === "object" && value !== null) {
+        for (const [key, item] of Object.entries(value)) assertFiniteNumbers(item, `${path}.${key}`);
+    }
+}
+
 interface PatternAggregate {
     readonly category: string;
     readonly name: string;
@@ -244,6 +258,9 @@ export async function compileCommunity(
     const modelUsers = new Map<string, number>();
     for (const { p } of profiles) {
         const seenSkills = new Set<string>();
+        const seenHooks = new Set<string>();
+        const seenHarnesses = new Set<string>();
+        const seenModels = new Set<string>();
         for (const s of p.rig.skills) {
             const id = normalizeSkillName(s.source, s.name);
             const cur = skillAgg.get(id) ?? { users: 0, runs: 0, sources: new Set<string>() };
@@ -256,13 +273,19 @@ export async function compileCommunity(
             skillAgg.set(id, cur);
         }
         for (const h of p.rig.hooks) {
+            if (seenHooks.has(h)) continue;
+            seenHooks.add(h);
             const cur = hookAgg.get(h) ?? { users: 0 };
             hookAgg.set(h, { users: cur.users + 1 });
         }
         for (const h of p.stats.harnesses) {
+            if (seenHarnesses.has(h)) continue;
+            seenHarnesses.add(h);
             harnessMix.set(h, (harnessMix.get(h) ?? 0) + 1);
         }
         for (const m of p.stats.models) {
+            if (seenModels.has(m.name)) continue;
+            seenModels.add(m.name);
             modelUsers.set(m.name, (modelUsers.get(m.name) ?? 0) + 1);
         }
     }
@@ -303,7 +326,7 @@ export async function compileCommunity(
         ]);
     }
 
-    return {
+    const output: CompiledOutput = {
         leaderboard: {
             compiled_at: opts.now,
             window_days: 30,
@@ -338,4 +361,6 @@ export async function compileCommunity(
         },
         dropped,
     };
+    assertFiniteNumbers(output);
+    return output;
 }

--- a/packages/community-compile/src/validate.ts
+++ b/packages/community-compile/src/validate.ts
@@ -82,6 +82,14 @@ const num = (v: unknown, what: string): number => {
     if (typeof v !== "number" || !Number.isFinite(v)) throw new Error(`invalid ${what}`);
     return v;
 };
+const boundedNum = (v: unknown, what: string, max: number): number => {
+    const n = num(v, what);
+    if (n < 0 || n > max) throw new Error(`invalid ${what}`);
+    return n;
+};
+const MAX_TOKENS = 100e9;
+const MAX_SESSIONS = 50_000;
+const MAX_SAFE_GIST_NUMBER = Number.MAX_SAFE_INTEGER;
 const str = (v: unknown, what: string): string => {
     if (typeof v !== "string") throw new Error(`invalid ${what}`);
     return v;
@@ -104,10 +112,12 @@ export function validateProfile(value: unknown): CompiledProfile {
     if (!Array.isArray(rig.skills) || !Array.isArray(rig.hooks)) throw new Error("invalid rig arrays");
 
     const github = str(value.github, "github");
-    const sessions = num(stats.sessions, "sessions");
-    const streak_days = num(stats.streak_days, "streak_days");
-    const total = num(tokens.total, "tokens.total");
-    const cost_usd = stats.cost_usd === undefined ? undefined : num(stats.cost_usd, "cost_usd");
+    const sessions = boundedNum(stats.sessions, "sessions", MAX_SESSIONS);
+    const streak_days = boundedNum(stats.streak_days, "streak_days", MAX_SESSIONS);
+    const total = boundedNum(tokens.total, "tokens.total", MAX_TOKENS);
+    const cost_usd = stats.cost_usd === undefined
+        ? undefined
+        : boundedNum(stats.cost_usd, "cost_usd", MAX_SAFE_GIST_NUMBER);
 
     for (const h of stats.harnesses) str(h, "harness");
     for (const h of rig.hooks) str(h, "hook");
@@ -118,7 +128,11 @@ export function validateProfile(value: unknown): CompiledProfile {
     });
     const skills = rig.skills.map((s) => {
         if (!isRecord(s)) throw new Error("invalid skill row");
-        return { name: str(s.name, "skill.name"), source: str(s.source, "skill.source"), runs: num(s.runs, "skill.runs") };
+        return {
+            name: str(s.name, "skill.name"),
+            source: str(s.source, "skill.source"),
+            runs: boundedNum(s.runs, "skill.runs", MAX_SAFE_GIST_NUMBER),
+        };
     });
 
     return {
@@ -139,12 +153,6 @@ export function patternKey(category: string, name: string): string {
     return `${category.trim()}/${name.trim()}`;
 }
 
-const finitePatternNumber = (v: unknown, what: string): number => {
-    const n = num(v, what);
-    if (n < 0) throw new Error(`invalid ${what}`);
-    return n;
-};
-
 function validatePatternRow(row: unknown): CompiledTastePattern {
     if (!isRecord(row) || !isRecord(row.evidence)) throw new Error("invalid pattern");
     const category = str(row.category, "pattern.category").trim();
@@ -154,13 +162,11 @@ function validatePatternRow(row: unknown): CompiledTastePattern {
     const trend = row.evidence.trend === undefined ? undefined : str(row.evidence.trend, "pattern.evidence.trend");
     if (trend !== undefined && !PATTERN_TREND_SET.has(trend)) throw new Error("invalid pattern.evidence.trend");
     const evidence: CompiledTastePattern["evidence"] = {
-        sessions: finitePatternNumber(row.evidence.sessions, "pattern.evidence.sessions"),
-        confidence: finitePatternNumber(row.evidence.confidence, "pattern.evidence.confidence"),
+        sessions: boundedNum(row.evidence.sessions, "pattern.evidence.sessions", MAX_SESSIONS),
+        confidence: boundedNum(row.evidence.confidence, "pattern.evidence.confidence", 1),
         ...(row.evidence.last_reinforced === undefined ? {} : { last_reinforced: str(row.evidence.last_reinforced, "pattern.evidence.last_reinforced") }),
         ...(trend === undefined ? {} : { trend: trend as PatternTrend }),
     };
-    if (evidence.confidence > 1) throw new Error("invalid pattern.evidence.confidence");
-
     if (category === "stack-choice") {
         const slot = str(row.slot, "pattern.slot").trim();
         if (slot === "") throw new Error("invalid pattern.slot");


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-otel-community-profile-mcp.

- #988: LogsPayload's repeated OTLP fields (logRecords, scopeLogs, attributes) are now optional with `[]` default, so an exporter that omits an empty scope's array no longer rejects the whole payload.
- #989: community compile clamps every gist numeric to sane bounds (rejects negative + overflow) at validation and rejects non-finite aggregates before serialization - untrusted gist numbers can no longer reach the published board as null/Infinity.
- #990: hook/harness/model user-counts now dedup each profile into a Set before incrementing (mirroring the skills path), so a profile listing a value twice no longer double-counts users.
- #991: the profile-widget README updater counts markers and refuses to write on nested/mismatched/out-of-order markers (index-slice instead of a greedy regex), so it can't corrupt a README.
- #992: the unsupported `agent` arg is removed from the MCP improve_recommend schema and RecommendInput (it was a silent no-op; the honest fix, an agent discriminator on the proposal contract, is out of scope).
- #970: workflow proposals now mint with their stored form (`dedupeSig("guidance", ...)`), so the #965 migration no longer re-keys and re-mints them; skill/hook/subagent mint sites verified already-consistent. A one-time cleanup removes OPEN, non-rejected, experiment-less `__legacy__` twins (guard re-checked in the DELETE); the `changed===0` early-return is dropped so the cleanup runs on a store already migrated last release.

Gates: all six areas' suites 145/145 (each red->green), tsc clean, both cast checks clean.

Fixes #988
Fixes #989
Fixes #990
Fixes #991
Fixes #992
Fixes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)