### PR TITLE
fix(ingest): chunk fetchFailedToolCalls to stop derive-signals segfaulting at scale (#1043)

### DIFF
--- a/apps/axctl/src/cli/commands/contribute.test.ts
+++ b/apps/axctl/src/cli/commands/contribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     buildFreshPattern,
+    isSafeSparId,
     patternChoiceLabel,
     selectProfilePattern,
     type FreshPatternInput,
@@ -83,5 +84,16 @@ describe("buildFreshPattern", () => {
             sessions: 4,
             confidence: 0.8,
         })).toThrow(/summary/);
+    });
+});
+
+describe("study contribution input", () => {
+    test("accepts a file-safe spar id", () => {
+        expect(isSafeSparId("ab12cd34-2026-06-13")).toBe(true);
+    });
+
+    test("rejects path traversal", () => {
+        expect(isSafeSparId("../../secret")).toBe(false);
+        expect(isSafeSparId("a/b")).toBe(false);
     });
 });

--- a/apps/axctl/src/cli/commands/contribute.ts
+++ b/apps/axctl/src/cli/commands/contribute.ts
@@ -3,14 +3,17 @@
  * or author one through structured prompts, into community/patterns/ via the
  * same fork+PR rails used by profile registration.
  */
-import { Effect, Schema } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Effect, FileSystem, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile } from "../../profile/render.ts";
 import { openPatternContribution, patternFilePath } from "../../profile/pattern-contribution.ts";
 import { PATTERN_CATEGORIES, TastePattern, type PatternCategory, type ProfileV1 } from "../../profile/schema.ts";
 import { slugify } from "../../profile/taste.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
+import { buildCommunityStudy, openStudyContribution, studyFilePath } from "../../profile/study-contribution.ts";
+import { dojoSparBriefPath, dojoSparScorePath } from "../../dojo/paths.ts";
+import { parseSparBrief, parseSparScore } from "../../dojo/spar.ts";
 import { gatherEnv } from "./profile.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, optionValue, parseCsvFlag } from "./shared.ts";
@@ -240,9 +243,63 @@ const contributePatternCommand = Command.make(
     ),
 );
 
+export const isSafeSparId = (id: string): boolean =>
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+
+export const cmdContributeStudy = (input: {
+    readonly id: string;
+    readonly preview: boolean;
+    readonly yes: boolean;
+}) => Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const briefPath = dojoSparBriefPath(input.id);
+    const scorePath = dojoSparScorePath(input.id);
+    const briefBytes = yield* fs.readFileString(briefPath);
+    const scoreBytes = yield* fs.readFileString(scorePath);
+    const brief = parseSparBrief(briefBytes);
+    const score = parseSparScore(scoreBytes);
+    if (brief === null) throw new Error(`invalid spar brief: ${briefPath}`);
+    if (score === null) throw new Error(`invalid spar score: ${scorePath}`);
+
+    const study = buildCommunityStudy({ brief, score, briefBytes, scoreBytes });
+    const path = studyFilePath(study);
+    console.log(prettyPrint(study));
+    console.log(`\nThis self-reported study will be proposed as ${path}.`);
+    console.log("It contains one comparison. It does not prove general efficacy.");
+    if (input.preview) {
+        console.log("Preview only. No PR was opened.");
+        return;
+    }
+    if (!input.yes) {
+        const answer = promptText("Open reviewed PR? [y/N]").toLowerCase();
+        if (answer !== "y" && answer !== "yes") {
+            console.log("Aborted. No PR was opened.");
+            return;
+        }
+    }
+    const result = yield* openStudyContribution({ study });
+    console.log(`study PR: ${result.prUrl}`);
+    console.log(`file:     ${result.path}`);
+}).pipe(Effect.provide(GitHubEnvLive));
+
+const contributeStudyCommand = Command.make(
+    "study",
+    {
+        id: Argument.string("spar-id"),
+        preview: Flag.boolean("preview").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ id, preview, yes }) => {
+        if (!isSafeSparId(id)) fail(`ax contribute study: invalid spar id "${id}"`);
+        return cmdContributeStudy({ id, preview, yes });
+    },
+).pipe(Command.withDescription(
+    "Preview one content-stripped Dojo spar study. Use --yes to open a reviewed GitHub PR.",
+));
+
 export const contributeCommand = Command.make("contribute").pipe(
     Command.withDescription("Contribute ax community artifacts through fork+PR rails"),
-    Command.withSubcommands([contributePatternCommand]),
+    Command.withSubcommands([contributePatternCommand, contributeStudyCommand]),
 );
 
 export const contributeRuntime: RuntimeManifest = {
@@ -251,6 +308,7 @@ export const contributeRuntime: RuntimeManifest = {
         fallback: "none",
         subcommands: {
             pattern: (args) => args.includes("--fresh") ? "none" : "cache",
+            study: "none",
         },
     },
 };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -30,6 +30,7 @@ import {
     dojoSparBriefPath,
     dojoSparDir,
     dojoSparReportPath,
+    dojoSparScorePath,
     localDate,
 } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
