### PR TITLE
fix(otel): metric-point natural key includes all data-point dimensions (#1011)

### DIFF
--- a/apps/axctl/src/cli/commands/contribute.test.ts
+++ b/apps/axctl/src/cli/commands/contribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     buildFreshPattern,
+    isSafeSparId,
     patternChoiceLabel,
     selectProfilePattern,
     type FreshPatternInput,
@@ -83,5 +84,16 @@ describe("buildFreshPattern", () => {
             sessions: 4,
             confidence: 0.8,
         })).toThrow(/summary/);
+    });
+});
+
+describe("study contribution input", () => {
+    test("accepts a file-safe spar id", () => {
+        expect(isSafeSparId("ab12cd34-2026-06-13")).toBe(true);
+    });
+
+    test("rejects path traversal", () => {
+        expect(isSafeSparId("../../secret")).toBe(false);
+        expect(isSafeSparId("a/b")).toBe(false);
     });
 });

--- a/apps/axctl/src/cli/commands/contribute.ts
+++ b/apps/axctl/src/cli/commands/contribute.ts
@@ -3,14 +3,17 @@
  * or author one through structured prompts, into community/patterns/ via the
  * same fork+PR rails used by profile registration.
  */
-import { Effect, Schema } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Effect, FileSystem, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile } from "../../profile/render.ts";
 import { openPatternContribution, patternFilePath } from "../../profile/pattern-contribution.ts";
 import { PATTERN_CATEGORIES, TastePattern, type PatternCategory, type ProfileV1 } from "../../profile/schema.ts";
 import { slugify } from "../../profile/taste.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
+import { buildCommunityStudy, openStudyContribution, studyFilePath } from "../../profile/study-contribution.ts";
+import { dojoSparBriefPath, dojoSparScorePath } from "../../dojo/paths.ts";
+import { parseSparBrief, parseSparScore } from "../../dojo/spar.ts";
 import { gatherEnv } from "./profile.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, optionValue, parseCsvFlag } from "./shared.ts";
@@ -240,9 +243,63 @@ const contributePatternCommand = Command.make(
     ),
 );
 
+export const isSafeSparId = (id: string): boolean =>
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+
+export const cmdContributeStudy = (input: {
+    readonly id: string;
+    readonly preview: boolean;
+    readonly yes: boolean;
+}) => Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const briefPath = dojoSparBriefPath(input.id);
+    const scorePath = dojoSparScorePath(input.id);
+    const briefBytes = yield* fs.readFileString(briefPath);
+    const scoreBytes = yield* fs.readFileString(scorePath);
+    const brief = parseSparBrief(briefBytes);
+    const score = parseSparScore(scoreBytes);
+    if (brief === null) throw new Error(`invalid spar brief: ${briefPath}`);
+    if (score === null) throw new Error(`invalid spar score: ${scorePath}`);
+
+    const study = buildCommunityStudy({ brief, score, briefBytes, scoreBytes });
+    const path = studyFilePath(study);
+    console.log(prettyPrint(study));
+    console.log(`\nThis self-reported study will be proposed as ${path}.`);
+    console.log("It contains one comparison. It does not prove general efficacy.");
+    if (input.preview) {
+        console.log("Preview only. No PR was opened.");
+        return;
+    }
+    if (!input.yes) {
+        const answer = promptText("Open reviewed PR? [y/N]").toLowerCase();
+        if (answer !== "y" && answer !== "yes") {
+            console.log("Aborted. No PR was opened.");
+            return;
+        }
+    }
+    const result = yield* openStudyContribution({ study });
+    console.log(`study PR: ${result.prUrl}`);
+    console.log(`file:     ${result.path}`);
+}).pipe(Effect.provide(GitHubEnvLive));
+
+const contributeStudyCommand = Command.make(
+    "study",
+    {
+        id: Argument.string("spar-id"),
+        preview: Flag.boolean("preview").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ id, preview, yes }) => {
+        if (!isSafeSparId(id)) fail(`ax contribute study: invalid spar id "${id}"`);
+        return cmdContributeStudy({ id, preview, yes });
+    },
+).pipe(Command.withDescription(
+    "Preview one content-stripped Dojo spar study. Use --yes to open a reviewed GitHub PR.",
+));
+
 export const contributeCommand = Command.make("contribute").pipe(
     Command.withDescription("Contribute ax community artifacts through fork+PR rails"),
-    Command.withSubcommands([contributePatternCommand]),
+    Command.withSubcommands([contributePatternCommand, contributeStudyCommand]),
 );
 
 export const contributeRuntime: RuntimeManifest = {
@@ -251,6 +308,7 @@ export const contributeRuntime: RuntimeManifest = {
         fallback: "none",
         subcommands: {
             pattern: (args) => args.includes("--fresh") ? "none" : "cache",
+            study: "none",
         },
     },
 };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -30,6 +30,7 @@ import {
     dojoSparBriefPath,
     dojoSparDir,
     dojoSparReportPath,
+    dojoSparScorePath,
     localDate,
 } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
@@ -659,11 +660,16 @@ const sparScoreCommand = Command.make(
             yield* fs.writeFileString(tmp, renderSparReport(score, brief));
             yield* fs.rename(tmp, path);
 
+            const scorePath = dojoSparScorePath(id);
+            const scoreTmp = `${scorePath}.tmp.${process.pid}`;
+            yield* fs.writeFileString(scoreTmp, `${prettyPrint(score)}\n`);
+            yield* fs.rename(scoreTmp, scorePath);
+
             console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
         }),
 ).pipe(
     Command.withDescription(
-        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+        "Score the agent's variant session and write Markdown plus machine-readable JSON receipts. --variant-session=<id> --json",
     ),
 );
 

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath, dojoSparScorePath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -18,6 +18,9 @@ describe("dojo paths", () => {
         );
         expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
+        );
+        expect(dojoSparScorePath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-score.json",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -19,6 +19,9 @@ export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): 
 export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoSparDir(base), `${id}-report.md`);
 
