### PR TITLE
fix(profile): render the clamped longest session as "24h+" not a bare 1440min (#1034)

### DIFF
--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -9,6 +9,7 @@ import { Effect, Schema } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile, type ProfileEnv } from "../../profile/render.ts";
+import { formatLongestSession } from "../../profile/insights.ts";
 import { fetchSkillInvocations, fetchSkillScopes } from "../../profile/queries.ts";
 import { deriveRig } from "../../profile/rig.ts";
 import type { ProfileV1 } from "../../profile/schema.ts";
@@ -216,7 +217,7 @@ export function formatProfile(p: ProfileV1): string {
         lines.push("");
         lines.push("insights:");
         lines.push(
-            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${integer(ins.longest_session_minutes)}min  ·  landed clean: ${deepPct}%`,
+            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${formatLongestSession(ins.longest_session_minutes)}  ·  landed clean: ${deepPct}%`,
         );
         lines.push(
             `  peak hour: ${String(ins.peak_hour_utc).padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,

--- a/apps/axctl/src/profile/insights.test.ts
+++ b/apps/axctl/src/profile/insights.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { deriveInsights } from "./insights.ts";
+import { deriveInsights, formatLongestSession, MAX_SESSION_MINUTES } from "./insights.ts";
 import type { DailyActivityRow, SessionDurationRow } from "./queries.ts";
 
 const s = (startIso: string, endIso: string): SessionDurationRow => ({
@@ -272,5 +272,20 @@ describe("deriveInsights", () => {
         });
         expect(r!.hours_total).toBeCloseTo(1.0, 1);
         expect(r!.max_parallel_sessions).toBe(1);
+    });
+});
+
+describe("formatLongestSession", () => {
+    test("renders a sub-clamp duration as measured minutes", () => {
+        expect(formatLongestSession(120)).toBe("120min");
+        expect(formatLongestSession(0)).toBe("0min");
+        expect(formatLongestSession(MAX_SESSION_MINUTES - 1)).toBe(`${MAX_SESSION_MINUTES - 1}min`);
+    });
+
+    test("renders the 24h clamp honestly as '24h+' rather than a bare 1440min (#1034)", () => {
+        expect(MAX_SESSION_MINUTES).toBe(1440);
+        expect(formatLongestSession(MAX_SESSION_MINUTES)).toBe("24h+");
+        // A wedged/resumed session saturates at the clamp - still shown as a cap.
+        expect(formatLongestSession(99_999)).toBe("24h+");
     });
 });

--- a/apps/axctl/src/profile/insights.ts
+++ b/apps/axctl/src/profile/insights.ts
@@ -9,6 +9,18 @@ import type { DailyActivityRow, SessionDurationRow, TopToolRow, WrappedCounts } 
 
 const MAX_SESSION_MS = 24 * 60 * 60 * 1000; // 24h cap per session
 
+/** The 24h clamp expressed in minutes (=1440); `longest_session_minutes` saturates here. */
+export const MAX_SESSION_MINUTES = MAX_SESSION_MS / 60_000;
+
+/**
+ * Render `longest_session_minutes` honestly. The value is CLAMPED at 24h to
+ * kill wedged-session bad data (a resumed-days-later session inflates
+ * `ended_at - started_at`), so a bare "1440min" reads as a measured duration
+ * when it is really the cap. Show "24h+" at/over the clamp instead.
+ */
+export const formatLongestSession = (minutes: number): string =>
+    minutes >= MAX_SESSION_MINUTES ? "24h+" : `${Math.round(minutes)}min`;
+
 export interface InsightsInput {
     readonly durations: ReadonlyArray<SessionDurationRow>;
     readonly peakHour: number | null;


### PR DESCRIPTION
Closes #1034.

**Problem.** `ax profile show` printed `longest: 1440min`. 1440 is the 24h clamp (`MAX_SESSION_MS`, insights.ts) that protects `hours_total` from wedged/resumed sessions (a session resumed days later inflates `ended_at - started_at`). Printed as a bare `1440min`, the cap reads as a measured duration.

**Fix (display-only; no schema change).** Add a pure `formatLongestSession` next to the clamp, plus an exported `MAX_SESSION_MINUTES` (=1440): renders `24h+` at/over the clamp, `<n>min` below it. `ax profile show` uses it. The derived NUMBER is unchanged — it still saturates at 1440 for the published gist + the aggregate — so no fixture churn and no gist-schema/community-validation change. The site's `fmtDuration` already renders 1440 as `24h` (acceptable), so it stays untouched (no CF Pages build coupling).

**Tests.** New `formatLongestSession` cases: sub-clamp → `Nmin`; at/over clamp → `24h+`; `MAX_SESSION_MINUTES === 1440`. Existing "sessions clamped at 24h" test still asserts the data value `1440` (unchanged). insights suite 18 pass; `check:no-node-fs` clean; package tsc 0 errors. **Verified against the real store:** `longest: 24h+`.