### PR TITLE
fix(dojo): agenda hygiene - deadline clamp, stale-brief filter, item title framing (#1044)

### DIFF
--- a/apps/axctl/src/cli/commands/contribute.test.ts
+++ b/apps/axctl/src/cli/commands/contribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     buildFreshPattern,
+    isSafeSparId,
     patternChoiceLabel,
     selectProfilePattern,
     type FreshPatternInput,
@@ -83,5 +84,16 @@ describe("buildFreshPattern", () => {
             sessions: 4,
             confidence: 0.8,
         })).toThrow(/summary/);
+    });
+});
+
+describe("study contribution input", () => {
+    test("accepts a file-safe spar id", () => {
+        expect(isSafeSparId("ab12cd34-2026-06-13")).toBe(true);
+    });
+
+    test("rejects path traversal", () => {
+        expect(isSafeSparId("../../secret")).toBe(false);
+        expect(isSafeSparId("a/b")).toBe(false);
     });
 });

--- a/apps/axctl/src/cli/commands/contribute.ts
+++ b/apps/axctl/src/cli/commands/contribute.ts
@@ -3,14 +3,17 @@
  * or author one through structured prompts, into community/patterns/ via the
  * same fork+PR rails used by profile registration.
  */
-import { Effect, Schema } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Effect, FileSystem, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile } from "../../profile/render.ts";
 import { openPatternContribution, patternFilePath } from "../../profile/pattern-contribution.ts";
 import { PATTERN_CATEGORIES, TastePattern, type PatternCategory, type ProfileV1 } from "../../profile/schema.ts";
 import { slugify } from "../../profile/taste.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
+import { buildCommunityStudy, openStudyContribution, studyFilePath } from "../../profile/study-contribution.ts";
+import { dojoSparBriefPath, dojoSparScorePath } from "../../dojo/paths.ts";
+import { parseSparBrief, parseSparScore } from "../../dojo/spar.ts";
 import { gatherEnv } from "./profile.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, optionValue, parseCsvFlag } from "./shared.ts";
@@ -240,9 +243,63 @@ const contributePatternCommand = Command.make(
     ),
 );
 
+export const isSafeSparId = (id: string): boolean =>
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+
+export const cmdContributeStudy = (input: {
+    readonly id: string;
+    readonly preview: boolean;
+    readonly yes: boolean;
+}) => Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const briefPath = dojoSparBriefPath(input.id);
+    const scorePath = dojoSparScorePath(input.id);
+    const briefBytes = yield* fs.readFileString(briefPath);
+    const scoreBytes = yield* fs.readFileString(scorePath);
+    const brief = parseSparBrief(briefBytes);
+    const score = parseSparScore(scoreBytes);
+    if (brief === null) throw new Error(`invalid spar brief: ${briefPath}`);
+    if (score === null) throw new Error(`invalid spar score: ${scorePath}`);
+
+    const study = buildCommunityStudy({ brief, score, briefBytes, scoreBytes });
+    const path = studyFilePath(study);
+    console.log(prettyPrint(study));
+    console.log(`\nThis self-reported study will be proposed as ${path}.`);
+    console.log("It contains one comparison. It does not prove general efficacy.");
+    if (input.preview) {
+        console.log("Preview only. No PR was opened.");
+        return;
+    }
+    if (!input.yes) {
+        const answer = promptText("Open reviewed PR? [y/N]").toLowerCase();
+        if (answer !== "y" && answer !== "yes") {
+            console.log("Aborted. No PR was opened.");
+            return;
+        }
+    }
+    const result = yield* openStudyContribution({ study });
+    console.log(`study PR: ${result.prUrl}`);
+    console.log(`file:     ${result.path}`);
+}).pipe(Effect.provide(GitHubEnvLive));
+
+const contributeStudyCommand = Command.make(
+    "study",
+    {
+        id: Argument.string("spar-id"),
+        preview: Flag.boolean("preview").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ id, preview, yes }) => {
+        if (!isSafeSparId(id)) fail(`ax contribute study: invalid spar id "${id}"`);
+        return cmdContributeStudy({ id, preview, yes });
+    },
+).pipe(Command.withDescription(
+    "Preview one content-stripped Dojo spar study. Use --yes to open a reviewed GitHub PR.",
+));
+
 export const contributeCommand = Command.make("contribute").pipe(
     Command.withDescription("Contribute ax community artifacts through fork+PR rails"),
-    Command.withSubcommands([contributePatternCommand]),
+    Command.withSubcommands([contributePatternCommand, contributeStudyCommand]),
 );
 
 export const contributeRuntime: RuntimeManifest = {
@@ -251,6 +308,7 @@ export const contributeRuntime: RuntimeManifest = {
         fallback: "none",
         subcommands: {
             pattern: (args) => args.includes("--fresh") ? "none" : "cache",
+            study: "none",
         },
     },
 };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -30,6 +30,7 @@ import {
     dojoSparBriefPath,
     dojoSparDir,
     dojoSparReportPath,
+    dojoSparScorePath,
     localDate,
 } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
