### PR TITLE
feat(mcp): expose prompts query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,14 +660,14 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 25 tools
-(`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 26 tools
+(`recall`, `prompts`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
 `skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
 `session_metrics`, `sessions_churn`, `signal_show`, `cost_models`, `cost_split`, `cost_images`,
 `cost_routability`, `cost_attribution`, `cost_cache`, `otel`, `runs_evidence`, `dispatches`, `dispatches_advice`, `dojo_agenda`, `directives_list`) so an agent can query the graph in-context.
 Works from source AND from the compiled binary - DuckDB is a native dep, but
 `libduckdb` is embedded at build time, so a `tools/list` handshake against
-`dist/axctl mcp` returns all 25. Mutating
+`dist/axctl mcp` returns all 26. Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
 exposed; `sessions_churn` takes an explicit `project` path instead of `--here`.
 

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -46,6 +46,7 @@ const EXPECTED_TOOLS = [
     "dispatches_advice",
     "dojo_agenda",
     "directives_list",
+    "prompts",
 ] as const;
 
 describe("axMcpTools registry", () => {

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -34,6 +34,7 @@ const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     dispatches_advice: ["days", "limit"],
     dojo_agenda: ["days", "spar"],
     directives_list: ["limit", "status"],
+    prompts: ["days", "limit", "query", "scope"],
 };
 
 describe("axMcpTools advertised surface", () => {
@@ -61,6 +62,7 @@ describe("axMcpTools advertised surface", () => {
         const runtimeOf = (name: string) => axMcpTools.find((tool) => tool.name === name)?.runtime;
 
         expect(runtimeOf("recall")).toBe("cache");
+        expect(runtimeOf("prompts")).toBe("cache");
         expect(runtimeOf("roles")).toBe("judgment");
         expect(runtimeOf("improve_list")).toBe("judgment");
         expect(runtimeOf("skills_by_role")).toBe("cache-judgment");

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -73,6 +73,11 @@ import {
     buildCostSplitNext,
 } from "../nav/next-links.ts";
 import { COST_DEFAULT_WINDOW_DAYS, fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
+import {
+    fetchPrompts,
+    PROMPTS_DEFAULT_LIMIT,
+    PROMPTS_DEFAULT_WINDOW_DAYS,
+} from "../queries/prompts.ts";
 import { OTEL_DEFAULT_WINDOW_DAYS, fetchOtelRollup } from "../queries/otel-rollup.ts";
 import { fetchRunEvidence } from "../queries/run-evidence.ts";
 import { fetchImageContext } from "../queries/image-context.ts";
@@ -250,6 +255,42 @@ const recallTool: AxMcpTool = defineMcpTool({
         });
         return { ...result, hits, next };
     },
+});
+
+const promptsTool: AxMcpTool = defineMcpTool({
+    name: "prompts",
+    runtime: "cache",
+    description:
+        "Reverse search the prompts you typed across every harness. Browse with no query, or search with a case-insensitive substring. Results are deduplicated by text and sorted newest first.",
+    inputSchema: {
+        query: z
+            .string()
+            .optional()
+            .describe("Case-insensitive substring to match. Omit to browse prompts."),
+        scope: z
+            .string()
+            .optional()
+            .describe("Absolute path scope. Matches that directory and its subdirectories."),
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 90)."),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Max distinct prompts to return (default 40)."),
+    },
+    run: async (args, rt) =>
+        await rt.runPromise(fetchPrompts({
+            sinceDays: args.days ?? PROMPTS_DEFAULT_WINDOW_DAYS,
+            limit: args.limit ?? PROMPTS_DEFAULT_LIMIT,
+            ...(args.query !== undefined ? { query: args.query } : {}),
+            ...(args.scope !== undefined ? { scope: args.scope } : {}),
+        })),
 });
 
 const sessionsAroundTool: AxMcpTool = defineMcpTool({
@@ -993,6 +1034,7 @@ const directivesListTool: AxMcpTool = defineMcpTool({
  */
 export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     recallTool,
+    promptsTool,
     sessionsAroundTool,
     sessionShowTool,
     skillsWeightedTool,

--- a/apps/site/app/components/features/features-page.tsx
+++ b/apps/site/app/components/features/features-page.tsx
@@ -648,7 +648,7 @@ export function FeaturesPage() {
           <div className="cli-row">
             <span className="cmd">ax mcp</span>
             <span className="desc">
-              Stdio MCP server - exposes ax&apos;s read-only queries as 17 tools so Claude Code or Codex can query the graph in-context.
+              Stdio MCP server - exposes ax&apos;s read-only queries as 26 tools so Claude Code or Codex can query the graph in-context.
             </span>
           </div>
           <div className="cli-row">

--- a/apps/site/app/components/showcases/profiles-community.tsx
+++ b/apps/site/app/components/showcases/profiles-community.tsx
@@ -99,7 +99,7 @@ export function ProfilesCommunityShowcase() {
       {/* ============ MCP ============ */}
       <div className="section-head">
         <h3>Hand the graph to an agent</h3>
-        <div className="meta">ax mcp · stdio · 17 read-only tools</div>
+        <div className="meta">ax mcp · stdio · 26 read-only tools</div>
       </div>
 
       <article className="surface mcp-card" aria-label="MCP server">
@@ -109,7 +109,7 @@ export function ProfilesCommunityShowcase() {
         </header>
         <p className="surface-note">
           <code>ax mcp</code> runs a stdio MCP server exposing ax&apos;s read-only queries as
-          17 tools, so an agent can interrogate your graph in-context - recall a past session,
+          26 tools, so an agent can interrogate your graph in-context - recall a past session,
           pull weighted skills, read a proposal - mid-task. Mutating ops are deliberately not
           exposed.
         </p>

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -743,11 +743,11 @@ ax otlpd listening on http://127.0.0.1:1738`,
         signature: "ax mcp",
         flags: [],
         receipt: `$ ax mcp
-ax MCP server ready (stdio) - 17 read-only tools
-  recall  sessions_around  session_show  skills_weighted  ...`,
+ax MCP server ready (stdio) - 26 read-only tools
+  recall  prompts  sessions_around  session_show  skills_weighted  ...`,
         detail: [
           "The session_show tool accepts turns: excerpt|full to return ordered normalized Turn content without reading harness-specific raw files.",
-          "Exposes 17 read-only tools (recall, sessions_around, session_show, session_metrics, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, signal_show, cost_models, cost_split, cost_routability, dispatches, dojo_agenda).",
+          "Exposes 26 read-only tools (recall, prompts, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, sessions_churn, signal_show, cost_models, cost_split, cost_images, cost_attribution, cost_cache, cost_routability, otel, runs_evidence, dispatches, dispatches_advice, dojo_agenda, directives_list).",
           "Mutating ops and git-resolved queries (sessions here/near) are intentionally not exposed.",
         ],
       },

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -94,7 +94,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax doctor` - validate the install (cache, skills)
 
 ### For agents (MCP)
-- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches, dojo_agenda; `session_show` accepts `turns: "excerpt" | "full"` for normalized Turn content
+- `ax mcp` - stdio MCP server exposing 26 read-only graph queries as tools: recall, prompts, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, sessions_churn, signal_show, cost_models, cost_split, cost_images, cost_attribution, cost_cache, cost_routability, otel, runs_evidence, dispatches, dispatches_advice, dojo_agenda, directives_list; `session_show` accepts `turns: "excerpt" | "full"` for normalized Turn content
 
 ## Q&A - "how do I..." mapped to the ax answer
 
@@ -135,7 +135,7 @@ A: `ax hooks backtest <file> --days=14` - replays your real tool-call history th
 A: `ax hooks init` scaffolds `~/.ax/hooks` (typed Effect TypeScript, `defineHook`); `ax hooks install <file> --providers=claude,codex` fans it out to both configs, or `ax hooks install --all --providers=claude,codex` registers the single dispatcher (one spawn multiplexes every guard) and migrates off legacy per-guard entries. A release binary needs no repo checkout for any of this.
 
 **Q: Can my agent query its own history mid-session, without me prompting it?**
-A: `ax mcp` - a stdio MCP server exposing the read-only graph queries as 16 tools. The agent asks "where is the spend" or "what did we try before" itself.
+A: `ax mcp` - a stdio MCP server exposing 26 read-only graph queries. The agent asks "where is the spend" or "what did we try before" itself.
 
 **Q: How do I show a session to a teammate?**
 A: `ax share <session-id>` - sanitized share via GitHub Gist, rendered in the hosted studio viewer.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -383,9 +383,10 @@ command = "ax"
 args = ["mcp"]
 ```
 
-The 17 tools, each mirroring the matching CLI command:
+The 26 tools, each mirroring the matching CLI command:
 
 - **recall** - full-text recall across turns / commits / skills (`ax recall`).
+- **prompts** - reverse search over prompts you typed, with deduplication and repeat counts (`ax prompts`).
 - **sessions_around** - sessions in a date window (`ax sessions around`).
 - **session_show** - one session's detail, with optional normalized Turn
   excerpts/full text, subagent expansion, and skill-by-role grouping
@@ -407,6 +408,11 @@ The 17 tools, each mirroring the matching CLI command:
 - **otel** - OTLP receiver health: signal freshness, session coverage, cost cross-check (`ax otel`).
 - **dispatches** - subagent dispatch analytics and routing candidates (`ax dispatches`).
 - **dojo_agenda** - dojo training agenda: budget envelope + prioritized work items (`ax dojo agenda`).
+- **directives_list** - tracked directive proposals, sorted by recurrence (`ax directives ngrams`).
+- **runs_evidence** - run evidence ledger for one session (`ax runs evidence`).
+- **sessions_churn** - verification churn by session and source (`ax sessions churn`).
+- **cost_images** - image-read context cost by session (`ax cost images`).
+- **dispatches_advice** - route advice to dispatch outcomes (`ax dispatches --advice`).
 
 > **Read-only.** Mutating ops (`improve accept/reject/verdict`, `skills
 > tag/lint`, `ingest`) stay on the CLI - they write task files / edges a human


### PR DESCRIPTION
Closes #838

Adds the read-only `prompts` MCP tool with the cache runtime. Updates roster tests and current product documentation.

Verification:
- MCP registry and runtime tests
- prompt query tests
- typecheck
- repository guard checks
- CLI and site documentation checks

---

_Generated with [ax](https://github.com/Necmttn/ax)._

