### PR TITLE
fix(advice): posixPath in advice-stage (check:no-node-fs gate)

### DIFF
--- a/apps/axctl/src/advice/advice-stage.ts
+++ b/apps/axctl/src/advice/advice-stage.ts
@@ -2,7 +2,7 @@ import { Cause, Effect, Schema } from "effect";
 import { cacheRow } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { DbError } from "@ax/lib/errors";
-import { dirname, join } from "node:path";
+import { posixPath } from "@ax/lib/shared/path";
 import { BaseStageStats, type IngestContext, StageMeta } from "../ingest/stage/types.ts";
 import type { StageDef } from "../ingest/stage/registry.ts";
 import { runJsonlProviderFiles } from "../ingest/jsonl-work-unit.ts";
@@ -17,12 +17,12 @@ export const defaultAdviceLogPath = (): string => `${process.env.HOME}/.ax/hooks
 const adviceLogCandidates = (): Effect.Effect<JsonlFileCandidate[]> =>
   Effect.promise(async () => {
     const live = defaultAdviceLogPath();
-    const dir = dirname(live);
+    const dir = posixPath.dirname(live);
     const glob = new Bun.Glob("advise-log*.jsonl");
     const candidates: JsonlFileCandidate[] = [];
     try {
       for await (const name of glob.scan({ cwd: dir, onlyFiles: true })) {
-        const path = join(dir, name);
+        const path = posixPath.join(dir, name);
         try {
           const stat = await Bun.file(path).stat();
           candidates.push({ path, mtimeMs: stat.mtimeMs, sizeBytes: stat.size });


### PR DESCRIPTION
Fix-forward: #1008 (#979 ledger rotation) imported `dirname`/`join` from `node:path` in advice-stage.ts, an ingest stage. The `check:no-node-fs` verify gate flags it (ingest code must use `@ax/lib/shared/path`). Swapped to `posixPath.dirname`/`.join`; advice suite still green, gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)