### PR TITLE
fix(cost): honest unpriced totals across analytics, routing-impact, codex, backfill + per-table collapse warning

### DIFF
--- a/apps/axctl/src/cli/commands/ax-routing-impact.ts
+++ b/apps/axctl/src/cli/commands/ax-routing-impact.ts
@@ -118,7 +118,7 @@ const reportImpactCommand = Command.make(
             const inputs: BlockInput[] = [];
             for (const b of done) {
                 const metrics = yield* fetchWindowMetrics(b.started_at, b.ended_at!).pipe(
-                    Effect.catch(() => Effect.succeed({ tokenCostUsd: 0, turns: 0 })),
+                    Effect.catch(() => Effect.succeed({ tokenCostUsd: 0, pricedRows: 0, totalRows: 0, turns: 0 })),
                 );
                 inputs.push({
                     arm: b.arm,
@@ -128,6 +128,8 @@ const reportImpactCommand = Command.make(
                     fiveHourStart: b.five_hour_start,
                     fiveHourEnd: b.five_hour_end,
                     tokenCostUsd: metrics.tokenCostUsd,
+                    pricedRows: metrics.pricedRows,
+                    totalRows: metrics.totalRows,
                     dispatchCount: 0,
                     inheritCount: 0,
                     turns: metrics.turns,

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -637,6 +637,66 @@ describe("Codex transcript extraction", () => {
         expect(session?.estimated_cost_usd).toBe(7);
     });
 
+    test("prices session usage that has no turn row (#999)", async () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-08-21T00:00:00.000Z",
+                payload: { id: "codex-pre-turn-price", cwd: "/tmp", model_provider: "openai" },
+            }),
+            JSON.stringify({ type: "turn_context", payload: { model: "test-model" } }),
+            JSON.stringify({
+                type: "event_msg",
+                payload: { type: "token_count", info: {
+                    total_token_usage: { input_tokens: 100, output_tokens: 0, total_tokens: 100 },
+                    last_token_usage: { input_tokens: 100, output_tokens: 0, total_tokens: 100 },
+                } },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+            }),
+            JSON.stringify({
+                type: "event_msg",
+                payload: { type: "token_count", info: {
+                    total_token_usage: { input_tokens: 110, output_tokens: 0, total_tokens: 110 },
+                    last_token_usage: { input_tokens: 10, output_tokens: 0, total_tokens: 10 },
+                } },
+            }),
+        ]);
+        const written = new Map<string, Record<string, unknown>[]>();
+        const write = {
+            put: (table: string, row: Record<string, unknown>) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), row]);
+            }),
+            putMany: (table: string, rows: Record<string, unknown>[]) => Effect.sync(() => {
+                written.set(table, [...(written.get(table) ?? []), ...rows]);
+            }),
+        };
+        const catalog = new Map<string, ModelPricing>([["test-model", {
+            provider: "test",
+            inputPerMillionUsd: 1,
+            outputPerMillionUsd: 1,
+            cacheCreationPerMillionUsd: 1,
+            cacheReadPerMillionUsd: 1,
+            fastMultiplier: 1,
+            pricingSource: "test-catalog",
+        }]]);
+
+        expect(extracted?.tokenUsage?.promptTokens).toBe(110);
+        expect(extracted?.turnTokenUsages.map((row) => row.promptTokens)).toEqual([10]);
+
+        await Effect.runPromise(__testWriteCodexTokenUsage(
+            write as never,
+            extracted!.tokenUsage,
+            extracted!.turnTokenUsages,
+            "codex",
+            catalog,
+        ));
+
+        expect(written.get("session_token_usage")?.[0]?.estimated_cost_usd).toBeCloseTo(0.00011, 12);
+    });
+
     // Plan 003 fix round 1: `codexTurnTokenUsageFromPayload`'s `first_total`
     // outcome (no previous cumulative snapshot to diff against) returns the
     // FULL cumulative total_token_usage.input_tokens unchanged - a sum by

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1250,18 +1250,59 @@ const writeCodexTokenUsage = (
     });
     const turnCosts = turnUsages.map(priceTurn);
     if (usage !== null) {
-        const cost = sessionTurnUsages.length > 0
-            ? sumCostEstimates(sessionTurnUsages.map(priceTurn))
-            : estimateCost({
+        const sessionFallback = () => estimateCost({
+            modelKey: usage.model,
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+            estimatedTokens: usage.estimatedTokens,
+            pricingCatalog,
+            aggregated: true,
+        });
+        const sessionCost = (): ReturnType<typeof estimateCost> => {
+            if (sessionTurnUsages.length === 0) return sessionFallback();
+
+            const sum = (select: (row: CodexTurnTokenUsage) => number | null): number =>
+                sessionTurnUsages.reduce((total, row) => total + (select(row) ?? 0), 0);
+            const covered = {
+                promptTokens: sum((row) => row.promptTokens),
+                completionTokens: sum((row) => row.completionTokens),
+                cacheReadInputTokens: sum((row) => row.cacheReadInputTokens),
+                estimatedTokens: sum((row) => row.estimatedTokens),
+            };
+            const knownTotals = [
+                [usage.promptTokens, covered.promptTokens],
+                [usage.completionTokens, covered.completionTokens],
+                [usage.cacheReadInputTokens, covered.cacheReadInputTokens],
+                [usage.estimatedTokens, covered.estimatedTokens],
+            ] as const;
+            // A reset or inconsistent provider total cannot produce a safe
+            // remainder. Use the session estimate instead of a negative leg.
+            if (knownTotals.some(([total, part]) => total !== null && part > total)) {
+                return sessionFallback();
+            }
+            const hasUncoveredUsage = knownTotals.some(([total, part]) => total !== null && part < total);
+            const pricedTurns = sessionTurnUsages.map(priceTurn);
+            if (!hasUncoveredUsage) return sumCostEstimates(pricedTurns);
+
+            const uncovered = estimateCost({
                 modelKey: usage.model,
-                promptTokens: usage.promptTokens,
-                completionTokens: usage.completionTokens,
+                promptTokens: usage.promptTokens === null ? null : usage.promptTokens - covered.promptTokens,
+                completionTokens: usage.completionTokens === null
+                    ? null
+                    : usage.completionTokens - covered.completionTokens,
                 cacheCreationInputTokens: null,
-                cacheReadInputTokens: usage.cacheReadInputTokens,
-                estimatedTokens: usage.estimatedTokens,
+                cacheReadInputTokens: usage.cacheReadInputTokens === null
+                    ? null
+                    : usage.cacheReadInputTokens - covered.cacheReadInputTokens,
+                estimatedTokens: Math.max(0, usage.estimatedTokens - covered.estimatedTokens),
                 pricingCatalog,
                 aggregated: true,
             });
+            return sumCostEstimates([...pricedTurns, uncovered]);
+        };
+        const cost = sessionCost();
         yield* write.put("session_token_usage", cacheRow({
             id: usage.session,
             session: usage.session,

--- a/apps/axctl/src/ingest/derive-cost-backfill.test.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.test.ts
@@ -106,6 +106,103 @@ describe("deriveCostBackfill on real DuckDB", () => {
         });
     });
 
+    dtest("sums complete turn-model prices for a mixed-model session (#1000)", async () => {
+        let cost: number | null = -1;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-cost-mixed-model-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* write.putMany("agent_model", [
+                    {
+                        id: "cheap", name: "cheap", provider: "test", display_name: "cheap",
+                        input_per_million_usd: 1, output_per_million_usd: 1,
+                        cache_creation_per_million_usd: 1, cache_read_per_million_usd: 1,
+                        fast_multiplier: 1, pricing_source: "test",
+                    },
+                    {
+                        id: "expensive", name: "expensive", provider: "test", display_name: "expensive",
+                        input_per_million_usd: 10, output_per_million_usd: 10,
+                        cache_creation_per_million_usd: 10, cache_read_per_million_usd: 10,
+                        fast_multiplier: 1, pricing_source: "test",
+                    },
+                ]);
+                yield* write.put("session_token_usage", usage("s1", "expensive", {
+                    source: "codex",
+                    prompt_tokens: 2_000_000,
+                    completion_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                    estimated_tokens: 2_000_000,
+                    transcript_bytes: 0,
+                }));
+                yield* write.putMany("turn_token_usage", [
+                    turnUsage("turn-cheap", "cheap", {
+                        source: "codex", prompt_tokens: 1_000_000, completion_tokens: 0,
+                        estimated_tokens: 1_000_000,
+                    }),
+                    turnUsage("turn-expensive", "expensive", {
+                        source: "codex", seq: 2, prompt_tokens: 1_000_000,
+                        completion_tokens: 0, estimated_tokens: 1_000_000,
+                    }),
+                ]);
+
+                yield* deriveCostBackfill(write);
+                cost = (yield* write.rows(
+                    Schema.Struct({ cost: Schema.NullOr(Schema.Number) }),
+                    "SELECT estimated_cost_usd AS cost FROM session_token_usage WHERE id = ?",
+                    ["s1"],
+                ))[0]!.cost;
+            }),
+        ));
+
+        expect(cost).toBe(11);
+    });
+
+    dtest("prices only the uncovered remainder and marks incomplete turn coverage (#1000)", async () => {
+        let row: { readonly cost: number | null; readonly source: string | null } | undefined;
+        await runWithPlatform(publishCacheFixture(tempDir("ax-cost-partial-turns-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* write.putMany("agent_model", [
+                    {
+                        id: "cheap", name: "cheap", provider: "test", display_name: "cheap",
+                        input_per_million_usd: 1, output_per_million_usd: 1,
+                        cache_creation_per_million_usd: 1, cache_read_per_million_usd: 1,
+                        fast_multiplier: 1, pricing_source: "test",
+                    },
+                    {
+                        id: "expensive", name: "expensive", provider: "test", display_name: "expensive",
+                        input_per_million_usd: 10, output_per_million_usd: 10,
+                        cache_creation_per_million_usd: 10, cache_read_per_million_usd: 10,
+                        fast_multiplier: 1, pricing_source: "test",
+                    },
+                ]);
+                yield* write.put("session_token_usage", usage("s1", "expensive", {
+                    source: "codex", prompt_tokens: 2_000_000, completion_tokens: 0,
+                    cache_creation_input_tokens: 0, cache_read_input_tokens: 0,
+                    estimated_tokens: 2_000_000, transcript_bytes: 0,
+                }));
+                yield* write.put("turn_token_usage", turnUsage("turn-cheap", "cheap", {
+                    source: "codex", prompt_tokens: 1_000_000, completion_tokens: 0,
+                    estimated_tokens: 1_000_000,
+                }));
+
+                yield* deriveCostBackfill(write);
+                row = (yield* write.rows(
+                    Schema.Struct({
+                        cost: Schema.NullOr(Schema.Number),
+                        source: Schema.NullOr(Schema.String),
+                    }),
+                    "SELECT estimated_cost_usd AS cost, pricing_source AS source"
+                        + " FROM session_token_usage WHERE id = ?",
+                    ["s1"],
+                ))[0];
+            }),
+        ));
+
+        expect(row).toEqual({
+            cost: 11,
+            source: "estimated:turn_sum+session_fallback:incomplete_turn_coverage",
+        });
+    });
+
     dtest("leaves unknown models null and becomes idempotent", async () => {
         let first: unknown;
         let second: unknown;

--- a/apps/axctl/src/ingest/derive-cost-backfill.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.ts
@@ -53,6 +53,7 @@ const MIN_TURN_ROWS_PER_RUN = MAX_ROWS_PER_RUN / 2;
 
 const UsageRow = Schema.Struct({
     id: Schema.String,
+    session: Schema.String,
     model: Schema.NullOr(Schema.String),
     prompt_tokens: Schema.NullOr(NumberFromBigIntColumn),
     completion_tokens: Schema.NullOr(NumberFromBigIntColumn),
@@ -62,6 +63,24 @@ const UsageRow = Schema.Struct({
     estimated_cost_usd: Schema.NullOr(Schema.Number),
     pricing_source: Schema.NullOr(Schema.String),
 });
+
+const TurnCoverageRow = Schema.Struct({
+    session: Schema.String,
+    turn_rows: NumberFromBigIntColumn,
+    priced_rows: NumberFromBigIntColumn,
+    prompt_tokens: NumberFromBigIntColumn,
+    completion_tokens: NumberFromBigIntColumn,
+    cache_creation_input_tokens: NumberFromBigIntColumn,
+    cache_read_input_tokens: NumberFromBigIntColumn,
+    estimated_tokens: NumberFromBigIntColumn,
+    cost_usd: Schema.NullOr(Schema.Number),
+});
+
+type TurnCoverage = typeof TurnCoverageRow.Type;
+
+const COMPLETE_TURN_PRICING_SOURCE = `${ESTIMATED_PRICING_PREFIX}turn_sum:complete_turn_coverage`;
+const INCOMPLETE_TURN_PRICING_SOURCE =
+    `${ESTIMATED_PRICING_PREFIX}turn_sum+session_fallback:incomplete_turn_coverage`;
 
 /**
  * Compute + persist `estimated_cost_usd` for stored token-usage rows that were
@@ -73,7 +92,7 @@ export const deriveCostBackfill = (
     Effect.gen(function* () {
         const turnRows = yield* write.rows(
             UsageRow,
-            `SELECT id, model, prompt_tokens, completion_tokens,`
+            `SELECT id, session, model, prompt_tokens, completion_tokens,`
             + ` cache_creation_input_tokens, cache_read_input_tokens, estimated_tokens,`
             + ` estimated_cost_usd, pricing_source`
             + ` FROM turn_token_usage WHERE estimated_cost_usd IS NULL LIMIT ?`,
@@ -84,29 +103,81 @@ export const deriveCostBackfill = (
             ? []
             : yield* write.rows(
                 UsageRow,
-                `SELECT id, model, prompt_tokens, completion_tokens,`
+                `SELECT id, session, model, prompt_tokens, completion_tokens,`
                 + ` cache_creation_input_tokens, cache_read_input_tokens, estimated_tokens,`
                 + ` estimated_cost_usd, pricing_source`
                 + ` FROM session_token_usage WHERE estimated_cost_usd IS NULL LIMIT ?`,
                 [sessionLimit],
             );
-        const rows = [
-            ...sessionRows.map((row) => ({ ...row, table: "session_token_usage" as const })),
-            ...turnRows.map((row) => ({ ...row, table: "turn_token_usage" as const })),
-        ];
+        const rows = [...sessionRows, ...turnRows];
         if (rows.length === 0) return { scanned: 0, backfilled: 0, unpriced: 0 };
 
         const catalog = yield* loadPricingCatalogForModels(write, rows.map((r) => strOrNull(r.model)));
 
         let backfilled = 0;
         let unpriced = 0;
-        for (const row of rows) {
+        for (const row of turnRows) {
             const storedCost = numOrNull(row.estimated_cost_usd);
             const storedSource = strOrNull(row.pricing_source);
             // Defensive double-guards (selection already excludes both): never
             // touch a row that somehow carries a stored cost, and never re-price
             // an already-estimated row (idempotency: catalog drift must not make
             // every derive run rewrite the whole table).
+            if (storedCost !== null || isEstimatedPricingSource(storedSource)) continue;
+            const cost = estimateCost({
+                modelKey: normalizeModelName(strOrNull(row.model)),
+                promptTokens: numOrNull(row.prompt_tokens),
+                completionTokens: numOrNull(row.completion_tokens),
+                cacheCreationInputTokens: numOrNull(row.cache_creation_input_tokens),
+                cacheReadInputTokens: numOrNull(row.cache_read_input_tokens),
+                estimatedTokens: numOrZero(row.estimated_tokens),
+                pricingCatalog: catalog,
+            });
+            if (cost.totalUsd === null || cost.pricingSource === null) {
+                unpriced += 1;
+                continue;
+            }
+            yield* write.exec(
+                `UPDATE turn_token_usage SET estimated_input_cost_usd = ?,`
+                    + ` estimated_output_cost_usd = ?, estimated_cache_creation_cost_usd = ?,`
+                    + ` estimated_cache_read_cost_usd = ?, estimated_cost_usd = ?, pricing_source = ?`
+                    + ` WHERE id = ? AND estimated_cost_usd IS NULL`,
+                [
+                    cost.inputUsd,
+                    cost.outputUsd,
+                    cost.cacheCreationUsd,
+                    cost.cacheReadUsd,
+                    cost.totalUsd,
+                    `${ESTIMATED_PRICING_PREFIX}${cost.pricingSource}`,
+                    row.id,
+                ],
+            );
+            backfilled += 1;
+        }
+
+        const coverageRows: TurnCoverage[] = [];
+        const coverageBatchSize = 500;
+        for (let start = 0; start < sessionRows.length; start += coverageBatchSize) {
+            const batch = sessionRows.slice(start, start + coverageBatchSize);
+            const placeholders = batch.map(() => "?").join(", ");
+            coverageRows.push(...yield* write.rows(
+                TurnCoverageRow,
+                `SELECT session, count(*) AS turn_rows, count(estimated_cost_usd) AS priced_rows,`
+                    + ` coalesce(sum(prompt_tokens), 0) AS prompt_tokens,`
+                    + ` coalesce(sum(completion_tokens), 0) AS completion_tokens,`
+                    + ` coalesce(sum(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,`
+                    + ` coalesce(sum(cache_read_input_tokens), 0) AS cache_read_input_tokens,`
+                    + ` coalesce(sum(estimated_tokens), 0) AS estimated_tokens,`
+                    + ` sum(estimated_cost_usd) AS cost_usd`
+                    + ` FROM turn_token_usage WHERE session IN (${placeholders}) GROUP BY session`,
+                batch.map((row) => row.session),
+            ));
+        }
+        const coverageBySession = new Map(coverageRows.map((row) => [row.session, row]));
+
+        for (const row of sessionRows) {
+            const storedCost = numOrNull(row.estimated_cost_usd);
+            const storedSource = strOrNull(row.pricing_source);
             if (storedCost !== null || isEstimatedPricingSource(storedSource)) continue;
             const usage = {
                 model: strOrNull(row.model),
@@ -118,34 +189,56 @@ export const deriveCostBackfill = (
                 estimated_cost_usd: null,
                 pricing_source: storedSource,
             };
-            if (row.table === "turn_token_usage") {
-                const cost = estimateCost({
-                    modelKey: normalizeModelName(usage.model),
-                    promptTokens: usage.prompt_tokens,
-                    completionTokens: usage.completion_tokens,
-                    cacheCreationInputTokens: usage.cache_creation_input_tokens,
-                    cacheReadInputTokens: usage.cache_read_input_tokens,
-                    estimatedTokens: usage.estimated_tokens,
-                    pricingCatalog: catalog,
-                });
-                if (cost.totalUsd === null || cost.pricingSource === null) {
+            const coverage = coverageBySession.get(row.session);
+            if (coverage !== undefined) {
+                if (coverage.priced_rows !== coverage.turn_rows || coverage.cost_usd === null) {
                     unpriced += 1;
                     continue;
                 }
+                const totals = [
+                    [usage.prompt_tokens, coverage.prompt_tokens],
+                    [usage.completion_tokens, coverage.completion_tokens],
+                    [usage.cache_creation_input_tokens, coverage.cache_creation_input_tokens],
+                    [usage.cache_read_input_tokens, coverage.cache_read_input_tokens],
+                    [usage.estimated_tokens, coverage.estimated_tokens],
+                ] as const;
+                if (totals.some(([total, covered]) => total !== null && covered > total)) {
+                    unpriced += 1;
+                    continue;
+                }
+                const incomplete = totals.some(([total, covered]) => total !== null && covered < total);
+                let sessionCost = coverage.cost_usd;
+                let pricingSource = COMPLETE_TURN_PRICING_SOURCE;
+                if (incomplete) {
+                    const remainder = estimateCost({
+                        modelKey: normalizeModelName(usage.model),
+                        promptTokens: usage.prompt_tokens === null
+                            ? null
+                            : usage.prompt_tokens - coverage.prompt_tokens,
+                        completionTokens: usage.completion_tokens === null
+                            ? null
+                            : usage.completion_tokens - coverage.completion_tokens,
+                        cacheCreationInputTokens: usage.cache_creation_input_tokens === null
+                            ? null
+                            : usage.cache_creation_input_tokens - coverage.cache_creation_input_tokens,
+                        cacheReadInputTokens: usage.cache_read_input_tokens === null
+                            ? null
+                            : usage.cache_read_input_tokens - coverage.cache_read_input_tokens,
+                        estimatedTokens: Math.max(0, usage.estimated_tokens - coverage.estimated_tokens),
+                        pricingCatalog: catalog,
+                        aggregated: true,
+                    });
+                    if (remainder.totalUsd === null) {
+                        unpriced += 1;
+                        continue;
+                    }
+                    sessionCost += remainder.totalUsd;
+                    pricingSource = INCOMPLETE_TURN_PRICING_SOURCE;
+                }
                 yield* write.exec(
-                    `UPDATE turn_token_usage SET estimated_input_cost_usd = ?,`
-                        + ` estimated_output_cost_usd = ?, estimated_cache_creation_cost_usd = ?,`
-                        + ` estimated_cache_read_cost_usd = ?, estimated_cost_usd = ?, pricing_source = ?`
+                    `UPDATE session_token_usage SET estimated_cost_usd = ?, pricing_source = ?`
                         + ` WHERE id = ? AND estimated_cost_usd IS NULL`,
-                    [
-                        cost.inputUsd,
-                        cost.outputUsd,
-                        cost.cacheCreationUsd,
-                        cost.cacheReadUsd,
-                        cost.totalUsd,
-                        `${ESTIMATED_PRICING_PREFIX}${cost.pricingSource}`,
-                        row.id,
-                    ],
+                    [sessionCost, pricingSource, row.id],
                 );
                 backfilled += 1;
                 continue;

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -139,6 +139,31 @@ describe("fetchCostModels - #696 unpriced/recompute semantics", () => {
         expect(result.rows[0]).toMatchObject({ cost_usd: 1, unpriced: true });
     });
 
+    test("keeps a stored partial cost when one catalog component has no rate (#997)", async () => {
+        const dbRows = [
+            { model: "partial-model", sessions: 2, priced_rows: 1, unpriced_rows: 1,
+              prompt_tokens: 0, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 1_000_000, cost_usd: 2 },
+        ];
+        const agentModelRows = [
+            {
+                name: "partial-model", provider: "test",
+                input_per_million_usd: 1, output_per_million_usd: 1,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: 1,
+                input_above_200k_per_million_usd: null, output_above_200k_per_million_usd: null,
+                cache_creation_above_200k_per_million_usd: null, cache_read_above_200k_per_million_usd: null,
+                fast_multiplier: 1, context_window: null, pricing_source: "test",
+            },
+        ];
+        const { layer } = makeTestCacheRead({
+            routes: { "FROM session_token_usage": dbRows, "FROM agent_model": agentModelRows },
+        });
+
+        const result = await runWithCache(layer, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 2, unpriced: true });
+    });
+
     test("never masks a real nonzero stored cost, even for a model absent from the built-in catalog", async () => {
         // "db-only-model" is priced ONLY via a DB agent_model refresh (litellm/
         // models.dev), never in BUILTIN_MODEL_PRICING_CATALOG. The old

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -160,7 +160,7 @@ function resolveRowCost(
         aggregated: true,
     });
     return estimate.totalUsd === null
-        ? { cost_usd: 0, unpriced: true }
+        ? { cost_usd: storedCost, unpriced: true }
         : { cost_usd: estimate.totalUsd, unpriced: false };
 }
 

--- a/apps/axctl/src/routing-impact/compute.test.ts
+++ b/apps/axctl/src/routing-impact/compute.test.ts
@@ -11,6 +11,8 @@ const block = (over: Partial<BlockInput> & { arm: BlockInput["arm"] }): BlockInp
     fiveHourStart: edge(10),
     fiveHourEnd: edge(40),
     tokenCostUsd: 100,
+    pricedRows: 1,
+    totalRows: 1,
     dispatchCount: 10,
     inheritCount: 5,
     turns: 300,
@@ -130,5 +132,16 @@ describe("buildImpactReport - off vs on comparison", () => {
         ]);
         expect(comparison).toBeNull();
         expect(notes.some((n) => n.includes("multiple blocks"))).toBe(true);
+    });
+
+    test("an incomplete token price omits the cost ratio and adds a note", () => {
+        const { blocks, comparison, notes } = buildImpactReport([
+            block({ arm: "off", tokenCostUsd: null, pricedRows: 1, totalRows: 2 }),
+            block({ arm: "on", tokenCostUsd: 40 }),
+        ]);
+
+        expect(blocks[0]!.tokenCostUsd).toBeNull();
+        expect(comparison!.costRatio).toBeNull();
+        expect(notes.some((note) => note.includes("token prices were incomplete"))).toBe(true);
     });
 });

--- a/apps/axctl/src/routing-impact/compute.ts
+++ b/apps/axctl/src/routing-impact/compute.ts
@@ -34,7 +34,9 @@ export interface BlockInput {
     readonly fiveHourStart: WindowEdge | null;
     readonly fiveHourEnd: WindowEdge | null;
     /** Token-equivalent cost summed over the block window (USD). */
-    readonly tokenCostUsd: number;
+    readonly tokenCostUsd: number | null;
+    readonly pricedRows: number;
+    readonly totalRows: number;
     /** Subagent dispatches that started in the block window. */
     readonly dispatchCount: number;
     /** Of those, how many ran on an inherited (unrouted) model. */
@@ -51,7 +53,9 @@ export interface BlockResult {
      *  quota was missing or the window reset mid-block (see windowReset). */
     readonly fiveHourPpConsumed: number | null;
     readonly windowReset: boolean;
-    readonly tokenCostUsd: number;
+    readonly tokenCostUsd: number | null;
+    readonly pricedRows: number;
+    readonly totalRows: number;
     readonly inheritPct: number | null;
     readonly dispatchCount: number;
     readonly turns: number;
@@ -115,7 +119,9 @@ const resolveBlock = (b: BlockInput): BlockResult => {
         durationMin,
         fiveHourPpConsumed,
         windowReset,
-        tokenCostUsd: round(b.tokenCostUsd, 2),
+        tokenCostUsd: b.tokenCostUsd === null ? null : round(b.tokenCostUsd, 2),
+        pricedRows: b.pricedRows,
+        totalRows: b.totalRows,
         inheritPct,
         dispatchCount: b.dispatchCount,
         turns: b.turns,
@@ -136,6 +142,9 @@ export const buildImpactReport = (blocks: ReadonlyArray<BlockInput>): ImpactRepo
     if (results.some((r) => r.fiveHourPpConsumed === null && !r.windowReset)) {
         notes.push("quota was unavailable for a block - window delta omitted for it.");
     }
+    if (results.some((r) => r.tokenCostUsd === null)) {
+        notes.push("token prices were incomplete for a block - token cost omitted for it.");
+    }
 
     // Comparison only when we have exactly one clean off and one clean on block.
     const off = results.filter((r) => r.arm === "off");
@@ -149,7 +158,9 @@ export const buildImpactReport = (blocks: ReadonlyArray<BlockInput>): ImpactRepo
                 o.workPerWindowPp !== null && n.workPerWindowPp !== null && o.workPerWindowPp > 0
                     ? round(n.workPerWindowPp / o.workPerWindowPp, 2)
                     : null,
-            costRatio: n.tokenCostUsd > 0 ? round(o.tokenCostUsd / n.tokenCostUsd, 2) : null,
+            costRatio: o.tokenCostUsd !== null && n.tokenCostUsd !== null && n.tokenCostUsd > 0
+                ? round(o.tokenCostUsd / n.tokenCostUsd, 2)
+                : null,
             inheritPctDrop:
                 o.inheritPct !== null && n.inheritPct !== null
                     ? round(o.inheritPct - n.inheritPct, 1)

--- a/apps/axctl/src/routing-impact/format.ts
+++ b/apps/axctl/src/routing-impact/format.ts
@@ -11,7 +11,7 @@ const armLabel = (b: BlockResult): string =>
 
 const pp = (n: number | null): string => (n === null ? "  -  " : `${n.toFixed(1)}pp`);
 const pct = (n: number | null): string => (n === null ? " - " : `${n.toFixed(0)}%`);
-const usd = (n: number): string => `$${n.toFixed(2)}`;
+const usd = (n: number | null): string => n === null ? "unknown" : `$${n.toFixed(2)}`;
 
 const blockLine = (b: BlockResult): string => {
     const win = b.windowReset ? "window reset" : pp(b.fiveHourPpConsumed);

--- a/apps/axctl/src/routing-impact/io.test.ts
+++ b/apps/axctl/src/routing-impact/io.test.ts
@@ -77,6 +77,18 @@ const fixture = () =>
                         usage_quality: "exact",
                         ts: at("2026-08-03T12:00:00.000Z"),
                     },
+                    {
+                        id: "tu-unpriced",
+                        session: "s2",
+                        turn: "t4",
+                        seq: 2n,
+                        source: "claude",
+                        estimated_tokens: 50n,
+                        estimated_cost_usd: null,
+                        usage_source: "transcript",
+                        usage_quality: "exact",
+                        ts: at("2026-08-10T12:00:00.000Z"),
+                    },
                 ]);
             }),
         ),
@@ -86,7 +98,12 @@ const metricsOver = (snapshotPath: string, startIso: string, endIso: string) =>
     Effect.runPromise(
         fetchWindowMetrics(startIso, endIso).pipe(
             Effect.provide(readFixture(snapshotPath, dylibPath)),
-        ) as Effect.Effect<{ readonly tokenCostUsd: number; readonly turns: number }>,
+        ) as Effect.Effect<{
+            readonly tokenCostUsd: number | null;
+            readonly pricedRows: number;
+            readonly totalRows: number;
+            readonly turns: number;
+        }>,
     );
 
 describe("fetchWindowMetrics", () => {
@@ -115,7 +132,7 @@ describe("fetchWindowMetrics", () => {
 
         expect(before.turns).toBe(2);
         expect(after.turns).toBe(1);
-        expect(before.tokenCostUsd + after.tokenCostUsd).toBeCloseTo(3.75, 6);
+        expect((before.tokenCostUsd ?? 0) + (after.tokenCostUsd ?? 0)).toBeCloseTo(3.75, 6);
     });
 
     dtest("an empty window is zeroes, not a failure", async () => {
@@ -126,6 +143,17 @@ describe("fetchWindowMetrics", () => {
             "2020-01-02T00:00:00.000Z",
         );
 
-        expect(metrics).toEqual({ tokenCostUsd: 0, turns: 0 });
+        expect(metrics).toEqual({ tokenCostUsd: 0, pricedRows: 0, totalRows: 0, turns: 0 });
+    });
+
+    dtest("marks window cost unknown when any used row is unpriced (#998)", async () => {
+        const f = await fixture();
+        const metrics = await metricsOver(
+            f.snapshotPath,
+            "2026-08-09T00:00:00.000Z",
+            "2026-08-11T00:00:00.000Z",
+        );
+
+        expect(metrics).toMatchObject({ tokenCostUsd: null, pricedRows: 0, totalRows: 1 });
     });
 });

--- a/apps/axctl/src/routing-impact/io.ts
+++ b/apps/axctl/src/routing-impact/io.ts
@@ -36,12 +36,19 @@ export const saveState = async (path: string, state: RoutingImpactState): Promis
 // ---------------------------------------------------------------------------
 
 export interface WindowMetrics {
-    readonly tokenCostUsd: number;
+    /** Null when at least one token row has no price. */
+    readonly tokenCostUsd: number | null;
+    readonly pricedRows: number;
+    readonly totalRows: number;
     /** assistant turns in the window - the work-volume proxy. */
     readonly turns: number;
 }
 
-const CostRow = Schema.Struct({ c: Schema.NullOr(Schema.Number) });
+const CostRow = Schema.Struct({
+    c: Schema.NullOr(Schema.Number),
+    priced_rows: NumberFromBigIntColumn,
+    total_rows: NumberFromBigIntColumn,
+});
 const TurnCountRow = Schema.Struct({ n: NumberFromBigIntColumn });
 
 /**
@@ -67,7 +74,10 @@ export const fetchWindowMetrics = (
         const cost = yield* cacheFirst(
             CostRow,
             {
-                sql: "SELECT sum(estimated_cost_usd) AS c FROM turn_token_usage WHERE ts > ? AND ts <= ?",
+                sql: `SELECT sum(estimated_cost_usd) AS c,
+                    count(estimated_cost_usd) AS priced_rows,
+                    count(*) AS total_rows
+                    FROM turn_token_usage WHERE ts > ? AND ts <= ?`,
                 params: window,
             },
             "routing impact cost",
@@ -81,5 +91,12 @@ export const fetchWindowMetrics = (
             "routing impact turns",
         );
 
-        return { tokenCostUsd: cost?.c ?? 0, turns: turns?.n ?? 0 };
+        const pricedRows = cost?.priced_rows ?? 0;
+        const totalRows = cost?.total_rows ?? 0;
+        return {
+            tokenCostUsd: pricedRows === totalRows ? cost?.c ?? 0 : null,
+            pricedRows,
+            totalRows,
+            turns: turns?.n ?? 0,
+        };
     });

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -308,7 +308,36 @@ describe("CacheWrite: the semantics the DDL cannot express", () => {
                 { id: "chunk-boundary", body: "second" },
                 { id: "same-chunk", body: "second" },
             ]);
-            expect(value?.collapsed).toBe(2);
+            expect(value?.collapsed).toEqual(new Map([["note", 2]]));
+        });
+    });
+
+    dtest("counts collapsed duplicate ids by table (#971)", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-putmany-duplicate-tables-");
+            const outcome = await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.putMany("note", [
+                            { id: "n1", body: "first" },
+                            { id: "n1", body: "second" },
+                            { id: "n1", body: "third" },
+                        ]);
+                        yield* write.putMany("keyed", [
+                            { id: "k1", natural_a: "a", natural_b: 1n, body: "first" },
+                            { id: "k1", natural_a: "a", natural_b: 1n, body: "second" },
+                        ]);
+                        return write.rowsCollapsed();
+                    }),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const collapsed = outcome._tag === "completed" ? outcome.value : null;
+            expect(collapsed).toEqual(new Map([
+                ["note", 2],
+                ["keyed", 1],
+            ]));
         });
     });
 

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -157,7 +157,7 @@ export interface CacheWriteService extends CacheReadService {
     readonly nulStripped: () => NulStripTotals;
     /** Duplicate-id rows removed from `putMany` inputs. The last occurrence
      *  for each id is the row that the writer keeps. */
-    readonly rowsCollapsed: () => number;
+    readonly rowsCollapsed: () => ReadonlyMap<string, number>;
     /** The live database being written (not the snapshot). */
     readonly livePath: string;
 }
