### PR TITLE
fix(prompts): apply legacy rules by source

### DIFF
--- a/apps/axctl/src/queries/prompts.duckdb.test.ts
+++ b/apps/axctl/src/queries/prompts.duckdb.test.ts
@@ -29,9 +29,9 @@ const { dylibPath, dtest, tempDir } = await duckdbTestSetup("prompts", { require
 const SESSION = "019e2531-b552-7b53-a029-c780adbb6560";
 const hoursAgo = (h: number): Date => new Date(Date.now() - h * 60 * 60 * 1000);
 
-const userTask = (id: string, seq: number, ts: Date, text: string) => ({
+const userTask = (id: string, seq: number, ts: Date, text: string, session = SESSION) => ({
     id,
-    session: SESSION,
+    session,
     seq: BigInt(seq),
     ts,
     role: "user",
@@ -69,6 +69,27 @@ describe("fetchPrompts over a published snapshot", () => {
                             "<task-notification>agent finished doing work",
                         ),
                     );
+
+                    // The same full-only prefix must be filtered for Claude and
+                    // Codex, but must remain visible for Pi, Omp, OpenCode, and
+                    // Cursor. The suffix makes each source row unique, so prompt
+                    // deduplication cannot hide a source-specific result.
+                    const sourceCases = [
+                        ["claude", "019e2531-b552-7b53-a029-c780adbb6561"],
+                        ["codex", "019e2531-b552-7b53-a029-c780adbb6562"],
+                        ["pi", "019e2531-b552-7b53-a029-c780adbb6563"],
+                        ["omp", "019e2531-b552-7b53-a029-c780adbb6564"],
+                        ["opencode", "019e2531-b552-7b53-a029-c780adbb6565"],
+                        ["cursor", "019e2531-b552-7b53-a029-c780adbb6566"],
+                    ] as const;
+                    for (const [source, session] of sourceCases) {
+                        const text = `Base directory for this skill: source=${source}`;
+                        yield* write.put("session", { id: session, source, cwd: "/Users/x/ax" });
+                        yield* write.put(
+                            "turn",
+                            userTask(`turn:source-${source}`, 1, hoursAgo(6), text, session),
+                        );
+                    }
 
                     // (3) LIKE-metachar rows. Unescaped, searching "100%"
                     // degenerates to "contains 100 anywhere" (the trailing
@@ -108,6 +129,13 @@ describe("fetchPrompts over a published snapshot", () => {
 
         // legacy machine text never reaches the output at all
         expect(browsed.rows.some((r) => r.text.startsWith("<task-notification>"))).toBe(false);
+
+        for (const source of ["claude", "codex"]) {
+            expect(browsed.rows.some((r) => r.source === source && r.text.includes(`source=${source}`))).toBe(false);
+        }
+        for (const source of ["pi", "omp", "opencode", "cursor"]) {
+            expect(browsed.rows.some((r) => r.source === source && r.text.includes(`source=${source}`))).toBe(true);
+        }
 
         // --- (3): a query containing a LIKE metacharacter ---------------------
         const searched = await Effect.runPromise(

--- a/apps/axctl/src/queries/prompts.test.ts
+++ b/apps/axctl/src/queries/prompts.test.ts
@@ -12,6 +12,7 @@ import {
 import {
     FULL_CONTEXT_RULES,
     IMAGE_ATTACHMENT_MARKERS,
+    PI_CONTEXT_RULES,
     type UserTextRules,
 } from "../ingest/normalized/message-kind.ts";
 
@@ -156,6 +157,29 @@ describe("promptsWhere", () => {
         // A subagent's opening turn IS a task - an agent wrote it. The kind is
         // right; the author is not who this command is about.
         expect(sql).toContain("s.source NOT LIKE '%-subagent'");
+    });
+
+    test("applies each legacy rule table only to its parser sources", () => {
+        const c = promptsWhere(base);
+        expect(c.sql).toContain("s.source IN ('claude', 'codex')");
+        expect(c.sql).toContain("s.source IN ('pi', 'omp')");
+        // Other and future sources take the no-op branch.
+        expect(c.sql).toContain("s.source NOT IN ('claude', 'codex', 'pi', 'omp')");
+
+        // The full-only prefix is bound once for FULL_CONTEXT_RULES. It is not
+        // present in the PI table, so a future edit cannot silently duplicate it.
+        expect(c.params.filter((p) => p === "Base directory for this skill:%")).toHaveLength(1);
+        expect(c.params.length).toBe(
+            1 + // the `sinceDays` placeholder from withinDaysClause
+            FULL_CONTEXT_RULES.control.length +
+                FULL_CONTEXT_RULES.contextStartsWith.length +
+                FULL_CONTEXT_RULES.contextIncludes.length +
+                FULL_CONTEXT_RULES.attachmentMarkers.length +
+                PI_CONTEXT_RULES.control.length +
+                PI_CONTEXT_RULES.contextStartsWith.length +
+                PI_CONTEXT_RULES.contextIncludes.length +
+                PI_CONTEXT_RULES.attachmentMarkers.length,
+        );
     });
 
     test("the window is cast, or it does not bind at all", () => {

--- a/apps/axctl/src/queries/prompts.ts
+++ b/apps/axctl/src/queries/prompts.ts
@@ -31,7 +31,11 @@ import { Effect, Schema } from "effect";
 import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import { cacheFirst, cacheRows } from "@ax/lib/duckdb/query";
 import { andAll, NO_CLAUSE, withinDaysClause, type Clause } from "@ax/lib/duckdb/clause";
-import { FULL_CONTEXT_RULES, type UserTextRules } from "../ingest/normalized/message-kind.ts";
+import {
+    FULL_CONTEXT_RULES,
+    PI_CONTEXT_RULES,
+    type UserTextRules,
+} from "../ingest/normalized/message-kind.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -98,7 +102,7 @@ export const promptsWhere = (input: PromptsInput): Clause =>
             params: [],
         },
         withinDaysClause("t.ts", input.sinceDays),
-        legacyInjectionClause(FULL_CONTEXT_RULES),
+        legacyInjectionClauseBySource(),
         scopeClause(input.scope),
         queryClause(input.query),
     ]);
@@ -148,6 +152,31 @@ export const legacyInjectionClause = (rules: UserTextRules): Clause => {
     }
 
     return parts.length === 0 ? NO_CLAUSE : { sql: parts.join(" "), params };
+};
+
+/**
+ * Apply the legacy classifier guard only to sources that use that classifier.
+ *
+ * The normalized ingest parsers use FULL_CONTEXT_RULES for Claude and Codex,
+ * PI_CONTEXT_RULES for Pi and Omp, and no context classifier for other sources.
+ * Keep that source split here so a prefix measured for one harness cannot remove
+ * a real prompt from another harness. Unknown sources stay unfiltered as well.
+ */
+const legacyInjectionClauseBySource = (): Clause => {
+    const full = legacyInjectionClause(FULL_CONTEXT_RULES);
+    const pi = legacyInjectionClause(PI_CONTEXT_RULES);
+    const fullBody = full.sql.slice("AND ".length);
+    const piBody = pi.sql.slice("AND ".length);
+
+    return {
+        sql:
+            "AND (" +
+            "s.source NOT IN ('claude', 'codex', 'pi', 'omp')" +
+            " OR (s.source IN ('claude', 'codex') AND " + fullBody + ")" +
+            " OR (s.source IN ('pi', 'omp') AND " + piBody + ")" +
+            ")",
+        params: [...full.params, ...pi.params],
+    };
 };
 
 /**


### PR DESCRIPTION
Closes #1047

Applies legacy prompt filters by provider. Claude and Codex use full rules. Pi and Omp use Pi rules. Other providers remain unfiltered.

Verification:
- prompt unit tests
- DuckDB prompt regression test across six providers
- typecheck
- repository guard checks

---

_Generated with [ax](https://github.com/Necmttn/ax)._

