### PR TITLE
fix(cache-lens): recurrence guard counts distinct sessions, not UTC calendar days (#943)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,8 +488,10 @@ discriminator pattern as directives/workflows) - triaged via `ax improve list`
 / `accept` like any other proposal. Mint is NOT apply: no behavior changes, only
 a shortlist row. FOUR guards, all required: (1) corroboration - the ledger's two
 independent prices agree within ±25% over the offender's comparable busts (zero
-comparable busts never mints); (2) recurrence - busts on >= 2 distinct UTC days
-(proxy for >= 2 ingest windows; the ledger carries no run id); (3) materiality -
+comparable busts never mints); (2) recurrence - busts across >= 2 distinct
+sessions (proxy for >= 2 ingest windows; the ledger carries no run id - a UTC
+calendar-day count was tried first and dropped for miscounting across
+timezone boundaries, #943); (3) materiality -
 normalized weekly cost >= $5; (4) cap - at most 3 OPEN cache-lens proposals at a
 time (existing + newly minted this run), highest-weekly-cost first, rest
 skipped. Candidates come from `fetchCacheLensCandidates`

--- a/apps/axctl/src/cli/commands/contribute.test.ts
+++ b/apps/axctl/src/cli/commands/contribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     buildFreshPattern,
+    isSafeSparId,
     patternChoiceLabel,
     selectProfilePattern,
     type FreshPatternInput,
@@ -83,5 +84,16 @@ describe("buildFreshPattern", () => {
             sessions: 4,
             confidence: 0.8,
         })).toThrow(/summary/);
+    });
+});
+
+describe("study contribution input", () => {
+    test("accepts a file-safe spar id", () => {
+        expect(isSafeSparId("ab12cd34-2026-06-13")).toBe(true);
+    });
+
+    test("rejects path traversal", () => {
+        expect(isSafeSparId("../../secret")).toBe(false);
+        expect(isSafeSparId("a/b")).toBe(false);
     });
 });

--- a/apps/axctl/src/cli/commands/contribute.ts
+++ b/apps/axctl/src/cli/commands/contribute.ts
@@ -3,14 +3,17 @@
  * or author one through structured prompts, into community/patterns/ via the
  * same fork+PR rails used by profile registration.
  */
-import { Effect, Schema } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Effect, FileSystem, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile } from "../../profile/render.ts";
 import { openPatternContribution, patternFilePath } from "../../profile/pattern-contribution.ts";
 import { PATTERN_CATEGORIES, TastePattern, type PatternCategory, type ProfileV1 } from "../../profile/schema.ts";
 import { slugify } from "../../profile/taste.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
+import { buildCommunityStudy, openStudyContribution, studyFilePath } from "../../profile/study-contribution.ts";
+import { dojoSparBriefPath, dojoSparScorePath } from "../../dojo/paths.ts";
+import { parseSparBrief, parseSparScore } from "../../dojo/spar.ts";
 import { gatherEnv } from "./profile.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, optionValue, parseCsvFlag } from "./shared.ts";
@@ -240,9 +243,63 @@ const contributePatternCommand = Command.make(
     ),
 );
 
+export const isSafeSparId = (id: string): boolean =>
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+
+export const cmdContributeStudy = (input: {
+    readonly id: string;
+    readonly preview: boolean;
+    readonly yes: boolean;
+}) => Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const briefPath = dojoSparBriefPath(input.id);
+    const scorePath = dojoSparScorePath(input.id);
+    const briefBytes = yield* fs.readFileString(briefPath);
+    const scoreBytes = yield* fs.readFileString(scorePath);
+    const brief = parseSparBrief(briefBytes);
+    const score = parseSparScore(scoreBytes);
+    if (brief === null) throw new Error(`invalid spar brief: ${briefPath}`);
+    if (score === null) throw new Error(`invalid spar score: ${scorePath}`);
+
+    const study = buildCommunityStudy({ brief, score, briefBytes, scoreBytes });
+    const path = studyFilePath(study);
+    console.log(prettyPrint(study));
+    console.log(`\nThis self-reported study will be proposed as ${path}.`);
+    console.log("It contains one comparison. It does not prove general efficacy.");
+    if (input.preview) {
+        console.log("Preview only. No PR was opened.");
+        return;
+    }
+    if (!input.yes) {
+        const answer = promptText("Open reviewed PR? [y/N]").toLowerCase();
+        if (answer !== "y" && answer !== "yes") {
+            console.log("Aborted. No PR was opened.");
+            return;
+        }
+    }
+    const result = yield* openStudyContribution({ study });
+    console.log(`study PR: ${result.prUrl}`);
+    console.log(`file:     ${result.path}`);
+}).pipe(Effect.provide(GitHubEnvLive));
+
+const contributeStudyCommand = Command.make(
+    "study",
+    {
+        id: Argument.string("spar-id"),
+        preview: Flag.boolean("preview").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ id, preview, yes }) => {
+        if (!isSafeSparId(id)) fail(`ax contribute study: invalid spar id "${id}"`);
+        return cmdContributeStudy({ id, preview, yes });
+    },
+).pipe(Command.withDescription(
+    "Preview one content-stripped Dojo spar study. Use --yes to open a reviewed GitHub PR.",
+));
+
 export const contributeCommand = Command.make("contribute").pipe(
     Command.withDescription("Contribute ax community artifacts through fork+PR rails"),
-    Command.withSubcommands([contributePatternCommand]),
+    Command.withSubcommands([contributePatternCommand, contributeStudyCommand]),
 );
 
 export const contributeRuntime: RuntimeManifest = {
@@ -251,6 +308,7 @@ export const contributeRuntime: RuntimeManifest = {
         fallback: "none",
         subcommands: {
             pattern: (args) => args.includes("--fresh") ? "none" : "cache",
+            study: "none",
         },
     },
 };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -30,6 +30,7 @@ import {
     dojoSparBriefPath,
     dojoSparDir,
     dojoSparReportPath,
+    dojoSparScorePath,
     localDate,
 } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