@@ -659,11 +660,16 @@ const sparScoreCommand = Command.make(
             yield* fs.writeFileString(tmp, renderSparReport(score, brief));
             yield* fs.rename(tmp, path);
 
+            const scorePath = dojoSparScorePath(id);
+            const scoreTmp = `${scorePath}.tmp.${process.pid}`;
+            yield* fs.writeFileString(scoreTmp, `${prettyPrint(score)}\n`);
+            yield* fs.rename(scoreTmp, scorePath);
+
             console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
         }),
 ).pipe(
     Command.withDescription(
-        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+        "Score the agent's variant session and write Markdown plus machine-readable JSON receipts. --variant-session=<id> --json",
     ),
 );
 

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath, dojoSparScorePath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -18,6 +18,9 @@ describe("dojo paths", () => {
         );
         expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
+        );
+        expect(dojoSparScorePath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-score.json",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -19,6 +19,9 @@ export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): 
 export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoSparDir(base), `${id}-report.md`);
 
+export const dojoSparScorePath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-score.json`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -7,6 +7,7 @@ import {
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
+    parseSparScore,
     renderSparBrief,
     renderSparReport,
     REPAIR_TOL,
@@ -121,6 +122,18 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+describe("parseSparScore", () => {
+    test("accepts a complete machine score", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.8 })), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify(score))).toEqual(score);
+    });
+
+    test("rejects a score with an invalid metric", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics()), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify({ ...score, variant: { ...score.variant, turns: "many" } }))).toBeNull();
     });
 });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -74,6 +74,22 @@ export interface SparScore {
     readonly verdict: SparVerdict;
 }
 
+const asDeltas = (v: unknown): SparDeltas | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const finite = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    const nullable = (x: unknown): x is number | null => x === null || finite(x);
+    if (!nullable(o.costUsd) || !nullable(o.turns) || !nullable(o.wallMs)) return null;
+    if (!finite(o.repairLines) || !finite(o.episodes)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+    };
+};
+
 // ---------------------------------------------------------------------------
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
@@ -209,6 +225,26 @@ const asBaselineMetrics = (v: unknown): SparMetrics | null => {
         episodes: o.episodes,
         landed: o.landed,
     };
+};
+
+/** Decode the durable JSON receipt written by `spar-score`. */
+export const parseSparScore = (content: string): SparScore | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const o = parsed as Record<string, unknown>;
+    const baseline = asBaselineMetrics(o.baseline);
+    const variant = asBaselineMetrics(o.variant);
+    const deltas = asDeltas(o.deltas);
+    if (typeof o.id !== "string" || o.id.length === 0) return null;
+    if (typeof o.variantSession !== "string" || o.variantSession.length === 0) return null;
+    if (o.verdict !== "win" && o.verdict !== "regression" && o.verdict !== "mixed") return null;
+    if (baseline === null || variant === null || deltas === null) return null;
+    return { id: o.id, variantSession: o.variantSession, baseline, variant, deltas, verdict: o.verdict };
 };
 
 export const parseSparBrief = (content: string): SparBrief | null => {

--- a/apps/axctl/src/ingest/derive-signals.failed-tools-chunk.test.ts
+++ b/apps/axctl/src/ingest/derive-signals.failed-tools-chunk.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The failed-tool-calls read that feeds friction/diagnostic events was a
+ * SEPARATE, still-unbounded materialisation from the turns fetch (#1021
+ * chunked turns; #1043 chunks this): `fetchFailedToolCalls` pulled every
+ * error `tool_call` in the window - 17 columns, including the text columns
+ * `output_excerpt` / `error_text` - into one JS array via a single
+ * `write.rows(...)`. Past ~60-90 days of history that crossed a threshold
+ * that segfaulted the DuckDB->JS bridge at ~2.5 GB RSS, even though the
+ * turns pass itself was already chunked and healthy.
+ *
+ * This suite pins the property that MUST survive folding that fetch into the
+ * per-{@link SESSION_BATCH_SIZE} chunk loop: every error tool_call across
+ * every chunk (a full batch plus a short remainder batch) is still captured
+ * exactly once as a friction event AND a diagnostic event - chunking must
+ * change memory shape, not output. It derives against a REAL DuckDB (the
+ * same fixture harness `derive-signals.chunk.test.ts` and
+ * `derive-signals.window.test.ts` use).
+ */
+import { describe, expect } from "bun:test";
+import { Effect } from "effect";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { deriveSignals, SESSION_BATCH_SIZE, type DeriveStats } from "./derive-signals.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("derive signals failed-tools chunking", { requireFts: true });
+
+// One full batch plus a remainder, so the loop crosses a chunk boundary and
+// the last chunk is short - the two cases a boundary bug hits. Every session
+// carries exactly one failed tool_call, so the expected friction/diagnostic
+// count is known up front: SESSION_COUNT of each, no more, no less.
+const SESSION_COUNT = SESSION_BATCH_SIZE + 7;
+const RECENT = new Date();
+
+const runFixture = (): Promise<DeriveStats> =>
+    runWithPlatform(Effect.gen(function* () {
+        let stats: DeriveStats | undefined;
+        yield* publishCacheFixture(tempDir("ax-signals-failed-tools-chunk-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                const sessions = Array.from({ length: SESSION_COUNT }, (_, i) => ({
+                    id: `s${String(i).padStart(4, "0")}`,
+                    source: "claude",
+                    started_at: RECENT,
+                }));
+                yield* write.putMany("session", sessions);
+                const turns = sessions.map((s) => ({
+                    id: `${s.id}-t0`,
+                    session: s.id,
+                    seq: 1n,
+                    ts: RECENT,
+                    role: "user",
+                    text_excerpt: "work",
+                }));
+                yield* write.putMany("turn", turns);
+                const toolCalls = sessions.map((s) => ({
+                    id: `${s.id}-tc0`,
+                    session: s.id,
+                    turn: `${s.id}-t0`,
+                    name: "Bash",
+                    seq: 1n,
+                    command_norm: "bun test",
+                    ts: RECENT,
+                    has_error: true,
+                    error_text: "exit 1",
+                    exit_code: 1n,
+                }));
+                yield* write.putMany("tool_call", toolCalls);
+                stats = yield* deriveSignals(write, {});
+            }));
+        if (stats === undefined) return yield* Effect.die("fixture body did not run");
+        return stats;
+    }));
+
+describe("deriveSignals failed-tool-calls chunking (#1043)", () => {
+    dtest("captures every error tool_call's friction + diagnostic event across chunk boundaries", async () => {
+        const stats = await runFixture();
+        expect(stats.sessions).toBe(SESSION_COUNT);
+        // One error per session -> exactly one friction + one diagnostic
+        // event per session, regardless of chunk boundaries. A dropped chunk
+        // undercounts; a double-fetched chunk overcounts - both fail here.
+        expect(stats.frictionEvents).toBe(SESSION_COUNT);
+        expect(stats.diagnosticEvents).toBe(SESSION_COUNT);
+    });
+});

--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -11,7 +11,7 @@ import {
     groupTurnsBySession, shouldDeriveAllTimeSkillPairs,
 } from "./signals/core.ts";
 import type {
-    CorrectionEdge, ProposedEdge, RecoveryEdge,
+    CorrectionEdge, DerivedDiagnosticEvent, DerivedFrictionEvent, ProposedEdge, RecoveryEdge,
     SessionTurns, SkillPairAccum, ToolCallLike,
 } from "./signals/types.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
@@ -122,11 +122,33 @@ const fetchSkillNames = (write: CacheWriteService): Effect.Effect<SkillName[], C
             .map((n) => SkillName.make(n));
     });
 
+/**
+ * Fetch the error `tool_call` rows for a bounded set of session ids - the
+ * same session-chunking `fetchSessionTurnsForIds` applies to turns (#1021),
+ * extended to cover this SEPARATE, previously-unbounded materialisation
+ * (#1043). Past ~60-90 days of history the single unbounded `WHERE
+ * tc.has_error = true` fetch (17 columns, including the `output_excerpt` /
+ * `error_text` text columns, for EVERY error in the window) crossed a
+ * threshold that segfaulted the DuckDB->JS bridge at ~2.5 GB RSS. Bounding by
+ * `tc.session IN (...)` caps each round-trip to at most one chunk's worth of
+ * sessions' errors.
+ *
+ * `sinceDays` stays as a second filter even though `sessionIds` is already
+ * window-derived from `fetchSessionIds`: a session can carry both an
+ * in-window turn (which puts it in the id list) and an out-of-window tool
+ * call, and a windowed derive must still skip that old call - pinned by
+ * `derive-signals.window.test.ts`. Keeping it is strictly cheaper than
+ * dropping it (an extra indexed predicate vs. pulling rows this stage would
+ * then have to discard).
+ */
 const fetchFailedToolCalls = (
     write: CacheWriteService,
+    sessionIds: ReadonlyArray<string>,
     sinceDays: number | undefined,
 ): Effect.Effect<ToolCallLike[], CacheWriteError> =>
     Effect.gen(function* () {
+        if (sessionIds.length === 0) return [];
+        const placeholders = sessionIds.map(() => "?").join(", ");
         const sinceFilter = sinceDays && sinceDays > 0 ? `AND tc.ts > CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - INTERVAL '${Math.trunc(sinceDays)} days'` : "";
         const sql = `
 SELECT