+export const dojoSparScorePath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-score.json`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -7,6 +7,7 @@ import {
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
+    parseSparScore,
     renderSparBrief,
     renderSparReport,
     REPAIR_TOL,
@@ -121,6 +122,18 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+describe("parseSparScore", () => {
+    test("accepts a complete machine score", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.8 })), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify(score))).toEqual(score);
+    });
+
+    test("rejects a score with an invalid metric", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics()), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify({ ...score, variant: { ...score.variant, turns: "many" } }))).toBeNull();
     });
 });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -74,6 +74,22 @@ export interface SparScore {
     readonly verdict: SparVerdict;
 }
 
+const asDeltas = (v: unknown): SparDeltas | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const finite = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    const nullable = (x: unknown): x is number | null => x === null || finite(x);
+    if (!nullable(o.costUsd) || !nullable(o.turns) || !nullable(o.wallMs)) return null;
+    if (!finite(o.repairLines) || !finite(o.episodes)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+    };
+};
+
 // ---------------------------------------------------------------------------
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
@@ -209,6 +225,26 @@ const asBaselineMetrics = (v: unknown): SparMetrics | null => {
         episodes: o.episodes,
         landed: o.landed,
     };
+};
+
+/** Decode the durable JSON receipt written by `spar-score`. */
+export const parseSparScore = (content: string): SparScore | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const o = parsed as Record<string, unknown>;
+    const baseline = asBaselineMetrics(o.baseline);
+    const variant = asBaselineMetrics(o.variant);
+    const deltas = asDeltas(o.deltas);
+    if (typeof o.id !== "string" || o.id.length === 0) return null;
+    if (typeof o.variantSession !== "string" || o.variantSession.length === 0) return null;
+    if (o.verdict !== "win" && o.verdict !== "regression" && o.verdict !== "mixed") return null;
+    if (baseline === null || variant === null || deltas === null) return null;
+    return { id: o.id, variantSession: o.variantSession, baseline, variant, deltas, verdict: o.verdict };
 };
 
 export const parseSparBrief = (content: string): SparBrief | null => {

--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -6,7 +6,17 @@ import { Effect, Schema } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
-import { ingestOtelSpool, otelSpoolStage, stampReceivedAt, type OtelSpoolIngestResult } from "./otel-spool.ts";
+import { cacheRow } from "@ax/lib/duckdb/row";
+import { WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
+import { metricPointRowId } from "../otel/rows.ts";
+import {
+    ingestOtelSpool,
+    METRIC_KEY_CUTOVER_SENTINEL_PATH,
+    METRIC_KEY_CUTOVER_VERSION,
+    otelSpoolStage,
+    stampReceivedAt,
+    type OtelSpoolIngestResult,
+} from "./otel-spool.ts";
 
 const roots: string[] = [];
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("OTLP spool ingest", {
@@ -68,6 +78,100 @@ describe("otel-spool ingest stage", () => {
     it("declares the ingest stage contract", () => {
         expect(otelSpoolStage.meta.key).toBe("otel-spool");
         expect(otelSpoolStage.meta.tags).toEqual(["ingest"]);
+    });
+});
+
+describe("metric-point natural-key cutover (#1011)", () => {
+    dtest("wipes stale-keyed rows/edges, replays under the new key, then marks itself done", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-spool-cutover-"));
+        roots.push(spoolDir);
+        await mkdir(spoolDir, { recursive: true });
+        const line = JSON.stringify({
+            received_at: "2026-08-14T12:00:00.000Z",
+            path: "/v1/metrics",
+            body: JSON.stringify(metricPayload),
+        });
+        await writeFile(join(spoolDir, "2026-08-14.jsonl"), `${line}\n`);
+
+        const staleId = "stale-pre-cutover-metric-id";
+
+        let first: OtelSpoolIngestResult | undefined;
+        let second: OtelSpoolIngestResult | undefined;
+        let metricRows: ReadonlyArray<{ readonly id: string; readonly metric: string; readonly session_id: string | null }> = [];
+        let telemetryEdgeRows: ReadonlyArray<{ readonly id: string }> = [];
+        let sentinelRows: ReadonlyArray<{ readonly sha: string | null }> = [];
+
+        await runWithPlatform(publishCacheFixture(tempDir("ax-otel-spool-cutover-writer-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                // Seed a PRE-cutover row (as if written under the old,
+                // dimension-collapsing key) plus a telemetry_of edge that
+                // targets it - both must be gone after the cutover.
+                yield* write.put("otel_metric_point", cacheRow({
+                    id: staleId,
+                    harness: "claude",
+                    metric: "claude_code.cost.usage",
+                    value: 0.99,
+                    unit: "USD",
+                    session_id: "stale-session",
+                    model: null,
+                    skill_name: null,
+                    agent_name: null,
+                    attrs: null,
+                    observed_at: new Date("2020-01-01T00:00:00Z"),
+                }));
+                yield* write.put("telemetry_of", cacheRow({
+                    id: "stale-telemetry-edge",
+                    in_id: "stale-session",
+                    out_id: staleId,
+                    out_table: "otel_metric_point",
+                    linked_at: new Date("2020-01-01T00:00:00Z"),
+                }));
+                // Precondition: no version marker yet.
+                const preSentinel = yield* write.rows(
+                    Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+                    `SELECT sha FROM ${WATERMARK_TABLE} WHERE path = ?`,
+                    [METRIC_KEY_CUTOVER_SENTINEL_PATH],
+                );
+                expect(preSentinel).toEqual([]);
+
+                first = yield* ingestOtelSpool(write, { spoolDir });
+                second = yield* ingestOtelSpool(write, { spoolDir });
+
+                metricRows = yield* write.rows(
+                    Schema.Struct({ id: Schema.String, metric: Schema.String, session_id: Schema.NullOr(Schema.String) }),
+                    "SELECT id, metric, session_id FROM otel_metric_point",
+                );
+                telemetryEdgeRows = yield* write.rows(
+                    Schema.Struct({ id: Schema.String }),
+                    "SELECT id FROM telemetry_of WHERE out_table = 'otel_metric_point'",
+                );
+                sentinelRows = yield* write.rows(
+                    Schema.Struct({ sha: Schema.NullOr(Schema.String) }),
+                    `SELECT sha FROM ${WATERMARK_TABLE} WHERE path = ?`,
+                    [METRIC_KEY_CUTOVER_SENTINEL_PATH],
+                );
+            }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+        ));
+
+        // The cutover fires on the FIRST call (sentinel absent): the stale
+        // row/edge are gone, and the retained spool file replays under the
+        // new key. The second call is an ordinary warm no-op - the cutover
+        // does not re-fire (sentinel now present).
+        expect(first).toMatchObject({ files: 1, payloads: 1, rows: 1, malformed: 0 });
+        expect(second).toMatchObject({ files: 0, skippedUnchanged: 1 });
+
+        expect(metricRows).toHaveLength(1);
+        expect(metricRows[0]!.id).not.toBe(staleId);
+        expect(metricRows[0]!.id).toBe(metricPointRowId({
+            harness: "claude", metric: "claude_code.cost.usage", value: 0.12, unit: "USD",
+            session_id: "session-1", model: null, skill_name: null, agent_name: null,
+            attrs: '{"session.id":"session-1"}', observed_at: new Date("2024-06-15T00:00:00.000Z"),
+        }));
+        expect(metricRows[0]!.metric).toBe("claude_code.cost.usage");
+        expect(metricRows[0]!.session_id).toBe("session-1");
+
+        expect(telemetryEdgeRows).toEqual([]);
+        expect(sentinelRows).toEqual([{ sha: METRIC_KEY_CUTOVER_VERSION }]);
     });
 });
 

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -1,6 +1,7 @@
-import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
+import { Effect, FileSystem, Option, Path, PlatformError, Schema } from "effect";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { DbError } from "@ax/lib/errors";
+import { WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
 import { defaultOtlpSpoolDir } from "../otel/spool-server.ts";
 import { SIGNALS } from "../otel/signals.ts";
 import { OTLP_SIGNAL_PATHS } from "../otel/signal.ts";
@@ -9,6 +10,88 @@ import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { walkJsonlFilesStrict, type JsonlFileCandidate } from "./walk-jsonl.ts";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
+
+/**
+ * ---------------------------------------------------------------------------
+ * Metric-point natural-key cutover (#1011)
+ * ---------------------------------------------------------------------------
+ * `otel_metric_point.id` used to hash only (harness, metric, session, model,
+ * skill) + observed_at, omitting most OTLP data-point dimensions (`type`,
+ * `query_source`, `agent.name`, an MCP server name, ...) - distinct points
+ * collapsed onto one id (~600-740 collapsed rows per warm ingest, pure wasted
+ * UPSERT work; no corruption, since dedup always kept the last write).
+ * `metricPointKey`/`metricPointRowId` (apps/axctl/src/otel/rows.ts) now fold
+ * in the full CANONICALIZED attrs JSON, which changes EVERY existing row's
+ * id. A warm ingest normally skips spool files whose (mtime, size) match
+ * their watermark, so without a cutover the stale collapsed rows would sit
+ * next to correctly-keyed new ones forever.
+ *
+ * This cutover runs ONCE per key-version (gated by
+ * METRIC_KEY_CUTOVER_VERSION, mirroring CONTENT_HASH_VERSION in
+ * watermark.ts) and, before the ordinary spool replay that follows:
+ *   1. deletes `telemetry_of` edges targeting otel_metric_point rows,
+ *   2. deletes every otel_metric_point row,
+ *   3. clears otel_spool file watermarks, so every RETAINED spool file
+ *      re-ingests under the ordinary `ingestOtelSpool` call right after -
+ *      that call is steps 4 (replay) and, on success, 5 (marker write).
+ *
+ * IDEMPOTENCY / CRASH WINDOW: the version marker is written ONLY after the
+ * replay succeeds. A crash between the wipe and the marker leaves the
+ * sentinel absent, so the NEXT run repeats the whole sequence: the deletes
+ * are plain DELETEs (idempotent - a second run against already-empty tables
+ * is a no-op) and the replay re-derives deterministic content-hash ids
+ * (idempotent UPSERT), so re-running from scratch is always safe. The only
+ * cost is redundant reprocessing of spool files a crashed run had already
+ * caught up on - it can never leave a mix of old- and new-keyed rows behind,
+ * because step 2 always wipes the table before any replay is trusted to
+ * repopulate it. This all happens against the LIVE cache file inside one
+ * ingest run; a reader of the PUBLISHED snapshot never observes the
+ * mid-cutover empty state, since publish only happens at a successful run's
+ * end.
+ *
+ * RETENTION ASYMMETRY (accepted, not fixed here): the spool retains 90 days
+ * of raw payloads but metric retention prunes at 30 days. Replay restores
+ * whatever raw input is still on disk, and ordinary retention prunes it back
+ * down afterward - a metric older than 90 days at cutover time cannot be
+ * recovered (it would already be gone under the old scheme too).
+ */
+/** Exported for test verification only - bump to re-arm the cutover on a
+ *  future key-scheme change. */
+export const METRIC_KEY_CUTOVER_VERSION = "attrs-key-v1";
+export const METRIC_KEY_CUTOVER_SENTINEL_PATH = "__metric_key_cutover__/otel_spool";
+
+const CutoverSentinelRow = Schema.Struct({ sha: Schema.NullOr(Schema.String) });
+
+const metricKeyCutoverDone = (write: CacheWriteService): Effect.Effect<boolean, CacheWriteError> =>
+    write.first(
+        CutoverSentinelRow,
+        `SELECT sha FROM ${WATERMARK_TABLE} WHERE path = ?`,
+        [METRIC_KEY_CUTOVER_SENTINEL_PATH],
+    ).pipe(
+        Effect.map(Option.match({
+            onNone: () => false,
+            onSome: (row) => row.sha === METRIC_KEY_CUTOVER_VERSION,
+        })),
+    );
+
+/** Steps 1-3: wipe stale metric-point rows/edges and clear otel_spool marks
+ *  so the replay that follows re-derives every retained spool file under the
+ *  new key. Each statement is independently idempotent - safe to re-run if a
+ *  prior attempt crashed before the version marker was written. */
+const runMetricKeyCutover = (write: CacheWriteService): Effect.Effect<void, CacheWriteError> =>
+    Effect.gen(function* () {
+        yield* write.exec("DELETE FROM telemetry_of WHERE out_table = ?", ["otel_metric_point"]);
+        yield* write.exec("DELETE FROM otel_metric_point");
+        yield* write.exec(`DELETE FROM ${WATERMARK_TABLE} WHERE source_kind = ?`, ["otel_spool"]);
+    });
+
+/** Step 5: write the version marker. Called ONLY after step 4 (the ordinary
+ *  replay in `ingestOtelSpool`) has succeeded. */
+const markMetricKeyCutoverDone = (write: CacheWriteService): Effect.Effect<void, CacheWriteError> =>
+    write.put(
+        WATERMARK_TABLE,
+        watermarkRow("otel_spool", METRIC_KEY_CUTOVER_SENTINEL_PATH, { sha: METRIC_KEY_CUTOVER_VERSION }),
+    );
 
 interface SpoolEnvelope {
     readonly path: string;
@@ -96,6 +179,14 @@ export const ingestOtelSpool = (
         let rows = 0;
         let malformed = 0;
 
+        // Metric-point natural-key cutover (#1011, see the block comment
+        // above): runs its destructive wipe BEFORE the watermark-driven
+        // replay below reads marks, so the cleared otel_spool marks are what
+        // the replay actually sees. The version marker is written only after
+        // that replay succeeds (below), never here.
+        const cutoverPending = !(yield* metricKeyCutoverDone(write));
+        if (cutoverPending) yield* runMetricKeyCutover(write);
+
         const result = yield* runJsonlProviderFiles<
             CacheWriteError | PlatformError.PlatformError,
             OtelWriter,
@@ -149,6 +240,11 @@ export const ingestOtelSpool = (
                 }),
         }).pipe(Effect.provide(OtelWriterLive(write)));
 
+        // Step 5: mark the cutover done ONLY now that the replay above (step
+        // 4) has completed without raising - a crash before this line leaves
+        // the sentinel absent, so the next run repeats the wipe + replay.
+        if (cutoverPending) yield* markMetricKeyCutoverDone(write);
+
         return {
             files: result.files,
             skippedUnchanged: result.skippedUnchanged,
@@ -177,7 +273,12 @@ export const otelSpoolStage: StageDef<
     FileSystem.FileSystem | Path.Path,
     DbError | CacheWriteError
 > = {
-    meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"], writes: [{ table: "otel_metric_point", mode: "parse" }, { table: "otel_span", mode: "parse" }, { table: "otel_log_event", mode: "parse" }, { table: "ingest_file_state", mode: "bookkeep" }, { table: "ingest_run", mode: "bookkeep" }] }),
+    // "telemetry_of"/"derive" covers the #1011 metric-key cutover's one-time
+    // DELETE of edges targeting otel_metric_point rows - legal without a
+    // WRITE_MODE_EXCEPTIONS entry since telemetry_of is already a derived-layer
+    // table (the correlation pass, ingest-run's NON_STAGE_WRITERS entry, is the
+    // table's other writer).
+    meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"], writes: [{ table: "otel_metric_point", mode: "parse" }, { table: "otel_span", mode: "parse" }, { table: "otel_log_event", mode: "parse" }, { table: "telemetry_of", mode: "derive" }, { table: "ingest_file_state", mode: "bookkeep" }, { table: "ingest_run", mode: "bookkeep" }] }),
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {
         const t0 = Date.now();
         const result = yield* ingestOtelSpool(write, {

--- a/apps/axctl/src/otel/normalize.ts
+++ b/apps/axctl/src/otel/normalize.ts
@@ -1,4 +1,4 @@
-import { attrMap, nanoToDate, type MetricsPayload, type OtlpInt64, type TracePayload, type LogsPayload } from "./otlp-schema.ts";
+import { attrMap, canonicalAttrsJson, nanoToDate, type MetricsPayload, type OtlpInt64, type TracePayload, type LogsPayload } from "./otlp-schema.ts";
 import type { OtelMetricPointRow, OtelSpanRow, OtelLogEventRow } from "./rows.ts";
 import { walkResources } from "./signal.ts";
 
@@ -27,7 +27,9 @@ export const normalizeMetrics = (payload: MetricsPayload): OtelMetricPointRow[] 
                         model: str(a.get("model")),
                         skill_name: str(a.get("skill.name")),
                         agent_name: str(a.get("agent.name")),
-                        attrs: a.size ? JSON.stringify(Object.fromEntries(a.entries())) : null,
+                        // Canonicalized (sorted-key) so it can be hashed into
+                        // metricPointKey without wire-order false positives (#1011).
+                        attrs: canonicalAttrsJson(a),
                         observed_at: nanoToDate(dp.timeUnixNano),
                     });
                 }
@@ -56,7 +58,7 @@ export const normalizeTrace = (payload: TracePayload): OtelSpanRow[] =>
                     started_at: started,
                     ended_at: ended,
                     duration_ms: ended.getTime() - started.getTime(),
-                    attrs: a.size ? JSON.stringify(Object.fromEntries(a.entries())) : null,
+                    attrs: canonicalAttrsJson(a),
                     observed_at: started,
                 };
             }),
@@ -155,7 +157,7 @@ export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] =>
                     tool_tokens: num(a.get("tool_token_count")),
                     duration_ms: num(a.get("duration_ms")),
                     status_code: num(a.get("http.response.status_code")),
-                    attrs: a.size ? JSON.stringify(Object.fromEntries(a)) : null,
+                    attrs: canonicalAttrsJson(a),
                     observed_at: eventTime(a, rec.observedTimeUnixNano, rec.timeUnixNano),
                 });
             }

--- a/apps/axctl/src/otel/otlp-schema.ts
+++ b/apps/axctl/src/otel/otlp-schema.ts
@@ -59,6 +59,23 @@ export const attrMap = (kvs: readonly KeyValue[] | undefined): Map<string, strin
     return m;
 };
 
+/**
+ * Deterministic (sorted-key) JSON encoding of an attribute map.
+ *
+ * `attrMap` preserves the WIRE order of an OTLP KeyValue list, which is not a
+ * stable property of a data point's identity - two exports of the same point
+ * can serialize its attributes in a different order. Anything that folds
+ * `attrs` into a row's identity (see `metricPointKey`, apps/axctl/src/otel/
+ * rows.ts) must hash the CONTENT, not the wire order, or attribute reordering
+ * alone would mint a new row for an unchanged point. Sorting keys here is
+ * what makes that safe.
+ */
+export const canonicalAttrsJson = (a: ReadonlyMap<string, string | number | boolean | null>): string | null => {
+    if (a.size === 0) return null;
+    const sorted = [...a.entries()].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+    return JSON.stringify(Object.fromEntries(sorted));
+};
+
 const Resource = Schema.Struct({ attributes: repeated(KeyValue) });
 
 const NumberDataPoint = Schema.Struct({

--- a/apps/axctl/src/otel/rows.test.ts
+++ b/apps/axctl/src/otel/rows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { metricPointKey, spanKey, type OtelMetricPointRow } from "./rows.ts";
+import { metricPointKey, metricPointRowId, spanKey, type OtelMetricPointRow } from "./rows.ts";
 import { logEventKey, type OtelLogEventRow } from "./rows.ts";
+import { canonicalAttrsJson } from "./otlp-schema.ts";
 
 describe("otel record keys", () => {
     test("metricPointKey is deterministic for same point", () => {
@@ -23,6 +24,66 @@ describe("otel record keys", () => {
 
     test("spanKey is the span_id", () => {
         expect(spanKey({ span_id: "abc" })).toBe("abc");
+    });
+});
+
+// ==================== #1011: attrs-dimension discrimination + hashed row id
+
+describe("metricPointKey / metricPointRowId discriminate every dimension (#1011)", () => {
+    const base: OtelMetricPointRow = {
+        harness: "claude", metric: "claude_code.cost.usage", value: 0.12,
+        unit: "USD", session_id: "s1", model: "opus", skill_name: null,
+        agent_name: null, attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"),
+    };
+
+    test("distinguishes points differing only in agent.name", () => {
+        const a = { ...base, agent_name: "a" };
+        const b = { ...base, agent_name: "b" };
+        expect(metricPointKey(a)).not.toBe(metricPointKey(b));
+        expect(metricPointRowId(a)).not.toBe(metricPointRowId(b));
+    });
+
+    test("distinguishes points differing only in `type` (carried in attrs)", () => {
+        const a = { ...base, attrs: canonicalAttrsJson(new Map([["type", "input"]])) };
+        const b = { ...base, attrs: canonicalAttrsJson(new Map([["type", "output"]])) };
+        expect(metricPointKey(a)).not.toBe(metricPointKey(b));
+        expect(metricPointRowId(a)).not.toBe(metricPointRowId(b));
+    });
+
+    test("distinguishes points differing only in query_source (carried in attrs)", () => {
+        const a = { ...base, attrs: canonicalAttrsJson(new Map([["query_source", "sonnet"]])) };
+        const b = { ...base, attrs: canonicalAttrsJson(new Map([["query_source", "haiku"]])) };
+        expect(metricPointKey(a)).not.toBe(metricPointKey(b));
+        expect(metricPointRowId(a)).not.toBe(metricPointRowId(b));
+    });
+
+    test("distinguishes points differing only in an MCP server name (carried in attrs)", () => {
+        const a = { ...base, attrs: canonicalAttrsJson(new Map([["mcp.server.name", "linear"]])) };
+        const b = { ...base, attrs: canonicalAttrsJson(new Map([["mcp.server.name", "figma"]])) };
+        expect(metricPointKey(a)).not.toBe(metricPointKey(b));
+        expect(metricPointRowId(a)).not.toBe(metricPointRowId(b));
+    });
+
+    test("attribute wire ORDER does not change the id - canonicalization sorts keys", () => {
+        const wireOrderOne = new Map([["type", "input"], ["query_source", "sonnet"]]);
+        const wireOrderTwo = new Map([["query_source", "sonnet"], ["type", "input"]]);
+        const a = { ...base, attrs: canonicalAttrsJson(wireOrderOne) };
+        const b = { ...base, attrs: canonicalAttrsJson(wireOrderTwo) };
+        expect(a.attrs).toBe(b.attrs); // canonicalAttrsJson itself is order-independent
+        expect(metricPointKey(a)).toBe(metricPointKey(b));
+        expect(metricPointRowId(a)).toBe(metricPointRowId(b));
+    });
+
+    test("same identity, different value - still collapses to ONE id (last-write-win)", () => {
+        const a = { ...base, value: 1 };
+        const b = { ...base, value: 2 };
+        expect(metricPointRowId(a)).toBe(metricPointRowId(b));
+    });
+
+    test("metricPointRowId is a hash, not the raw pipe-joined key verbatim", () => {
+        const id = metricPointRowId(base);
+        expect(id).not.toBe(metricPointKey(base));
+        expect(id).toMatch(/^[0-9a-f]{32}$/);
     });
 });
 

--- a/apps/axctl/src/otel/rows.ts
+++ b/apps/axctl/src/otel/rows.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { stableId } from "@ax/lib/stable-id";
 
 /** A normalized OTLP metric data point as stored in otel_metric_point. */
 export const OtelMetricPointRow = Schema.Struct({
@@ -30,11 +31,45 @@ export const OtelSpanRow = Schema.Struct({
 });
 export type OtelSpanRow = Schema.Schema.Type<typeof OtelSpanRow>;
 
-/** Deterministic id so re-delivered points UPSERT instead of duplicating. */
+/**
+ * Natural key for a metric data point (#1011 fix).
+ *
+ * MUST include every dimension that distinguishes two OTLP data points, not
+ * just the typed columns - `agent_name`, and anything ELSE a data point
+ * carries (`type`, `query_source`, an MCP server name, ...), lives in `attrs`
+ * (normalize.ts writes it CANONICALIZED - sorted keys - specifically so it
+ * can be folded in here without wire-order false positives). The prior key
+ * omitted `attrs` and `agent_name` entirely, so distinct points (differing
+ * only in a dimension outside the 5 typed columns) collapsed onto one id -
+ * ~600-740 collapsed rows per warm ingest, pure wasted UPSERT work.
+ *
+ * `value` is deliberately EXCLUDED: it is the measurement, not the point's
+ * identity, so a corrected value for the same point still overwrites
+ * (last-write-win) instead of minting a new row.
+ */
 export const metricPointKey = (r: OtelMetricPointRow): string => {
     const ts = r.observed_at instanceof Date ? r.observed_at.toISOString() : String(r.observed_at);
-    return `${r.harness}|${r.metric}|${r.session_id ?? ""}|${r.model ?? ""}|${r.skill_name ?? ""}|${ts}`;
+    return [
+        r.harness,
+        r.metric,
+        r.session_id ?? "",
+        r.model ?? "",
+        r.skill_name ?? "",
+        r.agent_name ?? "",
+        r.attrs ?? "",
+        ts,
+    ].join("|");
 };
+
+/**
+ * Row id: the natural key above, SHA-256-hashed via `stableId` (never
+ * `Bun.hash` - see stable-id.ts - so ids stay stable across a bun upgrade).
+ * The raw key is never stored verbatim as the id: `attrs` can be arbitrarily
+ * large and can itself contain `|`, so hashing is what keeps the id both
+ * bounded and collision-safe rather than relying on an unescaped separator.
+ */
+export const metricPointRowId = (r: OtelMetricPointRow): string =>
+    stableId("otel_metric_point", [metricPointKey(r)]);
 
 /** Spans carry a globally-unique span_id; use it directly. */
 export const spanKey = (r: Pick<OtelSpanRow, "span_id">): string => r.span_id;

--- a/apps/axctl/src/otel/signal.test.ts
+++ b/apps/axctl/src/otel/signal.test.ts
@@ -123,11 +123,14 @@ describe("metric/span record-key uniqueness - characterized, see PR for gaps", (
         expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ observed_at: new Date("2026-06-15T00:00:01Z") })));
     });
 
-    test("KNOWN GAP: metricPointKey omits agent_name though it is persisted (pinned to prove no drift)", () => {
-        // Two points identical except agent_name collide to ONE record id. This is a
-        // PRE-EXISTING gap (rows.ts:36) - pinned here, filed as a follow-up, not changed.
-        expect(metricPointKey(metricRow({ agent_name: "a" }))).toBe(metricPointKey(metricRow({ agent_name: "b" })));
-        // value/unit are not part of the key (the measurement, not identity)
+    test("FIXED (#1011): metricPointKey now discriminates agent_name too", () => {
+        // Previously a PRE-EXISTING gap (rows.ts:36): two points identical except
+        // agent_name collapsed to ONE record id. metricPointKey now folds
+        // agent_name (and the full canonicalized attrs blob) into the key, so
+        // distinct agents no longer alias.
+        expect(metricPointKey(metricRow({ agent_name: "a" }))).not.toBe(metricPointKey(metricRow({ agent_name: "b" })));
+        // value/unit are STILL not part of the key (the measurement, not identity) -
+        // this remains intentional, not a gap.
         expect(metricPointKey(metricRow({ value: 1 }))).toBe(metricPointKey(metricRow({ value: 2 })));
         expect(metricPointKey(metricRow({ unit: "tok" }))).toBe(metricPointKey(metricRow({ unit: "USD" })));
     });

--- a/apps/axctl/src/otel/writer.ts
+++ b/apps/axctl/src/otel/writer.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 import { cacheRow } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import {
-    metricPointKey,
+    metricPointRowId,
     spanKey,
     logEventKey,
     type OtelMetricPointRow,
@@ -21,7 +21,7 @@ export class OtelWriter extends Context.Service<OtelWriter, OtelWriterShape>()("
 export const OtelWriterLive = (write: CacheWriteService): Layer.Layer<OtelWriter> =>
     Layer.succeed(OtelWriter, OtelWriter.of({
         writeMetrics: (rows) => write.putMany("otel_metric_point", rows.map((r) => cacheRow({
-            id: metricPointKey(r),
+            id: metricPointRowId(r),
             harness: r.harness,
             metric: r.metric,
             value: r.value,

--- a/apps/axctl/src/profile/study-contribution.test.ts
+++ b/apps/axctl/src/profile/study-contribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AX_ATTRIBUTION_MD } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparScore } from "../dojo/spar.ts";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    buildCommunityStudy,
+    openStudyContribution,
+    studyFilePath,
+    type CommunityStudy,
+} from "./study-contribution.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const baseline = { costUsd: 1.2, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true };
+const variant = { costUsd: 0.8, turns: 14, wallMs: 480_000, repairLines: 30, episodes: 2, landed: true };
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "secret task text",
+    parentSha: "ab12cd34",
+    baselineSession: "secret-session",
+    worktree: ".claude/worktrees/secret-path",
+    baseline,
+    baselineIsSubagent: false,
+    delta: "secret intervention text",
+};
+const score: SparScore = { ...scoreSpar(baseline, variant), id: brief.id, variantSession: "secret-variant" };
+
+describe("buildCommunityStudy", () => {
+    test("builds a closed, content-stripped study", () => {
+        const study = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        expect(study.protocol).toEqual({ id: "verification-churn", version: 1 });
+        expect(study.evidence_class).toBe("self_reported");
+        expect(study.outcome).toBe("improved");
+        expect(study.metrics.cost_usd.delta).toBeCloseTo(-0.4);
+        const json = JSON.stringify(study);
+        expect(json).not.toContain(brief.prompt);
+        expect(json).not.toContain(brief.delta);
+        expect(json).not.toContain(brief.baselineSession);
+        expect(json).not.toContain(score.variantSession);
+        expect(json).not.toContain(brief.worktree);
+    });
+
+    test("rejects a score for a different spar", () => {
+        expect(() => buildCommunityStudy({ brief, score: { ...score, id: "other" }, briefBytes: "brief", scoreBytes: "score" }))
+            .toThrow(/does not match/);
+    });
+});
+
+describe("openStudyContribution", () => {
+    test("opens one reviewed PR for one study file", async () => {
+        const study: CommunityStudy = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        const path = studyFilePath(study);
+        const login = "Necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            login,
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${REGISTRY_REPO}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`GET /repos/${REGISTRY_REPO}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "ok" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+
+        const result = await Effect.runPromise(openStudyContribution({ study }).pipe(Effect.provide(t.layer)));
+        expect(result.path).toBe(path);
+        expect(t.calls.map((call) => `${call.method} ${call.path}`)[0]).toBe(`GET /repos/${REGISTRY_REPO}/contents/${path}`);
+        expect(t.calls.find((call) => call.path === `/repos/${REGISTRY_REPO}/pulls`)?.body).toMatchObject({
+            base: "main",
+            body: expect.stringContaining(AX_ATTRIBUTION_MD),
+        });
+    });
+});

