### PR TITLE
fix(doctor): distinguish a crashed-then-reaped ingest run from a stale graph (#1035)

### DIFF
--- a/apps/axctl/src/cli/install.doctor-onboarding.test.ts
+++ b/apps/axctl/src/cli/install.doctor-onboarding.test.ts
@@ -94,13 +94,43 @@ describe("doctor's fixed non-onboarding check set", () => {
         const report = await runDoctorReport(
             cacheLayer({
                 ingestRunsRows: [
-                    { id: "r1", command: "ingest", started_at: stuckStartedAt, last_progress_at: null },
+                    { id: "r1", command: "ingest", status: "running", started_at: stuckStartedAt, last_progress_at: null, ended_at: null },
                 ],
             }),
         );
         const check = report.checks.find((c) => c.name === "ingest-runs");
         expect(check?.ok).toBe(false);
         expect(check?.detail).toContain("stuck");
+    });
+
+    test("'ingest-runs' flags a crashed-then-reaped last run distinctly from a stuck one (#1035)", async () => {
+        // No stranded "running" row - the crash was already reaped to "partial".
+        // The old check read this as "ok"; it must now report a crashed last run.
+        const endedAt = new Date(Date.now() - 3 * 3_600_000);
+        const report = await runDoctorReport(
+            cacheLayer({
+                ingestRunsRows: [
+                    { id: "r9", command: "ingest", status: "partial", started_at: endedAt, last_progress_at: endedAt, ended_at: endedAt },
+                ],
+            }),
+        );
+        const check = report.checks.find((c) => c.name === "ingest-runs");
+        expect(check?.ok).toBe(false);
+        expect(check?.detail).toContain("did not finish");
+        expect(check?.detail).not.toContain("stuck"); // distinct wording from the stranded case
+    });
+
+    test("'ingest-runs' passes when the last run finished ok (defers staleness to 'cache')", async () => {
+        const okAt = new Date(Date.now() - 3_600_000);
+        const report = await runDoctorReport(
+            cacheLayer({
+                ingestRunsRows: [
+                    { id: "r10", command: "ingest", status: "ok", started_at: okAt, last_progress_at: okAt, ended_at: okAt },
+                ],
+            }),
+        );
+        const check = report.checks.find((c) => c.name === "ingest-runs");
+        expect(check?.ok).toBe(true);
     });
 
     test("'otlpd' is always ok=true - consent-gated telemetry is never a doctor failure", async () => {

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -418,18 +418,39 @@ export function staleRunningIngestRuns(
     return rows.filter((row) => isStrandedRun(row, nowMs, staleAfterMs));
 }
 
-const StaleIngestRunRow = Schema.Struct({
+const IngestRunDoctorRow = Schema.Struct({
     id: Schema.String,
     command: Schema.String,
+    status: Schema.String,
     started_at: TimestampColumn,
     last_progress_at: Schema.NullOr(TimestampColumn),
+    ended_at: Schema.NullOr(TimestampColumn),
 });
+
+/** Milliseconds since a decoded (Date) or raw (string) timestamp, else null. */
+function ageMsSince(value: unknown, nowMs: number): number | null {
+    const ms = value instanceof Date ? value.getTime() : (typeof value === "string" ? Date.parse(value) : NaN);
+    return Number.isFinite(ms) ? nowMs - ms : null;
+}
+
+/** "3h" / "5d" - coarse age for a doctor line. */
+function describeAge(ageMs: number): string {
+    const hours = Math.floor(ageMs / 3_600_000);
+    return hours >= 72 ? `${Math.floor(hours / 24)}d` : `${Math.max(hours, 0)}h`;
+}
 
 /**
  * "ingest-runs" doctor check, read straight off the published DuckDB
  * snapshot. ALWAYS returns a check (never omits it): a report that silently
  * drops a check on cache-unavailable is exactly the "stops evaluating and
  * prints nothing" failure mode doctor exists to avoid.
+ *
+ * Three-way verdict (#1035): a run STRANDED at "running" right now reads
+ * differently from one that already CRASHED and was reaped to "partial"/"error"
+ * (visible only after the sweep), which in turn reads differently from a merely
+ * STALE graph (deferred to the "cache" age check). The old check saw only
+ * currently-"running" rows, so once a crash was reaped it silently read "ok"
+ * and a run of failed ingests looked identical to "nobody ingested lately".
  */
 function collectIngestRunsDoctorCheck(
     staleAfterMs: number,
@@ -437,20 +458,45 @@ function collectIngestRunsDoctorCheck(
 ): Effect.Effect<DoctorCheck, never, CacheRead> {
     return Effect.gen(function* () {
         const cache = yield* CacheRead;
+        // ONE widened query (the fixture feeds this check exactly one canned
+        // row-set): newest runs of every status. Running rows drive the
+        // stranded check; the newest terminal row drives the crashed check.
+        // No date arithmetic, so no ICU cast is needed.
         const rows = yield* cache.rows(
-            StaleIngestRunRow,
-            "SELECT id, command, started_at, last_progress_at FROM ingest_run WHERE status = 'running';",
+            IngestRunDoctorRow,
+            "SELECT id, command, status, started_at, last_progress_at, ended_at " +
+                "FROM ingest_run ORDER BY started_at DESC LIMIT 50;",
         );
-        const stale = staleRunningIngestRuns(rows, Date.now(), staleAfterMs);
-        const ids = stale.slice(0, 3).map((row) => String(row.id ?? "?")).join(", ");
-        return {
-            name: "ingest-runs",
-            ok: stale.length === 0,
-            detail: stale.length === 0
-                ? `no ingest_run rows stuck in status "running"`
-                : `${stale.length} ingest_run row(s) stuck in status "running" past the ` +
+        const nowMs = Date.now();
+        const running = rows.filter((row) => row.status === "running");
+        const stale = staleRunningIngestRuns(running, nowMs, staleAfterMs);
+        if (stale.length > 0) {
+            const ids = stale.slice(0, 3).map((row) => String(row.id ?? "?")).join(", ");
+            return {
+                name: "ingest-runs",
+                ok: false,
+                detail: `${stale.length} ingest_run row(s) stuck in status "running" past the ` +
                     `${ingestTimeoutSeconds}s ingest timeout (${ids}); the run crashed or was killed ` +
                     `without finalizing - the next 'ax ingest' auto-sweeps them, or run 'ax ingest reap' now`,
+            };
+        }
+        // Rows arrive newest-first; the first terminal row is the last run's outcome.
+        const lastTerminal = rows.find((row) => row.status !== "running");
+        if (lastTerminal && (lastTerminal.status === "partial" || lastTerminal.status === "error")) {
+            const ageMs = ageMsSince(lastTerminal.ended_at ?? lastTerminal.started_at, nowMs);
+            const ago = ageMs === null ? "" : ` ${describeAge(ageMs)} ago`;
+            return {
+                name: "ingest-runs",
+                ok: false,
+                detail: `the last ingest run did not finish (status "${lastTerminal.status}"${ago}) - it ` +
+                    `crashed or was killed and was reaped; run 'ax ingest' to rebuild (see ingest_run.metrics ` +
+                    `/ ingest_stage.error_text for the cause)`,
+            };
+        }
+        return {
+            name: "ingest-runs",
+            ok: true,
+            detail: `no ingest_run rows stuck in status "running"`,
         };
     }).pipe(
         Effect.catch(() =>


### PR DESCRIPTION
Closes #1035.

**Problem.** `collectIngestRunsDoctorCheck` queried only `WHERE status = 'running'`, so it detected a crash only while the stranded row was still un-reaped. Once the reaper settled it to `partial` (reap-runs.ts:56) or a run errored to `error`, the check read "ok" and the separate `cache` check fell back to raw age. "The last 5 runs all crashed" looked identical to "nobody ingested in 13 days".

**Fix (query + doctor-check logic; no schema change).** Widen the SINGLE query — the positional test double feeds this check exactly one canned row-set, so it stays one query — to the newest runs of every status (`ORDER BY started_at DESC LIMIT 50`, no date arithmetic so no ICU cast). Branch three ways:
1. a run stranded at `running` now → unchanged "stuck … crashed or was killed" wording (+ `ax ingest reap`);
2. no stranded row, but the newest terminal run is `partial`/`error` → **new** "the last ingest run did not finish (status …, N ago)" line pointing at `ingest_run.metrics` / `ingest_stage.error_text`;
3. otherwise → `ok`, deferring staleness to the age-based `cache` check.

`status`/`ended_at` already carried the signal — no DDL change.

**Tests.** Existing stuck-running fixture row gained `status: "running"` (the stub ignores the Schema, so this is the input my classifier reads). New cases: a reaped `partial` last run → `ok:false` + "did not finish", asserted `not` to contain "stuck" (distinct from the stranded case); an `ok` last run → `ok:true`. Suite 17 pass. `check:timestamp-cast` + `check:no-node-fs` clean; package tsc 0 errors.