@@ -807,11 +807,19 @@ const reportNulStripped = (write: CacheWriteService, livePath: string): Effect.E
 /** Report duplicate-id rows that `putMany` collapsed before it wrote them. */
 const reportRowsCollapsed = (write: CacheWriteService, livePath: string): Effect.Effect<void> =>
     Effect.suspend(() => {
-        const rows = write.rowsCollapsed();
+        const byTable = write.rowsCollapsed();
+        const rows = [...byTable.values()].reduce((total, count) => total + count, 0);
         if (rows === 0) return Effect.void;
+        const topTables = [...byTable.entries()]
+            .sort(([leftTable, leftCount], [rightTable, rightCount]) =>
+                rightCount - leftCount || leftTable.localeCompare(rightTable),
+            )
+            .slice(0, 5)
+            .map(([table, count]) => `${table}=${count}`)
+            .join(", ");
         return Effect.logWarning(
             `ax cache: collapsed ${rows} duplicate-id row(s) before putMany batching while writing ${livePath}; ` +
-                "the last occurrence for each id was kept.",
+                `top tables: ${topTables}; the last occurrence for each id was kept.`,
         );
     });
 
@@ -852,7 +860,7 @@ const writerOver = (
      */
     let nulValues = 0;
     let nulStatements = 0;
-    let collapsedRows = 0;
+    const collapsedRows = new Map<string, number>();
     const execScrubbed = (
         sql: string,
         params?: ReadonlyArray<DuckDbParam>,
@@ -966,7 +974,10 @@ const writerOver = (
             const rowsById = new Map<DuckDbParam, Readonly<Record<string, DuckDbParam>>>();
             for (const row of rows) rowsById.set(row["id"], row);
             const deduplicated = [...rowsById.values()];
-            collapsedRows += rows.length - deduplicated.length;
+            const collapsed = rows.length - deduplicated.length;
+            if (collapsed > 0) {
+                collapsedRows.set(table, (collapsedRows.get(table) ?? 0) + collapsed);
+            }
 
             for (let start = 0; start < deduplicated.length; start += PUT_BATCH_ROWS) {
                 const batch = deduplicated.slice(start, start + PUT_BATCH_ROWS);
@@ -979,7 +990,7 @@ const writerOver = (
     const put: CacheWriteService["put"] = (table, row) => putMany(table, [row]);
 
     const nulStripped = (): NulStripTotals => ({ values: nulValues, statements: nulStatements });
-    const rowsCollapsed = (): number => collapsedRows;
+    const rowsCollapsed = (): ReadonlyMap<string, number> => new Map(collapsedRows);
 
     return { ...reader, exec, put, putMany, nulStripped, rowsCollapsed, livePath };
 };


### PR DESCRIPTION
Fleet fix2 (run map #1001), chunk fix2-cost-core (high effort). Makes the "unpriced -> honest, never a silent partial or display-model overprice" contract consistent across every cost surface #966 only half-fixed.

- #997: `resolveRowCost` returned cost_usd:0 when a priced group's recompute hit a missing component rate, erasing a real stored partial. Returns storedCost with unpriced:true.
- #998: routing-impact window cost was a bare SUM (NULL-skipping = silent partial). `io.ts` now returns priced/total row coverage with a nullable cost; `compute.ts` omits ratios and notes incompleteness; `format.ts` prints "unknown".
- #999: codex session cost summed turn rows while the session token total includes pre-turn events with no turn row (undercount). Now reconciles covered turn tokens vs session totals: fully covered -> sum turns; partial -> sum turns + price the uncovered remainder at the session model; a turn-part-exceeds-total reset -> safe session fallback (no negative leg).
- #1000: derive-cost-backfill session path priced all tokens at the display model (#936 overpricing survived). Now sums complete turn-model prices; partial coverage prices only the remainder and marks `incomplete_turn_coverage`; unpriced when a turn lacks a price.
- #971: the putMany collapse warning now counts by table (`Map<table,count>`) and prints the top 5. NOTE: an isolated ingest showed `otel_metric_point=4755` as the top collapse source - filed as a separate follow-up; this chunk does not change writer behavior.

Gates: cost-analytics + routing-impact + codex + backfill + seam suites 123/123 (all red->green), tsc clean, both cast checks clean.

Fixes #997
Fixes #998
Fixes #999
Fixes #1000
Fixes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)