--- a/apps/axctl/src/profile/study-contribution.ts
+++ b/apps/axctl/src/profile/study-contribution.ts
@@ -1,0 +1,147 @@
+/** One content-stripped, self-reported study from the fixed Dojo spar protocol. */
+import { createHash } from "node:crypto";
+import { Effect, Schema } from "effect";
+import { prettyPrint } from "@ax/lib/json";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparMetrics, type SparScore } from "../dojo/spar.ts";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+type Metric<T> = { readonly baseline: T; readonly variant: T; readonly delta: number | null };
+
+export interface CommunityStudy {
+    readonly schema_version: 1;
+    readonly kind: "self-reported-community-study";
+    readonly protocol: { readonly id: "verification-churn"; readonly version: 1 };
+    readonly evidence_class: "self_reported";
+    readonly outcome: "improved" | "regressed" | "mixed";
+    readonly privacy: "closed_fields_content_stripped";
+    readonly source: {
+        readonly spar_id_sha256: string;
+        readonly brief_sha256: string;
+        readonly score_sha256: string;
+        readonly intervention_sha256: string;
+    };
+    readonly metrics: {
+        readonly cost_usd: Metric<number | null>;
+        readonly turns: Metric<number | null>;
+        readonly wall_ms: Metric<number | null>;
+        readonly repair_lines: Metric<number>;
+        readonly episodes: Metric<number>;
+        readonly landed: { readonly baseline: boolean; readonly variant: boolean };
+    };
+    readonly limitations: readonly ["single_spar_comparison", "self_reported"];
+}
+
+const same = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+const metric = <T>(baseline: T, variant: T, delta: number | null): Metric<T> => ({ baseline, variant, delta });
+
+export function buildCommunityStudy(input: {
+    readonly brief: SparBrief;
+    readonly score: SparScore;
+    readonly briefBytes: string;
+    readonly scoreBytes: string;
+}): CommunityStudy {
+    if (input.brief.id !== input.score.id) throw new Error("spar score id does not match the brief id");
+    if (input.brief.delta.trim() === "") throw new Error("spar brief has no intervention in the Delta section");
+    if (input.brief.baselineIsSubagent) throw new Error("a subagent baseline cannot become a community study");
+    if (!same(input.brief.baseline, input.score.baseline)) throw new Error("spar score baseline does not match the frozen brief");
+
+    const calculated = scoreSpar(input.score.baseline, input.score.variant);
+    if (!same(calculated.deltas, input.score.deltas) || calculated.verdict !== input.score.verdict) {
+        throw new Error("spar score does not match the fixed protocol calculation");
+    }
+
+    const baseline: SparMetrics = input.score.baseline;
+    const variant: SparMetrics = input.score.variant;
+    const deltas = input.score.deltas;
+    return {
+        schema_version: 1,
+        kind: "self-reported-community-study",
+        protocol: { id: "verification-churn", version: 1 },
+        evidence_class: "self_reported",
+        outcome: input.score.verdict === "win" ? "improved" : input.score.verdict === "regression" ? "regressed" : "mixed",
+        privacy: "closed_fields_content_stripped",
+        source: {
+            spar_id_sha256: sha256(input.brief.id),
+            brief_sha256: sha256(input.briefBytes),
+            score_sha256: sha256(input.scoreBytes),
+            intervention_sha256: sha256(input.brief.delta.trim()),
+        },
+        metrics: {
+            cost_usd: metric(baseline.costUsd, variant.costUsd, deltas.costUsd),
+            turns: metric(baseline.turns, variant.turns, deltas.turns),
+            wall_ms: metric(baseline.wallMs, variant.wallMs, deltas.wallMs),
+            repair_lines: metric(baseline.repairLines, variant.repairLines, deltas.repairLines),
+            episodes: metric(baseline.episodes, variant.episodes, deltas.episodes),
+            landed: { baseline: baseline.landed, variant: variant.landed },
+        },
+        limitations: ["single_spar_comparison", "self_reported"],
+    };
+}
+
+export const studyFilePath = (study: CommunityStudy): string =>
+    `community/research/studies/verification-churn/${study.source.score_sha256.slice(0, 32)}.json`;
+
+const studyBranchName = (study: CommunityStudy): string =>
+    `ax-study-verification-churn-${study.source.score_sha256.slice(0, 12)}`;
+
+export class StudyContributionError extends Schema.TaggedErrorClass<StudyContributionError>(
+    "StudyContributionError",
+)("StudyContributionError", { message: Schema.String }) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const openStudyContribution = Effect.fn("profile.openStudyContribution")(
+    function* (input: { readonly study: CommunityStudy; readonly login?: string }) {
+        const gh = yield* GitHubEnv;
+        const login = input.login ?? (yield* gh.login());
+        if (login === null || login.trim() === "") {
+            return yield* new StudyContributionError({ message: "GitHub login unavailable; run `gh auth login` and retry." });
+        }
+
+        const path = studyFilePath(input.study);
+        const branch = studyBranchName(input.study);
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${path}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404 ? Effect.succeed(false) : Effect.fail(error)),
+        );
+        if (exists) return yield* new StudyContributionError({ message: `${path} already exists.` });
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+        const blob = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+            content: `${prettyPrint(input.study)}\n`, encoding: "utf-8",
+        }));
+        const tree = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+            base_tree: baseTreeSha,
+            tree: [{ path, mode: "100644", type: "blob", sha: blob.sha }],
+        }));
+        const commit = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+            message: `community: contribute verification churn study`, tree: tree.sha, parents: [baseSha],
+        }));
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, { ref: `refs/heads/${branch}`, sha: commit.sha });
+        const body = withAxAttribution([
+            "Contributes one content-stripped study from the fixed verification churn protocol.",
+            "The evidence is self-reported and contains one spar comparison.",
+            "This PR does not claim general efficacy.",
+            `File: \`${path}\``,
+            "Opened by `ax contribute study`.",
+        ].join("\n\n"));
+        const pr = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+            title: "community: contribute verification churn study",
+            head: `${login}:${branch}`,
+            base: "main",
+            body,
+        }));
+        return { status: "pr-opened" as const, prUrl: String(pr.html_url ?? ""), path };
+    },
+);

