### PR TITLE
feat(otel): forward received OTLP to the user's own collector (#1017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,10 +328,21 @@ finds a FOREIGN (non-loopback) prior endpoint before the overwrite; install
 warns, saves the original ONCE to `~/.ax/otel-previous.json`, and the `otel`
 doctor check surfaces the redirect. `ax install --keep-otel` leaves an existing
 foreign config untouched (ax OTLP surfaces stay dark; the user's collector keeps
-receiving). Forwarding (relay Claude -> ax -> the original collector, so ax is
-additive) is the tracked follow-up; the OTel-native alternative is a local
-collector fanning out to both. The Codex path (`applyCodexOtelToml`) was already
-shape-aware - it leaves a deliberately-different exporter kind alone.
+receiving). `ax install --otel-forward` (#1017) makes ax ADDITIVE instead:
+install captures the user's collector (endpoint + auth headers) from the
+pre-rewrite env into `~/.ax/otel-forward.json` (0600), and the `otlpd` receiver
+relays every accepted body onward - Claude -> ax -> the collector. The relay is
+best-effort and fire-and-forget (`apps/axctl/src/otel/forward-relay.ts`): it
+NEVER blocks the 2xx to the harness, so a down upstream cannot stall the
+exporter. The forward set is resolved by `resolveForwardTargets`
+(`forward-config.ts`), which forwards a signal ONLY when ax's rewrite actually
+DIVERTS it (logs always; metrics/traces only with no explicit per-signal
+endpoint) - forwarding a still-direct signal would DOUBLE-SEND. `--keep-otel`
+and `--otel-forward` are mutually exclusive. ax forces `http/json`, so a
+protobuf-only upstream fails the relay (surfaced, not fatal). The OTel-native
+alternative is a local collector fanning out to both. The Codex path
+(`applyCodexOtelToml`) was already shape-aware - it leaves a
+deliberately-different exporter kind alone.
 
 `ax otel [--days=N] [--json]` is the **read surface** for the receiver itself
 (previously write-only - data landed in `otel_*` and only enriched insights, with

--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -51,13 +51,17 @@ export const installCommand = Command.make("install", {
     telemetry: Flag.boolean("telemetry").pipe(Flag.withDefault(false)),
     noTelemetry: Flag.boolean("no-telemetry").pipe(Flag.withDefault(false)),
     keepOtel: Flag.boolean("keep-otel").pipe(Flag.withDefault(false)),
-}, ({ telemetry, noTelemetry, keepOtel }) => {
+    otelForward: Flag.boolean("otel-forward").pipe(Flag.withDefault(false)),
+}, ({ telemetry, noTelemetry, keepOtel, otelForward }) => {
     // Pure flag validation BEFORE any Effect/install work. fail() calls
     // process.exit(2) synchronously with a clean one-line message - no
     // thrown plain Error, no stack trace (matches ingest.ts/quota.ts/dojo.ts).
     const conflict = telemetryConsentConflict(telemetry, noTelemetry);
     if (conflict !== null) fail(conflict);
-    return cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry), keepOtel });
+    // --keep-otel (leave the user's collector) and --otel-forward (relay to it)
+    // are opposite intents - refuse both rather than silently pick one.
+    if (keepOtel && otelForward) fail("axctl install: --keep-otel and --otel-forward cannot be used together");
+    return cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry), keepOtel, otelForward });
 }).pipe(Command.withDescription("One-shot setup: symlink, optional OTLP receiver (then runs `ax setup`)"));
 
 export const setupCommand = Command.make(

--- a/apps/axctl/src/cli/install.doctor-onboarding.test.ts
+++ b/apps/axctl/src/cli/install.doctor-onboarding.test.ts
@@ -151,4 +151,16 @@ describe("otelRedirectDoctorCheck (#1014)", () => {
         expect(check.ok).toBe(true);
         expect(check.detail).toContain("no OTLP");
     });
+
+    test("forwarding (#1017) takes precedence and names the relayed signals", () => {
+        const check = otelRedirectDoctorCheck({
+            backupExists: true, // a backup can coexist; forwarding is the live truth
+            backupPath: "/home/u/.ax/otel-previous.json",
+            logsEndpoint: "http://127.0.0.1:1738/v1/logs",
+            forwardingSignals: ["logs", "metrics"],
+        });
+        expect(check.ok).toBe(true);
+        expect(check.detail).toContain("FORWARDS");
+        expect(check.detail).toContain("logs, metrics");
+    });
 });

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -7,6 +7,8 @@ import { posixPath } from "@ax/lib/shared/path";
 import { buildOnboardingReport, formatInstallOnboardingGuidance } from "./onboarding.ts";
 import { agentEventIndexDoctorCheck, readIndexUnhealthyMarker } from "../ingest/agent-event-index-heal.ts";
 import { applyClaudeOtelEnv, applyCodexOtelToml, detectClaudeOtelReplacements, type OtelEnvReplacement } from "../otel/install-config.ts";
