### PR TITLE
docs(goal): ax backlog burn-down + standing churn loop (#1051)

### DIFF
--- a/apps/axctl/src/cli/commands/contribute.test.ts
+++ b/apps/axctl/src/cli/commands/contribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     buildFreshPattern,
+    isSafeSparId,
     patternChoiceLabel,
     selectProfilePattern,
     type FreshPatternInput,
@@ -83,5 +84,16 @@ describe("buildFreshPattern", () => {
             sessions: 4,
             confidence: 0.8,
         })).toThrow(/summary/);
+    });
+});
+
+describe("study contribution input", () => {
+    test("accepts a file-safe spar id", () => {
+        expect(isSafeSparId("ab12cd34-2026-06-13")).toBe(true);
+    });
+
+    test("rejects path traversal", () => {
+        expect(isSafeSparId("../../secret")).toBe(false);
+        expect(isSafeSparId("a/b")).toBe(false);
     });
 });

--- a/apps/axctl/src/cli/commands/contribute.ts
+++ b/apps/axctl/src/cli/commands/contribute.ts
@@ -3,14 +3,17 @@
  * or author one through structured prompts, into community/patterns/ via the
  * same fork+PR rails used by profile registration.
  */
-import { Effect, Schema } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Effect, FileSystem, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile } from "../../profile/render.ts";
 import { openPatternContribution, patternFilePath } from "../../profile/pattern-contribution.ts";
 import { PATTERN_CATEGORIES, TastePattern, type PatternCategory, type ProfileV1 } from "../../profile/schema.ts";
 import { slugify } from "../../profile/taste.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
+import { buildCommunityStudy, openStudyContribution, studyFilePath } from "../../profile/study-contribution.ts";
+import { dojoSparBriefPath, dojoSparScorePath } from "../../dojo/paths.ts";
+import { parseSparBrief, parseSparScore } from "../../dojo/spar.ts";
 import { gatherEnv } from "./profile.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, optionValue, parseCsvFlag } from "./shared.ts";
@@ -240,9 +243,63 @@ const contributePatternCommand = Command.make(
     ),
 );
 
+export const isSafeSparId = (id: string): boolean =>
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+
+export const cmdContributeStudy = (input: {
+    readonly id: string;
+    readonly preview: boolean;
+    readonly yes: boolean;
+}) => Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const briefPath = dojoSparBriefPath(input.id);
+    const scorePath = dojoSparScorePath(input.id);
+    const briefBytes = yield* fs.readFileString(briefPath);
+    const scoreBytes = yield* fs.readFileString(scorePath);
+    const brief = parseSparBrief(briefBytes);
+    const score = parseSparScore(scoreBytes);
+    if (brief === null) throw new Error(`invalid spar brief: ${briefPath}`);
+    if (score === null) throw new Error(`invalid spar score: ${scorePath}`);
+
+    const study = buildCommunityStudy({ brief, score, briefBytes, scoreBytes });
+    const path = studyFilePath(study);
+    console.log(prettyPrint(study));
+    console.log(`\nThis self-reported study will be proposed as ${path}.`);
+    console.log("It contains one comparison. It does not prove general efficacy.");
+    if (input.preview) {
+        console.log("Preview only. No PR was opened.");
+        return;
+    }
+    if (!input.yes) {
+        const answer = promptText("Open reviewed PR? [y/N]").toLowerCase();
+        if (answer !== "y" && answer !== "yes") {
+            console.log("Aborted. No PR was opened.");
+            return;
+        }
+    }
+    const result = yield* openStudyContribution({ study });
+    console.log(`study PR: ${result.prUrl}`);
+    console.log(`file:     ${result.path}`);
+}).pipe(Effect.provide(GitHubEnvLive));
+
+const contributeStudyCommand = Command.make(
+    "study",
+    {
+        id: Argument.string("spar-id"),
+        preview: Flag.boolean("preview").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ id, preview, yes }) => {
+        if (!isSafeSparId(id)) fail(`ax contribute study: invalid spar id "${id}"`);
+        return cmdContributeStudy({ id, preview, yes });
+    },
+).pipe(Command.withDescription(
+    "Preview one content-stripped Dojo spar study. Use --yes to open a reviewed GitHub PR.",
+));
+
 export const contributeCommand = Command.make("contribute").pipe(
     Command.withDescription("Contribute ax community artifacts through fork+PR rails"),
-    Command.withSubcommands([contributePatternCommand]),
+    Command.withSubcommands([contributePatternCommand, contributeStudyCommand]),
 );
 
 export const contributeRuntime: RuntimeManifest = {
@@ -251,6 +308,7 @@ export const contributeRuntime: RuntimeManifest = {
         fallback: "none",
         subcommands: {
             pattern: (args) => args.includes("--fresh") ? "none" : "cache",
+            study: "none",
         },
     },
 };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -30,6 +30,7 @@ import {
     dojoSparBriefPath,
     dojoSparDir,
     dojoSparReportPath,
+    dojoSparScorePath,
     localDate,
 } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