@@ -134,7 +156,7 @@ SELECT
     tc.output_excerpt, tc.error_text, tc.exit_code, tc.duration_ms, tc.has_error,
     tc.cwd, tc.seq, tc.call_id, s.repository, s.checkout
 FROM tool_call tc JOIN session s ON s.id = tc.session
-WHERE tc.has_error = true ${sinceFilter}
+WHERE tc.has_error = true AND tc.session IN (${placeholders}) ${sinceFilter}
 ORDER BY tc.ts DESC`;
         const rows = yield* write.rows(Schema.Struct({
             id: Schema.String, session: Schema.String, turn: Schema.NullOr(Schema.String), name: Schema.String,
@@ -143,7 +165,7 @@ ORDER BY tc.ts DESC`;
             exit_code: Schema.NullOr(NumberFromBigIntColumn), duration_ms: Schema.NullOr(NumberFromBigIntColumn),
             has_error: Schema.Boolean, cwd: Schema.NullOr(Schema.String), seq: NumberFromBigIntColumn,
             call_id: Schema.NullOr(Schema.String), repository: Schema.NullOr(Schema.String), checkout: Schema.NullOr(Schema.String),
-        }), sql);
+        }), sql, [...sessionIds]);
         return [...rows] as unknown as ToolCallLike[];
     });
 