+import { resolveForwardTargets, buildForwardConfig, asForwardConfig, type OtelForwardTarget } from "../otel/forward-config.ts";
+import { defaultForwardConfigPath } from "../otel/spool-server.ts";
 import { DEFAULT_INGEST_TIMEOUT_SECONDS } from "@ax/lib/config";
 import { provisionRetroReviewerAgent } from "./managed-agents.ts";
 import {
@@ -337,12 +339,22 @@ export function otelRedirectDoctorCheck(args: {
     readonly backupExists: boolean;
     readonly backupPath: string;
     readonly logsEndpoint: string | null;
+    /** Forwarding signals from `~/.ax/otel-forward.json` (#1017), empty if off. */
+    readonly forwardingSignals?: readonly string[];
 }): DoctorCheck {
+    const forwarding = args.forwardingSignals ?? [];
+    if (forwarding.length > 0) {
+        return {
+            name: "otel",
+            ok: true,
+            detail: `ax receives + FORWARDS ${forwarding.join(", ")} to your own collector (--otel-forward); ax OTLP surfaces stay active`,
+        };
+    }
     if (args.backupExists) {
         return {
             name: "otel",
             ok: true,
-            detail: `ax redirected an existing OTLP destination to its receiver; original saved at ${args.backupPath} - restore to resume your own collector`,
+            detail: `ax redirected an existing OTLP destination to its receiver; original saved at ${args.backupPath} - restore, or re-run with --otel-forward to relay to it`,
         };
     }
     return {
@@ -514,10 +526,19 @@ export function collectDoctorReport(): Effect.Effect<
                 return env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT ?? env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null;
             } catch { return null; }
         });
+        // OTLP forwarding (#1017): is the relay config present + enabled?
+        const forwardingSignals = yield* Effect.promise(async () => {
+            try {
+                const raw = await Bun.file(defaultForwardConfigPath()).text();
+                const cfg = asForwardConfig(JSON.parse(raw));
+                return cfg?.enabled ? cfg.targets.map((t) => t.signal) : [];
+            } catch { return [] as string[]; }
+        });
         checks.push(otelRedirectDoctorCheck({
             backupExists: otelBackupExists,
             backupPath: otelBackupPath,
             logsEndpoint: claudeLogsEndpoint,
+            forwardingSignals,
         }));
         // agent_event ghost-index health (#680): a cheap fs read of the marker
         // the codex self-heal writes only when an auto-rebuild couldn't clear a
@@ -554,6 +575,13 @@ export function cmdInstall(options: {
      * foreign is configured.
      */
     readonly keepOtel?: boolean;
+    /**
+     * `--otel-forward` (#1017): redirect the harness to ax AND capture the
+     * user's own OTLP collector so `otlpd` relays each body onward - ax becomes
+     * additive, not exclusive. Mutually exclusive with `--keep-otel`. No-op
+     * when nothing foreign is configured.
+     */
+    readonly otelForward?: boolean;
 } = {}): Effect.Effect<
     void,
     Error,