@@ -659,11 +660,16 @@ const sparScoreCommand = Command.make(
             yield* fs.writeFileString(tmp, renderSparReport(score, brief));
             yield* fs.rename(tmp, path);
 
+            const scorePath = dojoSparScorePath(id);
+            const scoreTmp = `${scorePath}.tmp.${process.pid}`;
+            yield* fs.writeFileString(scoreTmp, `${prettyPrint(score)}\n`);
+            yield* fs.rename(scoreTmp, scorePath);
+
             console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
         }),
 ).pipe(
     Command.withDescription(
-        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+        "Score the agent's variant session and write Markdown plus machine-readable JSON receipts. --variant-session=<id> --json",
     ),
 );
 

--- a/apps/axctl/src/dojo/briefs.test.ts
+++ b/apps/axctl/src/dojo/briefs.test.ts
@@ -1,14 +1,14 @@
 // apps/axctl/src/dojo/briefs.test.ts
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
-import { classifyBriefFile, scanTaskDir } from "./briefs.ts";
+import { classifyBriefFile, scanTaskDir, STALE_BRIEF_DAYS } from "./briefs.ts";
 
-const runScan = (dir: string) =>
-    Effect.runPromise(scanTaskDir(dir).pipe(Effect.provide(BunFileSystem.layer)));
+const runScan = (dir: string, nowMs?: number) =>
+    Effect.runPromise(scanTaskDir(dir, nowMs).pipe(Effect.provide(BunFileSystem.layer)));
 
 describe("classifyBriefFile", () => {
     test("classify brief without primary_role is an unfilled item", () => {
@@ -84,5 +84,48 @@ describe("scanTaskDir", () => {
         const items = await runScan(dir);
         expect(items).toHaveLength(1);
         expect(items[0]?.id).toBe("brief:classify-superpowers__tdd.md");
+    });
+});
+
+describe("scanTaskDir staleness", () => {
+    // Pinned reference "now" - deterministic regardless of wall-clock vs the
+    // file's real mtime.
+    const NOW_MS = new Date("2026-08-20T12:00:00Z").getTime();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    test("a fresh brief (mtime = now) is surfaced", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        const filePath = join(dir, "a1b2c3d4.md");
+        writeFileSync(filePath, "---\nax_id: a1b2c3d4\n---\n");
+        const freshDate = new Date(NOW_MS);
+        utimesSync(filePath, freshDate, freshDate);
+        const items = await runScan(dir, NOW_MS);
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("brief:a1b2c3d4.md");
+    });
+
+    test("a brief with mtime older than STALE_BRIEF_DAYS is not surfaced", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        const filePath = join(dir, "a1b2c3d4.md");
+        writeFileSync(filePath, "---\nax_id: a1b2c3d4\n---\n");
+        const staleDate = new Date(NOW_MS - (STALE_BRIEF_DAYS + 1) * DAY_MS);
+        utimesSync(filePath, staleDate, staleDate);
+        const items = await runScan(dir, NOW_MS);
+        expect(items).toEqual([]);
+    });
+
+    test("two dated-duplicate briefs: only the fresh one is surfaced", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        const oldPath = join(dir, "routing-tune-2026-06-12.md");
+        const freshPath = join(dir, "routing-tune-20260812.md");
+        writeFileSync(oldPath, "| id | pattern |\n");
+        writeFileSync(freshPath, "| id | pattern |\n");
+        const staleDate = new Date(NOW_MS - (STALE_BRIEF_DAYS + 5) * DAY_MS);
+        const freshDate = new Date(NOW_MS - 1 * DAY_MS);
+        utimesSync(oldPath, staleDate, staleDate);
+        utimesSync(freshPath, freshDate, freshDate);
+        const items = await runScan(dir, NOW_MS);
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("brief:routing-tune-20260812.md");
     });
 });