@@ -195,6 +217,13 @@ export const deriveSignals = Effect.fn("derive.signals")(
         const correctionBatch: CorrectionEdge[] = [];
         const proposedBatch: ProposedEdge[] = [];
         const recoveryBatch: RecoveryEdge[] = [];
+        // Folded into the session-chunk loop below (#1043): each chunk's error
+        // tool_calls are fetched and turned into events immediately, so the
+        // full error corpus never sits in the heap at once the way a single
+        // post-loop fetch did. Only these (much smaller) derived-event
+        // batches accumulate across chunks.
+        const toolFrictionBatch: DerivedFrictionEvent[] = [];
+        const diagnosticBatch: DerivedDiagnosticEvent[] = [];
         const pairsAccum = new Map<string, SkillPairAccum>();
         // Skill pairs are all-time aggregates - a --since-scoped derive must
         // not clobber them. Hoisted above the loop so we neither accumulate
@@ -234,6 +263,18 @@ export const deriveSignals = Effect.fn("derive.signals")(
                     });
                 }
             }
+            // Same chunk of session ids that bounded the turns fetch above also
+            // bounds this fetch (#1043) - the failed-tool-calls read is a
+            // SEPARATE materialisation from turns and was still unbounded, which
+            // is what segfaulted a 90-day derive.
+            const chunkFailedToolCalls = yield* fetchFailedToolCalls(write, idChunk, opts.sinceDays).pipe(
+                Effect.tap((calls) => Effect.annotateCurrentSpan("signals.failed_tool_calls", calls.length)),
+                Effect.withSpan("signals.fetch-failed-tools", {
+                    attributes: { "signals.chunk_sessions": idChunk.length },
+                }),
+            );
+            toolFrictionBatch.push(...deriveFrictionFromToolCalls(chunkFailedToolCalls));
+            diagnosticBatch.push(...deriveDiagnosticsFromToolCalls(chunkFailedToolCalls));
         }
 
         const pairsList = shouldWriteSkillPairs
