### PR TITLE
fix(skills): reconcile a pending classify brief whose skill was already tagged (#1033)

### DIFF
--- a/apps/axctl/src/cli/skills-lint.test.ts
+++ b/apps/axctl/src/cli/skills-lint.test.ts
@@ -112,6 +112,27 @@ const roleNames = (directory: string) =>
         ),
     );
 
+/** Seed a `plays_role` edge into the sidecar, simulating `ax skills tag`. */
+const seedClassified = (directory: string, skillName: string, source: string) =>
+    Effect.runPromise(
+        Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            yield* judgment.exec("INSERT INTO role (id, name) VALUES (?, ?) ON CONFLICT (id) DO NOTHING", [
+                "role:framing",
+                "framing",
+            ]);
+            yield* judgment.exec(
+                "INSERT INTO plays_role (id, in_id, out_id, source, confidence) VALUES (?, ?, ?, ?, 1.0)",
+                [`plays_role:${skillName}:${source}`, skillRowId(skillName), "role:framing", source],
+            );
+        }).pipe(
+            Effect.provide(
+                JudgmentLayer({ sidecarPath: join(directory, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
+            ),
+            Effect.scoped,
+        ),
+    );
+
 describe("parseBrief", () => {
     test("normalizes and deduplicates valid roles", () => {
         const parsed = parseBrief(`---
@@ -176,6 +197,52 @@ describe("cmdSkillsLint", () => {
         expect(await fileExists(join(taskDir, "classify-pending.md"))).toBe(true);
         expect(await fileExists(join(taskDir, "classify-malformed.md"))).toBe(true);
         expect(await fileExists(join(taskDir, "classify-unknown.md"))).toBe(true);
+    });
+
+    test("reconciles a pending brief whose skill was already classified (e.g. by tag) (#1033)", async () => {
+        const directory = await tempDirectory();
+        const taskDir = join(directory, "tasks");
+        const file = join(taskDir, "classify-worktree-read-strategy.md");
+        await mkdir(taskDir, { recursive: true });
+        // A PENDING brief (empty primary_role) - would normally stay "pending".
+        await writeFile(file, `---\nax_classify: worktree-read-strategy\nprimary_role:\n---\n`);
+        // But the skill was already tagged into the sidecar.
+        await seedClassified(directory, "worktree-read-strategy", "user");
+
+        const report = await runLintJson(directory, new Set(["worktree-read-strategy"]));
+
+        expect(report).toMatchObject({ applied: 0, pending: 0, reconciled: 1, errors: 0 });
+        expect(report.briefs[0]).toMatchObject({ action: "reconciled", skill: "worktree-read-strategy" });
+        // The stale brief file is removed, so lint stops reporting it forever.
+        expect(await fileExists(file)).toBe(false);
+    });
+
+    test("dry-run reconciles in the report but leaves the stale brief on disk (#1033)", async () => {
+        const directory = await tempDirectory();
+        const taskDir = join(directory, "tasks");
+        const file = join(taskDir, "classify-worktree-read-strategy.md");
+        await mkdir(taskDir, { recursive: true });
+        await writeFile(file, `---\nax_classify: worktree-read-strategy\nprimary_role:\n---\n`);
+        await seedClassified(directory, "worktree-read-strategy", "user");
+
+        const report = await runLintJson(directory, new Set(["worktree-read-strategy"]), { dryRun: true });
+
+        expect(report).toMatchObject({ reconciled: 1, dryRun: true });
+        expect(await fileExists(file)).toBe(true);
+    });
+
+    test("leaves a pending brief pending when its skill is NOT yet classified (#1033)", async () => {
+        const directory = await tempDirectory();
+        const taskDir = join(directory, "tasks");
+        const file = join(taskDir, "classify-worktree-read-strategy.md");
+        await mkdir(taskDir, { recursive: true });
+        await writeFile(file, `---\nax_classify: worktree-read-strategy\nprimary_role:\n---\n`);
+        // No seed - the skill has no plays_role edge.
+
+        const report = await runLintJson(directory, new Set(["worktree-read-strategy"]));
+
+        expect(report).toMatchObject({ pending: 1, reconciled: 0 });
+        expect(await fileExists(file)).toBe(true);
     });
 
     test("dry-run checks identity but does not write or remove", async () => {

--- a/apps/axctl/src/cli/skills-lint.ts
+++ b/apps/axctl/src/cli/skills-lint.ts
@@ -14,6 +14,7 @@ import { prettyPrint } from "@ax/lib/json";
 import { validateRoleName, validateSkillName } from "@ax/lib/role-name";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { edgeRowId, roleRowId } from "@ax/lib/stable-id";
+import { fetchClassifiedSkillIds } from "../dashboard/role-queries.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,8 +31,14 @@ export interface BriefFrontmatter {
 
 export interface LintBriefResult {
     readonly file: string;
-    /** "applied" = edges written + file removed; "pending" = no primary_role; "error" = something went wrong */
-    readonly action: "applied" | "pending" | "error";
+    /**
+     * "applied" = edges written + file removed; "pending" = no primary_role and
+     * the skill is not yet classified; "reconciled" = pending brief whose skill
+     * was ALREADY classified elsewhere (e.g. `ax skills tag`), so the stale
+     * brief file was removed instead of left pending forever; "error" = something
+     * went wrong.
+     */
+    readonly action: "applied" | "pending" | "reconciled" | "error";
     /** The skill name from ax_classify, when present */
     readonly skill?: string;
     /** Number of edges written (primary + secondary deduplicated) */
@@ -44,6 +51,7 @@ export interface LintReport {
     readonly briefs: LintBriefResult[];
     readonly applied: number;
     readonly pending: number;
+    readonly reconciled: number;
     readonly errors: number;
     readonly dryRun: boolean;
 }
@@ -164,6 +172,33 @@ export function parseBrief(
             : undefined;
 
     return { ax_classify, primary_role, secondary, confidence, rationale };
+}
+
+/**
+ * Extract just the `ax_classify` skill name from a brief - even a PENDING one
+ * (no `primary_role`), where {@link parseBrief} returns null and drops it.
+ * Returns null when the name is absent or invalid. Used to reconcile a stale
+ * pending brief against the sidecar (#1033).
+ */
+export function briefSkillName(content: string): string | null {
+    const raw = extractFrontmatter(content);
+    if (!raw) return null;
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(raw);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const name = typeof (parsed as Record<string, unknown>)["ax_classify"] === "string"
+        ? ((parsed as Record<string, unknown>)["ax_classify"] as string).trim()
+        : "";
+    if (!name) return null;
+    try {
+        return validateSkillName(name);
+    } catch {
+        return null;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +331,15 @@ export const cmdSkillsLint = (
             .map((e) => path.join(opts.taskDir, e))
             .sort();
 
+        // The set of skill ids already classified in the sidecar (by tag,
+        // frontmatter, or a prior brief). A pending brief whose skill is in this
+        // set is stale - the decision was made elsewhere - so lint reconciles it
+        // rather than reporting "pending" forever (#1033). Fetched once, best-effort:
+        // if the sidecar cannot be read, treat nothing as classified (no reconcile).
+        const classifiedIds = new Set(
+            yield* fetchClassifiedSkillIds().pipe(Effect.catch(() => Effect.succeed([] as readonly string[]))),
+        );
+
         const results: LintBriefResult[] = [];
 
         for (const filePath of files) {
@@ -320,11 +364,31 @@ export const cmdSkillsLint = (
                 continue;
             }
 
-            // Pending brief (no primary_role)
+            // Pending brief (no primary_role). But `ax skills tag` (or a prior
+            // classify) may have ALREADY classified this skill in the sidecar
+            // since the brief was emitted - the brief is then stale, not pending.
+            // Reconcile: remove the orphaned file and report it distinctly, so a
+            // tagged skill no longer leaves its brief stuck "pending" forever (#1033).
             if (parsed === null) {
+                const skillName = briefSkillName(content);
+                const skillId = skillName === null ? null : yield* lookupSkillId(read, skillName).pipe(
+                    Effect.catch(() => Effect.succeed(null)),
+                );
+                if (skillId !== null && classifiedIds.has(skillId)) {
+                    if (!opts.dryRun) {
+                        yield* fs.remove(filePath).pipe(orAbsent<void>(undefined));
+                    }
+                    results.push({
+                        file: filePath,
+                        action: "reconciled",
+                        ...(skillName !== null && { skill: skillName }),
+                    });
+                    continue;
+                }
                 results.push({
                     file: filePath,
                     action: "pending",
+                    ...(skillName !== null && { skill: skillName }),
                 });
                 continue;
             }
@@ -365,12 +429,14 @@ export const cmdSkillsLint = (
 
         const applied = results.filter((r) => r.action === "applied").length;
         const pending = results.filter((r) => r.action === "pending").length;
+        const reconciled = results.filter((r) => r.action === "reconciled").length;
         const errors = results.filter((r) => r.action === "error").length;
 
         const report: LintReport = {
             briefs: results,
             applied,
             pending,
+            reconciled,
             errors,
             dryRun: opts.dryRun,
         };
@@ -388,6 +454,11 @@ export const cmdSkillsLint = (
                 console.log(
                     `applied  ${fileName}  skill=${r.skill ?? "?"}  edges=${r.edgesWritten ?? 0}${dryTag}`,
                 );
+            } else if (r.action === "reconciled") {
+                const dryTag = opts.dryRun ? " (dry-run)" : "";
+                console.log(
+                    `reconciled  ${fileName}  skill=${r.skill ?? "?"}  (already classified; stale brief removed)${dryTag}`,
+                );
             } else if (r.action === "error") {
                 console.error(`error    ${fileName}  ${r.error ?? "unknown error"}`);
             }
@@ -401,6 +472,7 @@ export const cmdSkillsLint = (
 
         const parts: string[] = [];
         if (applied > 0) parts.push(`${applied} applied${opts.dryRun ? " (dry-run)" : ""}`);
+        if (reconciled > 0) parts.push(`${reconciled} reconciled${opts.dryRun ? " (dry-run)" : ""}`);
         if (pending > 0) parts.push(`${pending} pending`);
         if (errors > 0) parts.push(`${errors} error${errors === 1 ? "" : "s"}`);
         console.log(parts.join(", ") + ".");


### PR DESCRIPTION
Closes #1033.

**Problem.** After `ax skills tag <skill> <role>`, the skill's classify brief stayed reported `pending` in `ax skills lint` forever. `tag` writes the decision to the sidecar `plays_role` table (`source='user'`), but `lint` derived pending-vs-applied purely from the brief file's `primary_role` frontmatter and never consulted `plays_role`. The DB said classified; the file said pending; the two were decoupled.

**Fix (query-side — lint becomes the single file-vs-DB reconciler; no DDL change).** `cmdSkillsLint` now loads the set of already-classified skill ids once (`fetchClassifiedSkillIds`, source ∈ frontmatter/brief/user, best-effort — an unreadable sidecar reconciles nothing). In the pending branch it resolves the brief's skill id and, if the skill is already classified, treats the brief as stale: removes the orphaned file and reports a new `reconciled` action instead of `pending`. New `briefSkillName` extracts `ax_classify` even from a pending brief (where `parseBrief` returns `null` and drops it). Dry-run reports `reconciled` without removing.

**Tests.** Against a real Judgment sidecar + stub CacheRead: a pending brief whose skill was seeded into `plays_role` → `reconciled: 1` + file removed; dry-run → `reconciled: 1` + file kept; an un-classified pending skill → stays `pending`, file kept. Existing pending/malformed/unknown and applied/dry-run tests still green (10 pass). Template round-trip 18 pass; `check:no-node-fs` clean; package tsc 0 errors.