--- a/community/README.md
+++ b/community/README.md
@@ -26,6 +26,14 @@ same schema before opening a PR. Pattern PRs are schema-checked by CI but stay
 human-reviewed; filename collisions fail validation so contributors engage the
 existing pattern instead of duplicating it.
 
+## research/studies/
+
+One file records one content-stripped Dojo spar comparison.
+Use `ax contribute study <spar-id>` to inspect the exact public JSON.
+The command requires consent before it opens a reviewed PR.
+These first studies are self-reported pilot data.
+They do not prove general efficacy.
+
 ## Compiled outputs (nightly)
 
 `leaderboard.json`, `skill-stats.json`, `hook-stats.json`,

--- a/community/research/studies/README.md
+++ b/community/research/studies/README.md
@@ -1,0 +1,23 @@
+# Community studies
+
+This directory stores one JSON file for each reviewed Dojo spar comparison.
+
+The pilot supports only `verification-churn` protocol version 1.
+It compares cost, turns, duration, repair lines, verification episodes, and landing status.
+
+The JSON uses closed fields.
+It excludes task text, intervention text, repository paths, and session identifiers.
+It includes hashes that bind the public record to the local brief and score.
+
+Each record has `evidence_class: "self_reported"`.
+Each record describes one comparison.
+Agents must not use one record as a general recommendation.
+
+Run this command after `ax dojo spar-score`:
+
+```text
+ax contribute study <spar-id>
+```
+
+The command shows the exact public JSON before it asks for consent.
+Use `--preview` to stop after the preview.

