### PR TITLE
fix(sessions): add count line; use first task turn as summary, not injected context (#1029)

### DIFF
--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -111,6 +111,10 @@ function formatSessionsTable(rows: SessionRow[]): string {
         const summary = msg.slice(0, summaryWidth);
         lines.push(`${started} ${source} ${repoShort} ${project} ${turns}  ${summary}`);
     }
+    // A total-count line (like `ax recall`), so the reader does not count rows
+    // by hand (dogfood #1029).
+    lines.push("");
+    lines.push(`${rows.length} session${rows.length === 1 ? "" : "s"}.`);
     return lines.join("\n");
 }
 

--- a/apps/axctl/src/dashboard/sessions-query.test.ts
+++ b/apps/axctl/src/dashboard/sessions-query.test.ts
@@ -64,6 +64,22 @@ describe("listSessionsHere", () => {
         expect(rows[0]).toMatchObject({ turn_count: 3, first_user_message: "first message" });
     });
 
+    dtest("the summary skips an injected context turn for the first real task turn (#1029)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-context-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", { id: "sc", repository: "r1", source: "codex", project: "p", cwd: "/w/ax", started_at: daysAgo(1) });
+                yield* w.putMany("turn", [
+                    // Codex records the AGENTS.md system prompt as the first user
+                    // turn, classified message_kind='context'.
+                    { id: "c1", session: "sc", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "# AGENTS.md instructions for /w/ax", message_kind: "context" },
+                    { id: "c2", session: "sc", seq: 2, ts: daysAgo(1), role: "user", text_excerpt: "fix the ingest bug", message_kind: "task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(fixture, dylibPath, listSessionsHere({ repositoryId: "r1" }));
+        expect(rows[0]?.first_user_message).toBe("fix the ingest bug");
+    });
+
     dtest("respects a custom --days window", async () => {
         const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-days-"), dylibPath, FIXTURE));
 

--- a/apps/axctl/src/dashboard/sessions-query.ts
+++ b/apps/axctl/src/dashboard/sessions-query.ts
@@ -83,8 +83,18 @@ const fetchSessions = (where: Clause): Effect.Effect<SessionRow[], never, CacheR
                       LEFT JOIN (SELECT session, count(*) AS turn_count FROM turn GROUP BY session) tc
                           ON tc.session = s.id
                       LEFT JOIN (
+                          -- Prefer the first real TASK turn over injected context
+                          -- (Codex records the AGENTS.md/CLAUDE.md system prompt as
+                          -- the first user turn, classified message_kind='context';
+                          -- it dominated the summary column and made the listing
+                          -- useless for Codex). Fall back to the earliest user turn
+                          -- when no task turn is classified (null message_kind, or a
+                          -- pre-reingest session).
                           SELECT session, text_excerpt,
-                                 row_number() OVER (PARTITION BY session ORDER BY seq ASC) AS rn
+                                 row_number() OVER (
+                                     PARTITION BY session
+                                     ORDER BY COALESCE(message_kind = 'task', FALSE) DESC, seq ASC
+                                 ) AS rn
                           FROM turn
                           WHERE role = 'user'
                       ) fu ON fu.session = s.id AND fu.rn = 1


### PR DESCRIPTION
Closes #1029. Found via onboarding dogfood.

## Problem
`ax sessions here` has no total-count line (the user counts rows by hand), and ~55/97 Codex rows showed `# AGENTS.md instructions for …` as the summary — Codex records the AGENTS.md/CLAUDE.md system prompt as the first user turn, and the summary column was the first user-role turn.

## Fix
- The shared `fetchSessions` projection prefers the first user turn with `message_kind='task'` over `context` (the injected block is already classified `context` by `classifyUserText`/`FULL_CONTEXT_RULES`), falling back to the earliest user turn when no task turn is classified (null `message_kind` / pre-reingest session). No marker duplication.
- `formatSessionsTable` prints a `N sessions.` footer, like `ax recall`. Shared by `here`/`around`/`near`.

## Verified
Against the real store — Codex summaries now read as real task text:
```
2026-08-14 …  codex   …  256  Read BRIEF.md at the worktree root and execute it fully, end…
94 sessions.
```
New test pins the context→task skip. Guard gates clean; sessions-query + sessions suites green.