@@ -659,11 +660,16 @@ const sparScoreCommand = Command.make(
             yield* fs.writeFileString(tmp, renderSparReport(score, brief));
             yield* fs.rename(tmp, path);
 
+            const scorePath = dojoSparScorePath(id);
+            const scoreTmp = `${scorePath}.tmp.${process.pid}`;
+            yield* fs.writeFileString(scoreTmp, `${prettyPrint(score)}\n`);
+            yield* fs.rename(scoreTmp, scorePath);
+
             console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
         }),
 ).pipe(
     Command.withDescription(
-        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+        "Score the agent's variant session and write Markdown plus machine-readable JSON receipts. --variant-session=<id> --json",
     ),
 );
 

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath, dojoSparScorePath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -18,6 +18,9 @@ describe("dojo paths", () => {
         );
         expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
+        );
+        expect(dojoSparScorePath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-score.json",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -19,6 +19,9 @@ export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): 
 export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoSparDir(base), `${id}-report.md`);
 
+export const dojoSparScorePath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-score.json`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -7,6 +7,7 @@ import {
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
+    parseSparScore,
     renderSparBrief,
     renderSparReport,
     REPAIR_TOL,
@@ -121,6 +122,18 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+describe("parseSparScore", () => {
+    test("accepts a complete machine score", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.8 })), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify(score))).toEqual(score);
+    });
+
+    test("rejects a score with an invalid metric", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics()), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify({ ...score, variant: { ...score.variant, turns: "many" } }))).toBeNull();
     });
 });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -74,6 +74,22 @@ export interface SparScore {
     readonly verdict: SparVerdict;
 }
 
+const asDeltas = (v: unknown): SparDeltas | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const finite = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    const nullable = (x: unknown): x is number | null => x === null || finite(x);
+    if (!nullable(o.costUsd) || !nullable(o.turns) || !nullable(o.wallMs)) return null;
+    if (!finite(o.repairLines) || !finite(o.episodes)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+    };
+};
+
 // ---------------------------------------------------------------------------
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
@@ -209,6 +225,26 @@ const asBaselineMetrics = (v: unknown): SparMetrics | null => {
         episodes: o.episodes,
         landed: o.landed,
     };
+};
+
+/** Decode the durable JSON receipt written by `spar-score`. */
+export const parseSparScore = (content: string): SparScore | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const o = parsed as Record<string, unknown>;
+    const baseline = asBaselineMetrics(o.baseline);
+    const variant = asBaselineMetrics(o.variant);
+    const deltas = asDeltas(o.deltas);
+    if (typeof o.id !== "string" || o.id.length === 0) return null;
+    if (typeof o.variantSession !== "string" || o.variantSession.length === 0) return null;
+    if (o.verdict !== "win" && o.verdict !== "regression" && o.verdict !== "mixed") return null;
+    if (baseline === null || variant === null || deltas === null) return null;
+    return { id: o.id, variantSession: o.variantSession, baseline, variant, deltas, verdict: o.verdict };
 };
 
 export const parseSparBrief = (content: string): SparBrief | null => {

--- a/apps/axctl/src/ingest/derive-proposals.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.test.ts
@@ -654,7 +654,6 @@ const makeCacheLensCandidate = (
     name: "design-curator",
     busts: 20,
     sessions: 8,
-    distinctDays: 5,
     bustCostUsd: 10, // 14d window -> $5/wk exactly at the threshold by default below
     comparableBusts: 20,
     comparableBustCostUsd: 10,
@@ -713,14 +712,14 @@ describe("evaluateCacheLensCandidate", () => {
         expect(evaluateCacheLensCandidate(candidate, 14)).toBeNull();
     });
 
-    test("(c) single-day recurrence does not mint", () => {
-        const candidate = makeCacheLensCandidate({ distinctDays: 1 });
+    test("(c) single-session recurrence does not mint", () => {
+        const candidate = makeCacheLensCandidate({ sessions: 1 });
         expect(evaluateCacheLensCandidate(candidate, 14)).toBeNull();
     });
 
     test("(d) below $5/wk materiality does not mint", () => {
         // $10 total over a 90d window -> $0.78/wk, well under $5.
-        const candidate = makeCacheLensCandidate({ distinctDays: 3, bustCostUsd: 10 });
+        const candidate = makeCacheLensCandidate({ bustCostUsd: 10 });
         expect(evaluateCacheLensCandidate(candidate, 90)).toBeNull();
     });
 
@@ -782,7 +781,7 @@ describe("deriveCacheLensProposalRows", () => {
 
     test("(b)/(c)/(d) a candidate failing any guard is skipped, not minted", () => {
         const badCorroboration = makeCacheLensCandidate({ name: "bad-corr", comparableCorroboratedCostUsd: 1 });
-        const badRecurrence = makeCacheLensCandidate({ name: "bad-days", distinctDays: 1 });
+        const badRecurrence = makeCacheLensCandidate({ name: "bad-sessions", sessions: 1 });
         const badMateriality = makeCacheLensCandidate({ name: "bad-cost", bustCostUsd: 0.5 });
         const { rows, skipped } = deriveCacheLensProposalRows(
             [badCorroboration, badRecurrence, badMateriality],

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -455,9 +455,12 @@ export const buildImageContextProposalWrites = (
 //      pricer vs flat-rate recompute) must agree over the offender's
 //      COMPARABLE busts (both prices present). Zero comparable busts never
 //      mints - there is nothing to corroborate against.
-//   2. Recurrence - busts on >= 2 distinct UTC days in the window. Proxy for
-//      ">= 2 ingest windows" - cache_bust_event carries no run id, so a
-//      calendar-day count is the closest signal available.
+//   2. Recurrence - busts across >= 2 distinct SESSIONS in the window. Proxy
+//      for ">= 2 ingest windows" - cache_bust_event carries no run id, so a
+//      session count is the closest signal available. NOT a UTC-calendar-day
+//      count (#943): a UTC-day proxy miscounts for a non-UTC operator - one
+//      local workday straddling UTC midnight reads as two days (false pass),
+//      and two local workdays sharing a UTC date read as one (false fail).
 //   3. Materiality - normalized weekly cost (bust_cost_usd scaled to a 7-day
 //      rate) >= $5. A one-off $50 bust in a 90-day window is not worth an
 //      operator's triage attention; a steady $6/wk drip is.
@@ -467,7 +470,7 @@ export const buildImageContextProposalWrites = (
 // ---------------------------------------------------------------------------
 
 export const CACHE_LENS_CORROBORATION_TOLERANCE = 0.25;
-export const CACHE_LENS_MIN_RECURRENCE_DAYS = 2;
+export const CACHE_LENS_MIN_RECURRENCE_SESSIONS = 2;
 export const CACHE_LENS_MATERIALITY_WEEKLY_USD = 5;
 export const CACHE_LENS_PROPOSAL_CAP = 3;
 export const CACHE_LENS_SECTION = "cache-lens";
@@ -504,7 +507,7 @@ export const evaluateCacheLensCandidate = (
     if (corroborationDeltaPct > CACHE_LENS_CORROBORATION_TOLERANCE) return null;
 
     // Guard 2: recurrence.
-    if (candidate.distinctDays < CACHE_LENS_MIN_RECURRENCE_DAYS) return null;
+    if (candidate.sessions < CACHE_LENS_MIN_RECURRENCE_SESSIONS) return null;
 
     // Guard 3: materiality.
     const windowDays = Math.max(1, sinceDays);
@@ -1099,10 +1102,11 @@ WHERE p.form = 'guidance' AND g.section = ? AND p.status = 'open'`,
         const existingCacheLensOpenSigs = new Set(existingCacheLensOpen.map((r) => r.dedupe_sig));
         // Evaluation window FLOORED at 14 days, independent of the ingest
         // since-window: a warm `--since=1` run would otherwise evaluate a