@@ -249,14 +290,13 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 skillPairs: pairsList.length,
             });
         }
-        const failedToolCalls = yield* fetchFailedToolCalls(write, opts.sinceDays).pipe(
-            Effect.tap((calls) => Effect.annotateCurrentSpan("signals.failed_tool_calls", calls.length)),
-            Effect.withSpan("signals.fetch-failed-tools"),
-        );
-        const toolFrictionBatch = deriveFrictionFromToolCalls(failedToolCalls);
+        // `toolFrictionBatch` / `diagnosticBatch` were built chunk-by-chunk in
+        // the loop above (#1043); `correctionBatch` still accumulates across
+        // the whole run (it's small - one row per correction, not one per
+        // error tool_call), so its friction derivation stays here, post-loop,
+        // exactly as before.
         const correctionFrictionBatch = deriveFrictionFromCorrections(correctionBatch);
         const frictionBatch = [...toolFrictionBatch, ...correctionFrictionBatch];
-        const diagnosticBatch = deriveDiagnosticsFromToolCalls(failedToolCalls);
         if (opts.onProgress) {
             yield* opts.onProgress({
                 sessions: totalSessions,

--- a/apps/axctl/src/profile/study-contribution.test.ts
+++ b/apps/axctl/src/profile/study-contribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AX_ATTRIBUTION_MD } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparScore } from "../dojo/spar.ts";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    buildCommunityStudy,
+    openStudyContribution,
+    studyFilePath,
+    type CommunityStudy,
+} from "./study-contribution.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const baseline = { costUsd: 1.2, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true };
+const variant = { costUsd: 0.8, turns: 14, wallMs: 480_000, repairLines: 30, episodes: 2, landed: true };
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "secret task text",
+    parentSha: "ab12cd34",
+    baselineSession: "secret-session",
+    worktree: ".claude/worktrees/secret-path",
+    baseline,
+    baselineIsSubagent: false,
+    delta: "secret intervention text",
+};
+const score: SparScore = { ...scoreSpar(baseline, variant), id: brief.id, variantSession: "secret-variant" };
+
+describe("buildCommunityStudy", () => {
+    test("builds a closed, content-stripped study", () => {
+        const study = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        expect(study.protocol).toEqual({ id: "verification-churn", version: 1 });
+        expect(study.evidence_class).toBe("self_reported");
+        expect(study.outcome).toBe("improved");
+        expect(study.metrics.cost_usd.delta).toBeCloseTo(-0.4);
+        const json = JSON.stringify(study);
+        expect(json).not.toContain(brief.prompt);
+        expect(json).not.toContain(brief.delta);
+        expect(json).not.toContain(brief.baselineSession);
+        expect(json).not.toContain(score.variantSession);
+        expect(json).not.toContain(brief.worktree);
+    });
+
+    test("rejects a score for a different spar", () => {
+        expect(() => buildCommunityStudy({ brief, score: { ...score, id: "other" }, briefBytes: "brief", scoreBytes: "score" }))
+            .toThrow(/does not match/);
+    });
+});
+
+describe("openStudyContribution", () => {
+    test("opens one reviewed PR for one study file", async () => {
+        const study: CommunityStudy = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        const path = studyFilePath(study);
+        const login = "Necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            login,
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${REGISTRY_REPO}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`GET /repos/${REGISTRY_REPO}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "ok" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+
+        const result = await Effect.runPromise(openStudyContribution({ study }).pipe(Effect.provide(t.layer)));
+        expect(result.path).toBe(path);
+        expect(t.calls.map((call) => `${call.method} ${call.path}`)[0]).toBe(`GET /repos/${REGISTRY_REPO}/contents/${path}`);
+        expect(t.calls.find((call) => call.path === `/repos/${REGISTRY_REPO}/pulls`)?.body).toMatchObject({
+            base: "main",
+            body: expect.stringContaining(AX_ATTRIBUTION_MD),
+        });
+    });
+});

--- a/apps/axctl/src/profile/study-contribution.ts
+++ b/apps/axctl/src/profile/study-contribution.ts
@@ -1,0 +1,147 @@
+/** One content-stripped, self-reported study from the fixed Dojo spar protocol. */
+import { createHash } from "node:crypto";
+import { Effect, Schema } from "effect";
+import { prettyPrint } from "@ax/lib/json";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparMetrics, type SparScore } from "../dojo/spar.ts";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+type Metric<T> = { readonly baseline: T; readonly variant: T; readonly delta: number | null };
+
+export interface CommunityStudy {
+    readonly schema_version: 1;
+    readonly kind: "self-reported-community-study";
+    readonly protocol: { readonly id: "verification-churn"; readonly version: 1 };
+    readonly evidence_class: "self_reported";
+    readonly outcome: "improved" | "regressed" | "mixed";
+    readonly privacy: "closed_fields_content_stripped";
+    readonly source: {
+        readonly spar_id_sha256: string;
+        readonly brief_sha256: string;
+        readonly score_sha256: string;
+        readonly intervention_sha256: string;
+    };
+    readonly metrics: {
+        readonly cost_usd: Metric<number | null>;
+        readonly turns: Metric<number | null>;
+        readonly wall_ms: Metric<number | null>;
+        readonly repair_lines: Metric<number>;
+        readonly episodes: Metric<number>;
+        readonly landed: { readonly baseline: boolean; readonly variant: boolean };
+    };
+    readonly limitations: readonly ["single_spar_comparison", "self_reported"];
+}
+
+const same = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+const metric = <T>(baseline: T, variant: T, delta: number | null): Metric<T> => ({ baseline, variant, delta });
+
+export function buildCommunityStudy(input: {
+    readonly brief: SparBrief;
+    readonly score: SparScore;
+    readonly briefBytes: string;
+    readonly scoreBytes: string;
+}): CommunityStudy {
+    if (input.brief.id !== input.score.id) throw new Error("spar score id does not match the brief id");
+    if (input.brief.delta.trim() === "") throw new Error("spar brief has no intervention in the Delta section");
+    if (input.brief.baselineIsSubagent) throw new Error("a subagent baseline cannot become a community study");
+    if (!same(input.brief.baseline, input.score.baseline)) throw new Error("spar score baseline does not match the frozen brief");
+
+    const calculated = scoreSpar(input.score.baseline, input.score.variant);
+    if (!same(calculated.deltas, input.score.deltas) || calculated.verdict !== input.score.verdict) {
+        throw new Error("spar score does not match the fixed protocol calculation");
+    }
+
+    const baseline: SparMetrics = input.score.baseline;
+    const variant: SparMetrics = input.score.variant;
+    const deltas = input.score.deltas;
+    return {
+        schema_version: 1,
+        kind: "self-reported-community-study",
+        protocol: { id: "verification-churn", version: 1 },
+        evidence_class: "self_reported",
+        outcome: input.score.verdict === "win" ? "improved" : input.score.verdict === "regression" ? "regressed" : "mixed",
+        privacy: "closed_fields_content_stripped",
+        source: {
+            spar_id_sha256: sha256(input.brief.id),
+            brief_sha256: sha256(input.briefBytes),
+            score_sha256: sha256(input.scoreBytes),
+            intervention_sha256: sha256(input.brief.delta.trim()),
+        },
+        metrics: {
+            cost_usd: metric(baseline.costUsd, variant.costUsd, deltas.costUsd),
+            turns: metric(baseline.turns, variant.turns, deltas.turns),
+            wall_ms: metric(baseline.wallMs, variant.wallMs, deltas.wallMs),
+            repair_lines: metric(baseline.repairLines, variant.repairLines, deltas.repairLines),
+            episodes: metric(baseline.episodes, variant.episodes, deltas.episodes),
+            landed: { baseline: baseline.landed, variant: variant.landed },
+        },
+        limitations: ["single_spar_comparison", "self_reported"],
+    };
+}
+
+export const studyFilePath = (study: CommunityStudy): string =>
+    `community/research/studies/verification-churn/${study.source.score_sha256.slice(0, 32)}.json`;
+
+const studyBranchName = (study: CommunityStudy): string =>
+    `ax-study-verification-churn-${study.source.score_sha256.slice(0, 12)}`;
+
+export class StudyContributionError extends Schema.TaggedErrorClass<StudyContributionError>(
+    "StudyContributionError",
+)("StudyContributionError", { message: Schema.String }) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const openStudyContribution = Effect.fn("profile.openStudyContribution")(
+    function* (input: { readonly study: CommunityStudy; readonly login?: string }) {
+        const gh = yield* GitHubEnv;
+        const login = input.login ?? (yield* gh.login());
+        if (login === null || login.trim() === "") {
+            return yield* new StudyContributionError({ message: "GitHub login unavailable; run `gh auth login` and retry." });
+        }
+
+        const path = studyFilePath(input.study);
+        const branch = studyBranchName(input.study);
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${path}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404 ? Effect.succeed(false) : Effect.fail(error)),
+        );
+        if (exists) return yield* new StudyContributionError({ message: `${path} already exists.` });
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+        const blob = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+            content: `${prettyPrint(input.study)}\n`, encoding: "utf-8",
+        }));
+        const tree = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+            base_tree: baseTreeSha,
+            tree: [{ path, mode: "100644", type: "blob", sha: blob.sha }],
+        }));
+        const commit = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+            message: `community: contribute verification churn study`, tree: tree.sha, parents: [baseSha],
+        }));
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, { ref: `refs/heads/${branch}`, sha: commit.sha });
+        const body = withAxAttribution([
+            "Contributes one content-stripped study from the fixed verification churn protocol.",
+            "The evidence is self-reported and contains one spar comparison.",
+            "This PR does not claim general efficacy.",
+            `File: \`${path}\``,
+            "Opened by `ax contribute study`.",
+        ].join("\n\n"));
+        const pr = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+            title: "community: contribute verification churn study",
+            head: `${login}:${branch}`,
+            base: "main",
+            body,
+        }));
+        return { status: "pr-opened" as const, prUrl: String(pr.html_url ?? ""), path };
+    },
+);