@@ -626,7 +654,9 @@ export function cmdInstall(options: {
             const claudeDirExists = yield* fs.exists(claudeDir).pipe(orAbsent(false));
             if (claudeDirExists) {
                 const keepOtel = options.keepOtel ?? false;
-                const replaced = yield* Effect.promise(async () => {
+                const otelForward = options.otelForward ?? false;
+                const { replaced, forwardTargets } = yield* Effect.promise(async () => {
+                    const none = { replaced: [] as OtelEnvReplacement[], forwardTargets: [] as OtelForwardTarget[] };
                     try {
                         let raw = "{}";
                         try { raw = await Bun.file(claudeSettings).text(); } catch { /* absent - use default */ }
@@ -639,15 +669,19 @@ export function cmdInstall(options: {
                         if (keepOtel && reps.length > 0) {
                             console.log(`  otel: --keep-otel - left your OTLP config in ${claudeSettings} untouched`);
                             console.log(`        ax OTLP surfaces ('ax otel', telemetry enrichment) stay inactive; run 'ax install' without --keep-otel to redirect.`);
-                            return [] as OtelEnvReplacement[];
+                            return none;
                         }
+                        // --otel-forward: capture the user's collector (endpoint +
+                        // headers) from the PRE-rewrite env so otlpd can relay onward.
+                        const env = (parsed.env ?? {}) as Record<string, string>;
+                        const forwardTargets = otelForward ? resolveForwardTargets(env) : [];
                         const next = applyClaudeOtelEnv(parsed, OTLP_ENDPOINT);
                         await Bun.write(claudeSettings, JSON.stringify(next, null, 2) + "\n");
                         console.log(`  otel: wrote Claude Code OTLP env → ${claudeSettings}`);
-                        return reps;
+                        return { replaced: reps, forwardTargets };
                     } catch (err) {
                         console.warn(`  otel: could not update ${claudeSettings}: ${(err as Error).message}`);
-                        return [] as OtelEnvReplacement[];
+                        return none;
                     }
                 });
                 if (replaced.length > 0) {
@@ -674,6 +708,22 @@ export function cmdInstall(options: {
                     }
                     console.warn(`        that collector no longer receives these signals.`);
                     console.warn(`        original ${backupExists ? "already saved" : "saved"} at ${backupPath} - restore to re-enable it.`);
+                }
+                // --otel-forward: write the relay config otlpd reads at boot, so
+                // ax becomes ADDITIVE - the harness feeds ax, ax feeds the user's
+                // collector. The config carries the collector's auth headers; it
+                // is 0600 (the secret already sat at rest in settings.json, same
+                // trust level).
+                if (otelForward && forwardTargets.length > 0) {
+                    const forwardPath = defaultForwardConfigPath();
+                    yield* fs.makeDirectory(posixPath.dirname(forwardPath), { recursive: true }).pipe(Effect.ignore);
+                    const cfg = buildForwardConfig(forwardTargets, new Date().toISOString());
+                    yield* fs.writeFileString(forwardPath, JSON.stringify(cfg, null, 2) + "\n").pipe(Effect.ignore);
+                    yield* fs.chmod(forwardPath, 0o600).pipe(Effect.ignore);
+                    console.log(`  otel: --otel-forward - ax will relay ${forwardTargets.map((t) => t.signal).join(", ")} to your collector (${forwardPath})`);
+                    console.log(`        the otlpd receiver applies this on its next start; run 'ax daemon restart' (or re-login) to pick it up now.`);
+                } else if (otelForward) {
+                    console.log(`  otel: --otel-forward - no existing collector found to relay to; ax OTLP set up normally.`);
                 }
             }
 

--- a/apps/axctl/src/otel/forward-config.test.ts
+++ b/apps/axctl/src/otel/forward-config.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import {
+    parseOtlpHeaders,
+    resolveForwardTargets,
+    buildForwardConfig,
+    signalOfPath,
+    asForwardConfig,
+    isLoopbackEndpoint,
+} from "./forward-config.ts";
+
+describe("forward-config (#1017)", () => {
+    describe("parseOtlpHeaders", () => {
+        test("parses a comma-separated k=v list", () => {
+            expect(parseOtlpHeaders("dd-api-key=abc123,x-team=platform")).toEqual({
+                "dd-api-key": "abc123",
+                "x-team": "platform",
+            });
+        });
+        test("splits only on the first = so values may contain =", () => {
+            expect(parseOtlpHeaders("authorization=Bearer a=b=c")).toEqual({
+                authorization: "Bearer a=b=c",
+            });
+        });
+        test("skips blanks and malformed entries", () => {
+            expect(parseOtlpHeaders(" , =novalue, k=v ,")).toEqual({ k: "v" });
+            expect(parseOtlpHeaders(undefined)).toEqual({});
+            expect(parseOtlpHeaders("")).toEqual({});
+        });
+    });
+
+    describe("resolveForwardTargets", () => {
+        const DD = "https://otlp.datadoghq.com";
+
+        test("the reporter's case: explicit foreign logs + metrics, ax diverts logs only", () => {
+            // ax overwrites the generic + logs endpoint, but NOT the explicit
+            // metrics endpoint - so metrics still flow direct and must NOT be
+            // forwarded (double-send), only logs.
+            const targets = resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: `${DD}/v1/metrics`,
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: `${DD}/v1/logs`,
+                OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/protobuf",
+                OTEL_EXPORTER_OTLP_HEADERS: "dd-api-key=secret",
+            });
+            expect(targets.map((t) => t.signal)).toEqual(["logs"]);
+            expect(targets[0].url).toBe(`${DD}/v1/logs`);
+            expect(targets[0].headers).toEqual({ "dd-api-key": "secret" });
+        });
+
+        test("a foreign GENERIC endpoint with no explicit per-signal diverts logs+metrics", () => {
+            const targets = resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_ENDPOINT: DD,
+                OTEL_EXPORTER_OTLP_HEADERS: "dd-api-key=secret",
+            });
+            // traces are opt-in (no exporter) but resolution is signal-agnostic;
+            // ax diverts every non-explicit signal off the generic endpoint.
+            expect(new Set(targets.map((t) => t.signal))).toEqual(new Set(["logs", "metrics", "traces"]));
+            const logs = targets.find((t) => t.signal === "logs");
+            expect(logs?.url).toBe(`${DD}/v1/logs`);
+            const metrics = targets.find((t) => t.signal === "metrics");
+            expect(metrics?.url).toBe(`${DD}/v1/metrics`);
+        });
+
+        test("an explicit foreign metrics endpoint is NOT forwarded (ax never diverts it)", () => {
+            const targets = resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: `${DD}/v1/metrics`,
+            });
+            expect(targets).toEqual([]);
+        });
+
+        test("per-signal headers override generic headers", () => {
+            const targets = resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: `${DD}/v1/logs`,
+                OTEL_EXPORTER_OTLP_HEADERS: "dd-api-key=generic,shared=1",
+                OTEL_EXPORTER_OTLP_LOGS_HEADERS: "dd-api-key=logs-specific",
+            });
+            expect(targets[0].headers).toEqual({ "dd-api-key": "logs-specific", shared: "1" });
+        });
+
+        test("nothing configured / already-ax loopback yields no targets", () => {
+            expect(resolveForwardTargets({})).toEqual([]);
+            expect(resolveForwardTargets(undefined)).toEqual([]);
+            expect(resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:1738",
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://127.0.0.1:1738/v1/logs",
+            })).toEqual([]);
+            expect(resolveForwardTargets({
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://localhost:4318/v1/logs",
+            })).toEqual([]);
+        });
+
+        test("trims a trailing slash on the generic endpoint", () => {
+            const targets = resolveForwardTargets({ OTEL_EXPORTER_OTLP_ENDPOINT: `${DD}/` });
+            expect(targets.find((t) => t.signal === "logs")?.url).toBe(`${DD}/v1/logs`);
+        });
+    });
+
+    describe("buildForwardConfig / signalOfPath / asForwardConfig", () => {
+        test("buildForwardConfig marks enabled by target presence", () => {
+            expect(buildForwardConfig([], "2026-08-24T00:00:00Z").enabled).toBe(false);
+            const cfg = buildForwardConfig(
+                [{ signal: "logs", url: "https://x/v1/logs", headers: {} }],
+                "2026-08-24T00:00:00Z",
+            );
+            expect(cfg.enabled).toBe(true);
+            expect(cfg.created_at).toBe("2026-08-24T00:00:00Z");
+        });
+
+        test("signalOfPath maps only the three OTLP paths", () => {
+            expect(signalOfPath("/v1/logs")).toBe("logs");
+            expect(signalOfPath("/v1/metrics")).toBe("metrics");
+            expect(signalOfPath("/v1/traces")).toBe("traces");
+            expect(signalOfPath("/v1/other")).toBeNull();
+            expect(signalOfPath("/health")).toBeNull();
+        });
+
+        test("asForwardConfig round-trips and rejects junk", () => {
+            const cfg = buildForwardConfig(
+                [{ signal: "logs", url: "https://x/v1/logs", headers: { "dd-api-key": "k" } }],
+                "2026-08-24T00:00:00Z",
+            );
+            expect(asForwardConfig(JSON.parse(JSON.stringify(cfg)))).toEqual(cfg);
+            expect(asForwardConfig(null)).toBeNull();
+            expect(asForwardConfig({ targets: "no" })).toBeNull();
+            // a bad target is dropped, not fatal
+            const partial = asForwardConfig({ enabled: true, targets: [{ signal: "bogus", url: "x" }, { signal: "logs", url: "https://x/v1/logs" }] });
+            expect(partial?.targets.map((t) => t.signal)).toEqual(["logs"]);
+        });
+
+        test("isLoopbackEndpoint recognizes ax hosts on any port", () => {
+            expect(isLoopbackEndpoint("http://127.0.0.1:1738")).toBe(true);
+            expect(isLoopbackEndpoint("http://localhost:4318/v1/logs")).toBe(true);
+            expect(isLoopbackEndpoint("https://otlp.datadoghq.com/v1/logs")).toBe(false);
+        });
+    });
+});