@@ -659,11 +660,16 @@ const sparScoreCommand = Command.make(
             yield* fs.writeFileString(tmp, renderSparReport(score, brief));
             yield* fs.rename(tmp, path);
 
+            const scorePath = dojoSparScorePath(id);
+            const scoreTmp = `${scorePath}.tmp.${process.pid}`;
+            yield* fs.writeFileString(scoreTmp, `${prettyPrint(score)}\n`);
+            yield* fs.rename(scoreTmp, scorePath);
+
             console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
         }),
 ).pipe(
     Command.withDescription(
-        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+        "Score the agent's variant session and write Markdown plus machine-readable JSON receipts. --variant-session=<id> --json",
     ),
 );
 

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath, dojoSparScorePath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -18,6 +18,9 @@ describe("dojo paths", () => {
         );
         expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
+        );
+        expect(dojoSparScorePath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-score.json",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -19,6 +19,9 @@ export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): 
 export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoSparDir(base), `${id}-report.md`);
 
+export const dojoSparScorePath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-score.json`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -7,6 +7,7 @@ import {
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
+    parseSparScore,
     renderSparBrief,
     renderSparReport,
     REPAIR_TOL,
@@ -121,6 +122,18 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+describe("parseSparScore", () => {
+    test("accepts a complete machine score", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.8 })), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify(score))).toEqual(score);
+    });
+
+    test("rejects a score with an invalid metric", () => {
+        const score = { ...scoreSpar(brief.baseline, baseMetrics()), id: brief.id, variantSession: "variant" };
+        expect(parseSparScore(JSON.stringify({ ...score, variant: { ...score.variant, turns: "many" } }))).toBeNull();
     });
 });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -74,6 +74,22 @@ export interface SparScore {
     readonly verdict: SparVerdict;
 }
 
+const asDeltas = (v: unknown): SparDeltas | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const finite = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    const nullable = (x: unknown): x is number | null => x === null || finite(x);
+    if (!nullable(o.costUsd) || !nullable(o.turns) || !nullable(o.wallMs)) return null;
+    if (!finite(o.repairLines) || !finite(o.episodes)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+    };
+};
+
 // ---------------------------------------------------------------------------
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
@@ -209,6 +225,26 @@ const asBaselineMetrics = (v: unknown): SparMetrics | null => {
         episodes: o.episodes,
         landed: o.landed,
     };
+};
+
+/** Decode the durable JSON receipt written by `spar-score`. */
+export const parseSparScore = (content: string): SparScore | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const o = parsed as Record<string, unknown>;
+    const baseline = asBaselineMetrics(o.baseline);
+    const variant = asBaselineMetrics(o.variant);
+    const deltas = asDeltas(o.deltas);
+    if (typeof o.id !== "string" || o.id.length === 0) return null;
+    if (typeof o.variantSession !== "string" || o.variantSession.length === 0) return null;
+    if (o.verdict !== "win" && o.verdict !== "regression" && o.verdict !== "mixed") return null;
+    if (baseline === null || variant === null || deltas === null) return null;
+    return { id: o.id, variantSession: o.variantSession, baseline, variant, deltas, verdict: o.verdict };
 };
 
 export const parseSparBrief = (content: string): SparBrief | null => {

--- a/apps/axctl/src/profile/study-contribution.test.ts
+++ b/apps/axctl/src/profile/study-contribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AX_ATTRIBUTION_MD } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparScore } from "../dojo/spar.ts";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    buildCommunityStudy,
+    openStudyContribution,
+    studyFilePath,
+    type CommunityStudy,
+} from "./study-contribution.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const baseline = { costUsd: 1.2, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true };
+const variant = { costUsd: 0.8, turns: 14, wallMs: 480_000, repairLines: 30, episodes: 2, landed: true };
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "secret task text",
+    parentSha: "ab12cd34",
+    baselineSession: "secret-session",
+    worktree: ".claude/worktrees/secret-path",
+    baseline,
+    baselineIsSubagent: false,
+    delta: "secret intervention text",
+};
+const score: SparScore = { ...scoreSpar(baseline, variant), id: brief.id, variantSession: "secret-variant" };
+
+describe("buildCommunityStudy", () => {
+    test("builds a closed, content-stripped study", () => {
+        const study = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        expect(study.protocol).toEqual({ id: "verification-churn", version: 1 });
+        expect(study.evidence_class).toBe("self_reported");
+        expect(study.outcome).toBe("improved");
+        expect(study.metrics.cost_usd.delta).toBeCloseTo(-0.4);
+        const json = JSON.stringify(study);
+        expect(json).not.toContain(brief.prompt);
+        expect(json).not.toContain(brief.delta);
+        expect(json).not.toContain(brief.baselineSession);
+        expect(json).not.toContain(score.variantSession);
+        expect(json).not.toContain(brief.worktree);
+    });
+
+    test("rejects a score for a different spar", () => {
+        expect(() => buildCommunityStudy({ brief, score: { ...score, id: "other" }, briefBytes: "brief", scoreBytes: "score" }))
+            .toThrow(/does not match/);
+    });
+});
+
+describe("openStudyContribution", () => {
+    test("opens one reviewed PR for one study file", async () => {
+        const study: CommunityStudy = buildCommunityStudy({ brief, score, briefBytes: "brief bytes", scoreBytes: "score bytes" });
+        const path = studyFilePath(study);
+        const login = "Necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            login,
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${REGISTRY_REPO}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`GET /repos/${REGISTRY_REPO}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "ok" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+
+        const result = await Effect.runPromise(openStudyContribution({ study }).pipe(Effect.provide(t.layer)));
+        expect(result.path).toBe(path);
+        expect(t.calls.map((call) => `${call.method} ${call.path}`)[0]).toBe(`GET /repos/${REGISTRY_REPO}/contents/${path}`);
+        expect(t.calls.find((call) => call.path === `/repos/${REGISTRY_REPO}/pulls`)?.body).toMatchObject({
+            base: "main",
+            body: expect.stringContaining(AX_ATTRIBUTION_MD),
+        });
+    });
+});