--- a/community/README.md
+++ b/community/README.md
@@ -26,6 +26,14 @@ same schema before opening a PR. Pattern PRs are schema-checked by CI but stay
 human-reviewed; filename collisions fail validation so contributors engage the
 existing pattern instead of duplicating it.
 
+## research/studies/
+
+One file records one content-stripped Dojo spar comparison.
+Use `ax contribute study <spar-id>` to inspect the exact public JSON.
+The command requires consent before it opens a reviewed PR.
+These first studies are self-reported pilot data.
+They do not prove general efficacy.
+
 ## Compiled outputs (nightly)
 
 `leaderboard.json`, `skill-stats.json`, `hook-stats.json`,

--- a/community/research/studies/README.md
+++ b/community/research/studies/README.md
@@ -1,0 +1,23 @@
+# Community studies
+
+This directory stores one JSON file for each reviewed Dojo spar comparison.
+
+The pilot supports only `verification-churn` protocol version 1.
+It compares cost, turns, duration, repair lines, verification episodes, and landing status.
+
+The JSON uses closed fields.
+It excludes task text, intervention text, repository paths, and session identifiers.
+It includes hashes that bind the public record to the local brief and score.
+
+Each record has `evidence_class: "self_reported"`.
+Each record describes one comparison.
+Agents must not use one record as a general recommendation.
+
+Run this command after `ax dojo spar-score`:
+
+```text
+ax contribute study <spar-id>
+```
+
+The command shows the exact public JSON before it asks for consent.
+Use `--preview` to stop after the preview.


