### PR TITLE
chore(install): make OTLP telemetry discoverable (#1019)

### DIFF
--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -48,10 +48,22 @@ export const updateCommand = Command.make(
 ).pipe(Command.withDescription("Update axctl from the latest GitHub release"));
 
 export const installCommand = Command.make("install", {
-    telemetry: Flag.boolean("telemetry").pipe(Flag.withDefault(false)),
-    noTelemetry: Flag.boolean("no-telemetry").pipe(Flag.withDefault(false)),
-    keepOtel: Flag.boolean("keep-otel").pipe(Flag.withDefault(false)),
-    otelForward: Flag.boolean("otel-forward").pipe(Flag.withDefault(false)),
+    telemetry: Flag.boolean("telemetry").pipe(
+        Flag.withDescription("Opt in to the local OTLP receiver: point Claude Code + Codex at ax (127.0.0.1:1738) so 'ax otel' + cost/latency enrichment work. Off by default; a bare install never touches your OTLP config."),
+        Flag.withDefault(false),
+    ),
+    noTelemetry: Flag.boolean("no-telemetry").pipe(
+        Flag.withDescription("Explicitly opt out of the OTLP receiver (revoke a prior --telemetry)."),
+        Flag.withDefault(false),
+    ),
+    keepOtel: Flag.boolean("keep-otel").pipe(
+        Flag.withDescription("With --telemetry: if you already point OTLP at your own collector, leave it untouched (ax OTLP surfaces stay dark). Mutually exclusive with --otel-forward."),
+        Flag.withDefault(false),
+    ),
+    otelForward: Flag.boolean("otel-forward").pipe(
+        Flag.withDescription("With --telemetry: send OTLP to ax AND relay it on to your existing collector (ax additive). Mutually exclusive with --keep-otel."),
+        Flag.withDefault(false),
+    ),
 }, ({ telemetry, noTelemetry, keepOtel, otelForward }) => {
     // Pure flag validation BEFORE any Effect/install work. fail() calls
     // process.exit(2) synchronously with a clean one-line message - no

--- a/apps/axctl/src/cli/install.doctor-onboarding.test.ts
+++ b/apps/axctl/src/cli/install.doctor-onboarding.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { CacheRead, CacheUnavailableError, type CacheReadService } from "@ax/lib/duckdb/seam";
 import { cacheReadResults } from "../testing/cache-read.ts";
-import { collectDoctorReport, formatDoctorReport, otelRedirectDoctorCheck } from "./install.ts";
+import { collectDoctorReport, formatDoctorReport, otelRedirectDoctorCheck, otelDiscoveryHint } from "./install.ts";
 
 // `collectDoctorReport` is an Effect requiring FileSystem + Path + CacheRead.
 // Run it against the REAL Bun-backed platform layers, exactly as the
@@ -162,5 +162,28 @@ describe("otelRedirectDoctorCheck (#1014)", () => {
         expect(check.ok).toBe(true);
         expect(check.detail).toContain("FORWARDS");
         expect(check.detail).toContain("logs, metrics");
+    });
+});
+
+describe("otelDiscoveryHint (#1019)", () => {
+    test("bare install with no collector names the opt-in", () => {
+        const lines = otelDiscoveryHint({ consent: "preserve", existingEndpoint: null });
+        expect(lines.length).toBeGreaterThan(0);
+        expect(lines.join("\n")).toContain("--telemetry");
+        expect(lines.join("\n")).toContain("OFF by default");
+    });
+
+    test("bare install WITH an existing collector offers forward vs replace", () => {
+        const lines = otelDiscoveryHint({ consent: "preserve", existingEndpoint: "https://otlp.datadoghq.com/v1/logs" });
+        const joined = lines.join("\n");
+        expect(joined).toContain("https://otlp.datadoghq.com/v1/logs");
+        expect(joined).toContain("--otel-forward");
+        expect(joined).toContain("ax install --telemetry");
+    });
+
+    test("silent on grant (already acted) and revoke (explicit opt-out)", () => {
+        expect(otelDiscoveryHint({ consent: "grant", existingEndpoint: null })).toEqual([]);
+        expect(otelDiscoveryHint({ consent: "grant", existingEndpoint: "https://x/v1/logs" })).toEqual([]);
+        expect(otelDiscoveryHint({ consent: "revoke", existingEndpoint: "https://x/v1/logs" })).toEqual([]);
     });
 });

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -367,6 +367,34 @@ export function otelRedirectDoctorCheck(args: {
 }
 
 /**
+ * Discoverability hint printed on a bare `ax install` (#1019). Telemetry is OFF
+ * by default and a bare install never touches OTLP - but then nothing tells the
+ * user (or an agent) that ax HAS an OTLP receiver at all. This names the opt-in,
+ * tailored by whether a foreign collector is already configured. Pure + exported
+ * for tests; the tail does the read-only detection and prints these lines.
+ *
+ * Only fires on `preserve` (the bare, no-flag case): `grant` already acted and
+ * printed what it did; `revoke` is an explicit opt-out we must not nag.
+ */
+export function otelDiscoveryHint(args: {
+    readonly consent: TelemetryConsent;
+    readonly existingEndpoint: string | null;
+}): string[] {
+    if (args.consent !== "preserve") return [];
+    if (args.existingEndpoint) {
+        return [
+            `  otel: telemetry is OFF; you already send OTLP to ${args.existingEndpoint}.`,
+            "        run ax alongside it:   ax install --telemetry --otel-forward",
+            "        or send only to ax:    ax install --telemetry   (backs up + replaces your endpoint)",
+        ];
+    }
+    return [
+        "  otel: ax can ingest OTLP telemetry (cost + latency cross-check), OFF by default.",
+        "        enable:  ax install --telemetry   (add --otel-forward if you already run a collector)",
+    ];
+}
+
+/**
  * Ingest wall-clock budget (seconds). Doctor has no AxConfig layer, so mirror
  * the `AX_INGEST_TIMEOUT_SECONDS` knob with the same lenient
  * parse-or-fallback the config layer uses.
@@ -748,12 +776,32 @@ export function cmdInstall(options: {
             }
         }
 
+        // Discoverability (#1019): a bare install never touches OTLP, so name
+        // the receiver + opt-in here, tailored to whether the user already runs
+        // their own collector. Read-only detection, preserve-path only.
+        const otelHintLines = yield* Effect.gen(function* () {
+            if (consent !== "preserve") return [] as string[];
+            const existingEndpoint = yield* Effect.promise(async () => {
+                try {
+                    const raw = await Bun.file(posixPath.join(HOME, ".claude", "settings.json")).text();
+                    const parsed = JSON.parse(raw) as Record<string, unknown>;
+                    const reps = detectClaudeOtelReplacements(parsed, "http://127.0.0.1:1738");
+                    return reps.find((r) => r.key.endsWith("_ENDPOINT"))?.previous ?? null;
+                } catch { return null; }
+            });
+            return otelDiscoveryHint({ consent, existingEndpoint });
+        });
+
         const { BANNER } = yield* Effect.promise(() => import("./banner.ts"));
         console.log(BANNER);
         console.log("  installed. try:");
         console.log("    axctl ingest          # initial fill");
         console.log("    axctl studio          # live web dashboard");
         console.log("    axctl tui             # interactive terminal dashboard");
+        if (otelHintLines.length > 0) {
+            console.log();
+            for (const line of otelHintLines) console.log(line);
+        }
         console.log();
         console.log("  set up agent guards (worktree safety + model-routing hooks):");
         console.log("    axctl hooks init && axctl hooks install --all --providers=claude,codex");


### PR DESCRIPTION
Follow-up to #1015 / #1018. Bare `ax install` (no `--telemetry`) correctly PRESERVES OTLP — but as a result nothing told the user *or an agent* that ax even has an OTLP receiver.

## Fix (pure discoverability, no behavior change)

- **`otelDiscoveryHint`** — a tail hint on the `preserve` (bare) path. With an existing foreign collector it offers **forward-alongside** (`--telemetry --otel-forward`) vs **replace** (`--telemetry`, backs up first); otherwise a one-liner that ax ingests OTLP cost/latency, opt in with `--telemetry`. Silent on `grant` (already acted) and `revoke` (explicit opt-out).
- **`Flag.withDescription`** on `--telemetry` / `--no-telemetry` / `--keep-otel` / `--otel-forward` so `ax install --help` explains them — an agent running `--help` can now discover the OTLP options.

## Verified

`ax install --help` now renders a description per flag (confirmed). 15 tests pass (+3 `otelDiscoveryHint` cases). `tsc` clean · all three verify gates clean.

Fixes #1019