--- a/apps/axctl/src/profile/study-contribution.ts
+++ b/apps/axctl/src/profile/study-contribution.ts
@@ -1,0 +1,147 @@
+/** One content-stripped, self-reported study from the fixed Dojo spar protocol. */
+import { createHash } from "node:crypto";
+import { Effect, Schema } from "effect";
+import { prettyPrint } from "@ax/lib/json";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import { scoreSpar, type SparBrief, type SparMetrics, type SparScore } from "../dojo/spar.ts";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import { REGISTRY_REPO } from "./pattern-contribution.ts";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+type Metric<T> = { readonly baseline: T; readonly variant: T; readonly delta: number | null };
+
+export interface CommunityStudy {
+    readonly schema_version: 1;
+    readonly kind: "self-reported-community-study";
+    readonly protocol: { readonly id: "verification-churn"; readonly version: 1 };
+    readonly evidence_class: "self_reported";
+    readonly outcome: "improved" | "regressed" | "mixed";
+    readonly privacy: "closed_fields_content_stripped";
+    readonly source: {
+        readonly spar_id_sha256: string;
+        readonly brief_sha256: string;
+        readonly score_sha256: string;
+        readonly intervention_sha256: string;
+    };
+    readonly metrics: {
+        readonly cost_usd: Metric<number | null>;
+        readonly turns: Metric<number | null>;
+        readonly wall_ms: Metric<number | null>;
+        readonly repair_lines: Metric<number>;
+        readonly episodes: Metric<number>;
+        readonly landed: { readonly baseline: boolean; readonly variant: boolean };
+    };
+    readonly limitations: readonly ["single_spar_comparison", "self_reported"];
+}
+
+const same = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+const metric = <T>(baseline: T, variant: T, delta: number | null): Metric<T> => ({ baseline, variant, delta });
+
+export function buildCommunityStudy(input: {
+    readonly brief: SparBrief;
+    readonly score: SparScore;
+    readonly briefBytes: string;
+    readonly scoreBytes: string;
+}): CommunityStudy {
+    if (input.brief.id !== input.score.id) throw new Error("spar score id does not match the brief id");
+    if (input.brief.delta.trim() === "") throw new Error("spar brief has no intervention in the Delta section");
+    if (input.brief.baselineIsSubagent) throw new Error("a subagent baseline cannot become a community study");
+    if (!same(input.brief.baseline, input.score.baseline)) throw new Error("spar score baseline does not match the frozen brief");
+
+    const calculated = scoreSpar(input.score.baseline, input.score.variant);
+    if (!same(calculated.deltas, input.score.deltas) || calculated.verdict !== input.score.verdict) {
+        throw new Error("spar score does not match the fixed protocol calculation");
+    }
+
+    const baseline: SparMetrics = input.score.baseline;
+    const variant: SparMetrics = input.score.variant;
+    const deltas = input.score.deltas;
+    return {
+        schema_version: 1,
+        kind: "self-reported-community-study",
+        protocol: { id: "verification-churn", version: 1 },
+        evidence_class: "self_reported",
+        outcome: input.score.verdict === "win" ? "improved" : input.score.verdict === "regression" ? "regressed" : "mixed",
+        privacy: "closed_fields_content_stripped",
+        source: {
+            spar_id_sha256: sha256(input.brief.id),
+            brief_sha256: sha256(input.briefBytes),
+            score_sha256: sha256(input.scoreBytes),
+            intervention_sha256: sha256(input.brief.delta.trim()),
+        },
+        metrics: {
+            cost_usd: metric(baseline.costUsd, variant.costUsd, deltas.costUsd),
+            turns: metric(baseline.turns, variant.turns, deltas.turns),
+            wall_ms: metric(baseline.wallMs, variant.wallMs, deltas.wallMs),
+            repair_lines: metric(baseline.repairLines, variant.repairLines, deltas.repairLines),
+            episodes: metric(baseline.episodes, variant.episodes, deltas.episodes),
+            landed: { baseline: baseline.landed, variant: variant.landed },
+        },
+        limitations: ["single_spar_comparison", "self_reported"],
+    };
+}
+
+export const studyFilePath = (study: CommunityStudy): string =>
+    `community/research/studies/verification-churn/${study.source.score_sha256.slice(0, 32)}.json`;
+
+const studyBranchName = (study: CommunityStudy): string =>
+    `ax-study-verification-churn-${study.source.score_sha256.slice(0, 12)}`;
+
+export class StudyContributionError extends Schema.TaggedErrorClass<StudyContributionError>(
+    "StudyContributionError",
+)("StudyContributionError", { message: Schema.String }) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+
+export const openStudyContribution = Effect.fn("profile.openStudyContribution")(
+    function* (input: { readonly study: CommunityStudy; readonly login?: string }) {
+        const gh = yield* GitHubEnv;
+        const login = input.login ?? (yield* gh.login());
+        if (login === null || login.trim() === "") {
+            return yield* new StudyContributionError({ message: "GitHub login unavailable; run `gh auth login` and retry." });
+        }
+
+        const path = studyFilePath(input.study);
+        const branch = studyBranchName(input.study);
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${path}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404 ? Effect.succeed(false) : Effect.fail(error)),
+        );
+        if (exists) return yield* new StudyContributionError({ message: `${path} already exists.` });
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${REGISTRY_REPO}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+        const blob = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+            content: `${prettyPrint(input.study)}\n`, encoding: "utf-8",
+        }));
+        const tree = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+            base_tree: baseTreeSha,
+            tree: [{ path, mode: "100644", type: "blob", sha: blob.sha }],
+        }));
+        const commit = asRecord(yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+            message: `community: contribute verification churn study`, tree: tree.sha, parents: [baseSha],
+        }));
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, { ref: `refs/heads/${branch}`, sha: commit.sha });
+        const body = withAxAttribution([
+            "Contributes one content-stripped study from the fixed verification churn protocol.",
+            "The evidence is self-reported and contains one spar comparison.",
+            "This PR does not claim general efficacy.",
+            `File: \`${path}\``,
+            "Opened by `ax contribute study`.",
+        ].join("\n\n"));
+        const pr = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+            title: "community: contribute verification churn study",
+            head: `${login}:${branch}`,
+            base: "main",
+            body,
+        }));
+        return { status: "pr-opened" as const, prUrl: String(pr.html_url ?? ""), path };
+    },
+);

