### PR TITLE
fix(insights): add denominators + cap hint; relabel friction session-cost column (#1027)

### DIFF
--- a/apps/axctl/src/cli/commands/report.ts
+++ b/apps/axctl/src/cli/commands/report.ts
@@ -9,7 +9,7 @@ import { Flag } from "effect/unstable/cli";
 import { LooseRowSchema } from "@ax/lib/duckdb/columns";
 import { cacheRows } from "@ax/lib/duckdb/query";
 import { prettyPrint } from "@ax/lib/json";
-import { INSIGHT_VIEWS, insightSqlForView } from "../../queries/insights.ts";
+import { frictionTotalSql, INSIGHT_VIEWS, insightSqlForView, toolFailureTotalsSql } from "../../queries/insights.ts";
 import { enrichInsightRows } from "../../queries/insights-enrich.ts";
 import { formatInsightRows } from "../insights-format.ts";
 import { writeDashboard } from "../../dashboard/report.ts";
@@ -37,7 +37,50 @@ const cmdInsights = (input: { readonly view: InsightView; readonly limit: number
         // Classifier views resolve their per-row context here via indexed
         // lookups (the correlated $parent.session form scanned ~1s/row).
         const rows = yield* enrichInsightRows(input.view, [...result] as Array<Record<string, unknown>>);
+        // JSON stays raw; the human views (tools/friction) gain a denominator
+        // header + a cap hint so a raw count reads as a rate, and a full page
+        // reads as "there is more" (#1027).
+        if (!input.json) {
+            const header = yield* insightDenominator(input.view);
+            if (header) console.log(header);
+        }
         console.log(formatInsightRows(input.view, [...rows], { json: input.json }));
+        if (!input.json && rows.length >= limit) {
+            console.log(`\n… showing the top ${limit}; raise with --limit=<n>.`);
+        }
+    });
+
+/** A one-line denominator header for the count-heavy views (#1027). Empty for
+ *  every other view. Reads all-time totals so the shown counts have a scale. */
+const insightDenominator = (view: InsightView) =>
+    Effect.gen(function* () {
+        const numberOf = (row: Record<string, unknown> | undefined, key: string): number => {
+            const v = row?.[key];
+            return typeof v === "number" && Number.isFinite(v) ? v : 0;
+        };
+        if (view === "tools") {
+            const [totals] = yield* cacheRows(
+                LooseRowSchema,
+                { sql: toolFailureTotalsSql(), params: [] },
+                "insights.tools.totals",
+            );
+            const total = numberOf(totals, "total_calls");
+            const failing = numberOf(totals, "failing_calls");
+            if (total === 0) return "";
+            const pct = ((failing / total) * 100).toFixed(1);
+            return `${failing.toLocaleString("en-US")} failing tool calls of ${total.toLocaleString("en-US")} total (${pct}%), all-time:\n`;
+        }
+        if (view === "friction") {
+            const [totals] = yield* cacheRows(
+                LooseRowSchema,
+                { sql: frictionTotalSql(), params: [] },
+                "insights.friction.totals",
+            );
+            const total = numberOf(totals, "total");
+            if (total === 0) return "";
+            return `${total.toLocaleString("en-US")} friction events, all-time:\n`;
+        }
+        return "";
     });
 
 const cmdReport = (input: { readonly limit: number; readonly out: string | undefined }) =>

--- a/apps/axctl/src/cli/insights-format.test.ts
+++ b/apps/axctl/src/cli/insights-format.test.ts
@@ -29,6 +29,15 @@ describe("formatInsightRows", () => {
         expect(out).not.toContain("Invalid");
     });
 
+    test("friction OTLP cost is labelled session-level, not per-error (#1027)", () => {
+        const out = formatInsightRows("friction", [
+            { kind: "tool_error", ts: "2026-08-18T02:36:34.830Z", text: "boom", project: "ax", otlp_cost_usd: 25.05 },
+        ]);
+        // `sess$=`, never a bare `cost$=` that reads as this error's cost.
+        expect(out).toContain("sess$=$25.050");
+        expect(out).not.toContain("cost$=");
+    });
+
     test("renders reactions as compact user-to-assistant pairs", () => {
         const output = formatInsightRows("reactions", [
             {

--- a/apps/axctl/src/cli/insights-format.ts
+++ b/apps/axctl/src/cli/insights-format.ts
@@ -230,10 +230,14 @@ function formatFrictionRows(rows: readonly InsightRow[]): string {
     if (rows.length === 0) return "No friction events found.";
     const hasCost = rows.some((r) => r.otlp_cost_usd != null);
     return rows.map((row, index) => {
+        // `sess$=` not `cost$=`: this is the whole SESSION's OTLP cost, not the
+        // cost of this one friction event, so two errors in the same session
+        // report the same figure and two in different sessions differ wildly
+        // (#1027). The label says which.
         const costStr = hasCost
             ? (row.otlp_cost_usd != null
-                ? `  cost$=${("$" + (row.otlp_cost_usd as number).toFixed(3))}`
-                : "  cost$=-")
+                ? `  sess$=${("$" + (row.otlp_cost_usd as number).toFixed(3))}`
+                : "  sess$=-")
             : "";
         return [
             `${index + 1}. ${textOf(row.kind)}${costStr}  ${compactDate(row.ts)}`,

--- a/apps/axctl/src/queries/insights.test.ts
+++ b/apps/axctl/src/queries/insights.test.ts
@@ -33,6 +33,8 @@ import {
     postFeatureFixesSql,
     skillCandidatesSql,
     toolFailuresSql,
+    toolFailureTotalsSql,
+    frictionTotalSql,
 } from "./insights.ts";
 
 const STALE_FIELDS = [
@@ -149,6 +151,17 @@ describe("insights query builders", () => {
         expect(sql).toContain("exit_code");
         expect(sql).toContain("LIMIT 7");
         expectNoStaleFields(sql);
+    });
+
+    test("toolFailureTotalsSql counts total + failing calls with the same benign-miss exclusion (#1027)", () => {
+        const sql = toolFailureTotalsSql();
+        expect(sql).toContain("COUNT(*) AS total_calls");
+        expect(sql).toContain("FILTER (WHERE tc.has_error = TRUE AND (co.kind IS NULL OR co.kind <> 'search_miss'))");
+        expect(sql).toContain("LEFT JOIN command_outcome co ON co.tool_call = tc.id");
+    });
+
+    test("frictionTotalSql counts all friction events (#1027)", () => {
+        expect(frictionTotalSql()).toContain("COUNT(*) AS total FROM friction_event");
     });
 
     test("sessionEvidenceSql summarizes sessions through current evidence tables", () => {

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -328,6 +328,26 @@ ORDER BY failure_count DESC, last_seen DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+/**
+ * The all-time denominators for `ax insights tools`: total tool calls and how
+ * many of them are genuine failures (same benign-search-miss exclusion as
+ * {@link toolFailuresSql}). Lets the view show a share, so a raw failure count
+ * reads as a rate, not an absolute number (#1027).
+ */
+export function toolFailureTotalsSql(): string {
+    return `
+SELECT
+    COUNT(*) AS total_calls,
+    COUNT(*) FILTER (WHERE tc.has_error = TRUE AND (co.kind IS NULL OR co.kind <> 'search_miss')) AS failing_calls
+FROM tool_call tc
+LEFT JOIN command_outcome co ON co.tool_call = tc.id;`.trim();
+}
+
+/** Total friction events, the denominator for `ax insights friction` (#1027). */
+export function frictionTotalSql(): string {
+    return "SELECT COUNT(*) AS total FROM friction_event;";
+}
+
 export function sessionEvidenceSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `


### PR DESCRIPTION
Closes #1027. Found via onboarding dogfood.

## Problem
`ax insights friction`/`tools`: raw counts (exec 6,622 failures) read as alarming or negligible with no total-call volume shown; the page is silently capped at `--limit`; the friction `cost$=` column is the whole session's OTLP cost, not the error's.

## Fix
- **`tools`** prints a denominator header — `N failing tool calls of M total (P%), all-time` — using the same benign-search-miss exclusion as `toolFailuresSql` (#1022), so the rate is honest.
- **`friction`** prints its all-time event total.
- **Both** print a cap-hint footer when the page is full: `… showing the top N; raise with --limit=<n>`.
- The friction cost column is relabelled **`sess$=`** so it no longer reads as this one error's cost.

Header/footer live in `cmdInsights`; JSON output is unchanged. New queries `toolFailureTotalsSql` + `frictionTotalSql`.

## Verified
End-to-end against the real store:
```
20,993 failing tool calls of 344,494 total (6.1%), all-time:
1. exec  -  6,622 failures  last 2026-08-24 …
… showing the top 3; raise with --limit=<n>.
```
Guard gates clean; 43 tests pass.