### PR DESCRIPTION
Closes #1043.

## Problem
`ax ingest --stages=signals --since=90` segfaults (native `panic(main thread): Segmentation fault`, ~2.5GB RSS). Deterministic on this corpus: `--since=60` OK, `--since=90` crashes.

The turns pass was chunked in #1021/#1024, but `fetchFailedToolCalls` was a **separate, still-unbounded** materialization — one query pulling every error `tool_call` in the window (17 columns incl. `output_excerpt`/`error_text`) into one JS array. Past ~60-90 days the result set crosses a threshold that segfaults the DuckDB→JS bridge.

## Fix
- `fetchFailedToolCalls` now takes a `sessionIds` chunk and filters `WHERE tc.session IN (?...)` — same pattern as `fetchSessionTurnsForIds`.
- The fetch + friction/diagnostic derivation is **folded into the existing session-chunk loop**, so only the small derived-event batches accumulate; the full error corpus never sits in the heap at once.
- `sinceDays` kept as a second filter (a session can carry an in-window turn and an out-of-window error tool_call — pinned by `derive-signals.window.test.ts`).
- Behavior identical: `putMany` upserts are id-keyed and order-independent.

## Verification
- `derive-signals.{chunk,stage,window}.test.ts` + new `derive-signals.failed-tools-chunk.test.ts` (seeds `SESSION_BATCH_SIZE+7` sessions across a chunk boundary): **5 pass**.
- Full `signals/` + `derive-signals*`: 49 pass.
- `check:timestamp-cast` clean; no new tsc errors.