--- a/community/README.md
+++ b/community/README.md
@@ -26,6 +26,14 @@ same schema before opening a PR. Pattern PRs are schema-checked by CI but stay
 human-reviewed; filename collisions fail validation so contributors engage the
 existing pattern instead of duplicating it.
 
+## research/studies/
+
+One file records one content-stripped Dojo spar comparison.
+Use `ax contribute study <spar-id>` to inspect the exact public JSON.
+The command requires consent before it opens a reviewed PR.
+These first studies are self-reported pilot data.
+They do not prove general efficacy.
+
 ## Compiled outputs (nightly)
 
 `leaderboard.json`, `skill-stats.json`, `hook-stats.json`,

--- a/community/research/studies/README.md
+++ b/community/research/studies/README.md
@@ -1,0 +1,23 @@
+# Community studies
+
+This directory stores one JSON file for each reviewed Dojo spar comparison.
+
+The pilot supports only `verification-churn` protocol version 1.
+It compares cost, turns, duration, repair lines, verification episodes, and landing status.
+
+The JSON uses closed fields.
+It excludes task text, intervention text, repository paths, and session identifiers.
+It includes hashes that bind the public record to the local brief and score.
+
+Each record has `evidence_class: "self_reported"`.
+Each record describes one comparison.
+Agents must not use one record as a general recommendation.
+
+Run this command after `ax dojo spar-score`:
+
+```text
+ax contribute study <spar-id>
+```
+
+The command shows the exact public JSON before it asks for consent.
+Use `--preview` to stop after the preview.

