### PR TITLE
fix(workflows): drop generic tool-triad arcs from improve recommend (#1036)

### DIFF
--- a/apps/axctl/src/queries/workflow-sequences.test.ts
+++ b/apps/axctl/src/queries/workflow-sequences.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { buildPerSession, isHarnessToolSkill, mineArcs } from "./workflow-sequences.ts";
+import { buildPerSession, isGenericToolArc, isHarnessToolSkill, mineArcs } from "./workflow-sequences.ts";
 
 test("buildPerSession orders a session's skills by turn_index", () => {
   const rows = [
@@ -82,6 +82,27 @@ test("buildPerSession + isHarnessToolSkill filter: harness-tool rows excluded fr
   const filtered = rawRows.filter((r) => !isHarnessToolSkill(r.skill));
   const perSession = buildPerSession(filtered);
   expect(perSession.get("s1")).toEqual(["plan", "tdd"]);
+});
+
+// ---------------------------------------------------------------------------
+// isGenericToolArc
+// ---------------------------------------------------------------------------
+
+test("isGenericToolArc: an arc of only generic tool primitives is generic", () => {
+  expect(isGenericToolArc(["pi:bash", "pi:read", "pi:edit"])).toBe(true);
+  expect(isGenericToolArc(["pi:bash", "pi:edit", "pi:read"])).toBe(true); // reordered permutation
+  expect(isGenericToolArc(["cursor-tool:read", "cursor-tool:write"])).toBe(true);
+  expect(isGenericToolArc(["Bash", "Read", "Edit"])).toBe(true); // unprefixed, mixed case
+});
+
+test("isGenericToolArc: an arc naming any real skill survives", () => {
+  expect(isGenericToolArc(["recall", "read", "edit", "test"])).toBe(false);
+  expect(isGenericToolArc(["pi:bash", "superpowers:brainstorming", "pi:edit"])).toBe(false);
+  expect(isGenericToolArc(["plan", "tdd", "commit"])).toBe(false);
+});
+
+test("isGenericToolArc: an empty arc is not generic", () => {
+  expect(isGenericToolArc([])).toBe(false);
 });
 
 test("mineArcs truncates sessions longer than MAX_SESSION_SKILLS without hanging", () => {

--- a/apps/axctl/src/queries/workflow-sequences.ts
+++ b/apps/axctl/src/queries/workflow-sequences.ts
@@ -62,6 +62,40 @@ export const HARNESS_TOOL_PREFIXES = ["codex:"] as const;
 export const isHarnessToolSkill = (name: string): boolean =>
     HARNESS_TOOL_PREFIXES.some((p) => name.startsWith(p));
 
+/**
+ * Generic per-tool-call pseudo-skills every JSONL provider synthesizes
+ * (`pi:bash`, `pi:read`, `cursor-tool:edit`, …). `isHarnessToolSkill` only
+ * excludes the `codex:` prefix, so these primitives leak into arc mining, occur
+ * in nearly every session (highest support), and - because different orderings
+ * of the same set are not subsequences of each other - survive maximality
+ * pruning as near-duplicate permutations. An arc composed ENTIRELY of these
+ * primitives is the default shape of a coding turn, not a codifiable workflow.
+ */
+const GENERIC_TOOL_BASENAMES: ReadonlySet<string> = new Set([
+    "bash",
+    "read",
+    "edit",
+    "write",
+    "ls",
+    "grep",
+    "glob",
+]);
+
+/** Strips any `harness:`/`harness-tool:` prefix, lowercased. */
+const toolBasename = (name: string): string => {
+    const i = name.indexOf(":");
+    return (i === -1 ? name : name.slice(i + 1)).toLowerCase();
+};
+
+/**
+ * True when EVERY step is a generic coding primitive - an arc with no real
+ * skill in it. `.every()` (not `.some()`) is deliberate: a mixed arc like
+ * `["recall", "read", "edit", "test"]` names a genuine recurring pattern
+ * alongside generic steps and MUST survive.
+ */
+export const isGenericToolArc = (steps: readonly string[]): boolean =>
+    steps.length > 0 && steps.every((s) => GENERIC_TOOL_BASENAMES.has(toolBasename(s)));
+
 // ---------------------------------------------------------------------------
 // buildPerSession
 // ---------------------------------------------------------------------------
@@ -262,10 +296,11 @@ export const fetchWorkflowArcs: (
         .filter((r) => r.session !== "" && r.skill !== "" && !isHarnessToolSkill(r.skill));
 
     const perSession = buildPerSession(rows);
-    return mineArcs(perSession, {
+    const arcs = mineArcs(perSession, {
         ...(input?.minSessions !== undefined && { minSessions: input.minSessions }),
         ...(input?.limit !== undefined && { limit: input.limit }),
     });
+    return arcs.filter((a) => !isGenericToolArc(a.steps));
 });
 
 const WorkflowSequenceRow = Schema.Struct({


### PR DESCRIPTION
Closes #1036.

**Problem.** `ax improve recommend` surfaced 4 of 5 recommendations as near-duplicate permutations of the same generic coding-tool triad (`pi:bash → pi:read → pi:edit` and its reorderings), crowding out the substantive cache-lens proposal.

**Cause.** `fetchWorkflowArcs` (workflow-sequences.ts) excluded only `codex:`-prefixed synthetic tool rows. Every other JSONL provider synthesizes the same per-tool-call pseudo-skills (`pi:<tool>`, `cursor-tool:*`, `opencode-tool:*`), all with `dir_path='(synthetic)'`. They occur in nearly every session (highest support); different orderings of the same primitive set are not subsequences of each other, so `mineArcs` maximality pruning keeps them all; `deriveWorkflowProposalRows` mints one high-frequency/high-confidence proposal per surviving arc, and `recommend()` ranks the whole guidance pool by `confidence × recency × log(freq)` with no section filter.

**Fix (pure TS, no SQL/schema change).** Add `isGenericToolArc` beside `isHarnessToolSkill` — true when EVERY step is a generic primitive (`{bash,read,edit,write,ls,grep,glob}`, prefix-stripped, lowercased). Filter `mineArcs` output in `fetchWorkflowArcs`, the single chokepoint feeding both `ax improve recommend` and `ax directives workflows`. `.every()` (not `.some()`) keeps a mixed arc like `["recall","read","edit","test"]`.

**Tests.** New `isGenericToolArc` cases (all-generic incl. reordered permutation → true; mixed-with-real-skill and empty → false). `derive-proposals.test.ts:588-591` calls `deriveWorkflowProposalRows` directly (bypasses `fetchWorkflowArcs`) so it stays green — verified 62 pass. workflow-sequences suite 12 pass. Package tsc clean; `check:no-node-fs` clean.