### PR TITLE
fix(install): stop silently replacing an existing OTLP endpoint (#1014)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,18 @@ writes the harness telemetry config
 (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:1738`,
 `http/json`; Codex `[otel]` block), idempotent + ax-marked. Provider name:
 `otel`. Spec: docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
+**Co-existence with a user's own collector (#1014).** The Claude env rewrite
+USED to overwrite a pre-existing `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` (e.g. a
+team's Datadog) silently - no report, no doctor line, no backup.
+`detectClaudeOtelReplacements` (`apps/axctl/src/otel/install-config.ts`) now
+finds a FOREIGN (non-loopback) prior endpoint before the overwrite; install
+warns, saves the original ONCE to `~/.ax/otel-previous.json`, and the `otel`
+doctor check surfaces the redirect. `ax install --keep-otel` leaves an existing
+foreign config untouched (ax OTLP surfaces stay dark; the user's collector keeps
+receiving). Forwarding (relay Claude -> ax -> the original collector, so ax is
+additive) is the tracked follow-up; the OTel-native alternative is a local
+collector fanning out to both. The Codex path (`applyCodexOtelToml`) was already
+shape-aware - it leaves a deliberately-different exporter kind alone.
 
 `ax otel [--days=N] [--json]` is the **read surface** for the receiver itself
 (previously write-only - data landed in `otel_*` and only enriched insights, with

--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -50,13 +50,14 @@ export const updateCommand = Command.make(
 export const installCommand = Command.make("install", {
     telemetry: Flag.boolean("telemetry").pipe(Flag.withDefault(false)),
     noTelemetry: Flag.boolean("no-telemetry").pipe(Flag.withDefault(false)),
-}, ({ telemetry, noTelemetry }) => {
+    keepOtel: Flag.boolean("keep-otel").pipe(Flag.withDefault(false)),
+}, ({ telemetry, noTelemetry, keepOtel }) => {
     // Pure flag validation BEFORE any Effect/install work. fail() calls
     // process.exit(2) synchronously with a clean one-line message - no
     // thrown plain Error, no stack trace (matches ingest.ts/quota.ts/dojo.ts).
     const conflict = telemetryConsentConflict(telemetry, noTelemetry);
     if (conflict !== null) fail(conflict);
-    return cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry) });
+    return cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry), keepOtel });
 }).pipe(Command.withDescription("One-shot setup: symlink, optional OTLP receiver (then runs `ax setup`)"));
 
 export const setupCommand = Command.make(

--- a/apps/axctl/src/cli/install.doctor-onboarding.test.ts
+++ b/apps/axctl/src/cli/install.doctor-onboarding.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { CacheRead, CacheUnavailableError, type CacheReadService } from "@ax/lib/duckdb/seam";
 import { cacheReadResults } from "../testing/cache-read.ts";
-import { collectDoctorReport, formatDoctorReport } from "./install.ts";
+import { collectDoctorReport, formatDoctorReport, otelRedirectDoctorCheck } from "./install.ts";
 
 // `collectDoctorReport` is an Effect requiring FileSystem + Path + CacheRead.
 // Run it against the REAL Bun-backed platform layers, exactly as the
@@ -63,6 +63,7 @@ describe("doctor's fixed non-onboarding check set", () => {
             "cache",
             "ingest-runs",
             "otlpd",
+            "otel",
             "agent-event-index",
         ]);
     });
@@ -106,5 +107,48 @@ describe("doctor's fixed non-onboarding check set", () => {
         const report = await runDoctorReport();
         const check = report.checks.find((c) => c.name === "otlpd");
         expect(check?.ok).toBe(true);
+    });
+
+    test("'otel' is always ok=true and present - a legitimate redirect is not a failure", async () => {
+        const report = await runDoctorReport();
+        const check = report.checks.find((c) => c.name === "otel");
+        expect(check).toBeDefined();
+        expect(check?.ok).toBe(true);
+    });
+});
+
+describe("otelRedirectDoctorCheck (#1014)", () => {
+    test("names the backup + restore path when a redirect was recorded", () => {
+        const check = otelRedirectDoctorCheck({
+            backupExists: true,
+            backupPath: "/home/u/.ax/otel-previous.json",
+            logsEndpoint: "http://127.0.0.1:1738/v1/logs",
+        });
+        expect(check.name).toBe("otel");
+        expect(check.ok).toBe(true);
+        expect(check.detail).toContain("redirected");
+        expect(check.detail).toContain("/home/u/.ax/otel-previous.json");
+        expect(check.detail).toContain("restore");
+    });
+
+    test("reports the current endpoint with no redirect when no backup exists", () => {
+        const check = otelRedirectDoctorCheck({
+            backupExists: false,
+            backupPath: "/home/u/.ax/otel-previous.json",
+            logsEndpoint: "http://127.0.0.1:1738/v1/logs",
+        });
+        expect(check.ok).toBe(true);
+        expect(check.detail).toContain("http://127.0.0.1:1738/v1/logs");
+        expect(check.detail).toContain("no external redirect");
+    });
+
+    test("says so when no OTLP endpoint is configured at all", () => {
+        const check = otelRedirectDoctorCheck({
+            backupExists: false,
+            backupPath: "/home/u/.ax/otel-previous.json",
+            logsEndpoint: null,
+        });
+        expect(check.ok).toBe(true);
+        expect(check.detail).toContain("no OTLP");
     });
 });

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -6,7 +6,7 @@ import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { posixPath } from "@ax/lib/shared/path";
 import { buildOnboardingReport, formatInstallOnboardingGuidance } from "./onboarding.ts";
 import { agentEventIndexDoctorCheck, readIndexUnhealthyMarker } from "../ingest/agent-event-index-heal.ts";
-import { applyClaudeOtelEnv, applyCodexOtelToml } from "../otel/install-config.ts";
+import { applyClaudeOtelEnv, applyCodexOtelToml, detectClaudeOtelReplacements, type OtelEnvReplacement } from "../otel/install-config.ts";
 import { DEFAULT_INGEST_TIMEOUT_SECONDS } from "@ax/lib/config";
 import { provisionRetroReviewerAgent } from "./managed-agents.ts";
 import {
@@ -325,6 +325,36 @@ export function otlpdDoctorCheck(agent: AgentRuntimeStatus): DoctorCheck {
 }
 
 /**
+ * Doctor check that surfaces an OTLP redirect (#1014). Before this, ax rewrote
+ * the harness's OTLP logs endpoint at install and NOTHING - not the install
+ * output, not doctor - said so; a user found it nine days later by diffing
+ * settings.json. The redirect is legitimate (ax needs the harness pointed at
+ * its receiver), so this is informational (ok:true), never a failure - but when
+ * a `~/.ax/otel-previous.json` backup exists it names the takeover and the
+ * restore path. Pure + exported for tests.
+ */
+export function otelRedirectDoctorCheck(args: {
+    readonly backupExists: boolean;
+    readonly backupPath: string;
+    readonly logsEndpoint: string | null;
+}): DoctorCheck {
+    if (args.backupExists) {
+        return {
+            name: "otel",
+            ok: true,
+            detail: `ax redirected an existing OTLP destination to its receiver; original saved at ${args.backupPath} - restore to resume your own collector`,
+        };
+    }
+    return {
+        name: "otel",
+        ok: true,
+        detail: args.logsEndpoint
+            ? `OTLP logs → ${args.logsEndpoint} (no external redirect recorded)`
+            : "no OTLP logs endpoint configured",
+    };
+}
+
+/**
  * Ingest wall-clock budget (seconds). Doctor has no AxConfig layer, so mirror
  * the `AX_INGEST_TIMEOUT_SECONDS` knob with the same lenient
  * parse-or-fallback the config layer uses.
@@ -472,6 +502,23 @@ export function collectDoctorReport(): Effect.Effect<
             ingestRunsCheck,
             otlpdDoctorCheck(otlpdStatus),
         ];
+
+        // OTLP redirect visibility (#1014): read whether install saved a
+        // foreign-endpoint backup, plus the harness's current logs endpoint.
+        const otelBackupPath = posixPath.join(HOME, ".ax", "otel-previous.json");
+        const otelBackupExists = yield* fs.exists(otelBackupPath).pipe(orAbsent(false));
+        const claudeLogsEndpoint = yield* Effect.promise(async () => {
+            try {
+                const raw = await Bun.file(posixPath.join(HOME, ".claude", "settings.json")).text();
+                const env = (JSON.parse(raw) as { env?: Record<string, string> }).env ?? {};
+                return env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT ?? env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null;
+            } catch { return null; }
+        });
+        checks.push(otelRedirectDoctorCheck({
+            backupExists: otelBackupExists,
+            backupPath: otelBackupPath,
+            logsEndpoint: claudeLogsEndpoint,
+        }));
         // agent_event ghost-index health (#680): a cheap fs read of the marker
         // the codex self-heal writes only when an auto-rebuild couldn't clear a
         // residual duplicate. No query, so it stays fast on a large agent_event.
@@ -497,7 +544,17 @@ export function formatDoctorReport(report: DoctorReport, json = false): string {
     return lines.join("\n");
 }
 
-export function cmdInstall(options: { readonly telemetry?: TelemetryConsent } = {}): Effect.Effect<
+export function cmdInstall(options: {
+    readonly telemetry?: TelemetryConsent;
+    /**
+     * `--keep-otel` (#1014): when the harness already points OTLP at a non-ax
+     * collector, leave that config untouched instead of redirecting it to ax's
+     * receiver. ax's OTLP-fed surfaces (`ax otel`, telemetry enrichment) stay
+     * dark, but the user's own collector keeps receiving. No-op when nothing
+     * foreign is configured.
+     */
+    readonly keepOtel?: boolean;
+} = {}): Effect.Effect<
     void,
     Error,
     FileSystem.FileSystem | Path.Path | CacheRead
@@ -568,18 +625,56 @@ export function cmdInstall(options: { readonly telemetry?: TelemetryConsent } = 
             // Claude: only touch if ~/.claude exists (harness is installed).
             const claudeDirExists = yield* fs.exists(claudeDir).pipe(orAbsent(false));
             if (claudeDirExists) {
-                yield* Effect.promise(async () => {
+                const keepOtel = options.keepOtel ?? false;
+                const replaced = yield* Effect.promise(async () => {
                     try {
                         let raw = "{}";
                         try { raw = await Bun.file(claudeSettings).text(); } catch { /* absent - use default */ }
                         const parsed = JSON.parse(raw) as Record<string, unknown>;
+                        // Detect a pre-existing non-ax OTLP destination BEFORE we
+                        // overwrite it, so the redirect is visible, not silent (#1014).
+                        const reps = detectClaudeOtelReplacements(parsed, OTLP_ENDPOINT);
+                        // --keep-otel: a foreign collector is already configured and
+                        // the user asked us to respect it - leave settings untouched.
+                        if (keepOtel && reps.length > 0) {
+                            console.log(`  otel: --keep-otel - left your OTLP config in ${claudeSettings} untouched`);
+                            console.log(`        ax OTLP surfaces ('ax otel', telemetry enrichment) stay inactive; run 'ax install' without --keep-otel to redirect.`);
+                            return [] as OtelEnvReplacement[];
+                        }
                         const next = applyClaudeOtelEnv(parsed, OTLP_ENDPOINT);
                         await Bun.write(claudeSettings, JSON.stringify(next, null, 2) + "\n");
                         console.log(`  otel: wrote Claude Code OTLP env → ${claudeSettings}`);
+                        return reps;
                     } catch (err) {
                         console.warn(`  otel: could not update ${claudeSettings}: ${(err as Error).message}`);
+                        return [] as OtelEnvReplacement[];
                     }
                 });
+                if (replaced.length > 0) {
+                    // Persist the original ONCE (never clobber an earlier backup) so
+                    // the user can restore their own collector, and warn loudly.
+                    const axDir = posixPath.join(HOME, ".ax");
+                    const backupPath = posixPath.join(axDir, "otel-previous.json");
+                    const backupExists = yield* fs.exists(backupPath).pipe(orAbsent(false));
+                    if (!backupExists) {
+                        yield* fs.makeDirectory(axDir, { recursive: true }).pipe(Effect.ignore);
+                        const payload = JSON.stringify({
+                            saved_at: new Date().toISOString(),
+                            source: claudeSettings,
+                            note: "ax install redirected these OTLP env keys to its local receiver (http://127.0.0.1:1738). Restore any value below in ~/.claude/settings.json to send that signal to your own collector again.",
+                            replaced: replaced.map((r) => ({ key: r.key, previous: r.previous })),
+                        }, null, 2) + "\n";
+                        yield* fs.writeFileString(backupPath, payload).pipe(Effect.ignore);
+                    }
+                    console.warn(`  otel: ⚠ redirected an existing non-ax OTLP destination in ${claudeSettings}:`);
+                    for (const r of replaced) {
+                        console.warn(`          ${r.key}`);
+                        console.warn(`            was: ${r.previous}`);
+                        console.warn(`            now: ${r.next}`);
+                    }
+                    console.warn(`        that collector no longer receives these signals.`);
+                    console.warn(`        original ${backupExists ? "already saved" : "saved"} at ${backupPath} - restore to re-enable it.`);
+                }
             }
 
             const codexDir = posixPath.join(HOME, ".codex");

--- a/apps/axctl/src/otel/install-config.test.ts
+++ b/apps/axctl/src/otel/install-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { applyClaudeOtelEnv, applyClaudeTraceOtelEnv, applyCodexOtelToml } from "./install-config.ts";
+import { applyClaudeOtelEnv, applyClaudeTraceOtelEnv, applyCodexOtelToml, detectClaudeOtelReplacements } from "./install-config.ts";
 
 const ENDPOINT = "http://127.0.0.1:1738";
 
@@ -191,5 +191,64 @@ describe("install-config", () => {
         const again = applyCodexOtelToml(afterCodexRewrite, ENDPOINT);
         parseToml(again);
         expect(again.match(/\[otel\.exporter|exporter = \{/g)?.length).toBe(1);
+    });
+
+    // #1014: ax install used to overwrite a user's OTLP endpoint silently.
+    // detectClaudeOtelReplacements is what makes the takeover visible.
+    describe("detectClaudeOtelReplacements (#1014)", () => {
+        test("reports a foreign logs endpoint + its protocol", () => {
+            const reps = detectClaudeOtelReplacements({
+                env: {
+                    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://otlp.datadoghq.com/v1/logs",
+                    OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/protobuf",
+                },
+            }, ENDPOINT);
+            const byKey = Object.fromEntries(reps.map((r) => [r.key, r]));
+            expect(byKey.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.previous).toBe("https://otlp.datadoghq.com/v1/logs");
+            expect(byKey.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.next).toBe(`${ENDPOINT}/v1/logs`);
+            expect(byKey.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL.previous).toBe("http/protobuf");
+        });
+
+        test("reports the generic endpoint too when it is foreign", () => {
+            const reps = detectClaudeOtelReplacements({
+                env: { OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.corp.internal:4318" },
+            }, ENDPOINT);
+            expect(reps.map((r) => r.key)).toContain("OTEL_EXPORTER_OTLP_ENDPOINT");
+        });
+
+        test("empty when nothing was configured before", () => {
+            expect(detectClaudeOtelReplacements({}, ENDPOINT)).toEqual([]);
+            expect(detectClaudeOtelReplacements({ env: {} }, ENDPOINT)).toEqual([]);
+        });
+
+        test("empty when the prior value is already ax (idempotent re-install)", () => {
+            const already = applyClaudeOtelEnv({}, ENDPOINT);
+            expect(detectClaudeOtelReplacements(already, ENDPOINT)).toEqual([]);
+        });
+
+        test("localhost and 127.0.0.1 on any port are treated as ax, not foreign", () => {
+            expect(detectClaudeOtelReplacements({
+                env: { OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://localhost:4318/v1/logs" },
+            }, ENDPOINT)).toEqual([]);
+            expect(detectClaudeOtelReplacements({
+                env: { OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9999" },
+            }, ENDPOINT)).toEqual([]);
+        });
+
+        test("a lone protocol difference on a loopback endpoint is not a takeover", () => {
+            // No foreign ENDPOINT key → nothing to report, even if a protocol differs.
+            expect(detectClaudeOtelReplacements({
+                env: {
+                    OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:1738",
+                    OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                },
+            }, ENDPOINT)).toEqual([]);
+        });
+
+        test("ignores blank/whitespace prior values", () => {
+            expect(detectClaudeOtelReplacements({
+                env: { OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "   " },
+            }, ENDPOINT)).toEqual([]);
+        });
     });
 });

--- a/apps/axctl/src/otel/install-config.ts
+++ b/apps/axctl/src/otel/install-config.ts
@@ -34,6 +34,67 @@ export const applyClaudeOtelEnv = (
     return { ...settings, env };
 };
 
+/**
+ * One OTLP env key ax overwrote whose PRIOR value pointed at a foreign
+ * (non-ax) collector.
+ */
+export interface OtelEnvReplacement {
+    readonly key: string;
+    readonly previous: string;
+    readonly next: string;
+}
+
+// The destination + protocol env keys `CC_ENV` writes. Switch keys
+// (CLAUDE_CODE_ENABLE_TELEMETRY, OTEL_*_EXPORTER) carry no target, so
+// overwriting them is never a "takeover" worth reporting.
+const OWNED_ENDPOINT_KEYS = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+] as const;
+const OWNED_PROTOCOL_KEYS = [
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+] as const;
+
+// ax's receiver is always a loopback host; a prior value on loopback is a
+// stale ax install, not a user's collector - never report it as foreign.
+const AX_LOOPBACK_RE = /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:\d+)?(\/|$)/i;
+
+const isForeignEndpoint = (value: string | undefined, next: string): boolean =>
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    value !== next &&
+    !AX_LOOPBACK_RE.test(value.trim());
+
+/**
+ * Detect the pre-existing FOREIGN OTLP destinations that {@link applyClaudeOtelEnv}
+ * would silently overwrite (#1014). `applyClaudeOtelEnv` still redirects the
+ * harness at ax's receiver - the caller uses this report to PRESERVE the old
+ * value and TELL the user, instead of a silent takeover.
+ *
+ * Only fires when at least one ENDPOINT key points somewhere non-ax: a lone
+ * protocol flip on a loopback endpoint is a no-op re-install, not a takeover.
+ * Idempotent - re-running install on an ax-configured machine reports nothing.
+ */
+export const detectClaudeOtelReplacements = (
+    settings: ClaudeSettings,
+    endpoint: string,
+): OtelEnvReplacement[] => {
+    const prev = settings.env ?? {};
+    const next = CC_ENV(endpoint);
+    const foreignEndpoints = OWNED_ENDPOINT_KEYS.filter((k) => isForeignEndpoint(prev[k], next[k]));
+    if (foreignEndpoints.length === 0) return [];
+    const foreignProtocols = OWNED_PROTOCOL_KEYS.filter((k) => {
+        const v = prev[k];
+        return typeof v === "string" && v.trim() !== "" && v !== next[k];
+    });
+    return [...foreignEndpoints, ...foreignProtocols].map((k) => ({
+        key: k,
+        previous: prev[k] as string,
+        next: next[k],
+    }));
+};
+
 /** Add Claude trace export env. This is intentionally separate and opt-in. */
 export const applyClaudeTraceOtelEnv = (
     settings: ClaudeSettings,


### PR DESCRIPTION
## Problem (#1014, external report)

`ax install` spread its OTLP env over `~/.claude/settings.json` unconditionally (`applyClaudeOtelEnv`), so a pre-existing `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` pointing at a user's own collector (their team's Datadog) was **overwritten with zero signal** — no install warning, no backup, and `ax doctor` said nothing. The reporter found it nine days later by diffing `settings.json`; for a team of ~20 sharing one dashboard, adoption would silently empty each engineer's event panels one install at a time.

The Codex path (`applyCodexOtelToml`) was already careful about exactly this; the Claude path was naive.

## Fix

- **`detectClaudeOtelReplacements`** — finds a FOREIGN (non-loopback) prior endpoint *before* the overwrite. Idempotent (re-install on an ax machine reports nothing); a lone protocol flip on a loopback endpoint is not treated as a takeover.
- **Install visibility** — warns loudly naming each replaced key (`was:` → `now:`), and saves the original **once** to `~/.ax/otel-previous.json` (never clobbers an earlier backup).
- **`otel` doctor check** — surfaces the redirect + restore path. `ok:true` (a consented redirect is legitimate, not a failure) but now visible — closing the "doctor stayed green" gap.
- **`ax install --keep-otel`** — leaves an existing foreign OTLP config untouched; ax OTLP surfaces stay dark, the user's collector keeps receiving.

## Co-existence plan (the reporter's #1 preference)

`--keep-otel` covers "keep mine, skip ax OTLP" now. **Forwarding** (Claude → ax → the original collector, so ax is *additive*) is the tracked follow-up — a receiver feature with egress/retry/format concerns. OTel-native alternative for teams: a local collector fanning out to both.

## Tests / gates

- `install-config.test.ts`: +7 cases (foreign logs+protocol, generic endpoint, empty, idempotent, loopback-any-port, lone-protocol-no-op, blank).
- `install.doctor-onboarding.test.ts`: `otel` added to the fixed-check order; +3 pure-check cases; +presence/ok assertion.
- `bun test` (both suites) 33 pass · `bunx tsc` clean · `check:no-node-fs` / `check:timestamp-cast` / `check:raw-numeric-cast` all clean.

Fixes #1014