--- a/docs/superpowers/plans/2026-08-25-backlog-burndown-goal.md
+++ b/docs/superpowers/plans/2026-08-25-backlog-burndown-goal.md
@@ -1,0 +1,165 @@
+# Goal: ax backlog burn-down + standing churn loop
+
+Tracking issue: #1051. Created 2026-08-25.
+
+## Objective
+
+Burn down the open backlog AND stand up a repeatable loop so quality keeps
+rising between feature waves. This is not a finite epic - it is the operating
+cadence the fleet runs whenever no larger feature is claimed. "Done" is a
+healthy queue (no stale-arch issues, no unaddressed follow-ups older than a
+wave, every merged fix verified), not an empty one.
+
+## The loop (the "keep iterating" engine)
+
+One pass, repeated:
+
+1. **Inventory** - `gh pr list` + `gh issue list`. Group new arrivals into the
+   tracks below. Retarget/close anything stale (see Track E rule).
+2. **Scope** - for any non-trivial issue, run an independent codex pass
+   (`codex exec -s read-only`) to validate the claimed root cause against real
+   code and surface hidden traps/dependencies BEFORE dispatch. Cheap, and it has
+   already reshaped plans here (#939 depends on #1011; #1011 was a real
+   collision, not designed re-emission).
+3. **Dispatch** - one issue → one `bun run wip claim <n> fix` worktree → one
+   sonnet implementer with a self-contained brief (exact files, fix, tests,
+   verify commands, stop conditions). Independent slices run in parallel.
+4. **Verify (self, not the subagent's word)** - re-read each diff; re-run the
+   touched suites + the repo gates (below). Expect ~one real defect per
+   delegated phase.
+5. **Merge** - squash-merge on green. Admin-merge only for locally-verified
+   changes on a current branch; let full CI `verify` gate any change touching
+   the ingest classifier, a shared cache table, or a data migration.
+6. **Release** - merges accumulate into the release-please PR; merge it to cut a
+   version once a wave lands.
+7. **Refill** - the continuous-discovery arm (Track G) feeds new issues back to
+   step 1.
+
+### Gates every PR clears
+- Repo guards: `check:no-node-fs`, `check:timestamp-cast`, `check:raw-numeric-cast`.
+- `#893` write-contract tests when touching cache tables
+  (`stage/table-writes.test.ts` + `table-writes.behavior.test.ts`).
+- Full CI `verify` (repo-wide `bun test` + typecheck) for: ingest classifier
+  changes, shared-table writes, destructive migrations. Touched-suite-only is
+  NOT sufficient there (a stale-branch date-rot and a classifier consumer have
+  both slipped past local runs).
+- Worktree isolation; one branch per issue; `git -C`, never `cd && git`.
+- Destructive migrations: version-marked, idempotent on crash, wipe-before-replay,
+  live-file-only (published snapshot never shows mid-migration state) - see the
+  #1011 cutover as the reference shape.
+
+## Tracks
+
+### Track A - ingest reliability & performance (highest leverage)
+The ingest path is where wrong answers hide and cost accrues.
+- **#917** bun SIGSEGV (~14GB) on full `--reparse=claude` - sibling of the
+  merged #1043; apply the same session-chunking to the reparse path, find any
+  other unbounded materialization.
+- **#771** one unreadable spool/JSONL file `Effect.die`s the whole pipeline -
+  degrade to a failed stage + warning; audit all `Effect.die(PlatformError)`
+  sites (pattern also in codex.ts).
+- **#839** publish rewrites the entire DB (4.94 GB / 22s) every run - dominates
+  warm incremental. **#833** snapshot published only at end (time-to-first-value
+  == whole run). **#865** `ingest_stage` records wall-clock, not self-time
+  (#841's surviving half). These three are the warm-ingest cost story; scope
+  together.
+- **#684** pi `producedCommits=0` despite real commits (`cwd??null`).
+- **#720** staleness probe orders by `started_at` but reports `ended_at`.
+- **#779** `agent_event.raw` dead weight (watermark-skipped files keep raw
+  forever). **#945** turn-grain blind spots (pi writes no `turn_token_usage`;
+  codex turn/session grains disagree 3.3x).
+- **#953** spool scratch dirs leak raw turn text on stage failure.
+  **#952** clone-guard hardening (post-clone WAL re-check, mtime grain).
+- **#769/#770/#773/#778** otlpd spool: re-tail growing files, pruned-file
+  watermark leak, receiver hardening, 30d-retention-vs-all-time doc drift.
+
+### Track B - cost / lens correctness
+Wrong numbers are worse than no numbers.
+- **#939** corroboration tautology - UNBLOCKED now #1011 merged. Corroborate the
+  ingest price against OTLP per-root-session cost (recursive lineage), count
+  only roots with both values, share one `relativeCostDelta` helper between the
+  guard and the CLI, drop the exact-equality heuristic. Model-version bump =
+  full ledger rebuild.
+- **#945** (also Track A) - the grain-disagreement is a cost-accuracy issue.
+
+### Track C - surfaces & MCP
+- **#838** expose `prompts` as an MCP tool - UNBLOCKED now #828 merged; small.
+- **#1047** `ax prompts` legacy clause applies claude/codex rules to ALL sources;
+  make it source-specific (full rules only for claude/codex).
+- **#688** large `--json` truncates mid-stream when piped.
+- **#767** `ax sql` + agent-accessible playbooks (feature, needs its own design;
+  prerequisite is per-column `COMMENT ON` so agent SQL stays honest - #869).
+- **#716/#717** authorize `/api/image` from the ingested graph, not a static
+  allowlist (security).
+
+### Track D - distribution & upgrade path
+- **#675** upgrade-in-place broken: schema self-heal is all-or-nothing, derive
+  stages crash on pre-existing data. High user impact - a broken upgrade looks
+  like a broken product.
+- **#796** ~25% of transcripts never land on some machines; full ingest exits 0
+  moving zero (linux). Confirmed for codex forks; the claude/pi half needs the
+  reporter's diagnostic re-run.
+- **#836** Homebrew tap. **#708/#714** wire the last CI gates
+  (`check:harness-docs` drift, the 5th e2e suite).
+
+### Track E - stale cleanup (verify, then close)
+Rule: open the artifact before declaring it dead. Each of these references the
+removed SurrealDB / `ax serve` daemon; confirm against current `main` (grep the
+named symbol), then close with a one-line reason or re-scope to the DuckDB world.
+- **#599** SMAppService daemon - tracking issue for PR #604, already closed as
+  obsolete; almost certainly close.
+- **#689** usage derive 300s watchdog "surreal 3.0.4". **#722**
+  `superviseReapLoop` (serve daemon). **#690** studio-desktop preload,
+  "0.38.0-era". **#618** handoff for `fix/614` studio backend.
+- **#786–#791** [v2-duckdb] sub-tasks - DuckDB is on main; some are done. Verify
+  each against shipped code before closing.
+- **#723/#721/#689** serve/derive-budget/reap follow-ups - re-scope or close.
+
+### Track F - epics & decisions (tracked here, NOT churned in this loop)
+Do not fold these into a churn wave; they need their own claim + design.
+- **#893** v3 Phase 4 (in-progress, claimed on another host).
+- **#649** Team dashboard v1 (in-progress). **#767** `ax sql`. **#593/#640**
+  proactive/deterministic routing.
+- Maps: #926, #768, #733, #728, #702, #699. Wayfinder: #755, #765, #762.
+
+### Track G - continuous discovery (keeps the queue alive)
+The loop starves without new, evidence-backed issues.
+- **Dogfood** the CLI each wave; file what breaks (this is how #1043 and the
+  dojo fixes surfaced).
+- **Bug-hunt sweeps** (the #926 pattern): parallel adversarial readers over a
+  subsystem → verified findings → issues.
+- **Dojo** (`ax dojo agenda`) burns surplus quota on self-improvement and mints
+  proposals; triage via `ax improve list`.
+- **Retro → proposal** loop on notable sessions.
+
+## Sequencing (waves)
+
+- **Wave 1 - quick unblocked wins:** #838, #1047, #771, #939. Small, self-
+  contained, mostly one-file. Land + release.
+- **Wave 2 - warm-ingest cost:** #839 + #833 + #865 together; then #917.
+- **Wave 3 - stale cleanup:** Track E verify-and-close pass (cheap, shrinks the
+  board and removes false signal).
+- **Wave 4 - upgrade/distribution:** #675, #796, #836.
+- **Continuous:** Track G runs alongside every wave.
+
+Waves are ordered by leverage-per-effort, not rigidly; pull any unblocked
+Track-A/B/C item forward when a wave has spare parallelism.
+
+## Definition of done (per wave) / health signals
+- Every merged fix: verified locally + through the required gate, closed with the
+  PR, released.
+- Board health: no open [v2-duckdb]/serve/surreal issue left unverified; no
+  follow-up older than two waves without a decision; `ax otel`, `ax cost cache`,
+  `ax dispatches` read sane on the maintainer's own store.
+- The loop is "done" for a session when the claimed wave lands green and the
+  release PR is merged - then it repeats.
+
+## Unresolved questions
+1. Release cadence - merge the release-please PR (#1046, v0.42.0) per wave, or
+   batch several waves per release?
+2. Stale cleanup (Track E) - close on the maintainer's judgment, or open a
+   single "verify+close" batch PR/comment thread for a human sign-off first?
+3. `ax sql` (#767) - in scope for this loop as a designed feature, or parked
+   under Track F until the `COMMENT ON` prerequisite (#869) ships?
+4. Parallelism budget - how many concurrent implementer worktrees per wave
+   before the shared main-merge gate becomes the bottleneck?


### PR DESCRIPTION
Closes #1051.

Adds `docs/superpowers/plans/2026-08-25-backlog-burndown-goal.md` — a durable goal package that:
- organizes every open issue into tracks (A ingest reliability, B cost-lens correctness, C surfaces/MCP, D distribution/upgrade, E stale-cleanup, F epics, G continuous-discovery);
- defines the standing review→scope(codex)→dispatch→verify→merge→release loop with the gates each PR clears;
- sequences the work into leverage-ordered waves (Wave 1 = unblocked quick wins #838/#1047/#771/#939) and marks what is UNBLOCKED by today's merges;
- ends with the open decisions (release cadence, stale-cleanup sign-off, `ax sql` scope, parallelism budget).

Docs-only. The doc is the north star; individual work still lands under its own issue + branch.