--- a/apps/axctl/src/dojo/briefs.ts
+++ b/apps/axctl/src/dojo/briefs.ts
@@ -1,10 +1,13 @@
-import { Effect, FileSystem, type PlatformError } from "effect";
+import { Effect, FileSystem, Option, type PlatformError } from "effect";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { orAbsent, skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import type { DojoItem } from "./schema.ts";
 
 const FILLED_PRIMARY_ROLE = /^primary_role:[^\S\n]*\S/m;
+
+/** A brief untouched (by mtime) for longer than this many days is stale and drops off the agenda. */
+export const STALE_BRIEF_DAYS = 30;
 
 /** Pure: filename + content -> open agenda item, or null when nothing to do. */
 export const classifyBriefFile = (name: string, content: string): DojoItem | null => {
@@ -58,24 +61,39 @@ export const classifyBriefFile = (name: string, content: string): DojoItem | nul
  * unreadable dir means "no open briefs". Each entry is classified first
  * (`classifyNoFollow`, the house pattern from ingest) and non-files
  * (subdirectories, symlinks) are skipped - readFileString on a directory
- * raises BadResource and would otherwise kill the whole source. The per-file
- * content read uses `skipNotFound(null)` + skip-on-null: a brief that
- * vanished mid-scan is SKIPPED (never classified from an empty string into a
- * spurious unfilled item); any other read fault (permission, IO) re-raises so
- * real data is never silently dropped.
+ * raises BadResource and would otherwise kill the whole source. A `File`
+ * entry is then stat'd (same `skipNotFound(null)` + skip-on-null treatment
+ * as the content read below - a brief that vanished mid-scan is SKIPPED) to
+ * check staleness: a brief whose mtime is older than `STALE_BRIEF_DAYS`
+ * before `nowMs` is dropped so it stops piling up on the agenda forever. A
+ * missing mtime (`Option.None`, platform-dependent) is treated as NOT stale -
+ * never drop a brief just because mtime is unavailable. The per-file content
+ * read uses `skipNotFound(null)` + skip-on-null: a brief that vanished mid-scan
+ * is SKIPPED (never classified from an empty string into a spurious unfilled
+ * item); any other read fault (permission, IO) re-raises so real data is
+ * never silently dropped.
  */
 export const scanTaskDir = (
     taskDir: string,
+    nowMs: number = Date.now(),
 ): Effect.Effect<DojoItem[], PlatformError.PlatformError, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         if (!(yield* fs.exists(taskDir).pipe(orAbsent(false)))) return [];
         const names = yield* fs.readDirectory(taskDir).pipe(orAbsent([] as string[]));
+        const staleCutoffMs = STALE_BRIEF_DAYS * 24 * 60 * 60 * 1000;
         const items: DojoItem[] = [];
         for (const name of names) {
             const path = posixPath.join(taskDir, name);
             const kind = yield* classifyNoFollow(path);
             if (kind !== "File") continue; // subdir/symlink/etc - not a brief
+            const info = yield* fs.stat(path).pipe(skipNotFound(null));
+            if (info === null) continue; // vanished mid-scan - skip, don't misclassify
+            const isStale = Option.match(info.mtime, {
+                onNone: () => false, // mtime unavailable - never drop on that basis
+                onSome: (mtime) => nowMs - mtime.getTime() > staleCutoffMs,
+            });
+            if (isStale) continue;
             const content = yield* fs.readFileString(path).pipe(skipNotFound(null));
             if (content === null) continue; // vanished mid-scan - skip, don't misclassify
             const item = classifyBriefFile(name, content);

--- a/apps/axctl/src/dojo/budget.test.ts
+++ b/apps/axctl/src/dojo/budget.test.ts
@@ -61,7 +61,9 @@ describe("computeBudgetEnvelope", () => {
         expect(env.has_surplus).toBe(false);
         expect(env.source).toBe("unavailable");
         expect(env.binding_window).toBeNull();
-        expect(env.deadline).toBe(new Date(NOW_MS).toISOString());
+        // deadline must be strictly after now - a bare "now" deadline is
+        // already stale by the time a human reads the agenda.
+        expect(Date.parse(env.deadline)).toBeGreaterThan(NOW_MS);
         const forced = computeBudgetEnvelope(null, { force: true }, NOW_MS);
         expect(forced.has_surplus).toBe(true);
         expect(forced.source).toBe("forced");
@@ -83,5 +85,26 @@ describe("computeBudgetEnvelope", () => {
         const env = computeBudgetEnvelope(snap, {}, NOW_MS);
         expect(env.binding_window).toBe("five_hour");
         expect(env.window_remaining_pct).toBe(20);
+    });
+
+    test("a stale snapshot's resets_at in the past is clamped to a future deadline, not passed through", () => {
+        const snap: QuotaSnapshot = {
+            ...snapshot(40, 70),
+            five_hour: { utilization: 40, resets_at: "2026-06-13T09:00:00.000Z" }, // 1h before NOW_MS
+        };
+        const env = computeBudgetEnvelope(snap, {}, NOW_MS);
+        expect(Date.parse(env.deadline)).toBeGreaterThanOrEqual(NOW_MS + 2 * 60 * 60 * 1000);
+    });
+
+    test("a resets_at in the future is used unchanged - clamp does not interfere", () => {
+        const env = computeBudgetEnvelope(snapshot(40, 70), {}, NOW_MS);
+        // earliest reset (five_hour, 2h out) is already in the future
+        expect(env.deadline).toBe("2026-06-13T12:00:00.000Z");
+    });
+
+    test("--until in the past is passed through unchanged - user override is never clamped", () => {
+        const pastIso = "2026-06-13T09:00:00.000Z"; // 1h before NOW_MS
+        const env = computeBudgetEnvelope(snapshot(40, 70), { untilIso: pastIso }, NOW_MS);
+        expect(env.deadline).toBe(pastIso);
     });
 });

--- a/apps/axctl/src/dojo/budget.ts
+++ b/apps/axctl/src/dojo/budget.ts
@@ -24,6 +24,15 @@ export const computeBudgetEnvelope = (
 ): BudgetEnvelope => {
     const reserve = opts.reservePct ?? DEFAULT_RESERVE_PCT;
 
+    /**
+     * A derived deadline must never land at or before now (a stale quota
+     * snapshot's resets_at can already be in the past, and the bare-now
+     * fallback was itself already stale). An explicit --until is user
+     * intent and bypasses this - see call sites below.
+     */
+    const clampFuture = (iso: string): string =>
+        Date.parse(iso) > nowMs ? iso : new Date(nowMs + FORCED_FALLBACK_WINDOW_MS).toISOString();
+
     const windows: Array<{ name: BindingWindow; remaining: number; resetsAt: string }> = [];
     if (snapshot?.five_hour) {
         windows.push({
@@ -47,8 +56,7 @@ export const computeBudgetEnvelope = (
             binding_window: null,
             window_remaining_pct: 0,
             reserve_pct: reserve,
-            deadline: opts.untilIso
-                ?? new Date(opts.force === true ? nowMs + FORCED_FALLBACK_WINDOW_MS : nowMs).toISOString(),
+            deadline: opts.untilIso ?? clampFuture(new Date(nowMs).toISOString()),
             source: opts.force === true ? "forced" : "unavailable",
         };
     }
@@ -76,7 +84,7 @@ export const computeBudgetEnvelope = (
         binding_window: binding.name,
         window_remaining_pct: binding.remaining,
         reserve_pct: reserve,
-        deadline: opts.untilIso ?? earliestReset,
+        deadline: opts.untilIso ?? clampFuture(earliestReset),
         source,
     };
 };

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -112,6 +112,39 @@ describe("item mappers", () => {
         expect(items.map((i) => i.id)).toEqual(["experiment:s5"]);
     });
 
+    test("churn hotspots: long multi-line taskLabel is folded into a bounded, single-line title", () => {
+        const longPrompt = [
+            "Please investigate the flaky ingest watermark bug and also while you're at it",
+            "refactor the whole spool writer, add tests, update docs, and write a design doc",
+            "covering every edge case you can think of, including the ones nobody asked about.",
+        ].join("\n");
+        const items = churnHotspotItems([
+            { ...churnRow("s7", 4, 1, 500), taskLabel: longPrompt },
+        ]);
+        expect(items).toHaveLength(1);
+        const title = items[0]!.title;
+        expect(title.length).toBeLessThanOrEqual(120);
+        expect(title).not.toContain("\n");
+    });
+
+    test("churn hotspots: null taskLabel does not throw and yields a sensible title", () => {
+        const items = churnHotspotItems([
+            { ...churnRow("s8", 4, 1, 500), taskLabel: null },
+        ]);
+        expect(items).toHaveLength(1);
+        expect(items[0]!.title).toContain("s8");
+        expect(items[0]!.title).not.toContain("null");
+    });
+
+    test("routing backtest title reframes spend as under-review, not a savings figure", () => {
+        const items = routingBacktestItems([tune("rt3", "^review", 5, 4.2, true)], 30);
+        expect(items).toHaveLength(1);
+        const title = items[0]!.title;
+        expect(title).toContain("under review");
+        expect(title).toContain("^review");
+        expect(title).toContain("$4.20");
+    });
+
     test("proposal mint emitted only when open proposals are scarce", () => {
         expect(proposalMintItem(0)).not.toBeNull();
         expect(proposalMintItem(2)).not.toBeNull();

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -33,12 +33,12 @@ export const routingBacktestItems = (
         .map((p) => ({
             id: `routing:${p.id}`,
             kind: "routing_backtest",
-            title: `Backtest routing class ${p.pattern} (${p.count} dispatches, $${p.total_cost_usd.toFixed(2)})`,
+            title: `Review routing for judgment class ${p.pattern} - ${p.count} dispatches, $${p.total_cost_usd.toFixed(2)} spend under review`,
             commands: [
                 `ax routing tune --days=${days} --emit-brief`,
                 `ax routing tune --apply=${p.id} --days=${days}`,
             ],
-            success: "class applied to routing table (origin: user) or rejected with rationale",
+            success: "class applied to routing table (origin: user) or rejected with rationale - never auto-applied",
             cost_class: "m",
         }));
 
@@ -63,6 +63,22 @@ export const REPAIR_LINE_HOTSPOT_THRESHOLD = 200;
 const sessionShort = (session: string): string =>
     session.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(-8);
 
+/** First line of `text`, trimmed. Mirrors metrics/session-churn.ts's module-local helper. */
+const singleLine = (text: string): string => text.split(/\r?\n/, 1)[0]?.trim() ?? text;
+
+/** Cut `text` to `max` chars with an ellipsis. Mirrors metrics/session-churn.ts's module-local helper. */
+const truncate = (text: string, max: number): string =>
+    text.length <= max ? text : `${text.slice(0, Math.max(0, max - 3))}...`;
+
+/** Max chars for a taskLabel folded into an item title (matches the churn renderer's own cap). */
+const TASK_LABEL_TITLE_MAX = 48;
+
+/** Short, title-safe rendering of a session's task label; falls back to the session id when absent. */
+const taskLabelForTitle = (r: SessionChurnRow): string =>
+    r.taskLabel === null
+        ? `session ${sessionShort(r.session)}`
+        : truncate(singleLine(r.taskLabel), TASK_LABEL_TITLE_MAX);
+
 export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] =>
     rows
         .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > REPAIR_LINE_HOTSPOT_THRESHOLD)
@@ -71,7 +87,7 @@ export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] 
         .map((r) => ({
             id: `experiment:${r.session}`,
             kind: "experiment",
-            title: `Worktree experiment: reduce ${r.topCheck} churn (${r.taskLabel})`,
+            title: `Worktree experiment: reduce ${r.topCheck} churn (${taskLabelForTitle(r)})`,
             commands: [
                 `ax sessions show ${r.session}`,
                 `git worktree add .claude/worktrees/dojo-${sessionShort(r.session)} -b dojo/${sessionShort(r.session)}`,

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath, dojoSparScorePath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -18,6 +18,9 @@ describe("dojo paths", () => {
         );
         expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
+        );
+        expect(dojoSparScorePath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-score.json",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -19,6 +19,9 @@ export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): 
 export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoSparDir(base), `${id}-report.md`);
 
+export const dojoSparScorePath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-score.json`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -7,6 +7,7 @@ import {
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
+    parseSparScore,
     renderSparBrief,
     renderSparReport,
     REPAIR_TOL,
@@ -121,6 +122,18 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+describe("parseSparScore", () => {
+    test("accepts a complete machine score", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.8 })), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify(score))).toEqual(score);
+    });
+
+    test("rejects a score with an invalid metric", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics()), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify({ ...score, variant: { ...score.variant, turns: "many" } }))).toBeNull();
     });
 });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -74,6 +74,22 @@ export interface SparScore {
     readonly verdict: SparVerdict;
 }
 
+const asDeltas = (v: unknown): SparDeltas | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const finite = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    const nullable = (x: unknown): x is number | null => x === null || finite(x);
+    if (!nullable(o.costUsd) || !nullable(o.turns) || !nullable(o.wallMs)) return null;
+    if (!finite(o.repairLines) || !finite(o.episodes)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+    };
+};
+
 // ---------------------------------------------------------------------------
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
@@ -209,6 +225,26 @@ const asBaselineMetrics = (v: unknown): SparMetrics | null => {
         episodes: o.episodes,
         landed: o.landed,
     };
+};
+
+/** Decode the durable JSON receipt written by `spar-score`. */
+export const parseSparScore = (content: string): SparScore | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const o = parsed as Record<string, unknown>;
+    const baseline = asBaselineMetrics(o.baseline);
+    const variant = asBaselineMetrics(o.variant);
+    const deltas = asDeltas(o.deltas);
+    if (typeof o.id !== "string" || o.id.length === 0) return null;
+    if (typeof o.variantSession !== "string" || o.variantSession.length === 0) return null;
+    if (o.verdict !== "win" && o.verdict !== "regression" && o.verdict !== "mixed") return null;
+    if (baseline === null || variant === null || deltas === null) return null;
+    return { id: o.id, variantSession: o.variantSession, baseline, variant, deltas, verdict: o.verdict };
 };
 
 export const parseSparBrief = (content: string): SparBrief | null => {

--- a/apps/axctl/src/profile/study-contribution.test.ts
+++ b/apps/axctl/src/profile/study-contribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AX_ATTRIBUTION_MD } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparScore } from "../dojo/spar.ts";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    buildCommunityStudy,
+    openStudyContribution,
+    studyFilePath,
+    type CommunityStudy,
+} from "./study-contribution.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const baseline = { costUsd: 1.2, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true };
+const variant = { costUsd: 0.8, turns: 14, wallMs: 480_000, repairLines: 30, episodes: 2, landed: true };
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "secret task text",
+    parentSha: "ab12cd34",
+    baselineSession: "secret-session",
+    worktree: ".claude/worktrees/secret-path",
+    baseline,
+    baselineIsSubagent: false,
+    delta: "secret intervention text",
+};
+const score: SparScore = { ...scoreSpar(baseline, variant), id: brief.id, variantSession: "secret-variant" };
+
+describe("buildCommunityStudy", () => {
+    test("builds a closed, content-stripped study", () => {
+        const study = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        expect(study.protocol).toEqual({ id: "verification-churn", version: 1 });
+        expect(study.evidence_class).toBe("self_reported");
+        expect(study.outcome).toBe("improved");
+        expect(study.metrics.cost_usd.delta).toBeCloseTo(-0.4);
+        const json = JSON.stringify(study);
+        expect(json).not.toContain(brief.prompt);
+        expect(json).not.toContain(brief.delta);
+        expect(json).not.toContain(brief.baselineSession);
+        expect(json).not.toContain(score.variantSession);
+        expect(json).not.toContain(brief.worktree);
+    });
+
+    test("rejects a score for a different spar", () => {
+        expect(() => buildCommunityStudy({ brief, score: { ...score, id: "other" }, briefBytes: "brief", scoreBytes: "score" }))
+            .toThrow(/does not match/);
+    });
+});
+
+describe("openStudyContribution", () => {
+    test("opens one reviewed PR for one study file", async () => {
+        const study: CommunityStudy = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        const path = studyFilePath(study);
+        const login = "Necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            login,
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${REGISTRY_REPO}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`GET /repos/${REGISTRY_REPO}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "ok" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+
+        const result = await Effect.runPromise(openStudyContribution({ study }).pipe(Effect.provide(t.layer)));
+        expect(result.path).toBe(path);
+        expect(t.calls.map((call) => `${call.method} ${call.path}`)[0]).toBe(`GET /repos/${REGISTRY_REPO}/contents/${path}`);
+        expect(t.calls.find((call) => call.path === `/repos/${REGISTRY_REPO}/pulls`)?.body).toMatchObject({
+            base: "main",
+            body: expect.stringContaining(AX_ATTRIBUTION_MD),
+        });
+    });
+});

--- a/apps/axctl/src/profile/study-contribution.ts
+++ b/apps/axctl/src/profile/study-contribution.ts
@@ -1,0 +1,147 @@
+/** One content-stripped, self-reported study from the fixed Dojo spar protocol. */
+import { createHash } from "node:crypto";
+import { Effect, Schema } from "effect";
+import { prettyPrint } from "@ax/lib/json";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparMetrics, type SparScore } from "../dojo/spar.ts";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+type Metric<T> = { readonly baseline: T; readonly variant: T; readonly delta: number | null };
+
+export interface CommunityStudy {
+    readonly schema_version: 1;
+    readonly kind: "self-reported-community-study";
+    readonly protocol: { readonly id: "verification-churn"; readonly version: 1 };
+    readonly evidence_class: "self_reported";
+    readonly outcome: "improved" | "regressed" | "mixed";
+    readonly privacy: "closed_fields_content_stripped";
+    readonly source: {
+        readonly spar_id_sha256: string;
+        readonly brief_sha256: string;
+        readonly score_sha256: string;
+        readonly intervention_sha256: string;
+    };
+    readonly metrics: {
+        readonly cost_usd: Metric<number | null>;
+        readonly turns: Metric<number | null>;
+        readonly wall_ms: Metric<number | null>;
+        readonly repair_lines: Metric<number>;
+        readonly episodes: Metric<number>;
+        readonly landed: { readonly baseline: boolean; readonly variant: boolean };
+    };
+    readonly limitations: readonly ["single_spar_comparison", "self_reported"];
+}
+
+const same = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+const metric = <T>(baseline: T, variant: T, delta: number | null): Metric<T> => ({ baseline, variant, delta });
+
+export function buildCommunityStudy(input: {
+    readonly brief: SparBrief;
+    readonly score: SparScore;
+    readonly briefBytes: string;
+    readonly scoreBytes: string;
+}): CommunityStudy {
+    if (input.brief.id !== input.score.id) throw new Error("spar score id does not match the brief id");
+    if (input.brief.delta.trim() === "") throw new Error("spar brief has no intervention in the Delta section");
+    if (input.brief.baselineIsSubagent) throw new Error("a subagent baseline cannot become a community study");
+    if (!same(input.brief.baseline, input.score.baseline)) throw new Error("spar score baseline does not match the frozen brief");
+
+    const calculated = scoreSpar(input.score.baseline, input.score.variant);
+    if (!same(calculated.deltas, input.score.deltas) || calculated.verdict !== input.score.verdict) {
+        throw new Error("spar score does not match the fixed protocol calculation");
+    }
+
+    const baseline: SparMetrics = input.score.baseline;
+    const variant: SparMetrics = input.score.variant;
+    const deltas = input.score.deltas;
+    return {
+        schema_version: 1,
+        kind: "self-reported-community-study",
+        protocol: { id: "verification-churn", version: 1 },
+        evidence_class: "self_reported",
+        outcome: input.score.verdict === "win" ? "improved" : input.score.verdict === "regression" ? "regressed" : "mixed",
+        privacy: "closed_fields_content_stripped",
+        source: {
+            spar_id_sha256: sha256(input.brief.id),
+            brief_sha256: sha256(input.briefBytes),
+            score_sha256: sha256(input.scoreBytes),
+            intervention_sha256: sha256(input.brief.delta.trim()),
+        },
+        metrics: {
+            cost_usd: metric(baseline.costUsd, variant.costUsd, deltas.costUsd),
+            turns: metric(baseline.turns, variant.turns, deltas.turns),
+            wall_ms: metric(baseline.wallMs, variant.wallMs, deltas.wallMs),
+            repair_lines: metric(baseline.repairLines, variant.repairLines, deltas.repairLines),
+            episodes: metric(baseline.episodes, variant.episodes, deltas.episodes),
+            landed: { baseline: baseline.landed, variant: variant.landed },
+        },
+        limitations: ["single_spar_comparison", "self_reported"],
+    };
+}
+
+export const studyFilePath = (study: CommunityStudy): string =>
+    `community/research/studies/verification-churn/${study.source.score_sha256.slice(0, 32)}.json`;
+
+const studyBranchName = (study: CommunityStudy): string =>
+    `ax-study-verification-churn-${study.source.score_sha256.slice(0, 12)}`;
+
+export class StudyContributionError extends Schema.TaggedErrorClass<StudyContributionError>(
+    "StudyContributionError",
+)("StudyContributionError", { message: Schema.String }) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const openStudyContribution = Effect.fn("profile.openStudyContribution")(
+    function* (input: { readonly study: CommunityStudy; readonly login?: string }) {
+        const gh = yield* GitHubEnv;
+        const login = input.login ?? (yield* gh.login());
+        if (login === null || login.trim() === "") {
+            return yield* new StudyContributionError({ message: "GitHub login unavailable; run `gh auth login` and retry." });
+        }
+
+        const path = studyFilePath(input.study);
+        const branch = studyBranchName(input.study);
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${path}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404 ? Effect.succeed(false) : Effect.fail(error)),
+        );
+        if (exists) return yield* new StudyContributionError({ message: `${path} already exists.` });
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+        const blob = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+            content: `${prettyPrint(input.study)}\n`, encoding: "utf-8",
+        }));
+        const tree = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+            base_tree: baseTreeSha,
+            tree: [{ path, mode: "100644", type: "blob", sha: blob.sha }],
+        }));
+        const commit = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+            message: `community: contribute verification churn study`, tree: tree.sha, parents: [baseSha],
+        }));
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, { ref: `refs/heads/${branch}`, sha: commit.sha });
+        const body = withAxAttribution([
+            "Contributes one content-stripped study from the fixed verification churn protocol.",
+            "The evidence is self-reported and contains one spar comparison.",
+            "This PR does not claim general efficacy.",
+            `File: \`${path}\``,
+            "Opened by `ax contribute study`.",
+        ].join("\n\n"));
+        const pr = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+            title: "community: contribute verification churn study",
+            head: `${login}:${branch}`,
+            base: "main",
+            body,
+        }));
+        return { status: "pr-opened" as const, prUrl: String(pr.html_url ?? ""), path };
+    },
+);

