### PR TITLE
fix(ingest): fail soft on provider filesystem errors

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -59,6 +59,7 @@ import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { canonicalCwdInRepoScope, readCodexSessionCwd } from "./codex-scope.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1495,7 +1496,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         // shadowed `write` routes every write in this stage through it. The
         // per-session agent_event DELETE stays a pass-through exec and fires
         // before that session's first append, so delete-before-insert holds.
-        const spoolDir = yield* spoolFs.makeTempDirectory({ prefix: "ax-spool-codex-" }).pipe(Effect.orDie);
+        const spoolDir = yield* spoolFs.makeTempDirectory({ prefix: "ax-spool-codex-" });
         const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
         const write = withTableSpool(directWrite, spool);
         // Shared across all files this stage run: the agent_event ghost-index
@@ -1910,9 +1911,18 @@ export const codexStage: StageDef<CodexStageStats, AxConfig | FileSystem.FileSys
         // A vanished session file is caught + skipped inside `ingestCodex`;
         // any PlatformError that escapes here is a genuine FS fault (e.g. an
         // unreadable sessions root or a non-NotFound stat/stream error), so
-        // it dies as a defect rather than masquerading as a recoverable
-        // DbError - mirroring `claudeStage`.
-        const result = yield* ingestCodex(write, {
+        // it reaches the stage boundary as a typed filesystem failure.
+        const empty = (error: PlatformError.PlatformError) => CodexStageStats.make({
+            durationMs: Date.now() - t0,
+            summary: "codex skipped (filesystem error; non-fatal)",
+            sessionsIngested: 0,
+            turnsIngested: 0,
+            toolCallsIngested: 0,
+            malformedLines: 0,
+            failedFiles: 1,
+            failedOpenError: error.message,
+        });
+        return yield* ingestCodex(write, {
             sinceDays,
             runId: ctx.runId,
             onProgress: annotateStageProgress,
@@ -1921,18 +1931,18 @@ export const codexStage: StageDef<CodexStageStats, AxConfig | FileSystem.FileSys
             // ingest leaves repoRoots undefined => all sessions.
             ...(ctx.repoPaths ? { repoRoots: ctx.repoPaths } : {}),
         }).pipe(
-            Effect.catchTag("PlatformError", (e) => Effect.die(e)),
+            Effect.map((result) => CodexStageStats.make({
+                durationMs: Date.now() - t0,
+                summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
+                    (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
+                    (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
+                sessionsIngested: result.sessions,
+                turnsIngested: result.turns,
+                toolCallsIngested: result.toolCalls,
+                malformedLines: result.malformedLines,
+                failedFiles: result.failedFiles,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage("codex", error, empty)),
         );
-        return CodexStageStats.make({
-            durationMs: Date.now() - t0,
-            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
-                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
-                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
-            sessionsIngested: result.sessions,
-            turnsIngested: result.turns,
-            toolCallsIngested: result.toolCalls,
-            malformedLines: result.malformedLines,
-            failedFiles: result.failedFiles,
-        });
     }),
 };

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -1,4 +1,4 @@
-import { Effect, FileSystem, Option, Path, Schema } from "effect";
+import { Effect, FileSystem, Option, Path, PlatformError, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { cacheRow, tsParam } from "@ax/lib/duckdb/row";
@@ -20,6 +20,7 @@ import {
 } from "./transcripts.ts";
 import { resolveSkillName } from "@ax/lib/skill-id";
 import { loadPricingCatalog } from "./model-pricing.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 
 interface SubagentManifest {
     readonly agentId: string;
@@ -184,7 +185,7 @@ export const deriveClaudeSubagents = (
     opts: DeriveClaudeSubagentsOpts = {},
 ): Effect.Effect<
     DeriveClaudeSubagentsStats,
-    CacheWriteError,
+    CacheWriteError | PlatformError.PlatformError,
     AxConfig | FileSystem.FileSystem | Path.Path
 > =>
     Effect.gen(function* () {
@@ -291,14 +292,14 @@ export const deriveClaudeSubagents = (
             // `extractFileWithSessionId` is now FileSystem-native: a subagent
             // transcript that VANISHED mid-run surfaces a NotFound
             // PlatformError, which we treat as "no usable content" (→ null)
-            // so the run continues; other FS failures die as defects.
+            // so the run continues; other FS failures remain typed failures.
             const extracted = yield* extractFileWithSessionId(
                 m.file,
                 m.project ?? "",
                 m.subagentSessionId,
             ).pipe(
                 Effect.catchTag("PlatformError", (e) =>
-                    isNotFound(e) ? Effect.succeed(null) : Effect.die(e),
+                    isNotFound(e) ? Effect.succeed(null) : Effect.fail(e),
                 ),
             );
 
@@ -498,11 +499,14 @@ export const subagentsStage: StageDef<SubagentsStats, AxConfig | FileSystem.File
     run: (_ctx: IngestContext, write) =>
         Effect.gen(function* () {
             const t0 = Date.now();
-            const result = yield* deriveClaudeSubagents(write);
-            return SubagentsStats.make({
-                durationMs: Date.now() - t0,
-                summary: `wrote ${result.written} subagent links`,
-                subagentLinksWritten: result.written,
-            });
+            const empty = (error: PlatformError.PlatformError) => SubagentsStats.make({ durationMs: Date.now() - t0, summary: "subagents skipped (filesystem error; non-fatal)", subagentLinksWritten: 0, failedOpenError: error.message });
+            return yield* deriveClaudeSubagents(write).pipe(
+                Effect.map((result) => SubagentsStats.make({
+                    durationMs: Date.now() - t0,
+                    summary: `wrote ${result.written} subagent links`,
+                    subagentLinksWritten: result.written,
+                })),
+                Effect.catchTag("PlatformError", (error) => skipPlatformStage("subagents", error, empty)),
+            );
         }),
 };

--- a/apps/axctl/src/ingest/git.ts
+++ b/apps/axctl/src/ingest/git.ts
@@ -7,6 +7,7 @@ import { watermarkRow } from "@ax/lib/duckdb/watermark";
 import { commitRowId, edgeRowId, stableId } from "@ax/lib/stable-id";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 import {
     checkoutRecordKey,
 } from "./record-keys.ts";
@@ -803,18 +804,27 @@ export const gitStage: StageDef<
             // Repo discovery tolerates a vanished override file / missing `.git`
             // (NotFound is recovered inside ingestGit); any PlatformError that
             // escapes here is a genuine FS fault (unreadable repo-list file or a
-            // non-NotFound stat error), so it dies as a defect rather than
-            // masquerading as a recoverable DbError.
-            const result = yield* ingestGit(write, {
+            // non-NotFound stat error), so the stage boundary logs a warning
+            // and returns zero stats rather than hiding the failure.
+            const empty = (error: PlatformError.PlatformError) => GitStageStats.make({
+                durationMs: Date.now() - t0,
+                summary: "git skipped (filesystem error; non-fatal)",
+                commitsIngested: 0,
+                repositoriesSeen: 0,
+                failedOpenError: error.message,
+            });
+            return yield* ingestGit(write, {
                 ...(sinceDays === undefined ? {} : { sinceDays }),
                 ...(ctx.repoPaths === undefined ? {} : { repoPaths: ctx.repoPaths }),
-            }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
-            return GitStageStats.make({
-                durationMs: Date.now() - t0,
-                summary: `ingested ${result.commits} commits from ${result.repos} repos`,
-                commitsIngested: result.commits,
-                repositoriesSeen: result.repos,
-            });
+            }).pipe(
+                Effect.map((result) => GitStageStats.make({
+                    durationMs: Date.now() - t0,
+                    summary: `ingested ${result.commits} commits from ${result.repos} repos`,
+                    commitsIngested: result.commits,
+                    repositoriesSeen: result.repos,
+                })),
+                Effect.catchTag("PlatformError", (error) => skipPlatformStage("git", error, empty)),
+            );
         },
     ),
 };

--- a/apps/axctl/src/ingest/hook-fire-spool.ts
+++ b/apps/axctl/src/ingest/hook-fire-spool.ts
@@ -9,6 +9,7 @@ import {
 } from "../hooks/spool.ts";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 
 export interface DrainHookFireSpoolOptions {
     readonly spoolDir?: string;
@@ -101,8 +102,8 @@ const EMPTY_DRAIN: DrainHookFireSpoolResult = { files: 0, rows: 0, malformed: 0 
  *
  * Two error kinds, handled differently, because `runPipeline` aborts the WHOLE
  * run on either a stage failure or a defect:
- *   - `PlatformError` is a genuine filesystem fault -> `Effect.die`, as
- *     `otelSpoolStage` does.
+ *   - `PlatformError` is a genuine filesystem fault -> log a warning and
+ *     return zero stats at the stage boundary.
  *   - `HookFireSpoolError` is dominated by spool-lock contention (a hook firing
  *     while ingest runs). The spool is never truncated and the drain is
  *     idempotent, so the right response is to defer to the next pass, not to
@@ -116,27 +117,35 @@ export const hookFireSpoolStage: StageDef<
     meta: StageMeta.make({ key: "hook-fire-spool", deps: [], tags: ["ingest"], writes: [{ table: "hook_fire", mode: "parse" }] }),
     run: Effect.fn(function* (_ctx: IngestContext, write: CacheWriteService) {
         const started = Date.now();
-        const outcome = yield* drainHookFireSpool(write).pipe(
+        const empty = (error: PlatformError.PlatformError) => HookFireSpoolStageStats.make({
+            durationMs: Date.now() - started,
+            summary: "hook-fire-spool skipped (filesystem error; non-fatal)",
+            filesRead: 0,
+            rowsIngested: 0,
+            malformedRows: 0,
+            failedOpenError: error.message,
+        });
+        return yield* drainHookFireSpool(write).pipe(
             Effect.map((result) => ({ result, deferred: null as string | null })),
-            Effect.catchTag("PlatformError", (error) => Effect.die(error)),
             Effect.catchTag("HookFireSpoolError", (error) =>
                 Effect.logWarning(
                     `ingest: hook fire spool not drained this pass - ${error.message}. ` +
                         `The spool is retained; the next ingest replays it.`,
-                ).pipe(Effect.as({ result: EMPTY_DRAIN, deferred: error.message as string | null })),
+                    ).pipe(Effect.as({ result: EMPTY_DRAIN, deferred: error.message as string | null })),
             ),
+            Effect.map((outcome) => HookFireSpoolStageStats.make({
+                durationMs: Date.now() - started,
+                summary: outcome.deferred !== null
+                    ? `deferred: ${outcome.deferred}`
+                    : `ingested ${outcome.result.rows} hook fire rows` +
+                        (outcome.result.malformed > 0
+                            ? `, ${outcome.result.malformed} malformed rows skipped`
+                            : ""),
+                filesRead: outcome.result.files,
+                rowsIngested: outcome.result.rows,
+                malformedRows: outcome.result.malformed,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage("hook-fire-spool", error, empty)),
         );
-        return HookFireSpoolStageStats.make({
-            durationMs: Date.now() - started,
-            summary: outcome.deferred !== null
-                ? `deferred: ${outcome.deferred}`
-                : `ingested ${outcome.result.rows} hook fire rows` +
-                    (outcome.result.malformed > 0
-                        ? `, ${outcome.result.malformed} malformed rows skipped`
-                        : ""),
-            filesRead: outcome.result.files,
-            rowsIngested: outcome.result.rows,
-            malformedRows: outcome.result.malformed,
-        });
     }),
 };

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -10,6 +10,7 @@ import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { walkJsonlFilesStrict, type JsonlFileCandidate } from "./walk-jsonl.ts";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 
 /**
  * ---------------------------------------------------------------------------
@@ -281,19 +282,27 @@ export const otelSpoolStage: StageDef<
     meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"], writes: [{ table: "otel_metric_point", mode: "parse" }, { table: "otel_span", mode: "parse" }, { table: "otel_log_event", mode: "parse" }, { table: "telemetry_of", mode: "derive" }, { table: "ingest_file_state", mode: "bookkeep" }, { table: "ingest_run", mode: "bookkeep" }] }),
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {
         const t0 = Date.now();
-        const result = yield* ingestOtelSpool(write, {
-            ...(ctx.runId === undefined ? {} : { runId: ctx.runId }),
-        }).pipe(Effect.catchTag("PlatformError", (error) => Effect.die(error)));
-        return OtelSpoolStageStats.make({
+        const empty = (error: PlatformError.PlatformError) => OtelSpoolStageStats.make({
             durationMs: Date.now() - t0,
-            summary: `ingested ${result.payloads} OTLP payloads, ${result.rows} rows` +
-                (result.malformed > 0 ? `, ${result.malformed} malformed payloads skipped` : "") +
-                (result.failedFiles > 0 ? `, ${result.failedFiles} files failed` : ""),
-            filesIngested: result.files,
-            payloadsIngested: result.payloads,
-            rowsIngested: result.rows,
-            malformedPayloads: result.malformed,
-            failedFiles: result.failedFiles,
+            summary: "otel-spool skipped (filesystem error; non-fatal)",
+            filesIngested: 0, payloadsIngested: 0, rowsIngested: 0,
+            malformedPayloads: 0, failedFiles: 1, failedOpenError: error.message,
         });
+        return yield* ingestOtelSpool(write, {
+            ...(ctx.runId === undefined ? {} : { runId: ctx.runId }),
+        }).pipe(
+            Effect.map((result) => OtelSpoolStageStats.make({
+                durationMs: Date.now() - t0,
+                summary: `ingested ${result.payloads} OTLP payloads, ${result.rows} rows` +
+                    (result.malformed > 0 ? `, ${result.malformed} malformed payloads skipped` : "") +
+                    (result.failedFiles > 0 ? `, ${result.failedFiles} files failed` : ""),
+                filesIngested: result.files,
+                payloadsIngested: result.payloads,
+                rowsIngested: result.rows,
+                malformedPayloads: result.malformed,
+                failedFiles: result.failedFiles,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage("otel-spool", error, empty)),
+        );
     }),
 };

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -1,4 +1,4 @@
-import { Effect, FileSystem, Path, Schema } from "effect";
+import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
@@ -19,6 +19,7 @@ import { toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import { JSONL_WORK_UNIT_WRITES, NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
 import type { StageDef } from "./stage/registry.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 import {
     booleanField,
     boundedExcerpt,
@@ -758,7 +759,7 @@ const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.i
         const fs = yield* FileSystem.FileSystem;
         // v3 Phase 2 (#886): high-volume tables buffer in an NDJSON spool; the
         // shadowed `write` routes every write in this stage through it.
-        const spoolDir = yield* fs.makeTempDirectory({ prefix: `ax-spool-${desc.provider}-` }).pipe(Effect.orDie);
+        const spoolDir = yield* fs.makeTempDirectory({ prefix: `ax-spool-${desc.provider}-` });
         const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
         const write = withTableSpool(directWrite, spool);
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
@@ -874,25 +875,40 @@ const makePiLikeStage = (
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {
         const t0 = Date.now();
         const sinceDays = sinceDaysFromCtx(ctx);
+        const empty = (error: PlatformError.PlatformError) => PiStageStats.make({
+            durationMs: Date.now() - t0,
+            summary: `${desc.provider} skipped (filesystem error; non-fatal)`,
+            filesIngested: 0,
+            sessionsIngested: 0,
+            eventsIngested: 0,
+            turnsIngested: 0,
+            toolCallsIngested: 0,
+            skipped: 0,
+            warnings: 0,
+            failedFiles: 1,
+            failedOpenError: error.message,
+        });
         // The directory walk recovers every PlatformError internally, and a
         // per-file `readFileString` fault is now recorded + skipped by the
         // per-file isolation seam (#261, see file-isolation.ts), so no
-        // PlatformError escapes the ingest. Only connection loss and failure
-        // storms abort the stage, as a DbError.
-        const result = yield* ingest(write, { sinceDays, runId: ctx.runId });
-        return PiStageStats.make({
-            durationMs: Date.now() - t0,
-            summary: `ingested ${result.files} files, ${result.sessions} sessions, ${result.events} events, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
-                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
-            filesIngested: result.files,
-            sessionsIngested: result.sessions,
-            eventsIngested: result.events,
-            turnsIngested: result.turns,
-            toolCallsIngested: result.toolCalls,
-            skipped: result.skipped,
-            warnings: result.warnings,
-            failedFiles: result.failedFiles,
-        });
+        // A discovery or spool setup PlatformError reaches the stage boundary,
+        // which records failed-open stats. Database errors still abort the stage.
+        return yield* ingest(write, { sinceDays, runId: ctx.runId }).pipe(
+            Effect.map((result) => PiStageStats.make({
+                durationMs: Date.now() - t0,
+                summary: `ingested ${result.files} files, ${result.sessions} sessions, ${result.events} events, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
+                    (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
+                filesIngested: result.files,
+                sessionsIngested: result.sessions,
+                eventsIngested: result.events,
+                turnsIngested: result.turns,
+                toolCallsIngested: result.toolCalls,
+                skipped: result.skipped,
+                warnings: result.warnings,
+                failedFiles: result.failedFiles,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage(desc.provider, error, empty)),
+        );
     }),
 });
 

--- a/apps/axctl/src/ingest/platform-stage.test.ts
+++ b/apps/axctl/src/ingest/platform-stage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer, Path, PlatformError } from "effect";
+import { layerTestFileSystem } from "@ax/lib/testing/test-filesystem";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { IngestContext } from "./stage/types.ts";
+import { otelSpoolStage } from "./otel-spool.ts";
+import { BaseStageStats } from "./stage/types.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
+
+describe("platform stage failure boundary", () => {
+    it("logs a warning and returns explicit zero-count stats", async () => {
+        const error = PlatformError.systemError({
+            _tag: "PermissionDenied",
+            module: "FileSystem",
+            method: "readDirectory",
+            pathOrDescriptor: "/unreadable",
+        });
+        const stats = BaseStageStats.make({ durationMs: 0, summary: "skipped" });
+
+        await expect(
+            Effect.runPromise(skipPlatformStage("codex", error, () => stats)),
+        ).resolves.toEqual(stats);
+    });
+
+    it("lets the OTLP stage complete after spool discovery fails", async () => {
+        const error = PlatformError.systemError({
+            _tag: "PermissionDenied",
+            module: "FileSystem",
+            method: "readDirectory",
+            pathOrDescriptor: "/spool/2026-08-25.jsonl",
+        });
+        const previous = process.env.AX_OTLP_SPOOL_DIR;
+        process.env.AX_OTLP_SPOOL_DIR = "/spool";
+        try {
+            const stats = await Effect.runPromise(
+                otelSpoolStage.run(
+                    IngestContext.make({ cwd: "/", since: new Date(0), debug: false }),
+                    {} as CacheWriteService,
+                ).pipe(
+                    Effect.provide(Layer.mergeAll(
+                        layerTestFileSystem(
+                            { "/spool/2026-08-25.jsonl": "{}\n" },
+                            { errors: { "/spool/2026-08-25.jsonl": error } },
+                        ),
+                        Path.layer,
+                    )),
+                ),
+            );
+            expect(stats).toMatchObject({
+                summary: "otel-spool skipped (filesystem error; non-fatal)",
+                filesIngested: 0,
+                payloadsIngested: 0,
+                rowsIngested: 0,
+                malformedPayloads: 0,
+                failedFiles: 1,
+            });
+        } finally {
+            if (previous === undefined) delete process.env.AX_OTLP_SPOOL_DIR;
+            else process.env.AX_OTLP_SPOOL_DIR = previous;
+        }
+    });
+});

--- a/apps/axctl/src/ingest/platform-stage.ts
+++ b/apps/axctl/src/ingest/platform-stage.ts
@@ -1,0 +1,13 @@
+import { Effect, PlatformError } from "effect";
+import type { BaseStageStats } from "./stage/types.ts";
+
+/** Skip one provider stage after a typed filesystem failure. */
+export const skipPlatformStage = <A extends BaseStageStats>(
+    provider: string,
+    error: PlatformError.PlatformError,
+    stats: (error: PlatformError.PlatformError) => A,
+): Effect.Effect<A> =>
+    Effect.logWarning(`ingest: ${provider} stage skipped because of a filesystem error`, {
+        provider,
+        error: error.message,
+    }).pipe(Effect.as(stats(error)));

--- a/apps/axctl/src/ingest/run-stage-settle.test.ts
+++ b/apps/axctl/src/ingest/run-stage-settle.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { Cause, Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Schema } from "effect";
 import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 import { settleStage } from "./run.ts";
 import { BaseStageStats } from "./stage/types.ts";
 import { CacheWriteUnlockedError } from "@ax/lib/duckdb/seam";
 import type { IngestStageError } from "./stage/registry.ts";
+
+class FailedOpenStats extends BaseStageStats.extend<FailedOpenStats>("FailedOpenStats")({
+    failedFiles: Schema.Number,
+}) {}
 
 /** A concrete member of the `IngestStageError` union (it is a type union, not a
  *  class), so a typed-failure Exit can actually be constructed. */
@@ -24,7 +28,7 @@ const stageFailure = (message: string) =>
  */
 
 interface Recorded {
-    readonly finishes: Array<{ readonly status: unknown; readonly errorText: unknown }>;
+    readonly finishes: Array<{ readonly status: unknown; readonly errorText: unknown; readonly counts: unknown }>;
     readonly events: Array<Record<string, unknown>>;
 }
 
@@ -40,7 +44,7 @@ const recordingWrite = (): { readonly write: CacheWriteService; readonly rec: Re
         exec: (sql: string, params?: ReadonlyArray<unknown>) =>
             Effect.sync(() => {
                 if (sql.includes("UPDATE ingest_stage SET status")) {
-                    rec.finishes.push({ status: params?.[0], errorText: params?.[2] });
+                    rec.finishes.push({ status: params?.[0], errorText: params?.[2], counts: params?.[1] });
                 }
             }),
         put: (table: string, row: Record<string, unknown>) =>
@@ -81,6 +85,22 @@ describe("settleStage", () => {
         // writer nulls the column.
         expect(rec.finishes[0]?.errorText).toBeNull();
         expect(rec.events).toHaveLength(1);
+    });
+
+    it("records a failed-open success as an error and warning with counts", async () => {
+        const rec = await Effect.runPromise(
+            settle(Exit.succeed(FailedOpenStats.make({
+                durationMs: 5,
+                summary: "skipped",
+                failedOpenError: "PermissionDenied: /spool",
+                failedFiles: 1,
+            }))),
+        );
+        expect(rec.finishes[0]?.status).toBe("error");
+        expect(String(rec.finishes[0]?.errorText)).toContain("PermissionDenied");
+        expect(String(rec.finishes[0]?.counts)).toContain("failedFiles");
+        expect(rec.events[0]?.level).toBe("warn");
+        expect(rec.events[0]?.message).toContain("PermissionDenied");
     });
 
     it("records error with the failure text on a typed failure", async () => {

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -200,6 +200,18 @@ export const settleStage = (
 ): Effect.Effect<void, CacheWriteError> => {
     if (Exit.isSuccess(exit)) {
         const counts = numericCounts(exit.value);
+        if (exit.value.failedOpenError !== undefined) {
+            const message = exit.value.failedOpenError;
+            return Effect.gen(function* () {
+                yield* writeIngestStageFinish(write, { ...ledgerKey, status: "error", errorText: message, counts, selfMs });
+                yield* writeIngestEvent(write, {
+                    ...ledgerKey,
+                    level: "warn",
+                    message,
+                    counts,
+                });
+            });
+        }
         return Effect.gen(function* () {
             yield* writeIngestStageFinish(write, { ...ledgerKey, status: "ok", counts, selfMs });
             yield* writeIngestEvent(write, {

--- a/apps/axctl/src/ingest/stage/types.ts
+++ b/apps/axctl/src/ingest/stage/types.ts
@@ -9,6 +9,8 @@ import { IngestStageTag } from "./tags.ts";
 export class BaseStageStats extends Schema.Class<BaseStageStats>("BaseStageStats")({
     durationMs: Schema.Number,
     summary: Schema.String,
+    /** A failed-open stage returns success so independent stages can continue. */
+    failedOpenError: Schema.optional(Schema.String),
 }) {}
 
 /** Ambient context every stage's run receives. Pipeline owns lifetime; stages

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -77,6 +77,7 @@ import {
 } from "./model-pricing.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { INGEST_SPOOL_TABLES, runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 import {
     extractClaudeCompaction,
     type CompactionWrite,
@@ -1761,7 +1762,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
         // agent_event DELETE - passes through to the direct path. The shadowed
         // `write` below routes EVERY write in this stage through the decorator;
         // the work-unit owns the flush cadence and defers watermarks past it.
-        const spoolDir = yield* fs.makeTempDirectory({ prefix: "ax-spool-claude-" }).pipe(Effect.orDie);
+        const spoolDir = yield* fs.makeTempDirectory({ prefix: "ax-spool-claude-" });
         const spool = makeTableSpool({ tables: INGEST_SPOOL_TABLES, dir: spoolDir });
         const write = withTableSpool(directWrite, spool);
         const transcriptsDir = cfg.paths.transcriptsDir;
@@ -2098,27 +2099,37 @@ export const claudeStage: StageDef<ClaudeStats, AxConfig | FileSystem.FileSystem
         // The vanished-transcript case is caught + skipped inside
         // `ingestTranscripts`; any PlatformError that escapes here is a
         // genuine FS failure (e.g. an unreadable transcripts root or a
-        // non-NotFound stat/stream error) so it dies as a defect rather
-        // than masquerading as a recoverable DbError.
-        const result = yield* ingestTranscripts(write, {
+        // non-NotFound stat/stream error) so the stage boundary logs a warning
+        // and returns zero stats rather than hiding the failure.
+        const empty = (error: PlatformError.PlatformError) => ClaudeStats.make({
+            durationMs: Date.now() - t0,
+            summary: "claude skipped (filesystem error; non-fatal)",
+            sessionsIngested: 0,
+            turnsIngested: 0,
+            toolCallsIngested: 0,
+            malformedLines: 0,
+            failedFiles: 1,
+            failedOpenError: error.message,
+        });
+        return yield* ingestTranscripts(write, {
             sinceDays,
             project: ctx.claudeProject,
             runId: ctx.runId,
             onProgress: annotateStageProgress,
             onFileFailures,
         }).pipe(
-            Effect.catchTag("PlatformError", (e) => Effect.die(e)),
+            Effect.map((result) => ClaudeStats.make({
+                durationMs: Date.now() - t0,
+                summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
+                    (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
+                    (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
+                sessionsIngested: result.sessions,
+                turnsIngested: result.turns,
+                toolCallsIngested: result.toolCalls,
+                malformedLines: result.malformedLines,
+                failedFiles: result.failedFiles,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage("claude", error, empty)),
         );
-        return ClaudeStats.make({
-            durationMs: Date.now() - t0,
-            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
-                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
-                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
-            sessionsIngested: result.sessions,
-            turnsIngested: result.turns,
-            toolCallsIngested: result.toolCalls,
-            malformedLines: result.malformedLines,
-            failedFiles: result.failedFiles,
-        });
     }),
 };


### PR DESCRIPTION
Closes #771

Keeps typed provider filesystem failures out of the defect channel. Affected stages log a warning, record a durable failed-open error with zero counts, and allow unrelated pipeline stages to continue. Database failures and programmer defects remain fatal.

Covered providers:
- Claude, Codex, Pi, and Omp transcript stages
- OTLP and hook-fire spools
- Git ingest
- Claude subagent derivation

Verification:
- injected permission failure and durable settlement tests
- stage runner continuation tests
- provider isolation and OTLP tests
- typecheck and repository guards

---

_Generated with [ax](https://github.com/Necmttn/ax)._

