### PR TITLE
fix(release): use current Intel macOS runner

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,10 +45,12 @@ jobs:
         include:
           - runner: macos-14
             artifact: axctl-darwin-arm64
-          # Intel macOS. `scripts/build-duckdb.sh` branches on `uname -s` only, so
+          # Intel macOS. GitHub retired the macos-13 image; macos-15-intel is
+          # the current x64 standard runner label. `scripts/build-duckdb.sh`
+          # branches on `uname -s` only, so
           # this leg builds a native x64 libduckdb with no arch-specific casing,
           # and `install.sh` already maps `x86_64` -> `x64` (#835).
-          - runner: macos-13
+          - runner: macos-15-intel
             artifact: axctl-darwin-x64
           - runner: ubuntu-24.04
             artifact: axctl-linux-x64


### PR DESCRIPTION
Fixes #835

## Summary

- Replace the retired `macos-13` runner with `macos-15-intel`.
- Keep the existing `axctl-darwin-x64` artifact contract.
- Record the current GitHub runner label in the workflow comment.

## Evidence

The v0.41.0 and v0.42.0 release runs leave the Intel job queued without a start time. GitHub retired macOS 13. The official runner catalog lists `macos-15-intel` for x64.

## Verification

- `bunx prettier --check .github/workflows/release-please.yml`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`

---

_Generated with [ax](https://github.com/Necmttn/ax)._