--- a/packages/lib/src/stable-id.ts
+++ b/packages/lib/src/stable-id.ts
@@ -255,6 +255,7 @@ export const NATURAL_KEY_RECIPES: Readonly<Record<string, string>> = {
         "source_kind + the watched path - see watermarkRowId (@ax/lib/duckdb/watermark). The absolute path IS the key here, the one place that is right: a watermark is a statement about one file on THIS machine, in a per-machine rebuildable cache, so it has no path-independent identity",
     invoked: "edgeRowId('invoked', turn row id, skill row id, JSON.stringify(args)) - args discriminates two invocations of the same skill in one turn",
     has_content: "edgeRowId('has_content', tool_call row id, content_type row id) - one classification per (tool_call, content_type) pair, so no discriminator",
+    otel_metric_point: "harness + metric + session_id + model + skill_name + agent_name + the CANONICALIZED (sorted-key) attrs JSON + observed_at - see metricPointKey/metricPointRowId (apps/axctl/src/otel/rows.ts); value is excluded (the measurement, not the point's identity)",
     "<edge>": "edgeRowId: edge table + in_id + out_id + optional discriminator",
     "<derived>": "derivedRowId: owning session row id + source table + source row id + optional extra parts",
 };

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -2469,6 +2469,17 @@ CREATE INDEX IF NOT EXISTS ingest_file_state_kind_sha ON ingest_file_state(sourc
 -- re-applied to an already-large otel_log_event (codex emits ~1.5M log rows);
 -- CONCURRENTLY builds in the background without locking.
 -- (DuckDB has no CONCURRENTLY index build; the concurrency note is historical.)
+--
+-- otel_metric_point.id NATURAL KEY (#1011, cutover-versioned - see
+-- METRIC_KEY_CUTOVER_VERSION in apps/axctl/src/ingest/otel-spool.ts):
+-- SHA-256(harness, metric, session_id, model, skill_name, agent_name,
+-- CANONICAL attrs JSON [sorted keys - covers every other data-point
+-- dimension: `type`, `query_source`, an MCP server name, ...], observed_at)
+-- via `metricPointKey`/`metricPointRowId` (apps/axctl/src/otel/rows.ts).
+-- `value` is EXCLUDED (the measurement, not the point's identity - a
+-- corrected value for the same point overwrites rather than minting a new
+-- row). The prior key omitted `attrs` and `agent_name`, so distinct points
+-- differing only in one of those collapsed onto one id.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS otel_metric_point (
     id VARCHAR PRIMARY KEY,


### PR DESCRIPTION
Closes #1011. Confirmed an id-collision bug (not designed re-emission) by independent codex review.

## Problem
`metricPointKey` hashed only 5 typed columns + `observed_at`, omitting `agent_name` and everything in `attrs` (`type`, `query_source`, MCP server names, ...). Distinct OTLP data points collapsed onto one id — ~600-740 collapsed rows per warm ingest (wasted UPSERT work; dedup kept last-write, so no corruption).

## Fix
- `normalize.ts` canonicalizes `attrs` JSON (sorted keys) for all signals, so wire-order can't create a false-distinct id.
- `metricPointKey` folds in `agent_name` + canonical `attrs`; `value` stays out (measurement, not identity — corrected values still last-write-win). `metricPointRowId` SHA-256-hashes via `stableId` (never `Bun.hash`), so an arbitrarily large `|`-bearing `attrs` blob is never the id verbatim.
- **One-time version-marked cutover** (`METRIC_KEY_CUTOVER_VERSION`, mirroring `CONTENT_HASH_VERSION`): the key change re-ids every row, and warm ingest skips unchanged spool files, so the cutover wipes `telemetry_of` edges → wipes `otel_metric_point` → clears `otel_spool` watermarks, then the ordinary replay repopulates under the new key. The version marker is written **only after replay succeeds** — a crash before it repeats the whole wipe+replay (idempotent DELETEs + deterministic-id UPSERT; never a mix of old/new keys). All against the live cache file; the published snapshot never shows the mid-cutover empty state.
- Retention asymmetry (spool 90d, metric 30d) accepted: metrics >90d were already unrecoverable under the old scheme.

## Verification
- `otel/` + `otel-spool.test.ts` (incl. new cutover test) + `stage/table-writes.test.ts` + `table-writes.behavior.test.ts`: **129 pass**.
- New `rows.test.ts` cases: key/id discriminate `agent.name`/`type`/`query_source`/MCP name; attribute-order invariance; same-identity-different-value still collapses; id is a 32-hex hash.
- `check:no-node-fs`, `check:timestamp-cast` clean; no new tsc errors.

Unblocks #939 (corroboration needs reliable OTLP cost).