-        // 1-day window in which the >=2-distinct-days recurrence guard can
-        // never pass (minting dead on exactly the runs that dominate) and the
-        // x7 weekly extrapolation would rest on a single day's sample. The
-        // ledger is cumulative (incremental upserts keyed by ttu.id), so
+        // 1-day window too narrow for the >=2-sessions recurrence guard to
+        // reliably see genuine recurrence (minting starved on exactly the
+        // runs that dominate) and the x7 weekly extrapolation would rest on a
+        // single day's sample. The ledger is cumulative (incremental upserts
+        // keyed by ttu.id), so
         // reading 14d back on a warm run is always valid.
         const cacheLensWindowDays = Math.max(sinceDays, 14);
         const cacheLensCandidates = yield* fetchCacheLensCandidates(write, { sinceDays: cacheLensWindowDays });

--- a/apps/axctl/src/profile/study-contribution.test.ts
+++ b/apps/axctl/src/profile/study-contribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AX_ATTRIBUTION_MD } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparScore } from "../dojo/spar.ts";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    buildCommunityStudy,
+    openStudyContribution,
+    studyFilePath,
+    type CommunityStudy,
+} from "./study-contribution.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const baseline = { costUsd: 1.2, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true };
+const variant = { costUsd: 0.8, turns: 14, wallMs: 480_000, repairLines: 30, episodes: 2, landed: true };
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "secret task text",
+    parentSha: "ab12cd34",
+    baselineSession: "secret-session",
+    worktree: ".claude/worktrees/secret-path",
+    baseline,
+    baselineIsSubagent: false,
+    delta: "secret intervention text",
+};
+const score: SparScore = { ...scoreSpar(baseline, variant), id: brief.id, variantSession: "secret-variant" };
+
+describe("buildCommunityStudy", () => {
+    test("builds a closed, content-stripped study", () => {
+        const study = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        expect(study.protocol).toEqual({ id: "verification-churn", version: 1 });
+        expect(study.evidence_class).toBe("self_reported");
+        expect(study.outcome).toBe("improved");
+        expect(study.metrics.cost_usd.delta).toBeCloseTo(-0.4);
+        const json = JSON.stringify(study);
+        expect(json).not.toContain(brief.prompt);
+        expect(json).not.toContain(brief.delta);
+        expect(json).not.toContain(brief.baselineSession);
+        expect(json).not.toContain(score.variantSession);
+        expect(json).not.toContain(brief.worktree);
+    });
+
+    test("rejects a score for a different spar", () => {
+        expect(() => buildCommunityStudy({ brief, score: { ...score, id: "other" }, briefBytes: "brief", scoreBytes: "score" }))
+            .toThrow(/does not match/);
+    });
+});
+
+describe("openStudyContribution", () => {
+    test("opens one reviewed PR for one study file", async () => {
+        const study: CommunityStudy = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        const path = studyFilePath(study);
+        const login = "Necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            login,
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${REGISTRY_REPO}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`GET /repos/${REGISTRY_REPO}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "ok" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+
+        const result = await Effect.runPromise(openStudyContribution({ study }).pipe(Effect.provide(t.layer)));
+        expect(result.path).toBe(path);
+        expect(t.calls.map((call) => `${call.method} ${call.path}`)[0]).toBe(`GET /repos/${REGISTRY_REPO}/contents/${path}`);
+        expect(t.calls.find((call) => call.path === `/repos/${REGISTRY_REPO}/pulls`)?.body).toMatchObject({
+            base: "main",
+            body: expect.stringContaining(AX_ATTRIBUTION_MD),
+        });
+    });
+});

--- a/apps/axctl/src/profile/study-contribution.ts
+++ b/apps/axctl/src/profile/study-contribution.ts
@@ -1,0 +1,147 @@
+/** One content-stripped, self-reported study from the fixed Dojo spar protocol. */
+import { createHash } from "node:crypto";
+import { Effect, Schema } from "effect";
+import { prettyPrint } from "@ax/lib/json";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparMetrics, type SparScore } from "../dojo/spar.ts";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+type Metric<T> = { readonly baseline: T; readonly variant: T; readonly delta: number | null };
+
+export interface CommunityStudy {
+    readonly schema_version: 1;
+    readonly kind: "self-reported-community-study";
+    readonly protocol: { readonly id: "verification-churn"; readonly version: 1 };
+    readonly evidence_class: "self_reported";
+    readonly outcome: "improved" | "regressed" | "mixed";
+    readonly privacy: "closed_fields_content_stripped";
+    readonly source: {
+        readonly spar_id_sha256: string;
+        readonly brief_sha256: string;
+        readonly score_sha256: string;
+        readonly intervention_sha256: string;
+    };
+    readonly metrics: {
+        readonly cost_usd: Metric<number | null>;
+        readonly turns: Metric<number | null>;
+        readonly wall_ms: Metric<number | null>;
+        readonly repair_lines: Metric<number>;
+        readonly episodes: Metric<number>;
+        readonly landed: { readonly baseline: boolean; readonly variant: boolean };
+    };
+    readonly limitations: readonly ["single_spar_comparison", "self_reported"];
+}
+
+const same = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+const metric = <T>(baseline: T, variant: T, delta: number | null): Metric<T> => ({ baseline, variant, delta });
+
+export function buildCommunityStudy(input: {
+    readonly brief: SparBrief;
+    readonly score: SparScore;
+    readonly briefBytes: string;
+    readonly scoreBytes: string;
+}): CommunityStudy {
+    if (input.brief.id !== input.score.id) throw new Error("spar score id does not match the brief id");
+    if (input.brief.delta.trim() === "") throw new Error("spar brief has no intervention in the Delta section");
+    if (input.brief.baselineIsSubagent) throw new Error("a subagent baseline cannot become a community study");
+    if (!same(input.brief.baseline, input.score.baseline)) throw new Error("spar score baseline does not match the frozen brief");
+
+    const calculated = scoreSpar(input.score.baseline, input.score.variant);
+    if (!same(calculated.deltas, input.score.deltas) || calculated.verdict !== input.score.verdict) {
+        throw new Error("spar score does not match the fixed protocol calculation");
+    }
+
+    const baseline: SparMetrics = input.score.baseline;
+    const variant: SparMetrics = input.score.variant;
+    const deltas = input.score.deltas;
+    return {
+        schema_version: 1,
+        kind: "self-reported-community-study",
+        protocol: { id: "verification-churn", version: 1 },
+        evidence_class: "self_reported",
+        outcome: input.score.verdict === "win" ? "improved" : input.score.verdict === "regression" ? "regressed" : "mixed",
+        privacy: "closed_fields_content_stripped",
+        source: {
+            spar_id_sha256: sha256(input.brief.id),
+            brief_sha256: sha256(input.briefBytes),
+            score_sha256: sha256(input.scoreBytes),
+            intervention_sha256: sha256(input.brief.delta.trim()),
+        },
+        metrics: {
+            cost_usd: metric(baseline.costUsd, variant.costUsd, deltas.costUsd),
+            turns: metric(baseline.turns, variant.turns, deltas.turns),
+            wall_ms: metric(baseline.wallMs, variant.wallMs, deltas.wallMs),
+            repair_lines: metric(baseline.repairLines, variant.repairLines, deltas.repairLines),
+            episodes: metric(baseline.episodes, variant.episodes, deltas.episodes),
+            landed: { baseline: baseline.landed, variant: variant.landed },
+        },
+        limitations: ["single_spar_comparison", "self_reported"],
+    };
+}
+
+export const studyFilePath = (study: CommunityStudy): string =>
+    `community/research/studies/verification-churn/${study.source.score_sha256.slice(0, 32)}.json`;
+
+const studyBranchName = (study: CommunityStudy): string =>
+    `ax-study-verification-churn-${study.source.score_sha256.slice(0, 12)}`;
+
+export class StudyContributionError extends Schema.TaggedErrorClass<StudyContributionError>(
+    "StudyContributionError",
+)("StudyContributionError", { message: Schema.String }) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const openStudyContribution = Effect.fn("profile.openStudyContribution")(
+    function* (input: { readonly study: CommunityStudy; readonly login?: string }) {
+        const gh = yield* GitHubEnv;
+        const login = input.login ?? (yield* gh.login());
+        if (login === null || login.trim() === "") {
+            return yield* new StudyContributionError({ message: "GitHub login unavailable; run `gh auth login` and retry." });
+        }
+
+        const path = studyFilePath(input.study);
+        const branch = studyBranchName(input.study);
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${path}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404 ? Effect.succeed(false) : Effect.fail(error)),
+        );
+        if (exists) return yield* new StudyContributionError({ message: `${path} already exists.` });
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+        const blob = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+            content: `${prettyPrint(input.study)}\n`, encoding: "utf-8",
+        }));
+        const tree = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+            base_tree: baseTreeSha,
+            tree: [{ path, mode: "100644", type: "blob", sha: blob.sha }],
+        }));
+        const commit = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+            message: `community: contribute verification churn study`, tree: tree.sha, parents: [baseSha],
+        }));
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, { ref: `refs/heads/${branch}`, sha: commit.sha });
+        const body = withAxAttribution([
+            "Contributes one content-stripped study from the fixed verification churn protocol.",
+            "The evidence is self-reported and contains one spar comparison.",
+            "This PR does not claim general efficacy.",
+            `File: \`${path}\``,
+            "Opened by `ax contribute study`.",
+        ].join("\n\n"));
+        const pr = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+            title: "community: contribute verification churn study",
+            head: `${login}:${branch}`,
+            base: "main",
+            body,
+        }));
+        return { status: "pr-opened" as const, prUrl: String(pr.html_url ?? ""), path };
+    },
+);