--- a/apps/axctl/src/otel/forward-config.ts
+++ b/apps/axctl/src/otel/forward-config.ts
@@ -1,0 +1,149 @@
+/**
+ * OTLP forwarding config (#1017, follow-up to #1014).
+ *
+ * `ax install --otel-forward` makes ax ADDITIVE instead of exclusive: the
+ * harness points at ax's receiver, ax spools locally AND relays each body to
+ * the user's own collector (the endpoint ax would otherwise have overwritten).
+ *
+ * This module is PURE - types, header parsing, and target resolution. The
+ * install side writes the config; `otlpd` (`spool-server.ts`) loads it and
+ * relays. No I/O here so the resolution logic stays unit-testable.
+ *
+ * The correctness heart is {@link resolveForwardTargets}: it forwards a signal
+ * ONLY when ax's rewrite actually DIVERTS it to the loopback receiver. A signal
+ * that still flows straight to the user's collector (e.g. an explicit
+ * `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` ax never touches) is NOT forwarded -
+ * forwarding it would DOUBLE-SEND the user's data.
+ */
+
+export type OtelSignal = "logs" | "metrics" | "traces";
+
+export const OTEL_SIGNALS: readonly OtelSignal[] = ["logs", "metrics", "traces"];
+
+export interface OtelForwardTarget {
+    readonly signal: OtelSignal;
+    /** Full destination URL (already carries the `/v1/<signal>` path). */
+    readonly url: string;
+    /** Auth/routing headers to replay (e.g. Datadog's `dd-api-key`). */
+    readonly headers: Readonly<Record<string, string>>;
+}
+
+export interface OtelForwardConfig {
+    readonly enabled: boolean;
+    readonly created_at: string;
+    readonly targets: readonly OtelForwardTarget[];
+}
+
+const trimEndpoint = (endpoint: string): string => endpoint.replace(/\/+$/, "");
+
+// ax's receiver is always loopback; a target already on loopback is ax itself,
+// never a user's collector - mirrors install-config's AX_LOOPBACK_RE.
+const AX_LOOPBACK_RE = /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:\d+)?(\/|$)/i;
+
+export const isLoopbackEndpoint = (value: string): boolean =>
+    AX_LOOPBACK_RE.test(value.trim());
+
+const nonEmpty = (v: string | undefined): v is string => typeof v === "string" && v.trim() !== "";
+
+/**
+ * Parse an `OTEL_EXPORTER_OTLP_*_HEADERS` value: a comma-separated list of
+ * `key=value` pairs (W3C Baggage form, per the OTEL env spec). Only the FIRST
+ * `=` splits, so a value may itself contain `=`. Blank entries are skipped.
+ */
+export const parseOtlpHeaders = (raw: string | undefined): Record<string, string> => {
+    if (!nonEmpty(raw)) return {};
+    const out: Record<string, string> = {};
+    for (const part of raw.split(",")) {
+        const eq = part.indexOf("=");
+        if (eq <= 0) continue;
+        const key = part.slice(0, eq).trim();
+        const value = part.slice(eq + 1).trim();
+        if (key !== "") out[key] = value;
+    }
+    return out;
+};
+
+const signalKey = (signal: OtelSignal, suffix: "ENDPOINT" | "HEADERS"): string =>
+    `OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_${suffix}`;
+
+/**
+ * Resolve the per-signal forward targets from the harness env AS IT WAS BEFORE
+ * ax's rewrite. `env` is the pre-rewrite `settings.json` env block.
+ *
+ * A signal is forwarded when:
+ *   1. its effective destination before ax was FOREIGN (non-loopback), AND
+ *   2. ax's rewrite DIVERTS it to the loopback receiver.
+ *
+ * Divert rule (ax's `CC_ENV` writes the generic endpoint + an explicit LOGS
+ * endpoint, but NOT explicit metrics/traces endpoints):
+ *   - logs: ax always writes `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` -> ALWAYS diverted.
+ *   - metrics/traces: ax writes only the generic endpoint, and an explicit
+ *     per-signal endpoint out-ranks the generic in the OTEL SDK -> diverted
+ *     ONLY when there is NO explicit per-signal endpoint.
+ */
+export const resolveForwardTargets = (
+    env: Record<string, string> | undefined,
+): OtelForwardTarget[] => {
+    const e = env ?? {};
+    const genericEndpoint = e.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const genericHeaders = parseOtlpHeaders(e.OTEL_EXPORTER_OTLP_HEADERS);
+    const targets: OtelForwardTarget[] = [];
+
+    for (const signal of OTEL_SIGNALS) {
+        const explicit = e[signalKey(signal, "ENDPOINT")];
+        const before = nonEmpty(explicit)
+            ? explicit.trim()
+            : nonEmpty(genericEndpoint)
+                ? `${trimEndpoint(genericEndpoint.trim())}/v1/${signal}`
+                : undefined;
+        if (!before || isLoopbackEndpoint(before)) continue;
+
+        const diverted = signal === "logs" ? true : !nonEmpty(explicit);
+        if (!diverted) continue;
+
+        const headers = { ...genericHeaders, ...parseOtlpHeaders(e[signalKey(signal, "HEADERS")]) };
+        targets.push({ signal, url: before, headers });
+    }
+    return targets;
+};
+
+/** Build the on-disk config object from a resolved target list. */
+export const buildForwardConfig = (
+    targets: readonly OtelForwardTarget[],
+    createdAtIso: string,
+): OtelForwardConfig => ({
+    enabled: targets.length > 0,
+    created_at: createdAtIso,
+    targets,
+});
+
+/** Map an OTLP request pathname (`/v1/logs`) to its signal, or null. */
+export const signalOfPath = (pathname: string): OtelSignal | null => {
+    for (const signal of OTEL_SIGNALS) {
+        if (pathname === `/v1/${signal}`) return signal;
+    }
+    return null;
+};
+
+/** Narrow an unknown parsed JSON value to a usable OtelForwardConfig. */
+export const asForwardConfig = (value: unknown): OtelForwardConfig | null => {
+    if (typeof value !== "object" || value === null) return null;
+    const v = value as Record<string, unknown>;
+    if (!Array.isArray(v.targets)) return null;
+    const targets: OtelForwardTarget[] = [];
+    for (const t of v.targets) {
+        if (typeof t !== "object" || t === null) continue;
+        const tt = t as Record<string, unknown>;
+        const signal = tt.signal;
+        const url = tt.url;
+        if ((signal !== "logs" && signal !== "metrics" && signal !== "traces") || typeof url !== "string") continue;
+        const headers: Record<string, string> = {};
+        if (typeof tt.headers === "object" && tt.headers !== null) {
+            for (const [k, hv] of Object.entries(tt.headers as Record<string, unknown>)) {
+                if (typeof hv === "string") headers[k] = hv;
+            }
+        }
+        targets.push({ signal, url, headers });
+    }
+    return { enabled: v.enabled === true && targets.length > 0, created_at: String(v.created_at ?? ""), targets };
+};