--- a/community/README.md
+++ b/community/README.md
@@ -26,6 +26,14 @@ same schema before opening a PR. Pattern PRs are schema-checked by CI but stay
 human-reviewed; filename collisions fail validation so contributors engage the
 existing pattern instead of duplicating it.
 
+## research/studies/
+
+One file records one content-stripped Dojo spar comparison.
+Use `ax contribute study <spar-id>` to inspect the exact public JSON.
+The command requires consent before it opens a reviewed PR.
+These first studies are self-reported pilot data.
+They do not prove general efficacy.
+
 ## Compiled outputs (nightly)
 
 `leaderboard.json`, `skill-stats.json`, `hook-stats.json`,

--- a/community/research/studies/README.md
+++ b/community/research/studies/README.md
@@ -1,0 +1,23 @@
+# Community studies
+
+This directory stores one JSON file for each reviewed Dojo spar comparison.
+
+The pilot supports only `verification-churn` protocol version 1.
+It compares cost, turns, duration, repair lines, verification episodes, and landing status.
+
+The JSON uses closed fields.
+It excludes task text, intervention text, repository paths, and session identifiers.
+It includes hashes that bind the public record to the local brief and score.
+
+Each record has `evidence_class: "self_reported"`.
+Each record describes one comparison.
+Agents must not use one record as a general recommendation.
+
+Run this command after `ax dojo spar-score`:
+
+```text
+ax contribute study <spar-id>
+```
+
+The command shows the exact public JSON before it asks for consent.
+Use `--preview` to stop after the preview.