--- a/apps/axctl/src/queries/cache-bust.duckdb.test.ts
+++ b/apps/axctl/src/queries/cache-bust.duckdb.test.ts
@@ -17,6 +17,7 @@ import { Effect, Schema } from "effect";
 import { CacheRead, type CacheWriteService } from "@ax/lib/duckdb/seam";
 import { publishCacheFixture, readFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { evaluateCacheLensCandidate } from "../ingest/derive-proposals.ts";
 import { runCacheBustModels, type CacheBustModelStats } from "../ingest/models/cache-bust-models.ts";
 import { fetchCacheBustCost, fetchCacheLensCandidates } from "./cache-bust.ts";
 
@@ -220,8 +221,8 @@ describe("fetchCacheLensCandidates over a published snapshot (slice B, #868)", (
                         display_name: "Claude Opus 4.8", cache_creation_per_million_usd: 18.75,
                     });
                     yield* write.putMany("turn_token_usage", [
-                        // Same skill, two busts exactly 24h apart -> 2 distinct UTC
-                        // days (the recurrence guard's proxy), both priced twice.
+                        // Same skill, two busts on two distinct sessions -> the
+                        // recurrence guard's proxy, both priced twice.
                         usageRow({
                             id: "ttu:d1", session: SESSION_A, seq: 1, ts: hoursAgo(2), source: "claude",
                             cacheCreationTokens: 1_000_000n, cacheCreationUsd: 20, modelRef: "am:opus",
@@ -255,7 +256,7 @@ describe("fetchCacheLensCandidates over a published snapshot (slice B, #868)", (
 
         const skill = candidates.find((c) => c.kind === "skill" && c.name === "design-curator");
         expect(skill).toMatchObject({
-            kind: "skill", name: "design-curator", busts: 2, sessions: 2, distinctDays: 2,
+            kind: "skill", name: "design-curator", busts: 2, sessions: 2,
             bustCostUsd: 40, comparableBusts: 2, comparableBustCostUsd: 40,
         });
         expect(skill?.comparableCorroboratedCostUsd).toBeCloseTo(37.5, 5);
@@ -263,9 +264,112 @@ describe("fetchCacheLensCandidates over a published snapshot (slice B, #868)", (
 
         const agent = candidates.find((c) => c.kind === "agent" && c.name === "review-bot");
         expect(agent).toMatchObject({
-            kind: "agent", name: "review-bot", busts: 1, sessions: 1, distinctDays: 1,
+            kind: "agent", name: "review-bot", busts: 1, sessions: 1,
             bustCostUsd: 4, comparableBusts: 0, comparableBustCostUsd: 0, comparableCorroboratedCostUsd: 0,
         });
         expect(agent?.reasonCounts).toEqual([{ reason: "previous_message_not_found", count: 1 }]);
+    });
+
+    // Regression (#943): the recurrence guard used to count DISTINCT UTC
+    // CALENDAR DAYS (`count(DISTINCT CAST(ts AS DATE))`), which miscounts for
+    // any non-UTC operator. It now counts DISTINCT SESSIONS instead - these
+    // two cases are exactly the pairs the old proxy got backwards.
+    dtest("recurrence guard: two sessions on ONE UTC date pass (old UTC-day proxy would fail this)", async () => {
+        const dir = tempDir("cache-lens-same-utc-date-two-sessions");
+        // Both busts sit at UTC noon today, 2 hours apart - guaranteed to
+        // share a UTC calendar date, but attributed to two DISTINCT sessions.
+        const now = new Date();
+        const utcNoonToday = new Date(Date.UTC(
+            now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0,
+        ));
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* write.put("agent_model", {
+                        id: "am:opus", name: "claude-opus-4-8", provider: "anthropic",
+                        display_name: "Claude Opus 4.8", cache_creation_per_million_usd: 18.75,
+                    });
+                    yield* write.putMany("turn_token_usage", [
+                        usageRow({
+                            id: "ttu:same-date-1", session: SESSION_A, seq: 1, ts: utcNoonToday, source: "claude",
+                            cacheCreationTokens: 1_000_000n, cacheCreationUsd: 20, modelRef: "am:opus",
+                            skill: "same-utc-date-skill", cacheMiss: "messages_changed",
+                        }),
+                        usageRow({
+                            id: "ttu:same-date-2", session: SESSION_B, seq: 1,
+                            ts: new Date(utcNoonToday.getTime() + 2 * 60 * 60 * 1000), source: "claude",
+                            cacheCreationTokens: 1_000_000n, cacheCreationUsd: 20, modelRef: "am:opus",
+                            skill: "same-utc-date-skill", cacheMiss: "messages_changed",
+                        }),
+                    ]);
+                    yield* runCacheBustModels(write, 30);
+                }),
+            ),
+        );
+
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+        const candidates = await Effect.runPromise(
+            Effect.gen(function* () {
+                const read = yield* CacheRead;
+                return yield* fetchCacheLensCandidates(read, { sinceDays: 7 });
+            }).pipe(Effect.provide(layer)),
+        );
+        const candidate = candidates.find((c) => c.kind === "skill" && c.name === "same-utc-date-skill");
+        expect(candidate?.sessions).toBe(2);
+        // Full guard pipeline (corroboration + recurrence + materiality)
+        // passes - the old distinct-UTC-day proxy would have read 1 day here
+        // and rejected it.
+        expect(candidate ? evaluateCacheLensCandidate(candidate, 7) : null).not.toBeNull();
+    });
+
+    dtest("recurrence guard: one session spanning TWO UTC dates fails (old UTC-day proxy would pass this)", async () => {
+        const dir = tempDir("cache-lens-two-utc-dates-one-session");
+        // Two busts on the SAME session, exactly 24h apart - guaranteed to
+        // fall on two distinct UTC calendar dates (UTC has no DST, so +24h
+        // always advances the calendar date by exactly one), but only ONE
+        // distinct session.
+        const now = new Date();
+        const utcNoonToday = new Date(Date.UTC(
+            now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0,
+        ));
+        const utcNoonYesterday = new Date(utcNoonToday.getTime() - 24 * 60 * 60 * 1000);
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* write.put("agent_model", {
+                        id: "am:opus", name: "claude-opus-4-8", provider: "anthropic",
+                        display_name: "Claude Opus 4.8", cache_creation_per_million_usd: 18.75,
+                    });
+                    yield* write.putMany("turn_token_usage", [
+                        usageRow({
+                            id: "ttu:two-dates-1", session: SESSION_A, seq: 1, ts: utcNoonYesterday, source: "claude",
+                            cacheCreationTokens: 1_000_000n, cacheCreationUsd: 20, modelRef: "am:opus",
+                            skill: "two-utc-dates-skill", cacheMiss: "messages_changed",
+                        }),
+                        usageRow({
+                            id: "ttu:two-dates-2", session: SESSION_A, seq: 2, ts: utcNoonToday, source: "claude",
+                            cacheCreationTokens: 1_000_000n, cacheCreationUsd: 20, modelRef: "am:opus",
+                            skill: "two-utc-dates-skill", cacheMiss: "messages_changed",
+                        }),
+                    ]);
+                    yield* runCacheBustModels(write, 30);
+                }),
+            ),
+        );
+
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+        const candidates = await Effect.runPromise(
+            Effect.gen(function* () {
+                const read = yield* CacheRead;
+                return yield* fetchCacheLensCandidates(read, { sinceDays: 7 });
+            }).pipe(Effect.provide(layer)),
+        );
+        const candidate = candidates.find((c) => c.kind === "skill" && c.name === "two-utc-dates-skill");
+        // Corroboration passes (comparableBusts=2, ingest and flat-rate agree)
+        // and materiality passes ($40 over 7d), so recurrence is the ONLY
+        // guard standing between this candidate and a mint.
+        expect(candidate?.comparableBusts).toBe(2);
+        expect(candidate?.sessions).toBe(1);
+        expect(candidate ? evaluateCacheLensCandidate(candidate, 7) : null).toBeNull();
     });
 });