--- a/apps/axctl/src/otel/forward-relay.test.ts
+++ b/apps/axctl/src/otel/forward-relay.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { relayOtlp, makeRelayLogger } from "./forward-relay.ts";
+import { buildForwardConfig, type OtelForwardConfig } from "./forward-config.ts";
+
+const DD = "https://otlp.datadoghq.com";
+const cfg = (enabled = true): OtelForwardConfig => ({
+    ...buildForwardConfig(
+        [{ signal: "logs", url: `${DD}/v1/logs`, headers: { "dd-api-key": "secret" } }],
+        "2026-08-24T00:00:00Z",
+    ),
+    enabled,
+});
+
+describe("relayOtlp (#1017)", () => {
+    test("POSTs the body + headers to the matching signal target", async () => {
+        const calls: Array<{ url: string; init: RequestInit }> = [];
+        const fakeFetch = (async (url: string, init: RequestInit) => {
+            calls.push({ url, init });
+            return new Response("ok", { status: 200 });
+        }) as unknown as typeof fetch;
+
+        let ok: string | undefined;
+        await relayOtlp(cfg(), "/v1/logs", "{\"body\":1}", { fetch: fakeFetch, onSuccess: (s) => { ok = s; } });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe(`${DD}/v1/logs`);
+        expect(calls[0].init.method).toBe("POST");
+        expect(calls[0].init.body).toBe("{\"body\":1}");
+        expect((calls[0].init.headers as Record<string, string>)["dd-api-key"]).toBe("secret");
+        expect((calls[0].init.headers as Record<string, string>)["content-type"]).toBe("application/json");
+        expect(ok).toBe("logs");
+    });
+
+    test("skips when no target matches the signal", async () => {
+        let called = false;
+        const fakeFetch = (async () => { called = true; return new Response("ok"); }) as unknown as typeof fetch;
+        await relayOtlp(cfg(), "/v1/metrics", "{}", { fetch: fakeFetch });
+        expect(called).toBe(false);
+    });
+
+    test("skips entirely when forwarding is disabled", async () => {
+        let called = false;
+        const fakeFetch = (async () => { called = true; return new Response("ok"); }) as unknown as typeof fetch;
+        await relayOtlp(cfg(false), "/v1/logs", "{}", { fetch: fakeFetch });
+        expect(called).toBe(false);
+    });
+
+    test("a non-2xx upstream is reported via onError, never thrown", async () => {
+        const fakeFetch = (async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
+        let errSignal: string | undefined;
+        await expect(relayOtlp(cfg(), "/v1/logs", "{}", {
+            fetch: fakeFetch,
+            onError: (s) => { errSignal = s; },
+        })).resolves.toBeUndefined();
+        expect(errSignal).toBe("logs");
+    });
+
+    test("a thrown fetch (upstream down) is swallowed and reported", async () => {
+        const fakeFetch = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+        const errors: unknown[] = [];
+        await expect(relayOtlp(cfg(), "/v1/logs", "{}", {
+            fetch: fakeFetch,
+            onError: (_s, e) => { errors.push(e); },
+        })).resolves.toBeUndefined();
+        expect(errors).toHaveLength(1);
+    });
+
+    test("makeRelayLogger warns once per signal", () => {
+        const seen: string[] = [];
+        const orig = console.warn;
+        console.warn = (m?: unknown) => { seen.push(String(m)); };
+        try {
+            const log = makeRelayLogger();
+            log("logs", new Error("down"));
+            log("logs", new Error("still down"));
+            log("metrics", new Error("down"));
+        } finally {
+            console.warn = orig;
+        }
+        expect(seen.filter((m) => m.includes("logs"))).toHaveLength(1);
+        expect(seen.filter((m) => m.includes("metrics"))).toHaveLength(1);
+    });
+});

--- a/apps/axctl/src/otel/forward-relay.ts
+++ b/apps/axctl/src/otel/forward-relay.ts
@@ -1,0 +1,74 @@
+/**
+ * Best-effort OTLP relay (#1017). Called from the `otlpd` receiver AFTER a body
+ * is spooled: it re-POSTs the same JSON body to the user's own collector.
+ *
+ * Contract, all load-bearing:
+ *   - NEVER throws to the caller - the receiver must still return 2xx to the
+ *     harness even when the upstream is down (an exporter that sees a 5xx
+ *     retry-storms).
+ *   - Bounded by a timeout so a hung upstream cannot pin the write chain.
+ *   - `fetch` is injected so the relay is unit-testable without a network.
+ *
+ * ax forces `http/json`, so it relays JSON. A protobuf-only upstream rejects it;
+ * that surfaces via `onError`, it is not fatal (documented caveat).
+ */
+import { signalOfPath, type OtelForwardConfig } from "./forward-config.ts";
+
+export interface RelayDeps {
+    readonly fetch: typeof fetch;
+    readonly timeoutMs?: number;
+    /** Observe a failed relay (upstream down, non-2xx, timeout). Never throws. */
+    readonly onError?: (signal: string, error: unknown) => void;
+    readonly onSuccess?: (signal: string) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Relay one accepted OTLP request to its matching upstream target. Resolves
+ * (never rejects) once the relay completes or is skipped.
+ */
+export const relayOtlp = async (
+    config: OtelForwardConfig,
+    pathname: string,
+    body: string,
+    deps: RelayDeps,
+): Promise<void> => {
+    if (!config.enabled) return;
+    const signal = signalOfPath(pathname);
+    if (!signal) return;
+    const target = config.targets.find((t) => t.signal === signal);
+    if (!target) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    try {
+        const res = await deps.fetch(target.url, {
+            method: "POST",
+            headers: { "content-type": "application/json", ...target.headers },
+            body,
+            signal: controller.signal,
+        });
+        if (res.ok) deps.onSuccess?.(signal);
+        else deps.onError?.(signal, new Error(`upstream responded ${res.status}`));
+    } catch (error) {
+        deps.onError?.(signal, error);
+    } finally {
+        clearTimeout(timer);
+    }
+};
+
+/**
+ * A once-per-signal stderr warner for the receiver: a down upstream must not
+ * spam the otlpd log on every batch, so warn the FIRST failure per signal per
+ * process, then stay quiet.
+ */
+export const makeRelayLogger = (): ((signal: string, error: unknown) => void) => {
+    const warned = new Set<string>();
+    return (signal, error) => {
+        if (warned.has(signal)) return;
+        warned.add(signal);
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`otlp-forward: relay of ${signal} failed (${message}); further ${signal} failures silenced this run`);
+    };
+};

--- a/apps/axctl/src/otel/spool-server.test.ts
+++ b/apps/axctl/src/otel/spool-server.test.ts
@@ -187,6 +187,65 @@ describe("OTLP spool receiver", () => {
         expect(() => JSON.parse(lines[0]!)).not.toThrow();
         expect(() => JSON.parse(lines[1]!)).not.toThrow();
     });
+
+    it("forwards an accepted body to the configured collector AND still spools it (#1017)", async () => {
+        const now = new Date("2026-08-14T09:00:00.000Z");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-fwd-"));
+        roots.push(spoolDir);
+        const forwardConfigPath = join(spoolDir, "otel-forward.json");
+        await writeFile(forwardConfigPath, JSON.stringify({
+            enabled: true,
+            created_at: now.toISOString(),
+            targets: [{ signal: "logs", url: "https://collector.example/v1/logs", headers: { "dd-api-key": "k" } }],
+        }));
+
+        const relayed: Array<{ url: string; body: string; headers: Record<string, string> }> = [];
+        let resolveRelay: () => void = () => {};
+        const relayDone = new Promise<void>((r) => { resolveRelay = r; });
+        const relayFetch = (async (url: string, init: RequestInit) => {
+            relayed.push({ url, body: String(init.body), headers: init.headers as Record<string, string> });
+            resolveRelay();
+            return new Response("ok", { status: 200 });
+        }) as unknown as typeof fetch;
+
+        const server = await Effect.runPromise(
+            startOtlpSpoolServer({ spoolDir, port: 0, now: () => now, forwardConfigPath, relayFetch })
+                .pipe(Effect.provide(platformLayer)),
+        );
+        servers.push(server);
+
+        const response = await fetch(`${server.url}/v1/logs`, { method: "POST", body: '{"resourceLogs":[1]}' });
+        expect(response.status).toBe(200); // the 2xx never waits on the relay
+
+        await relayDone; // the fire-and-forget relay ran
+        expect(relayed).toHaveLength(1);
+        expect(relayed[0].url).toBe("https://collector.example/v1/logs");
+        expect(relayed[0].body).toBe('{"resourceLogs":[1]}');
+        expect(relayed[0].headers["dd-api-key"]).toBe("k");
+
+        // The body still landed in the local spool - forwarding is ADDITIVE.
+        const text = await readFile(join(spoolDir, "2026-08-14.jsonl"), "utf8");
+        expect(JSON.parse(text.trim()).body).toBe('{"resourceLogs":[1]}');
+    });
+
+    it("does not forward when the config is absent or disabled", async () => {
+        const now = new Date("2026-08-14T09:00:00.000Z");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-nofwd-"));
+        roots.push(spoolDir);
+        let called = false;
+        const relayFetch = (async () => { called = true; return new Response("ok"); }) as unknown as typeof fetch;
+        const server = await Effect.runPromise(
+            startOtlpSpoolServer({
+                spoolDir, port: 0, now: () => now,
+                forwardConfigPath: join(spoolDir, "absent.json"),
+                relayFetch,
+            }).pipe(Effect.provide(platformLayer)),
+        );
+        servers.push(server);
+        await fetch(`${server.url}/v1/logs`, { method: "POST", body: '{"resourceLogs":[]}' });
+        await new Promise((r) => setTimeout(r, 20));
+        expect(called).toBe(false);
+    });
 });
 
 describe("defaultOtlpSpoolDir (decoupled from AX_DATA_DIR)", () => {

--- a/apps/axctl/src/otel/spool-server.ts
+++ b/apps/axctl/src/otel/spool-server.ts
@@ -4,6 +4,17 @@ import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { isAllowedHost } from "../dashboard/host-guard.ts";
 import { OTLP_SIGNAL_PATHS } from "./signal.ts";
+import { asForwardConfig, type OtelForwardConfig } from "./forward-config.ts";
+import { relayOtlp, makeRelayLogger } from "./forward-relay.ts";
+
+/**
+ * Path to the OTLP forwarding config (#1017). `ax install --otel-forward`
+ * writes it; the receiver reads it once at boot and relays each accepted body
+ * to the user's own collector. Its own dedicated override, sibling of the
+ * spool dir override.
+ */
+export const defaultForwardConfigPath = (): string =>
+    process.env.AX_OTLP_FORWARD_CONFIG ?? `${homedir()}/.ax/otel-forward.json`;
 
 export const OTLP_ACK = { partialSuccess: {} } as const;
 export const OTLP_SPOOL_RETENTION_DAYS = 90;
@@ -106,6 +117,10 @@ export interface StartOtlpSpoolServerOptions {
     readonly hostname?: string;
     readonly port?: number;
     readonly now?: () => Date;
+    /** Override the forwarding config path (#1017); tests point it at a fixture. */
+    readonly forwardConfigPath?: string;
+    /** Injectable fetch for the relay so the forward path is testable. */
+    readonly relayFetch?: typeof fetch;
 }
 
 export interface OtlpSpoolServer {
@@ -132,6 +147,27 @@ export const startOtlpSpoolServer = (
         const now = opts.now ?? (() => new Date());
         yield* fs.makeDirectory(spoolDir, { recursive: true });
         yield* pruneOtlpSpool({ spoolDir, now: now() });
+
+        // OTLP forwarding (#1017): load the opt-in config ONCE at boot. When
+        // enabled, each accepted body is also relayed to the user's own
+        // collector - best-effort, never blocking the 2xx (see forward-relay).
+        const forwardConfigPath = opts.forwardConfigPath ?? defaultForwardConfigPath();
+        const forwardConfig: OtelForwardConfig | null = yield* fs
+            .readFileString(forwardConfigPath)
+            .pipe(
+                Effect.map((raw) => {
+                    try { return asForwardConfig(JSON.parse(raw)); } catch { return null; }
+                }),
+                Effect.orElseSucceed(() => null),
+            );
+        const relayEnabled = forwardConfig?.enabled === true;
+        const relayFetch = opts.relayFetch ?? fetch;
+        const relayLog = makeRelayLogger();
+        if (relayEnabled) {
+            console.log(
+                `otlp-forward: relaying ${forwardConfig!.targets.map((t) => t.signal).join(", ")} to the configured collector`,
+            );
+        }
 
         const runFs = Effect.runPromiseWith(context);
 
@@ -205,6 +241,15 @@ export const startOtlpSpoolServer = (
                     }
                     const body = await request.text().catch(() => "");
                     await append(pathname, body).catch(() => undefined);
+                    // Relay to the user's own collector when forwarding is on.
+                    // Fire-and-forget: NEVER awaited before the 2xx, so a slow or
+                    // down upstream cannot stall the harness's exporter.
+                    if (relayEnabled && forwardConfig) {
+                        void relayOtlp(forwardConfig, pathname, body, {
+                            fetch: relayFetch,
+                            onError: relayLog,
+                        });
+                    }
                     return Response.json(OTLP_ACK);
                 },
             }),


### PR DESCRIPTION
Follow-up to #1014 / #1015. `--keep-otel` lets a user keep their own collector but then ax gets no telemetry. `ax install --otel-forward` makes ax **additive**: the harness feeds ax, ax spools locally **and** relays each body to the user's own collector.

## How it works

- **`forward-config.ts`** (pure): `resolveForwardTargets` captures the collector from the *pre-rewrite* env — endpoint **and** auth headers (`OTEL_EXPORTER_OTLP_*_HEADERS`, e.g. Datadog's `dd-api-key`). The correctness heart: it forwards a signal **only when ax's rewrite actually DIVERTS it** (logs always; metrics/traces only when there's no explicit per-signal endpoint). A signal that still flows straight to the user's collector is **not** forwarded — that would DOUBLE-SEND.
- **`forward-relay.ts`**: best-effort, fire-and-forget. **Never** throws to the caller and **never** blocks the receiver's 2xx (an exporter that sees a 5xx retry-storms); timeout-bounded; injectable `fetch`. A down upstream is warned once per signal per process.
- **`spool-server.ts`**: loads the opt-in config once at boot; after spooling each body, relays it. **Additive** — the local spool is unchanged.
- **install `--otel-forward`**: writes `~/.ax/otel-forward.json` (`0600` — the secret already sat in `settings.json`, same trust level). Mutually exclusive with `--keep-otel`.
- **`otel` doctor check** names the forwarded signals.

**Caveat:** ax forces `http/json`, so a protobuf-only upstream fails the relay (surfaced via `onError`, not fatal).

## Tests / gates

- `forward-config.test.ts` (13): header parse, divert rule incl. the reporter's explicit-metrics case (NOT forwarded), generic→per-signal, loopback, trailing slash, round-trip.
- `forward-relay.test.ts` (6): POST body+headers, skip/disabled, non-2xx + thrown swallowed, once-per-signal logger.
- `spool-server.test.ts` (+2 integration): forwards AND still spools, 2xx never waits on relay; no-forward when config absent.
- `install.doctor-onboarding.test.ts` (+1): forwarding branch.
- 65 pass · `bunx tsc` clean · `check:no-node-fs` / `check:timestamp-cast` / `check:raw-numeric-cast` clean · `--keep-otel`+`--otel-forward` rejected.

Fixes #1017