### PR TITLE
feat(ingest): publish first cold snapshot early

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1892,6 +1892,7 @@ export const codexStage: StageDef<CodexStageStats, AxConfig | FileSystem.FileSys
         key: "codex",
         deps: ["skills", "commands", "pricing"],
         tags: ["ingest"],
+        firstValue: true,
         writes: [
             ...NORMALIZED_BATCH_WRITES,
             { table: "session_token_usage", mode: "parse" },

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -1159,6 +1159,7 @@ export const cursorStage: StageDef<CursorStageStats, AxConfig | FileSystem.FileS
         key: "cursor",
         deps: ["skills", "commands"],
         tags: ["ingest"],
+        firstValue: true,
         writes: [...NORMALIZED_BATCH_WRITES, { table: "ingest_file_state", mode: "bookkeep" }],
     }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -1274,7 +1274,7 @@ export class OpenCodeStageStats extends BaseStageStats.extend<OpenCodeStageStats
 }) {}
 
 export const opencodeStage: StageDef<OpenCodeStageStats, AxConfig | FileSystem.FileSystem | Path.Path, import("./stage/registry.ts").IngestStageError> = {
-    meta: StageMeta.make({ key: "opencode", deps: ["skills", "commands"], tags: ["ingest"], writes: NORMALIZED_BATCH_WRITES }),
+    meta: StageMeta.make({ key: "opencode", deps: ["skills", "commands"], tags: ["ingest"], firstValue: true, writes: NORMALIZED_BATCH_WRITES }),
     // Unnamed Effect.fn: the stage runner's LiveTrace.step span already names
     // this boundary by the stage key, so a named span here would double-wrap.
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -864,6 +864,7 @@ const makePiLikeStage = (
         key: desc.provider,
         deps: ["skills", "commands"],
         tags: ["ingest"],
+        firstValue: true,
         writes: [
             ...NORMALIZED_BATCH_WRITES,
             { table: "session_token_usage", mode: "parse" },

--- a/apps/axctl/src/ingest/run.test.ts
+++ b/apps/axctl/src/ingest/run.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { existsSync, readFileSync } from "node:fs";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { AxConfigTest } from "@ax/lib/config";
+import { DbError } from "@ax/lib/errors";
 import { ProcessServiceLive } from "@ax/lib/process";
 import { withIngestLock } from "@ax/lib/ingest-lock";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { LiveTraceLayer } from "@ax/lib/live-traces/Tracer";
 import { TraceSinkLive, TraceTransportTag, type TraceTransport } from "@ax/lib/live-traces/Sink";
-import { StageRegistryLive, type StageDef } from "./stage/registry.ts";
+import { CacheRead, CacheReadLayer } from "@ax/lib/duckdb";
+import { StageRegistryLive, type IngestStageError, type StageDef } from "./stage/registry.ts";
 import { BaseStageStats, StageMeta } from "./stage/types.ts";
 import { runIngest, stageEventName, withIngestRunFinish } from "./run.ts";
 
@@ -29,6 +32,35 @@ const traceLayer = () => {
     );
     return Layer.mergeAll(sink, LiveTraceLayer.pipe(Layer.provide(sink)));
 };
+
+/** Run `runIngest` fully wired (registry + config + trace layers), against
+ *  whichever live/snapshot paths the caller pinned via env. */
+const runIngestOnce = (
+    dataDir: string,
+    stages: ReadonlyArray<StageDef<BaseStageStats, never, IngestStageError>>,
+    runId: string,
+) =>
+    withIngestLock({
+        lockPath: `${dataDir}/ingest.lock`,
+        command: "test ingest",
+        staleMs: 60_000,
+        onBusy: () => Effect.die("test ingest lock is busy"),
+    }, runIngest({
+        command: "ingest",
+        args: [],
+        cwd: "/tmp/ax",
+        now: () => new Date("2026-05-29T00:00:00Z"),
+        runId: () => runId,
+    })).pipe(Effect.provide(Layer.mergeAll(
+        StageRegistryLive(stages),
+        traceLayer(),
+        AxConfigTest({ paths: { dataDir } }).pipe(
+            Layer.provide(BunFileSystem.layer),
+        ),
+        ProcessServiceLive,
+        BunFileSystem.layer,
+        BunPath.layer,
+    )));
 
 describe("stageEventName", () => {
     it("uses canonical and fallback labels", () => {
@@ -161,5 +193,173 @@ describe("runIngest on real DuckDB", () => {
             if (previous === undefined) delete process.env.AX_DUCKDB_DYLIB;
             else process.env.AX_DUCKDB_DYLIB = previous;
         }
+    });
+});
+
+describe("runIngest cold-start intermediate publish (#833)", () => {
+    /** A first-value provider stage - what claude/codex/pi/omp/opencode/cursor
+     *  carry in production (see registry.test.ts's "marks exactly the six..."). */
+    const firstValueStage = (
+        key: string,
+        deps: string[] = [],
+    ): StageDef<BaseStageStats, never, IngestStageError> => ({
+        meta: StageMeta.make({ key, deps, tags: ["ingest"], writes: [], firstValue: true }),
+        run: (_ctx, write) => Effect.gen(function* () {
+            const sessionId = `${key}_session`;
+            yield* write.put("session", { id: sessionId, source: key });
+            yield* write.put("turn", {
+                id: `${sessionId}_turn`,
+                session: sessionId,
+                seq: 1,
+                ts: new Date("2026-05-29T00:00:00Z"),
+                role: "user",
+                text: "first value",
+            });
+            return BaseStageStats.make({ durationMs: 0, summary: `${key} done` });
+        }),
+    });
+
+    /** A stage that never carries `firstValue` - lands in the remainder phase
+     *  on a cold run. Signals `started` the instant its body begins (BEFORE
+     *  it does anything else), then blocks on `gate` - so awaiting `started`
+     *  is a deterministic proof that everything sequenced before it in
+     *  `runIngest` (the whole first-value phase, its FTS build, and its
+     *  intermediate publish) has already been awaited to completion. No
+     *  timing/sleep assertions anywhere in this suite. */
+    const blockedRemainderStage = (
+        key: string,
+        started: Deferred.Deferred<void>,
+        gate: Deferred.Deferred<void>,
+    ): StageDef<BaseStageStats, never, IngestStageError> => ({
+        meta: StageMeta.make({ key, deps: [], tags: ["ingest"], writes: [] }),
+        run: () => Effect.gen(function* () {
+            yield* Deferred.succeed(started, undefined);
+            yield* Deferred.await(gate);
+            return BaseStageStats.make({ durationMs: 0, summary: `${key} done` });
+        }),
+    });
+
+    /** Pin AX_DUCKDB_DYLIB + AX_DUCKDB_SNAPSHOT for the duration of `body`,
+     *  restoring both afterwards - `runIngest` never overrides `snapshotPath`
+     *  itself, so this is how a test controls where it publishes. */
+    const withPinnedEnv = async <A>(dataDir: string, body: (snapshotPath: string) => Promise<A>): Promise<A> => {
+        const previousDylib = process.env.AX_DUCKDB_DYLIB;
+        const previousSnapshot = process.env.AX_DUCKDB_SNAPSHOT;
+        const snapshotPath = `${dataDir}/ax-snapshot.duckdb`;
+        if (dylibPath !== null) process.env.AX_DUCKDB_DYLIB = dylibPath;
+        process.env.AX_DUCKDB_SNAPSHOT = snapshotPath;
+        try {
+            return await body(snapshotPath);
+        } finally {
+            if (previousDylib === undefined) delete process.env.AX_DUCKDB_DYLIB;
+            else process.env.AX_DUCKDB_DYLIB = previousDylib;
+            if (previousSnapshot === undefined) delete process.env.AX_DUCKDB_SNAPSHOT;
+            else process.env.AX_DUCKDB_SNAPSHOT = previousSnapshot;
+        }
+    };
+
+    dtest("cold start: publishes before a blocked remainder stage finishes, then still publishes the final snapshot", async () => {
+        if (dylibPath === null) return;
+        const dataDir = tempDir("ax-run-cold-intermediate-");
+        await withPinnedEnv(dataDir, async (snapshotPath) => {
+            expect(existsSync(snapshotPath)).toBe(false); // genuinely cold
+
+            const { started, gate } = await Effect.runPromise(Effect.gen(function* () {
+                return { started: yield* Deferred.make<void>(), gate: yield* Deferred.make<void>() };
+            }));
+            const stages: Array<StageDef<BaseStageStats, never, IngestStageError>> = [
+                stage("skills"),
+                firstValueStage("claude", ["skills"]),
+                blockedRemainderStage("remainder", started, gate),
+            ];
+
+            const fiber = Effect.runFork(runIngestOnce(dataDir, stages, "cold_run"));
+
+            // Deterministic: the remainder stage can only have STARTED after
+            // runIngest sequentially awaited the whole first-value phase, its
+            // TURN-only FTS build, and the intermediate publish - see the
+            // comment on `blockedRemainderStage`.
+            await Effect.runPromise(Deferred.await(started));
+            expect(existsSync(snapshotPath)).toBe(true);
+
+            // The intermediate snapshot is a real, readable publish - not a
+            // half-written file.
+            const midRunRows = await Effect.runPromise(
+                Effect.gen(function* () {
+                    const read = yield* CacheRead;
+                    return yield* read.raw(
+                        "SELECT r.id, r.status, count(DISTINCT s.id) AS sessions, " +
+                            "count(DISTINCT t.id) AS turns " +
+                            "FROM ingest_run r, session s, turn t " +
+                            "WHERE r.id = 'cold_run' GROUP BY r.id, r.status",
+                    );
+                }).pipe(Effect.provide(CacheReadLayer({ snapshotPath }))),
+            );
+            expect(midRunRows).toMatchObject({
+                rows: [{ id: "cold_run", status: "running", sessions: 1n, turns: 1n }],
+            });
+
+            await Effect.runPromise(Deferred.succeed(gate, undefined));
+            const result = await Effect.runPromise(Fiber.join(fiber));
+            expect(result).toMatchObject({ _tag: "completed", value: { runId: "cold_run", status: "ok" } });
+
+            // The final publish still occurs on success, reflecting the
+            // completed run.
+            const finalRows = await Effect.runPromise(
+                Effect.gen(function* () {
+                    const read = yield* CacheRead;
+                    return yield* read.raw("SELECT id, status FROM ingest_run WHERE id = 'cold_run'");
+                }).pipe(Effect.provide(CacheReadLayer({ snapshotPath }))),
+            );
+            expect(finalRows).toMatchObject({ rows: [{ id: "cold_run", status: "ok" }] });
+        });
+    });
+
+    dtest("warm start: an already-published snapshot is not intermediately replaced", async () => {
+        if (dylibPath === null) return;
+        const dataDir = tempDir("ax-run-warm-no-intermediate-");
+        await withPinnedEnv(dataDir, async (snapshotPath) => {
+            // Seed a real published snapshot first.
+            await Effect.runPromise(runIngestOnce(dataDir, [stage("skills")], "warm_seed"));
+            expect(existsSync(snapshotPath)).toBe(true);
+            const beforeSecondRun = readFileSync(snapshotPath);
+
+            const { started, gate } = await Effect.runPromise(Effect.gen(function* () {
+                return { started: yield* Deferred.make<void>(), gate: yield* Deferred.make<void>() };
+            }));
+            const stages: Array<StageDef<BaseStageStats, never, IngestStageError>> = [
+                stage("skills"),
+                firstValueStage("claude", ["skills"]),
+                blockedRemainderStage("remainder", started, gate),
+            ];
+
+            const fiber = Effect.runFork(runIngestOnce(dataDir, stages, "warm_run"));
+            await Effect.runPromise(Deferred.await(started));
+
+            // No intermediate publish on a warm start: byte-identical while
+            // the remainder stage is still blocked.
+            expect(readFileSync(snapshotPath).equals(beforeSecondRun)).toBe(true);
+
+            await Effect.runPromise(Deferred.succeed(gate, undefined));
+            await Effect.runPromise(Fiber.join(fiber));
+
+            // The final publish still happens once the whole run completes.
+            expect(readFileSync(snapshotPath).equals(beforeSecondRun)).toBe(false);
+        });
+    });
+
+    dtest("cold start: a failed first-value phase never publishes", async () => {
+        if (dylibPath === null) return;
+        const dataDir = tempDir("ax-run-cold-fail-");
+        await withPinnedEnv(dataDir, async (snapshotPath) => {
+            const failing: StageDef<BaseStageStats, never, IngestStageError> = {
+                meta: StageMeta.make({ key: "claude", deps: [], tags: ["ingest"], writes: [], firstValue: true }),
+                run: () => Effect.fail(new DbError({ operation: "query", message: "boom" })),
+            };
+
+            const exit = await Effect.runPromiseExit(runIngestOnce(dataDir, [failing], "cold_fail"));
+            expect(Exit.isFailure(exit)).toBe(true);
+            expect(existsSync(snapshotPath)).toBe(false);
+        });
     });
 });

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -1,11 +1,11 @@
-import { Cause, Effect, Exit, Option, References } from "effect";
+import { Cause, Effect, Exit, FileSystem, Option, References } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { withCacheWrite, type CacheWriteError, type CacheWriteService } from "@ax/lib/duckdb/seam";
-import { buildFtsIndexes } from "@ax/lib/duckdb/fts";
+import { snapshotPath as resolveDefaultSnapshotPath } from "@ax/lib/duckdb";
+import { buildFtsIndexes, TURN_FTS_TARGET } from "@ax/lib/duckdb/fts";
 import { posixPath } from "@ax/lib/shared/path";
 import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
 import { duckdbAssetPathOption } from "../duckdb-embed-wiring.ts";
-import type { FileSystem } from "effect";
 import { LiveTrace } from "@ax/lib/live-traces/index";
 import { TraceSink } from "@ax/lib/live-traces/Sink";
 import { ProcessService } from "@ax/lib/process";
@@ -23,7 +23,7 @@ import {
     makeStageSelfTime,
 } from "@ax/lib/duckdb/self-time";
 import { runPipeline } from "./stage/runner.ts";
-import { selectByKeys, selectByTag } from "./stage/select.ts";
+import { firstValuePhaseStages, selectByKeys, selectByTag } from "./stage/select.ts";
 import { StageRegistry, type IngestStageError, type StageRegistryShape } from "./stage/registry.ts";
 import { BaseStageStats, IngestContext, type StageDef } from "./stage/types.ts";
 import { reapStaleIngestRuns } from "./reap-runs.ts";
@@ -463,15 +463,52 @@ export const runIngest = (
             wrapStage(runId, stageDef as StageDef<BaseStageStats, AxConfig | ProcessService, IngestStageError>)
         );
 
-        const stageStats = yield* runPipeline(
-            wrappedStages,
-            ctx,
-            write,
-            {
-                ...(deadlineMs === undefined ? {} : { deadlineMs }),
-                recordStageOutcome: recordRunnerStageOutcome(runId, write),
-            },
-        ).pipe(
+        // Cold-start intermediate publish (#833): give a fresh install a
+        // first usable snapshot instead of making it wait out the whole
+        // graph. Allowed ONLY when no snapshot existed before this run
+        // started - an existing good snapshot is never replaced early, only
+        // by the normal end-of-run publish on success. Checked against the
+        // SAME default `snapshotPath()` `withCacheWrite` above publishes to
+        // (this call never overrides it).
+        const fs = yield* FileSystem.FileSystem;
+        const snapshotExistedAtStart = yield* fs.exists(resolveDefaultSnapshotPath()).pipe(
+            // Uncertain is treated as "existed": the risk of skipping a
+            // harmless intermediate publish is nothing; the risk of running
+            // one against an unreadable "no" is a possible clobber.
+            Effect.orElseSucceed(() => true),
+        );
+        const firstPhaseKeys = snapshotExistedAtStart
+            ? new Set<string>()
+            : new Set(firstValuePhaseStages(selectedStages).map((s) => s.meta.key));
+        const firstPhaseWrapped = wrappedStages.filter((s) => firstPhaseKeys.has(s.meta.key));
+        const remainderWrapped = wrappedStages.filter((s) => !firstPhaseKeys.has(s.meta.key));
+
+        const pipelineOpts = {
+            ...(deadlineMs === undefined ? {} : { deadlineMs }),
+            recordStageOutcome: recordRunnerStageOutcome(runId, write),
+        };
+
+        const runPhases = Effect.gen(function* () {
+            if (firstPhaseWrapped.length === 0 || remainderWrapped.length === 0) {
+                return yield* runPipeline(wrappedStages, ctx, write, pipelineOpts);
+            }
+            // Phase 1, run to completion - every OTHER stage fiber is paused
+            // (not started) until this whole call resolves, which is what
+            // makes the publish right after safe: nothing else can be
+            // writing on this connection while it runs.
+            const firstPhaseStats = yield* runPipeline(firstPhaseWrapped, ctx, write, pipelineOpts);
+            // Only the turn FTS target - the final ingest still builds every
+            // target (see below); a first snapshot is for `ax recall` over
+            // turns, not the much smaller commit table.
+            yield* buildFtsIndexes(write, [TURN_FTS_TARGET]);
+            yield* write.publishIntermediateSnapshot();
+            // Phase 2, the remaining stages - only starts now, after the
+            // publish above has already been awaited.
+            const remainderStats = yield* runPipeline(remainderWrapped, ctx, write, pipelineOpts);
+            return [...firstPhaseStats, ...remainderStats];
+        });
+
+        const stageStats = yield* runPhases.pipe(
             LiveTrace.withTrace({
                 traceId: `ingest:${runId}`,
                 label: `ingest ${selectedStages.map((s) => s.meta.key).join(",")}`,

--- a/apps/axctl/src/ingest/stage/registry.test.ts
+++ b/apps/axctl/src/ingest/stage/registry.test.ts
@@ -77,6 +77,11 @@ describe("StageRegistry", () => {
         expect(uniqueKeys.size).toBe(keys.length);
     });
 
+    it("marks exactly the six normalized transcript providers as firstValue (#833)", () => {
+        const firstValueKeys = ALL_STAGES.filter((s) => s.meta.firstValue === true).map((s) => s.meta.key);
+        expect(firstValueKeys.sort()).toEqual(["claude", "codex", "cursor", "omp", "opencode", "pi"]);
+    });
+
     it("all stage deps reference valid stage keys (deps-validity guard)", () => {
         const keySet = new Set(ALL_STAGES.map((s) => s.meta.key));
         const invalid: Array<{ stage: string; dep: string }> = [];

--- a/apps/axctl/src/ingest/stage/select.test.ts
+++ b/apps/axctl/src/ingest/stage/select.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
 import { StageRegistry, StageRegistryLive } from "./registry.ts";
-import { selectByKeys, selectByTag } from "./select.ts";
+import { firstValuePhaseStages, selectByKeys, selectByTag } from "./select.ts";
 import { BaseStageStats, StageMeta, type StageDef } from "./types.ts";
 
-const stage = (key: string, tags: string[], deps: string[] = []): StageDef => ({
-    meta: StageMeta.make({ key, deps, tags: tags as never, writes: [] }),
+const stage = (
+    key: string,
+    tags: string[],
+    deps: string[] = [],
+    firstValue?: boolean,
+): StageDef => ({
+    meta: StageMeta.make({ key, deps, tags: tags as never, writes: [], ...(firstValue === undefined ? {} : { firstValue }) }),
     run: () => Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: key })),
 });
 
@@ -47,5 +52,57 @@ describe("selectByTag", () => {
         const Live = StageRegistryLive(fixture);
         const out = await Effect.runPromise(program.pipe(Effect.provide(Live)));
         expect(out.map((s) => s.meta.key)).toEqual(["signals"]);
+    });
+});
+
+describe("firstValuePhaseStages", () => {
+    it("returns only firstValue-marked stages plus their transitive deps, in original order", () => {
+        const stages = [
+            stage("skills", ["ingest"]),
+            stage("commands", ["ingest"]),
+            stage("pricing", ["ingest"]),
+            stage("claude", ["ingest"], ["skills", "commands", "pricing"], true),
+            stage("git", ["ingest"]),
+            stage("signals", ["derive"], ["claude"]),
+        ];
+        const out = firstValuePhaseStages(stages);
+        expect(out.map((s) => s.meta.key)).toEqual(["skills", "commands", "pricing", "claude"]);
+    });
+
+    it("returns an empty array when no stage is marked firstValue", () => {
+        const stages = [stage("skills", ["ingest"]), stage("git", ["ingest"], ["skills"])];
+        expect(firstValuePhaseStages(stages)).toEqual([]);
+    });
+
+    it("walks multi-level transitive deps", () => {
+        const stages = [
+            stage("skills", ["ingest"]),
+            stage("agent-def", ["ingest"], ["skills"]),
+            stage("claude-config", ["ingest"], ["agent-def"]),
+            stage("claude", ["ingest"], ["claude-config"], true),
+        ];
+        const out = firstValuePhaseStages(stages);
+        expect(out.map((s) => s.meta.key)).toEqual(["skills", "agent-def", "claude-config", "claude"]);
+    });
+
+    it("ignores a dep that is outside the given stage set (already handled by selected-stage filters)", () => {
+        // "pricing" is a dep of "claude" but was filtered out of `stages` upstream
+        // (e.g. by --stages=), so it must not appear here or crash the walk.
+        const stages = [
+            stage("skills", ["ingest"]),
+            stage("claude", ["ingest"], ["skills", "pricing"], true),
+        ];
+        const out = firstValuePhaseStages(stages);
+        expect(out.map((s) => s.meta.key)).toEqual(["skills", "claude"]);
+    });
+
+    it("does not duplicate a stage that is both firstValue and a shared dep", () => {
+        const stages = [
+            stage("skills", ["ingest"]),
+            stage("claude", ["ingest"], ["skills"], true),
+            stage("codex", ["ingest"], ["skills"], true),
+        ];
+        const out = firstValuePhaseStages(stages);
+        expect(out.map((s) => s.meta.key)).toEqual(["skills", "claude", "codex"]);
     });
 });

--- a/apps/axctl/src/ingest/stage/select.ts
+++ b/apps/axctl/src/ingest/stage/select.ts
@@ -27,3 +27,35 @@ export const selectByTag = (
     tag: IngestStageTag,
 ): ReadonlyArray<StageDef<BaseStageStats, unknown, IngestStageError>> =>
     registry.byTag(tag);
+
+/**
+ * The cold-start FIRST-VALUE phase (#833): every stage marked
+ * `meta.firstValue === true` in `stages`, plus their transitive deps -
+ * walked within `stages` ONLY, so a caller's own selection (`--stages=`,
+ * `--derive-only`) is respected rather than reached around. A dep that was
+ * filtered out of `stages` upstream is silently skipped, exactly like
+ * `runPipeline`'s own dep-await does (it only waits on deps present in the
+ * stage set it was given).
+ *
+ * Returned in `stages`' original relative order - already topologically
+ * sound for `runPipeline` (deps precede dependents in every real stage
+ * list), and preserving it keeps this a pure filter rather than a second
+ * sort with its own chance to disagree with the registry.
+ */
+export const firstValuePhaseStages = <S extends BaseStageStats, R, E>(
+    stages: ReadonlyArray<StageDef<S, R, E>>,
+): ReadonlyArray<StageDef<S, R, E>> => {
+    const byKey = new Map(stages.map((s) => [s.meta.key, s] as const));
+    const included = new Set<string>();
+    const visit = (key: string): void => {
+        if (included.has(key)) return;
+        const found = byKey.get(key);
+        if (found === undefined) return;
+        included.add(key);
+        for (const dep of found.meta.deps) visit(dep);
+    };
+    for (const s of stages) {
+        if (s.meta.firstValue === true) visit(s.meta.key);
+    }
+    return stages.filter((s) => included.has(s.meta.key));
+};

--- a/apps/axctl/src/ingest/stage/types.test.ts
+++ b/apps/axctl/src/ingest/stage/types.test.ts
@@ -30,6 +30,27 @@ describe("StageMeta", () => {
         expect(decoded.key).toBe("signals");
         expect(decoded.writes[0]?.mode).toBe("derive");
     });
+
+    it("leaves firstValue undefined when omitted (not a first-value provider)", () => {
+        const decoded = Schema.decodeUnknownSync(StageMeta)({
+            key: "signals",
+            deps: [],
+            tags: ["derive"],
+            writes: [],
+        });
+        expect(decoded.firstValue).toBeUndefined();
+    });
+
+    it("marks a stage as a first-value provider", () => {
+        const decoded = Schema.decodeUnknownSync(StageMeta)({
+            key: "claude",
+            deps: [],
+            tags: ["ingest"],
+            writes: [],
+            firstValue: true,
+        });
+        expect(decoded.firstValue).toBe(true);
+    });
 });
 
 describe("IngestContext", () => {

--- a/apps/axctl/src/ingest/stage/types.ts
+++ b/apps/axctl/src/ingest/stage/types.ts
@@ -79,6 +79,26 @@ export class StageMeta extends Schema.Class<StageMeta>("StageMeta")({
     deps: Schema.Array(Schema.String),
     tags: Schema.Array(IngestStageTag),
     writes: Schema.Array(TableWrite),
+    /**
+     * Marks a stage as a FIRST-VALUE provider for the cold-start intermediate
+     * publish (#833): the SIX normalized transcript providers (claude, codex,
+     * pi, omp, opencode, cursor) that turn raw transcripts into `session`/
+     * `turn`/`tool_call` rows, and nothing else.
+     *
+     * Deliberately its OWN field rather than reusing `tags` (`"ingest"` also
+     * covers skills/commands/pricing/git/github-pr - not what a first
+     * usable snapshot needs) or a `writes` MODE (`"parse"` covers every
+     * event-layer writer, including catalog stages this phase must still
+     * wait on as DEPS but not select for on their own). Those two carry
+     * mixed meanings; this field carries exactly one.
+     *
+     * `undefined`/`false` (the default - most stages omit this field
+     * entirely) means "not a first-value provider". The cold-start phase
+     * that reads this (`firstValuePhaseStages` in `./select.ts`) also pulls
+     * in each marked stage's transitive deps, so skills/commands/pricing
+     * still run before claude/codex do.
+     */
+    firstValue: Schema.optional(Schema.Boolean),
 }) {}
 
 /** A stage = metadata + a typed Effect runner. `R` is the union of Effect

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -2078,6 +2078,7 @@ export const claudeStage: StageDef<ClaudeStats, AxConfig | FileSystem.FileSystem
         key: "claude",
         deps: ["skills", "commands", "pricing"],
         tags: ["ingest"],
+        firstValue: true,
         writes: [
             ...NORMALIZED_BATCH_WRITES,
             { table: "session_token_usage", mode: "parse" },

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -38,6 +38,11 @@ const dylibEnv = <A>(body: () => Promise<A>): Promise<A> => {
 };
 
 const DDL = `
+-- Mirrors the real schema's session table just enough for the empty-publish
+-- guard (publishWouldNotDestroyData counts rows here, not "skill").
+CREATE TABLE IF NOT EXISTS session (
+    id VARCHAR PRIMARY KEY
+);
 CREATE TABLE IF NOT EXISTS skill (
     id VARCHAR PRIMARY KEY,
     name VARCHAR NOT NULL,
@@ -667,6 +672,93 @@ describe("CacheWrite: publish", () => {
                 _tag: "completed",
                 value: [{ id: "run-1", body: "status=partial" }],
             });
+        });
+    });
+});
+
+describe("CacheWrite: publishIntermediateSnapshot (#833)", () => {
+    dtest("publishes what has been written so far, mid-body, before the body returns", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-intermediate-publish-");
+            await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("skill", { id: "s1", name: "first phase" });
+                        yield* write.publishIntermediateSnapshot();
+                        // A snapshot exists and is readable RIGHT NOW, while this
+                        // body effect is still running (nothing has returned yet).
+                        expect(existsSync(p.snapshotPath)).toBe(true);
+                        const seenMidRun = yield* Effect.gen(function* () {
+                            const read = yield* CacheRead;
+                            return yield* read.rows(SkillRow, "SELECT id, name, ingested_at FROM skill");
+                        }).pipe(Effect.provide(CacheReadLayer({ snapshotPath: p.snapshotPath })));
+                        expect(seenMidRun.map((r) => r.name)).toEqual(["first phase"]);
+                    }),
+                ),
+            );
+        });
+    });
+
+    dtest("does not disable the automatic final publish - later writes still land", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-intermediate-then-final-");
+            await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("skill", { id: "s1", name: "first phase" });
+                        yield* write.publishIntermediateSnapshot();
+                        yield* write.put("skill", { id: "s2", name: "second phase" });
+                    }),
+                ),
+            );
+            const found = await run(
+                Effect.gen(function* () {
+                    const read = yield* CacheRead;
+                    return yield* read.rows(SkillRow, "SELECT id, name, ingested_at FROM skill ORDER BY id");
+                }).pipe(Effect.provide(CacheReadLayer({ snapshotPath: p.snapshotPath }))),
+            );
+            expect(found.map((r) => r.name)).toEqual(["first phase", "second phase"]);
+        });
+    });
+
+    dtest("honors the same empty-publish guard as the final publish", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-intermediate-empty-guard-");
+            // A populated snapshot already exists (the guard counts `session` rows).
+            await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("session", { id: "sess-1" });
+                        yield* write.put("skill", { id: "s1", name: "good" });
+                    }),
+                ),
+            );
+            const before = readFileSync(p.snapshotPath);
+
+            // A SEPARATE, genuinely empty live database (same snapshot target)
+            // tries to publish intermediately - the shape the guard exists for.
+            await run(
+                withIngestLock(
+                    {
+                        lockPath: p.lockPath,
+                        command: "seam-test-empty-intermediate",
+                        staleMs: 60_000,
+                        onBusy: () => Effect.succeed("busy" as const),
+                    },
+                    withCacheWrite(
+                        {
+                            livePath: join(p.dir, "live-empty.duckdb"),
+                            lockPath: p.lockPath,
+                            snapshotPath: p.snapshotPath,
+                            schemaSql: DDL,
+                            publish: false,
+                        },
+                        (write) => write.publishIntermediateSnapshot(),
+                    ),
+                ),
+            );
+
+            expect(readFileSync(p.snapshotPath).equals(before)).toBe(true);
         });
     });
 });

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -160,6 +160,26 @@ export interface CacheWriteService extends CacheReadService {
     readonly rowsCollapsed: () => ReadonlyMap<string, number>;
     /** The live database being written (not the snapshot). */
     readonly livePath: string;
+    /**
+     * Publish a snapshot from THIS connection's current state, right now,
+     * without waiting for the write body to finish. Runs the exact same path
+     * `withCacheWrite`'s own on-success publish runs (same empty-publish
+     * guard via {@link publishWouldNotDestroyData}, same
+     * `DuckDbService.publishSnapshot(..., { from: conn })` call) - so it sees
+     * exactly what has been committed on this connection so far, nothing
+     * more, and it will not clobber a populated snapshot with an empty
+     * database any more than the final publish would.
+     *
+     * NARROW BY DESIGN, not a general "publish whenever" escape hatch. Its
+     * one sanctioned caller is the cold-start intermediate publish in
+     * `runIngest` (#833): after the first-value provider stages
+     * (claude/codex/pi/omp/opencode/cursor + their deps) finish and every
+     * OTHER stage fiber is paused, so nothing else can write to this
+     * connection while the snapshot is being staged. Calling it while other
+     * writers are still active is a torn-read hazard - the guard here
+     * protects against an EMPTY publish, not a partial one.
+     */
+    readonly publishIntermediateSnapshot: () => Effect.Effect<void, CacheWriteError>;
 }
 
 /** Running totals of writer-side NUL stripping for one `withCacheWrite` body. */
@@ -663,7 +683,8 @@ export const withCacheWrite = <A, E, R>(
                         }
                     }
 
-                    const write = writerOver(conn, options.livePath, target);
+                    const publishNow = () => publishSnapshotNow(fs, opened.db, conn, options.livePath, target);
+                    const write = writerOver(conn, options.livePath, target, publishNow);
                     // Reported on EVERY exit path (`ensuring`), not just a
                     // successful one: a body that scrubbed rows and then failed
                     // for an unrelated reason still changed data on the way
@@ -678,14 +699,12 @@ export const withCacheWrite = <A, E, R>(
                     // leave the previous snapshot exactly as it was. A
                     // maintenance caller opts OUT entirely (see `publish`) -
                     // its body succeeding says nothing about the state of the
-                    // database it would be publishing.
+                    // database it would be publishing. Same helper the
+                    // service's own `publishIntermediateSnapshot` calls, so
+                    // both paths share one empty-publish guard and one
+                    // `publishSnapshot` call site.
                     if (options.publish !== false) {
-                        const safe = yield* publishWouldNotDestroyData(fs, conn, target);
-                        if (safe) {
-                            yield* opened.db
-                                .publishSnapshot(options.livePath, target, { from: conn })
-                                .pipe(Effect.mapError((err) => toPublishError(err, target)));
-                        }
+                        yield* publishNow();
                     }
                     return value;
                 }),
@@ -831,11 +850,36 @@ const toPublishError = (
         ? err
         : new SnapshotPublishError({ snapshotPath: target, message: err.message });
 
+/**
+ * THE ONE PUBLISH CALL SITE. Runs the empty-publish guard, then (only if it
+ * passes) `DuckDbService.publishSnapshot(..., { from: conn })` on the
+ * caller's already-open connection - see RULING R14 in this module's header
+ * for why `from: conn` is load-bearing. Shared by `withCacheWrite`'s
+ * on-success publish and `CacheWriteService.publishIntermediateSnapshot`, so
+ * neither can drift from the other's safety checks.
+ */
+const publishSnapshotNow = (
+    fs: FileSystem.FileSystem,
+    db: DuckDbService,
+    conn: DuckDbConnection,
+    livePath: string,
+    target: string,
+): Effect.Effect<void, CacheWriteError> =>
+    Effect.gen(function* () {
+        const safe = yield* publishWouldNotDestroyData(fs, conn, target);
+        if (safe) {
+            yield* db
+                .publishSnapshot(livePath, target, { from: conn })
+                .pipe(Effect.mapError((err) => toPublishError(err, target)));
+        }
+    });
+
 /** Build the write service over an open read-write connection. */
 const writerOver = (
     conn: DuckDbConnection,
     livePath: string,
     target: string,
+    publishIntermediateSnapshot: () => Effect.Effect<void, CacheWriteError>,
 ): CacheWriteService => {
     // The writer owns exactly one connection for its whole lifetime, so
     // "borrowing" it is just calling with it - no identity check, no reopen: a
@@ -992,5 +1036,5 @@ const writerOver = (
     const nulStripped = (): NulStripTotals => ({ values: nulValues, statements: nulStatements });
     const rowsCollapsed = (): ReadonlyMap<string, number> => new Map(collapsedRows);
 
-    return { ...reader, exec, put, putMany, nulStripped, rowsCollapsed, livePath };
+    return { ...reader, exec, put, putMany, nulStripped, rowsCollapsed, livePath, publishIntermediateSnapshot };
 };


### PR DESCRIPTION
Fixes #833

## Summary

- Add explicit first-value stage metadata for the six normalized transcript providers.
- Run those providers and their selected dependencies as a cold-start phase.
- Publish the first snapshot only when no snapshot existed at run start.
- Build the turn FTS index before that publish.
- Keep existing warm-run and final-publish failure safety.
- Reuse one guarded publish path on the same writer connection.

## Safety

The first phase completes before the second phase starts. No stage can write during the intermediate publish. An existing snapshot is never replaced before full success.

## Verification

- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- focused ingest and DuckDB tests: 70 pass
- write contract tests: 13 pass
- full repository tests with required FTS DuckDB: 6507 pass, 12 gated skips, 0 fail

---

_Generated with [ax](https://github.com/Necmttn/ax)._