--- a/apps/axctl/src/queries/cache-bust.ts
+++ b/apps/axctl/src/queries/cache-bust.ts
@@ -214,9 +214,11 @@ export interface CacheLensCandidateRow {
     /** attribution_skill / attribution_agent exactly as the harness stamped it. */
     readonly name: string;
     readonly busts: number;
+    /** Distinct sessions carrying a bust - the recurrence proxy (see #943:
+     *  a UTC-calendar-day count miscounts across timezone boundaries - one
+     *  local workday straddling UTC midnight reads as two days, and two
+     *  local workdays sharing a UTC date read as one). */
     readonly sessions: number;
-    /** Distinct UTC calendar days carrying a bust - the recurrence proxy. */
-    readonly distinctDays: number;
     /** sum(bust_cost_usd) over ALL this offender's busts. */
     readonly bustCostUsd: number;
     /** busts where BOTH prices exist - the corroboration-comparable subset. */
@@ -232,7 +234,6 @@ const OffenderRollupRow = Schema.Struct({
     name: Schema.String,
     busts: NumberFromBigIntColumn,
     sessions: NumberFromBigIntColumn,
-    distinct_days: NumberFromBigIntColumn,
     bust_cost_usd: Schema.Number,
     comparable_busts: NumberFromBigIntColumn,
     comparable_bust_cost_usd: Schema.Number,
@@ -262,7 +263,6 @@ const OFFENDER_ROLLUP_SQL = `
     SELECT kind, name,
            count(*) AS busts,
            count(DISTINCT session) AS sessions,
-           count(DISTINCT CAST(ts AS DATE)) AS distinct_days,
            CAST(coalesce(sum(bust_cost_usd), 0) AS DOUBLE) AS bust_cost_usd,
            count(*) FILTER (WHERE bust_cost_usd IS NOT NULL AND corroborated_cost_usd IS NOT NULL) AS comparable_busts,
            CAST(coalesce(sum(bust_cost_usd) FILTER (WHERE bust_cost_usd IS NOT NULL AND corroborated_cost_usd IS NOT NULL), 0) AS DOUBLE) AS comparable_bust_cost_usd,
@@ -313,7 +313,6 @@ export const fetchCacheLensCandidates = Effect.fn("queries.fetchCacheLensCandida
             name: row.name,
             busts: row.busts,
             sessions: row.sessions,
-            distinctDays: row.distinct_days,
             bustCostUsd: row.bust_cost_usd,
             comparableBusts: row.comparable_busts,
             comparableBustCostUsd: row.comparable_bust_cost_usd,

--- a/community/README.md
+++ b/community/README.md
@@ -26,6 +26,14 @@ same schema before opening a PR. Pattern PRs are schema-checked by CI but stay
 human-reviewed; filename collisions fail validation so contributors engage the
 existing pattern instead of duplicating it.
 
+## research/studies/
+
+One file records one content-stripped Dojo spar comparison.
+Use `ax contribute study <spar-id>` to inspect the exact public JSON.
+The command requires consent before it opens a reviewed PR.
+These first studies are self-reported pilot data.
+They do not prove general efficacy.
+
 ## Compiled outputs (nightly)
 
 `leaderboard.json`, `skill-stats.json`, `hook-stats.json`,

--- a/community/research/studies/README.md
+++ b/community/research/studies/README.md
@@ -1,0 +1,23 @@
+# Community studies
+
+This directory stores one JSON file for each reviewed Dojo spar comparison.
+
+The pilot supports only `verification-churn` protocol version 1.
+It compares cost, turns, duration, repair lines, verification episodes, and landing status.
+
+The JSON uses closed fields.
+It excludes task text, intervention text, repository paths, and session identifiers.
+It includes hashes that bind the public record to the local brief and score.
+
+Each record has `evidence_class: "self_reported"`.
+Each record describes one comparison.
+Agents must not use one record as a general recommendation.
+
+Run this command after `ax dojo spar-score`:
+
+```text
+ax contribute study <spar-id>
+```
+
+The command shows the exact public JSON before it asks for consent.
+Use `--preview` to stop after the preview.


### PR DESCRIPTION
Closes #943.

## Problem
The #868 cache-lens minting guard 2 required busts on `>= 2 distinct UTC days` (`count(DISTINCT CAST(ts AS DATE))`). For a non-UTC operator this miscounts across the UTC-midnight boundary — measured live, a 14.1h span across two LOCAL workdays was rejected as 1 UTC day.

## Fix
- Guard on **distinct sessions** (`count(DISTINCT session)`, already in the rollup) instead of UTC calendar days. Timezone-independent, and a closer ">= 2 ingest windows" proxy.
- Rename `CACHE_LENS_MIN_RECURRENCE_DAYS` → `CACHE_LENS_MIN_RECURRENCE_SESSIONS` (value 2).
- Remove the now-dead `distinct_days` column (SQL projection, schema, interface, mapping) — repo-wide grep confirmed nothing else consumed it.
- Sync the CLAUDE.md guard-2 description.

Session recurrence is still not ingest-run recurrence (one session, many busts, counts once) — but it is strictly better than the UTC-day proxy and uses a field already present.

## Verification
- `cache-bust.duckdb.test.ts` + `derive-proposals.test.ts`: **67 pass**. Two new real-DuckDB regression tests: two sessions/one UTC date now mint; one session/two UTC dates now reject.
- `check:timestamp-cast` clean; no new tsc errors.

Sibling #939 (corroboration tautology) is deferred — its proper fix needs OTLP per-root-session cost and depends on #1011.