### PR DESCRIPTION
Closes #1044. Four small fixes found while dogfooding `ax dojo agenda`, plus one honest retraction.

## Fixes
1. **Budget deadline never in the past** (`dojo/budget.ts`) — `computeBudgetEnvelope` clamps any DERIVED deadline (the quota-unavailable fallback and a stale `resets_at`) to `nowMs + FORCED_FALLBACK_WINDOW_MS`. An explicit `--until` (user intent) still bypasses the clamp.
2. **Stale-brief filter** (`dojo/briefs.ts`) — `scanTaskDir` stats each brief and drops any whose mtime is older than `STALE_BRIEF_DAYS` (30), so months-old and duplicate briefs stop reappearing. Missing mtime never drops a brief. `nowMs` is an injectable param (default `Date.now()`); existing call site unchanged.
3. **Experiment title no longer pastes the raw prompt** (`dojo/items.ts`) — `churnHotspotItems` single-lines + truncates `taskLabel` (48 chars, matching the churn renderer), null-safe.
4. **Judgment routing backtests reframed** (`dojo/items.ts`) — "Review routing for judgment class … $X spend under review" instead of a bare `($X)` that read as guaranteed savings; success line spells out "never auto-applied".

## Retracted (not a bug)
A fifth dogfood finding — "classify briefs not surfaced in the agenda" — was a **measurement artifact**: I measured `classify: 0` *after* `ax skills lint` had already removed the briefs, and the first agenda ran *before* `ax skills classify` created them. The agenda has no item cap and `classifyBriefFile` maps unfilled `classify-*.md` correctly. No code change.

## Verification
- `bun test apps/axctl/src/dojo/` → 134 pass, 0 fail (12 files)
- `bun run check:no-node-fs` → clean (production `briefs.ts` uses the Effect FileSystem service; `node:fs` only in the exempt test file)
- `bunx tsc --noEmit -p apps/axctl/tsconfig.json` → no new errors in dojo

Each fix was implemented by an isolated subagent on its own file pair; diffs reviewed and the full suite re-run before merge.