### PR TITLE
fix(ingest): bound reparse memory pressure

### DIFF
--- a/apps/axctl/src/ingest/derive-signals.chunk.test.ts
+++ b/apps/axctl/src/ingest/derive-signals.chunk.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect } from "bun:test";
 import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { deriveSignals, SESSION_BATCH_SIZE, type DeriveStats } from "./derive-signals.ts";
@@ -45,7 +46,7 @@ const runFixture = (): Promise<DeriveStats> =>
                         text_excerpt: "work",
                     })));
                 yield* write.putMany("turn", turns);
-                stats = yield* deriveSignals(write, {});
+                stats = yield* deriveSignals(write, {}).pipe(Effect.provide(BunFileSystem.layer));
             }));
         if (stats === undefined) return yield* Effect.die("fixture body did not run");
         return stats;

--- a/apps/axctl/src/ingest/derive-signals.failed-tools-chunk.test.ts
+++ b/apps/axctl/src/ingest/derive-signals.failed-tools-chunk.test.ts
@@ -18,6 +18,7 @@
  */
 import { describe, expect } from "bun:test";
 import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { deriveSignals, SESSION_BATCH_SIZE, type DeriveStats } from "./derive-signals.ts";
@@ -64,7 +65,7 @@ const runFixture = (): Promise<DeriveStats> =>
                     exit_code: 1n,
                 }));
                 yield* write.putMany("tool_call", toolCalls);
-                stats = yield* deriveSignals(write, {});
+                stats = yield* deriveSignals(write, {}).pipe(Effect.provide(BunFileSystem.layer));
             }));
         if (stats === undefined) return yield* Effect.die("fixture body did not run");
         return stats;

--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -1,8 +1,9 @@
-import { Effect, Schema } from "effect";
+import { Effect, FileSystem, PlatformError, Schema } from "effect";
 import { SkillName } from "@ax/lib/brands";
 import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
 import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
+import { makeTableSpool, withTableSpool } from "@ax/lib/duckdb/spool";
 import { edgeRowId } from "@ax/lib/stable-id";
 import {
     deriveCorrections, deriveDiagnosticsFromToolCalls,
@@ -11,11 +12,12 @@ import {
     groupTurnsBySession, shouldDeriveAllTimeSkillPairs,
 } from "./signals/core.ts";
 import type {
-    CorrectionEdge, DerivedDiagnosticEvent, DerivedFrictionEvent, ProposedEdge, RecoveryEdge,
+    CorrectionEdge, ProposedEdge, RecoveryEdge,
     SessionTurns, SkillPairAccum, ToolCallLike,
 } from "./signals/types.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
+import { skipPlatformStage } from "./platform-stage.ts";
 
 // Derivation rules live in ./signals/core.ts (pure, fixture-tested by
 // signals/core.test.ts); this file is stage wiring only: SELECTs, the
@@ -34,7 +36,17 @@ import type { StageDef } from "./stage/registry.ts";
  * (`pairsAccum`, `correctionBatch`, ...) live in `deriveSignals`, so partial
  * chunks still sum to the same result the single fetch produced.
  */
-export const SESSION_BATCH_SIZE = 200;
+export const SESSION_BATCH_SIZE = 25;
+
+const SIGNALS_SPOOL_TABLES = [
+    "corrected_by",
+    "proposed",
+    "recovered_by",
+    "skill_paired",
+    "friction_event",
+    "diagnostic_event",
+] as const;
+const SIGNALS_SPOOL_FLUSH_ROWS = 25_000;
 
 /** Group an ordered id list into fixed-size chunks. */
 const chunk = <A>(items: ReadonlyArray<A>, size: number): A[][] => {
@@ -71,10 +83,9 @@ ORDER BY t.session ASC`;
 
 /**
  * Fetch the (session → turns) bundles for a bounded set of session ids. Each
- * turn carries its outgoing `->invoked->skill.name` array so we can detect
- * "proposed but not invoked" without a second query. Same window filter as the
- * id pass, so a session partially in-window contributes only its in-window
- * turns - exactly what the old single fetch did.
+ * The turn rows and invoked-skill edges use separate queries. The former
+ * grouped join built a large native list aggregate before returning any rows.
+ * That query still crashed Bun for one 49k-turn session after session chunking.
  */
 const fetchSessionTurnsForIds = (
     write: CacheWriteService,
@@ -84,29 +95,42 @@ const fetchSessionTurnsForIds = (
     Effect.gen(function* () {
         if (sessionIds.length === 0) return [];
         const placeholders = sessionIds.map(() => "?").join(", ");
-        const sql = `
+        const turnsSql = `
 SELECT
     t.id, t.session, t.seq, t.role, t.text_excerpt, t.ts, t.has_error,
-    s.repository, s.checkout, s.cwd,
-    COALESCE(to_json(list(DISTINCT sk.name) FILTER (WHERE sk.name IS NOT NULL))::VARCHAR, '[]') AS invoked_skills
+    s.repository, s.checkout, s.cwd
 FROM turn t JOIN session s ON s.id = t.session
-LEFT JOIN invoked i ON i.in_id = t.id LEFT JOIN skill sk ON sk.id = i.out_id
 WHERE t.session IN (${placeholders}) ${turnSinceClause(sinceDays, "AND")}
-GROUP BY t.id, t.session, t.seq, t.role, t.text_excerpt, t.ts, t.has_error, s.repository, s.checkout, s.cwd
 ORDER BY t.session ASC, t.seq ASC`;
         const rows = yield* write.rows(Schema.Struct({
             id: Schema.String, session: Schema.String, seq: NumberFromBigIntColumn, role: Schema.String,
             text_excerpt: Schema.NullOr(Schema.String), ts: TimestampColumn, has_error: Schema.Boolean,
             repository: Schema.NullOr(Schema.String), checkout: Schema.NullOr(Schema.String),
-            cwd: Schema.NullOr(Schema.String), invoked_skills: Schema.String,
-        }), sql, [...sessionIds]);
+            cwd: Schema.NullOr(Schema.String),
+        }), turnsSql, [...sessionIds]);
+        const invokedRows = yield* write.rows(Schema.Struct({
+            turn_id: Schema.String,
+            skill_name: Schema.String,
+        }), `
+SELECT DISTINCT i.in_id AS turn_id, sk.name AS skill_name
+FROM invoked i
+JOIN skill sk ON sk.id = i.out_id
+JOIN turn t ON t.id = i.in_id
+WHERE t.session IN (${placeholders}) ${turnSinceClause(sinceDays, "AND")}
+ORDER BY i.in_id, sk.name`, [...sessionIds]);
+        const invokedByTurn = new Map<string, SkillName[]>();
+        for (const row of invokedRows) {
+            const names = invokedByTurn.get(row.turn_id) ?? [];
+            names.push(SkillName.make(row.skill_name));
+            invokedByTurn.set(row.turn_id, names);
+        }
         const mapped = rows.map((row) => ({
             id: row.id, session: row.session, seq: row.seq, role: row.role,
             text_excerpt: row.text_excerpt ?? undefined, ts: row.ts, has_error: row.has_error,
             ...(row.repository === null ? {} : { repository: row.repository }),
             ...(row.checkout === null ? {} : { checkout: row.checkout }),
             ...(row.cwd === null ? {} : { cwd: row.cwd }),
-            invoked_skills: (JSON.parse(row.invoked_skills) as string[]).map((name) => SkillName.make(name)),
+            invoked_skills: invokedByTurn.get(row.id) ?? [],
         }));
         return groupTurnsBySession(mapped);
     });
@@ -194,6 +218,10 @@ export interface DeriveOpts {
 
 export const deriveSignals = Effect.fn("derive.signals")(
     function* (write: CacheWriteService, opts: Partial<DeriveOpts> = {}) {
+        const fs = yield* FileSystem.FileSystem;
+        const spoolDir = yield* fs.makeTempDirectory({ prefix: "ax-spool-signals-" });
+        const spool = makeTableSpool({ tables: SIGNALS_SPOOL_TABLES, dir: spoolDir });
+        const spooledWrite = withTableSpool(write, spool);
         const skillNames = yield* fetchSkillNames(write).pipe(
             Effect.withSpan("signals.fetch-skills"),
         );
@@ -214,24 +242,23 @@ export const deriveSignals = Effect.fn("derive.signals")(
         let recoveries = 0;
         let sessionsSeen = 0;
 
-        const correctionBatch: CorrectionEdge[] = [];
-        const proposedBatch: ProposedEdge[] = [];
-        const recoveryBatch: RecoveryEdge[] = [];
-        // Folded into the session-chunk loop below (#1043): each chunk's error
-        // tool_calls are fetched and turned into events immediately, so the
-        // full error corpus never sits in the heap at once the way a single
-        // post-loop fetch did. Only these (much smaller) derived-event
-        // batches accumulate across chunks.
-        const toolFrictionBatch: DerivedFrictionEvent[] = [];
-        const diagnosticBatch: DerivedDiagnosticEvent[] = [];
+        let frictionEvents = 0;
+        let diagnosticEvents = 0;
         const pairsAccum = new Map<string, SkillPairAccum>();
         // Skill pairs are all-time aggregates - a --since-scoped derive must
         // not clobber them. Hoisted above the loop so we neither accumulate
         // pairs we'd discard nor report a mid-loop count that resets to 0.
         // Mirrors the includeSkillPairs gate in core's deriveSignalsFromEvidence.
         const shouldWriteSkillPairs = shouldDeriveAllTimeSkillPairs(opts.sinceDays);
+        if (shouldWriteSkillPairs) {
+            yield* write.exec("DELETE FROM friction_event");
+            yield* write.exec("DELETE FROM diagnostic_event").pipe(Effect.withSpan("signals.clear.derived-events"));
+        }
 
         for (const idChunk of chunk(sessionIds, SESSION_BATCH_SIZE)) {
+            const chunkCorrections: CorrectionEdge[] = [];
+            const chunkProposed: ProposedEdge[] = [];
+            const chunkRecoveries: RecoveryEdge[] = [];
             const bundles = yield* fetchSessionTurnsForIds(write, idChunk, opts.sinceDays).pipe(
                 Effect.withSpan("signals.fetch-turns", {
                     attributes: { "signals.chunk_sessions": idChunk.length },
@@ -246,9 +273,9 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 corrections += c.length;
                 proposedSkillEdges += p.length;
                 recoveries += r.length;
-                correctionBatch.push(...c);
-                proposedBatch.push(...p);
-                recoveryBatch.push(...r);
+                chunkCorrections.push(...c);
+                chunkProposed.push(...p);
+                chunkRecoveries.push(...r);
                 if (shouldWriteSkillPairs) deriveSkillPairs(bundle, pairsAccum);
                 if (opts.onProgress && (sessionsSeen <= 5 || sessionsSeen % 50 === 0)) {
                     yield* opts.onProgress({
@@ -273,8 +300,38 @@ export const deriveSignals = Effect.fn("derive.signals")(
                     attributes: { "signals.chunk_sessions": idChunk.length },
                 }),
             );
-            toolFrictionBatch.push(...deriveFrictionFromToolCalls(chunkFailedToolCalls));
-            diagnosticBatch.push(...deriveDiagnosticsFromToolCalls(chunkFailedToolCalls));
+            const chunkFriction = [
+                ...deriveFrictionFromToolCalls(chunkFailedToolCalls),
+                ...deriveFrictionFromCorrections(chunkCorrections),
+            ];
+            const chunkDiagnostics = deriveDiagnosticsFromToolCalls(chunkFailedToolCalls);
+            yield* spooledWrite.putMany("corrected_by", chunkCorrections.map((edge) => cacheRow({
+                id: edgeRowId("corrected_by", edge.fromTurnKey, edge.toTurnKey), in_id: edge.fromTurnKey,
+                out_id: edge.toTurnKey, pattern: edge.pattern, ts: tsParam(edge.ts) ?? new Date(),
+            })));
+            const wasCorrectedTurnKeys = correctedInvokedTurnKeys(chunkCorrections);
+            for (const key of wasCorrectedTurnKeys) yield* write.exec("UPDATE invoked SET was_corrected = true WHERE in_id = ?", [key]);
+            yield* spooledWrite.putMany("proposed", chunkProposed.map((edge) => cacheRow({
+                id: edgeRowId("proposed", edge.fromTurnKey, edge.skillKey), in_id: edge.fromTurnKey,
+                out_id: edge.skillKey, ts: tsParam(edge.ts) ?? new Date(), context_excerpt: edge.contextExcerpt,
+            })));
+            yield* spooledWrite.putMany("recovered_by", chunkRecoveries.map((edge) => cacheRow({
+                id: edgeRowId("recovered_by", edge.fromTurnKey, edge.skillKey), in_id: edge.fromTurnKey,
+                out_id: edge.skillKey, ts: tsParam(edge.ts) ?? new Date(), error_excerpt: edge.errorExcerpt ?? null,
+            })));
+            yield* spooledWrite.putMany("friction_event", chunkFriction.map((event) => cacheRow({
+                id: event.key, session: event.sessionId, turn: event.turnKey, kind: event.kind,
+                text: event.text, labels: jsonParam(event.labels), metrics: jsonParam(event.metrics),
+                raw: jsonParam(event.raw), ts: tsParam(event.ts) ?? new Date(),
+            })));
+            yield* spooledWrite.putMany("diagnostic_event", chunkDiagnostics.map((event) => cacheRow({
+                id: event.key, session: event.sessionId, turn: event.turnKey, kind: event.kind,
+                status: event.status, text: event.text, labels: jsonParam(event.labels),
+                metrics: jsonParam(event.metrics), raw: jsonParam(event.raw), ts: tsParam(event.ts) ?? new Date(),
+            })));
+            frictionEvents += chunkFriction.length;
+            diagnosticEvents += chunkDiagnostics.length;
+            if (spool.pendingRows() >= SIGNALS_SPOOL_FLUSH_ROWS) yield* spool.flush(write);
         }
 
         const pairsList = shouldWriteSkillPairs
@@ -290,13 +347,6 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 skillPairs: pairsList.length,
             });
         }
-        // `toolFrictionBatch` / `diagnosticBatch` were built chunk-by-chunk in
-        // the loop above (#1043); `correctionBatch` still accumulates across
-        // the whole run (it's small - one row per correction, not one per
-        // error tool_call), so its friction derivation stays here, post-loop,
-        // exactly as before.
-        const correctionFrictionBatch = deriveFrictionFromCorrections(correctionBatch);
-        const frictionBatch = [...toolFrictionBatch, ...correctionFrictionBatch];
         if (opts.onProgress) {
             yield* opts.onProgress({
                 sessions: totalSessions,
@@ -305,38 +355,12 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 proposedSkillEdges,
                 recoveries,
                 skillPairs: pairsList.length,
-                frictionEvents: frictionBatch.length,
-                diagnosticEvents: diagnosticBatch.length,
+                frictionEvents,
+                diagnosticEvents,
             });
         }
-
-        yield* write.putMany("corrected_by", correctionBatch.map((edge) => cacheRow({
-            id: edgeRowId("corrected_by", edge.fromTurnKey, edge.toTurnKey), in_id: edge.fromTurnKey,
-            out_id: edge.toTurnKey, pattern: edge.pattern, ts: tsParam(edge.ts) ?? new Date(),
-        }))).pipe(
-            Effect.withSpan("signals.write.corrections", {
-                attributes: { "signals.count": correctionBatch.length },
-            }),
-        );
-        // Denormalise was_corrected onto invoked edges so cmdTaste's
-        // corrections subquery becomes a pure index/scan filter (issue #31).
-        const wasCorrectedTurnKeys = correctedInvokedTurnKeys(correctionBatch);
-        for (const key of wasCorrectedTurnKeys) yield* write.exec("UPDATE invoked SET was_corrected = true WHERE in_id = ?", [key]);
-        yield* Effect.void.pipe(
-            Effect.withSpan("signals.write.was-corrected", {
-                attributes: { "signals.count": wasCorrectedTurnKeys.length },
-            }),
-        );
-        yield* write.putMany("proposed", proposedBatch.map((edge) => cacheRow({
-            id: edgeRowId("proposed", edge.fromTurnKey, edge.skillKey), in_id: edge.fromTurnKey,
-            out_id: edge.skillKey, ts: tsParam(edge.ts) ?? new Date(), context_excerpt: edge.contextExcerpt,
-        }))).pipe(
-            Effect.withSpan("signals.write.proposed", {
-                attributes: { "signals.count": proposedBatch.length },
-            }),
-        );
         if (shouldWriteSkillPairs) {
-            yield* write.putMany("skill_paired", pairsList.map(({ edgeId, pair }) => cacheRow({
+            yield* spooledWrite.putMany("skill_paired", pairsList.map(({ edgeId, pair }) => cacheRow({
                 id: edgeId, in_id: pair.fromKey, out_id: pair.toKey, count: pair.count,
                 last_seen: tsParam(pair.lastSeen) ?? new Date(),
             }))).pipe(
@@ -345,42 +369,8 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 }),
             );
         }
-        yield* write.putMany("recovered_by", recoveryBatch.map((edge) => cacheRow({
-            id: edgeRowId("recovered_by", edge.fromTurnKey, edge.skillKey), in_id: edge.fromTurnKey,
-            out_id: edge.skillKey, ts: tsParam(edge.ts) ?? new Date(), error_excerpt: edge.errorExcerpt ?? null,
-        }))).pipe(
-            Effect.withSpan("signals.write.recovered", {
-                attributes: { "signals.count": recoveryBatch.length },
-            }),
-        );
-        // On a FULL re-derive, clear the standalone derived-event tables before
-        // re-inserting so a row the current logic no longer emits cannot orphan
-        // with a stale ts (#549). `shouldWriteSkillPairs` is exactly the
-        // full-derive gate (sinceDays undefined / <=0); a --since run keeps the
-        // UPSERT-only path so it never drops rows whose source is out of window.
-        if (shouldWriteSkillPairs) {
-            yield* write.exec("DELETE FROM friction_event");
-            yield* write.exec("DELETE FROM diagnostic_event").pipe(Effect.withSpan("signals.clear.derived-events"));
-        }
-        yield* write.putMany("friction_event", frictionBatch.map((event) => cacheRow({
-            id: event.key, session: event.sessionId, turn: event.turnKey, kind: event.kind,
-            text: event.text, labels: jsonParam(event.labels), metrics: jsonParam(event.metrics),
-            raw: jsonParam(event.raw), ts: tsParam(event.ts) ?? new Date(),
-        }))).pipe(
-            Effect.withSpan("signals.write.friction", {
-                attributes: { "signals.count": frictionBatch.length },
-            }),
-        );
-        yield* write.putMany("diagnostic_event", diagnosticBatch.map((event) => cacheRow({
-            id: event.key, session: event.sessionId, turn: event.turnKey, kind: event.kind,
-            status: event.status, text: event.text, labels: jsonParam(event.labels),
-            metrics: jsonParam(event.metrics), raw: jsonParam(event.raw), ts: tsParam(event.ts) ?? new Date(),
-        }))).pipe(
-            Effect.withSpan("signals.write.diagnostics", {
-                attributes: { "signals.count": diagnosticBatch.length },
-            }),
-        );
-
+        yield* spool.flush(write);
+        yield* fs.remove(spoolDir, { recursive: true }).pipe(Effect.ignore);
         yield* Effect.logDebug("signals derived", {
             sessions: totalSessions,
             turns: turnCount,
@@ -388,8 +378,8 @@ export const deriveSignals = Effect.fn("derive.signals")(
             proposedSkillEdges,
             skillPairs: pairsList.length,
             recoveries,
-            frictionEvents: frictionBatch.length,
-            diagnosticEvents: diagnosticBatch.length,
+            frictionEvents,
+            diagnosticEvents,
         });
         return {
             sessions: totalSessions,
@@ -398,8 +388,8 @@ export const deriveSignals = Effect.fn("derive.signals")(
             proposedSkillEdges,
             skillPairs: pairsList.length,
             recoveries,
-            frictionEvents: frictionBatch.length,
-            diagnosticEvents: diagnosticBatch.length,
+            frictionEvents,
+            diagnosticEvents,
         } satisfies DeriveStats;
     },
 );
@@ -424,7 +414,7 @@ export class SignalsStats extends BaseStageStats.extend<SignalsStats>("SignalsSt
     proposedSkillEdges: Schema.Number,
 }) {}
 
-export const signalsStage: StageDef<SignalsStats, never, CacheWriteError> = {
+export const signalsStage: StageDef<SignalsStats, FileSystem.FileSystem, CacheWriteError> = {
     meta: StageMeta.make({
         key: "signals",
         deps: ["claude", "codex", "pi", "omp", "opencode", "cursor", "subagents", "spawned", "git"],
@@ -444,14 +434,25 @@ export const signalsStage: StageDef<SignalsStats, never, CacheWriteError> = {
     run: Effect.fn(function* (ctx: IngestContext, write: CacheWriteService) {
         const t0 = Date.now();
         const sinceDays = sinceDaysFromCtx(ctx);
-        const result = yield* deriveSignals(write, { sinceDays });
-        return SignalsStats.make({
+        const empty = (error: PlatformError.PlatformError) => SignalsStats.make({
             durationMs: Date.now() - t0,
-            summary: `derived ${result.frictionEvents} friction, ${result.diagnosticEvents} diagnostic events`,
-            frictionEvents: result.frictionEvents,
-            diagnosticEvents: result.diagnosticEvents,
-            corrections: result.corrections,
-            proposedSkillEdges: result.proposedSkillEdges,
+            summary: "signals skipped (filesystem error; non-fatal)",
+            frictionEvents: 0,
+            diagnosticEvents: 0,
+            corrections: 0,
+            proposedSkillEdges: 0,
+            failedOpenError: error.message,
         });
+        return yield* deriveSignals(write, { sinceDays }).pipe(
+            Effect.map((result) => SignalsStats.make({
+                durationMs: Date.now() - t0,
+                summary: `derived ${result.frictionEvents} friction, ${result.diagnosticEvents} diagnostic events`,
+                frictionEvents: result.frictionEvents,
+                diagnosticEvents: result.diagnosticEvents,
+                corrections: result.corrections,
+                proposedSkillEdges: result.proposedSkillEdges,
+            })),
+            Effect.catchTag("PlatformError", (error) => skipPlatformStage("signals", error, empty)),
+        );
     }),
 };

--- a/apps/axctl/src/ingest/derive-signals.window.test.ts
+++ b/apps/axctl/src/ingest/derive-signals.window.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, expect } from "bun:test";
 import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { deriveSignals, type DeriveStats } from "./derive-signals.ts";
@@ -49,8 +50,8 @@ const runFixture = (): Promise<Runs> =>
                         error_text: "exit 1", exit_code: 1n,
                     },
                 ]);
-                const windowed = yield* deriveSignals(write, { sinceDays: 7 });
-                const allTime = yield* deriveSignals(write, {});
+                const windowed = yield* deriveSignals(write, { sinceDays: 7 }).pipe(Effect.provide(BunFileSystem.layer));
+                const allTime = yield* deriveSignals(write, {}).pipe(Effect.provide(BunFileSystem.layer));
                 runs = { windowed, allTime };
             }));
         if (runs === undefined) return yield* Effect.die("fixture body did not run");

--- a/apps/axctl/src/ingest/reparse-targets.test.ts
+++ b/apps/axctl/src/ingest/reparse-targets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     applyReparseSelection,
+    REPARSE_ACTIVE_ENV,
     REPARSE_TARGET_ENV,
     REPARSE_TARGETS,
     resolveReparseTargets,
@@ -51,7 +52,7 @@ describe("applyReparseSelection", () => {
     test("sets each env var to 1 on the given env", () => {
         const env: Record<string, string | undefined> = {};
         applyReparseSelection(resolveReparseTargets("claude"), env);
-        expect(env).toEqual({ AX_REDERIVE_CLAUDE: "1" });
+        expect(env).toEqual({ AX_REDERIVE_CLAUDE: "1", [REPARSE_ACTIVE_ENV]: "1" });
     });
 
     test("leaves unrelated vars untouched", () => {
@@ -59,6 +60,7 @@ describe("applyReparseSelection", () => {
         applyReparseSelection(resolveReparseTargets("git"), env);
         expect(env.PATH).toBe("/bin");
         expect(env.AX_REDERIVE_GIT).toBe("1");
+        expect(env[REPARSE_ACTIVE_ENV]).toBe("1");
         expect(env.AX_REDERIVE_CLAUDE).toBeUndefined();
     });
 });

--- a/apps/axctl/src/ingest/reparse-targets.ts
+++ b/apps/axctl/src/ingest/reparse-targets.ts
@@ -39,6 +39,9 @@ export const REPARSE_TARGETS = Object.keys(REPARSE_TARGET_ENV) as ReparseTarget[
 /** The wildcard accepted in place of a target list. */
 export const REPARSE_ALL = "all";
 
+/** Marks the whole ingest run as a memory-heavy reparse. */
+export const REPARSE_ACTIVE_ENV = "AX_REPARSE_ACTIVE";
+
 export interface ReparseSelection {
     /** Env vars to set to "1", deduped, in {@link REPARSE_TARGETS} order. */
     readonly envVars: ReadonlyArray<string>;
@@ -94,4 +97,5 @@ export const applyReparseSelection = (
     env: Record<string, string | undefined> = process.env,
 ): void => {
     for (const name of selection.envVars) env[name] = "1";
+    env[REPARSE_ACTIVE_ENV] = "1";
 };

--- a/apps/axctl/src/ingest/session-chunk.ts
+++ b/apps/axctl/src/ingest/session-chunk.ts
@@ -1,0 +1,14 @@
+/**
+ * Group an ordered id list into fixed-size chunks - shared by every derive
+ * stage that fetches a bounded session-id list up front, then processes one
+ * batch of sessions' rows at a time so the whole corpus never sits in the Bun
+ * VM heap at once (#1021, #917: a full-corpus `--reparse=claude` run
+ * segfaulted at ~14 GB RSS). `derive-signals.ts` predates this module and
+ * keeps its own local copy deliberately untouched; every stage chunked after
+ * it imports this one instead of re-declaring the same four-line loop.
+ */
+export const chunkIds = <A>(items: ReadonlyArray<A>, size: number): A[][] => {
+    const out: A[][] = [];
+    for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+    return out;
+};

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -130,6 +130,11 @@ describe("runPipeline", () => {
         expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "0" } as NodeJS.ProcessEnv)).toBe(PIPELINE_CONCURRENCY);
         expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "banana" } as NodeJS.ProcessEnv)).toBe(PIPELINE_CONCURRENCY);
         expect(pipelineConcurrency({ AX_PIPELINE_CONCURRENCY: "2.7" } as NodeJS.ProcessEnv)).toBe(2);
+        expect(pipelineConcurrency({ AX_REPARSE_ACTIVE: "1" } as NodeJS.ProcessEnv)).toBe(1);
+        expect(pipelineConcurrency({
+            AX_REPARSE_ACTIVE: "1",
+            AX_PIPELINE_CONCURRENCY: "2",
+        } as NodeJS.ProcessEnv)).toBe(2);
     });
 
     it("does not let a dep-free long stage block downstream stages whose deps are met", async () => {

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -9,6 +9,7 @@ import {
 } from "@ax/lib/duckdb/self-time";
 import { INGEST_FILE_FAILURES_KEY } from "../stream-events.ts";
 import { deriveReserveMs, deriveStageBudget } from "./derive-budget.ts";
+import { REPARSE_ACTIVE_ENV } from "../reparse-targets.ts";
 import type { BaseStageStats, IngestContext, StageDef } from "./types.ts";
 
 /** Max stages running their `run` Effect concurrently. Each stage has its own
@@ -30,8 +31,22 @@ export const PIPELINE_CONCURRENCY = 4;
  */
 export const pipelineConcurrency = (env: NodeJS.ProcessEnv = process.env): number => {
     const raw = nonNegativeNumberEnv(env.AX_PIPELINE_CONCURRENCY, 0);
-    return raw >= 1 ? Math.floor(raw) : PIPELINE_CONCURRENCY;
+    if (raw >= 1) return Math.floor(raw);
+    return env[REPARSE_ACTIVE_ENV] === "1" ? 1 : PIPELINE_CONCURRENCY;
 };
+
+/**
+ * A full reparse allocates large provider and derive batches in one Bun VM.
+ * Release completed stage rows before the next serialized stage starts.
+ */
+export const collectAfterReparseStage = (
+    env: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<void> =>
+    env[REPARSE_ACTIVE_ENV] === "1"
+        ? Effect.sync(() => {
+            Bun.gc(true);
+        })
+        : Effect.void;
 
 /** How often the pipeline logs which stages are still running, so a hung or
  *  slow stage is attributable instead of looking like a silent stall (#671).
@@ -370,6 +385,7 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                     inFlight.add(s.meta.key);
                 }).pipe(
                     Effect.andThen(() => guarded),
+                    Effect.tap(() => collectAfterReparseStage()),
                     Effect.ensuring(Effect.sync(() => {
                         inFlight.delete(s.meta.key);
                     })),

--- a/apps/axctl/src/ingest/turn-analysis.chunk.test.ts
+++ b/apps/axctl/src/ingest/turn-analysis.chunk.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `deriveTurnAnalysis` now fetches turns one SESSION CHUNK at a time and
+ * writes each chunk's `turn_analysis`/`expresses`/`reacts_to` rows before
+ * fetching the next (#917): a single unbounded `SELECT ... FROM turn` (full
+ * `text` column) was one of the fetches behind the ~14 GB RSS segfault on a
+ * full `--reparse=claude` backfill.
+ *
+ * The one piece of state that genuinely spans chunks is the `semantic_signal`
+ * firstSeen/lastSeen/confidence merge: a signal key (kind + label) is not
+ * session-scoped, so the SAME key can recur in a later chunk and must widen
+ * the earlier chunk's window rather than being overwritten by it (an
+ * `INSERT OR REPLACE` per chunk would silently lose that history). This
+ * suite pins, against a REAL DuckDB with an injected small `batchSize`:
+ *
+ *  - every session is visited and every turn is counted exactly once
+ *  - a signal spanning the FIRST and LAST chunk still merges to the true
+ *    firstSeen/lastSeen/confidence, not just the last chunk that touched it
+ *  - the persisted `turn_analysis`/`semantic_signal`/`expresses`/`reacts_to`
+ *    rows are identical whether derived in one chunk or many
+ *  - a second (incremental) run over the same store is a no-op (idempotence)
+ */
+import { describe, expect } from "bun:test";
+import { Effect, Schema } from "effect";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { deriveTurnAnalysis, semanticSignalKey, type TurnAnalysisStats } from "./turn-analysis.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("turn analysis chunking", { requireFts: true });
+
+// Small injected batch size so the fixture crosses two chunk boundaries
+// (3 + 3 + 1) without seeding hundreds of fixture rows.
+const BATCH_SIZE = 3;
+const SESSION_COUNT = 7;
+const RECENT = new Date("2026-01-15T00:00:00.000Z");
+const EARLY = new Date("2020-01-01T00:00:00.000Z");
+const LATE = new Date("2030-01-01T00:00:00.000Z");
+const STOP_DOING_KEY = semanticSignalKey("correction", "stop_doing");
+
+/**
+ * Every session gets an assistant turn followed by a user turn. The FIRST
+ * session (chunk 1) and the LAST session (chunk 3, past the boundary) both
+ * carry a "stop_doing" correction - same signal key, different timestamps -
+ * so the derive's cross-chunk signal merge is exercised, not just its
+ * per-chunk row counting.
+ */
+const seedSessionsAndTurns = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const sessions = Array.from({ length: SESSION_COUNT }, (_, i) => ({
+            id: `s${String(i).padStart(4, "0")}`,
+            source: "claude",
+            started_at: RECENT,
+        }));
+        yield* write.putMany("session", sessions);
+
+        const turns = sessions.flatMap((s, i) => {
+            const isFirst = i === 0;
+            const isLast = i === SESSION_COUNT - 1;
+            const userTs = isFirst ? EARLY : isLast ? LATE : RECENT;
+            const userText = isFirst || isLast ? "stop doing that" : `please look at src/${s.id}.ts`;
+            const userIntentKind = isFirst || isLast ? "correction" : "organic_task";
+            return [
+                {
+                    id: `${s.id}-t0`, session: s.id, seq: 1n, ts: RECENT, role: "assistant",
+                    message_kind: "assistant", intent_kind: null, text: "Implemented the fix.", text_excerpt: "Implemented the fix.",
+                },
+                {
+                    id: `${s.id}-t1`, session: s.id, seq: 2n, ts: userTs, role: "user",
+                    message_kind: "task", intent_kind: userIntentKind, text: userText, text_excerpt: userText,
+                },
+            ];
+        });
+        yield* write.putMany("turn", turns);
+    });
+
+const AnalysisRow = Schema.Struct({
+    id: Schema.String, turn: Schema.String, session: Schema.NullOr(Schema.String), speaker: Schema.String,
+    act: Schema.String, sentiment: Schema.String, polarity: Schema.String, confidence: Schema.Number,
+    signals: Schema.NullOr(Schema.String),
+});
+const SignalRow = Schema.Struct({
+    id: Schema.String, kind: Schema.String, label: Schema.String, confidence: Schema.Number,
+    first_seen: Schema.NullOr(Schema.Date), last_seen: Schema.NullOr(Schema.Date),
+});
+const ExpressesRow = Schema.Struct({
+    id: Schema.String, in_id: Schema.String, out_id: Schema.String, session: Schema.NullOr(Schema.String),
+    confidence: Schema.Number,
+});
+const ReactsToRow = Schema.Struct({
+    id: Schema.String, in_id: Schema.String, out_id: Schema.String, session: Schema.NullOr(Schema.String),
+    polarity: Schema.String, act: Schema.String, signal: Schema.NullOr(Schema.String),
+});
+
+const projectAnalysisRows = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const analyses = yield* write.rows(AnalysisRow, "SELECT id, turn, session, speaker, act, sentiment, polarity, confidence, signals FROM turn_analysis ORDER BY id");
+        const signals = yield* write.rows(SignalRow, "SELECT id, kind, label, confidence, first_seen, last_seen FROM semantic_signal ORDER BY id");
+        const expresses = yield* write.rows(ExpressesRow, "SELECT id, in_id, out_id, session, confidence FROM expresses ORDER BY id");
+        const reactsTo = yield* write.rows(ReactsToRow, "SELECT id, in_id, out_id, session, polarity, act, signal FROM reacts_to ORDER BY id");
+        return { analyses, signals, expresses, reactsTo };
+    });
+
+interface AnalysisRows {
+    readonly analyses: readonly Schema.Schema.Type<typeof AnalysisRow>[];
+    readonly signals: readonly Schema.Schema.Type<typeof SignalRow>[];
+    readonly expresses: readonly Schema.Schema.Type<typeof ExpressesRow>[];
+    readonly reactsTo: readonly Schema.Schema.Type<typeof ReactsToRow>[];
+}
+
+interface Run {
+    readonly stats: TurnAnalysisStats;
+    readonly rows: AnalysisRows;
+}
+
+const runFixture = (dirPrefix: string, batchSize: number): Promise<Run> =>
+    runWithPlatform(Effect.gen(function* () {
+        let result: Run | undefined;
+        yield* publishCacheFixture(tempDir(dirPrefix), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* seedSessionsAndTurns(write);
+                const stats = yield* deriveTurnAnalysis(write, { sinceDays: undefined, batchSize });
+                const rows = yield* projectAnalysisRows(write);
+                result = { stats, rows };
+            }));
+        if (result === undefined) return yield* Effect.die("fixture body did not run");
+        return result;
+    }));
+
+describe("deriveTurnAnalysis session chunking (#917)", () => {
+    dtest("visits every session and sums every turn across chunk boundaries", async () => {
+        const run = await runFixture("ax-turn-analysis-chunk-", BATCH_SIZE);
+        expect(run.stats.turnsAnalyzed).toBe(SESSION_COUNT * 2);
+        expect(run.rows.analyses).toHaveLength(SESSION_COUNT * 2);
+    });
+
+    dtest("a signal spanning the first and last chunk merges firstSeen/lastSeen, not just the last chunk", async () => {
+        const run = await runFixture("ax-turn-analysis-signal-span-", BATCH_SIZE);
+        const stopDoing = run.rows.signals.find((s) => s.id === STOP_DOING_KEY);
+        expect(stopDoing).toBeDefined();
+        expect(stopDoing?.first_seen?.toISOString()).toBe(EARLY.toISOString());
+        expect(stopDoing?.last_seen?.toISOString()).toBe(LATE.toISOString());
+    });
+
+    dtest("chunked and single-batch derives persist identical analysis rows", async () => {
+        const chunked = await runFixture("ax-turn-analysis-chunked-", BATCH_SIZE);
+        const single = await runFixture("ax-turn-analysis-single-", SESSION_COUNT * 10);
+
+        expect(chunked.stats).toEqual(single.stats);
+        expect(chunked.rows.analyses).toEqual(single.rows.analyses);
+        expect(chunked.rows.signals).toEqual(single.rows.signals);
+        expect(chunked.rows.expresses).toEqual(single.rows.expresses);
+        expect(chunked.rows.reactsTo).toEqual(single.rows.reactsTo);
+    });
+
+    dtest("a second incremental run over the same store is a no-op", async () => {
+        const dir = tempDir("ax-turn-analysis-idempotent-");
+        const runs = await runWithPlatform(Effect.gen(function* () {
+            let first: TurnAnalysisStats | undefined;
+            let second: TurnAnalysisStats | undefined;
+            yield* publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* seedSessionsAndTurns(write);
+                    first = yield* deriveTurnAnalysis(write, { sinceDays: undefined, batchSize: BATCH_SIZE });
+                    second = yield* deriveTurnAnalysis(write, { sinceDays: undefined, batchSize: BATCH_SIZE });
+                }));
+            if (first === undefined || second === undefined) return yield* Effect.die("fixture body did not run");
+            return { first, second };
+        }));
+
+        expect(runs.first.turnsAnalyzed).toBe(SESSION_COUNT * 2);
+        expect(runs.second.turnsAnalyzed).toBe(0);
+        expect(runs.second.expressesEdges).toBe(0);
+        expect(runs.second.reactsToEdges).toBe(0);
+        // Signals are re-derived (in memory) from an empty `analyses` set on
+        // the no-op run, so the accumulator is empty and nothing is promoted
+        // - the persisted rows from the first run stay untouched (no DELETE).
+        expect(runs.second.signalsPromoted).toBe(0);
+    });
+});

--- a/apps/axctl/src/ingest/turn-analysis.ts
+++ b/apps/axctl/src/ingest/turn-analysis.ts
@@ -5,11 +5,22 @@ import { cacheRow, jsonParam, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { stableId } from "@ax/lib/stable-id";
 import { classifyFeedback, classifyUserAsk } from "./ask-outcome.ts";
+import { chunkIds } from "./session-chunk.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 
 export const TurnAnalysisKey = Schema.Literal("turn-analysis");
 export type TurnAnalysisKey = typeof TurnAnalysisKey.Type;
+
+/**
+ * How many sessions' turns one `fetchTurnsForSessions` round-trip pulls.
+ * A single unbounded `SELECT ... FROM turn` (with the full `text` column, not
+ * just `text_excerpt`) materialised the whole turn corpus in the Bun VM heap
+ * at once and was one of the fetches behind the ~14 GB RSS segfault on a full
+ * `--reparse=claude` backfill (#917, same root cause as #1021). Mirrors
+ * `derive-signals.ts`'s `SESSION_BATCH_SIZE` / two-pass session-id fetch.
+ */
+export const SESSION_BATCH_SIZE = 25;
 
 export type TurnSpeaker = "user" | "assistant" | "tool";
 export type TurnAnalysisAct =
@@ -428,33 +439,63 @@ const expressesRecordKey = (turnKey: string, signalKey: string): string =>
 const reactsToRecordKey = (fromTurnKey: string, toTurnKey: string): string =>
     stableId("reacts_to", [fromTurnKey, toTurnKey]);
 
-export const buildTurnAnalysisRows = (
-    analyses: readonly TurnAnalysisWrite[],
-) => {
-    const signals = new Map<string, SemanticSignalWrite>();
-    for (const analysis of analyses) {
-        if (!analysis.semanticSignal) continue;
-        const existing = signals.get(analysis.semanticSignal.key);
-        if (!existing) {
-            signals.set(analysis.semanticSignal.key, {
-                ...analysis.semanticSignal,
-                firstSeen: analysis.semanticSignal.ts,
-                lastSeen: analysis.semanticSignal.ts,
-            });
-            continue;
-        }
-        const firstSeen = new Date(existing.firstSeen ?? existing.ts).getTime() <= new Date(analysis.semanticSignal.ts).getTime()
-            ? existing.firstSeen ?? existing.ts
-            : analysis.semanticSignal.ts;
-        const lastSeen = new Date(existing.lastSeen ?? existing.ts).getTime() >= new Date(analysis.semanticSignal.ts).getTime()
-            ? existing.lastSeen ?? existing.ts
-            : analysis.semanticSignal.ts;
-        signals.set(analysis.semanticSignal.key, {
-            ...existing,
-            confidence: Math.max(existing.confidence, analysis.semanticSignal.confidence),
-            firstSeen,
-            lastSeen,
+/**
+ * Fold one turn's semantic signal into a `(signal key -> merged write)`
+ * accumulator: first occurrence seeds firstSeen/lastSeen from its own ts,
+ * every later occurrence widens firstSeen down / lastSeen up and takes the
+ * max confidence. Min/max is commutative, so this can run once over the
+ * whole corpus or incrementally over successive session chunks and land on
+ * the same merged value either way - the property the chunked derive below
+ * depends on (a signal key can span sessions in different chunks).
+ */
+const mergeSignalIntoAccumulator = (
+    accum: Map<string, SemanticSignalWrite>,
+    semanticSignal: SemanticSignalWrite,
+): void => {
+    const existing = accum.get(semanticSignal.key);
+    if (!existing) {
+        accum.set(semanticSignal.key, {
+            ...semanticSignal,
+            firstSeen: semanticSignal.ts,
+            lastSeen: semanticSignal.ts,
         });
+        return;
+    }
+    const firstSeen = new Date(existing.firstSeen ?? existing.ts).getTime() <= new Date(semanticSignal.ts).getTime()
+        ? existing.firstSeen ?? existing.ts
+        : semanticSignal.ts;
+    const lastSeen = new Date(existing.lastSeen ?? existing.ts).getTime() >= new Date(semanticSignal.ts).getTime()
+        ? existing.lastSeen ?? existing.ts
+        : semanticSignal.ts;
+    accum.set(semanticSignal.key, {
+        ...existing,
+        confidence: Math.max(existing.confidence, semanticSignal.confidence),
+        firstSeen,
+        lastSeen,
+    });
+};
+
+const signalAccumToRows = (accum: ReadonlyMap<string, SemanticSignalWrite>) =>
+    [...accum.values()].map((signalWrite) => cacheRow({
+        id: signalWrite.key, kind: signalWrite.kind, label: signalWrite.label,
+        canonical_text: signalWrite.canonicalText, description: signalWrite.description ?? null,
+        method: "heuristic", confidence: signalWrite.confidence,
+        first_seen: tsParam(signalWrite.firstSeen ?? signalWrite.ts),
+        last_seen: tsParam(signalWrite.lastSeen ?? signalWrite.ts), metrics: jsonParam({ source: "turn_analysis" }),
+    }));
+
+/**
+ * Build the per-turn `turn_analysis`/`expresses`/`reacts_to` rows for one
+ * batch of analyses, folding each analysis's semantic signal into `signals`
+ * (mutated in place) rather than returning a batch-local signals list - the
+ * caller decides when the accumulator is complete enough to flush.
+ */
+const buildTurnAnalysisChunkRows = (
+    analyses: readonly TurnAnalysisWrite[],
+    signals: Map<string, SemanticSignalWrite>,
+) => {
+    for (const analysis of analyses) {
+        if (analysis.semanticSignal) mergeSignalIntoAccumulator(signals, analysis.semanticSignal);
     }
     return {
         analyses: analyses.map((analysis) => cacheRow({
@@ -462,13 +503,6 @@ export const buildTurnAnalysisRows = (
             speaker: analysis.speaker, act: analysis.act, sentiment: analysis.sentiment,
             polarity: analysis.polarity, confidence: analysis.confidence, method: analysis.method,
             signals: jsonParam(analysis.signals), text: analysis.text, ts: tsParam(analysis.ts), updated_at: new Date(),
-        })),
-        signals: [...signals.values()].map((signalWrite) => cacheRow({
-            id: signalWrite.key, kind: signalWrite.kind, label: signalWrite.label,
-            canonical_text: signalWrite.canonicalText, description: signalWrite.description ?? null,
-            method: "heuristic", confidence: signalWrite.confidence,
-            first_seen: tsParam(signalWrite.firstSeen ?? signalWrite.ts),
-            last_seen: tsParam(signalWrite.lastSeen ?? signalWrite.ts), metrics: jsonParam({ source: "turn_analysis" }),
         })),
         expresses: analyses.filter((analysis) => analysis.semanticSignal !== null).map((analysis) => cacheRow({
             id: expressesRecordKey(analysis.turnKey, analysis.semanticSignal!.key), in_id: analysis.turnKey,
@@ -484,6 +518,14 @@ export const buildTurnAnalysisRows = (
     };
 };
 
+export const buildTurnAnalysisRows = (
+    analyses: readonly TurnAnalysisWrite[],
+) => {
+    const signals = new Map<string, SemanticSignalWrite>();
+    const rows = buildTurnAnalysisChunkRows(analyses, signals);
+    return { ...rows, signals: signalAccumToRows(signals) };
+};
+
 export function deriveTurnAnalysisRows(rows: readonly TurnAnalysisInput[]): TurnAnalysisWrite[] {
     const previousAssistantBySession = new Map<string, string>();
     return rows.map((row) => {
@@ -495,18 +537,46 @@ export function deriveTurnAnalysisRows(rows: readonly TurnAnalysisInput[]): Turn
     });
 }
 
-const fetchTurns = (write: CacheWriteService, sinceDays: number | undefined): Effect.Effect<readonly TurnAnalysisInput[], CacheReadError> =>
+/**
+ * Every session id that has at least one in-window turn, ordered so chunks
+ * are stable run to run - the cheap first pass (one column, no text) that
+ * bounds the second, expensive pass below.
+ */
+const fetchTurnAnalysisSessionIds = (
+    write: CacheWriteService,
+    sinceDays: number | undefined,
+): Effect.Effect<string[], CacheReadError> =>
     Effect.gen(function* () {
+        const sql = `
+SELECT DISTINCT t.session AS session
+FROM turn t JOIN session s ON s.id = t.session
+${sinceDays === undefined ? "" : "WHERE t.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
+ORDER BY t.session ASC`;
+        const rows = yield* write.rows(Schema.Struct({ session: Schema.String }), sql, sinceDays === undefined ? [] : [sinceDays]);
+        return rows.map((r) => r.session);
+    });
+
+/** Turn rows for a bounded set of session ids - same window filter as the id pass. */
+const fetchTurnsForSessions = (
+    write: CacheWriteService,
+    sessionIds: ReadonlyArray<string>,
+    sinceDays: number | undefined,
+): Effect.Effect<readonly TurnAnalysisInput[], CacheReadError> =>
+    Effect.gen(function* () {
+        if (sessionIds.length === 0) return [];
+        const placeholders = sessionIds.map(() => "?").join(", ");
+        const sql = `
+SELECT t.id, t.session, CAST(t.seq AS DOUBLE) AS seq, t.role, s.source,
+       t.message_kind, t.intent_kind, t.text, t.text_excerpt, t.ts
+FROM turn t JOIN session s ON s.id = t.session
+WHERE t.session IN (${placeholders}) ${sinceDays === undefined ? "" : "AND t.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
+ORDER BY t.session, t.seq`;
         return yield* write.rows(Schema.Struct({
             id: Schema.String, session: Schema.String, seq: Schema.Number, role: Schema.String,
             source: Schema.NullOr(Schema.String), message_kind: Schema.NullOr(Schema.String),
             intent_kind: Schema.NullOr(Schema.String), text: Schema.NullOr(Schema.String),
             text_excerpt: Schema.NullOr(Schema.String), ts: TimestampColumn,
-        }), `SELECT t.id, t.session, CAST(t.seq AS DOUBLE) AS seq, t.role, s.source,
-                    t.message_kind, t.intent_kind, t.text, t.text_excerpt, t.ts
-             FROM turn t JOIN session s ON s.id = t.session
-             ${sinceDays === undefined ? "" : "WHERE t.ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
-             ORDER BY t.session, t.seq`, sinceDays === undefined ? [] : [sinceDays]);
+        }), sql, sinceDays === undefined ? [...sessionIds] : [...sessionIds, sinceDays]);
     });
 
 /**
@@ -524,55 +594,72 @@ const loadAnalyzedTurnKeys = (write: CacheWriteService): Effect.Effect<Set<strin
         return set;
     });
 
-const persistTurnAnalysisRows = (write: CacheWriteService, analyses: readonly TurnAnalysisWrite[]) =>
-    Effect.gen(function* () {
-        const rows = buildTurnAnalysisRows(analyses);
-        yield* write.putMany("turn_analysis", rows.analyses);
-        yield* write.putMany("semantic_signal", rows.signals);
-        yield* write.putMany("expresses", rows.expresses);
-        yield* write.putMany("reacts_to", rows.reactsTo);
-    });
-
 export const deriveTurnAnalysis = (
     write: CacheWriteService,
-    opts: { readonly sinceDays: number | undefined } = { sinceDays: undefined },
+    opts: { readonly sinceDays: number | undefined; readonly batchSize?: number } = { sinceDays: undefined },
 ): Effect.Effect<TurnAnalysisStats, CacheReadError | CacheWriteError> =>
     Effect.gen(function* () {
         // Escape hatch: when the derivation logic itself changes, force a full
         // reset + re-derive of every turn analysis.
         const full = process.env.AX_REDERIVE_ANALYSIS === "1";
-        const rows = yield* fetchTurns(write, opts.sinceDays);
-        // Derive over the full ordered row set so the reacts_to "previous
-        // assistant turn" lookahead has complete session context, then filter
-        // down to only the turns that still need persisting.
-        const allAnalyses = deriveTurnAnalysisRows(rows);
+        const fullRederive = full && opts.sinceDays === undefined;
+        const batchSize = opts.batchSize ?? SESSION_BATCH_SIZE;
 
-        if (full && opts.sinceDays === undefined) {
+        if (fullRederive) {
             for (const table of ["reacts_to", "expresses", "turn_analysis", "semantic_signal"]) yield* write.exec(`DELETE FROM ${table}`);
-            yield* persistTurnAnalysisRows(write, allAnalyses);
-            return {
-                turnsAnalyzed: allAnalyses.length,
-                signalsPromoted: new Set(allAnalyses.map((a) => a.semanticSignal?.key).filter(Boolean)).size,
-                expressesEdges: allAnalyses.filter((a) => a.semanticSignal !== null).length,
-                reactsToEdges: allAnalyses.filter((a) => a.reactsToTurnKey !== null).length,
-            };
         }
 
         // Incremental: turns are append-only, so an existing `turn_analysis`
         // row is output-equivalent (its turn text/role/kind never mutate, and
         // its reacts_to/expresses edges have deterministic ids). Skip those;
         // only derive turns not yet analyzed. No blanket DELETE - the
-        // turn_analysis id is the turn key, so each UPSERT lands in place. This
-        // is a near-no-op on warm runs where almost every turn already exists.
-        const analyzed = yield* loadAnalyzedTurnKeys(write);
-        const analyses = allAnalyses.filter((a) => !analyzed.has(a.turnKey));
-        yield* persistTurnAnalysisRows(write, analyses);
-        return {
-            turnsAnalyzed: analyses.length,
-            signalsPromoted: new Set(analyses.map((a) => a.semanticSignal?.key).filter(Boolean)).size,
-            expressesEdges: analyses.filter((a) => a.semanticSignal !== null).length,
-            reactsToEdges: analyses.filter((a) => a.reactsToTurnKey !== null).length,
-        };
+        // turn_analysis id is the turn key, so each UPSERT lands in place.
+        // This is a near-no-op on warm runs where almost every turn already
+        // exists. In a full rederive every turn is treated as new, so the
+        // analyzed set is never consulted.
+        const analyzed = fullRederive ? undefined : yield* loadAnalyzedTurnKeys(write);
+
+        // Two passes, so the whole turn corpus (including the full `text`
+        // column) never sits in the heap at once (#917): the cheap id pass
+        // bounds what the expensive pass then pulls one session-chunk at a
+        // time. A session's turns are never split across chunks, so the
+        // reacts_to "previous assistant turn" lookback (per-session state)
+        // stays correct per chunk. The `signals` accumulator below is the one
+        // piece of state that genuinely spans chunks - a signal key (kind +
+        // label) is not session-scoped, so the SAME key can recur in a later
+        // chunk and must widen the earlier chunk's firstSeen/lastSeen rather
+        // than being overwritten by it. It stays cheap to carry across
+        // chunks because it is bounded by the small, fixed set of distinct
+        // signal labels, not by corpus size - unlike the per-turn rows below,
+        // which write out (and are dropped) one chunk at a time.
+        const sessionIds = yield* fetchTurnAnalysisSessionIds(write, opts.sinceDays);
+        const signals = new Map<string, SemanticSignalWrite>();
+        let turnsAnalyzed = 0;
+        let expressesEdges = 0;
+        let reactsToEdges = 0;
+
+        for (const idChunk of chunkIds(sessionIds, batchSize)) {
+            const rows = yield* fetchTurnsForSessions(write, idChunk, opts.sinceDays);
+            const allAnalyses = deriveTurnAnalysisRows(rows);
+            const analyses = analyzed === undefined ? allAnalyses : allAnalyses.filter((a) => !analyzed.has(a.turnKey));
+
+            const chunkRows = buildTurnAnalysisChunkRows(analyses, signals);
+            yield* write.putMany("turn_analysis", chunkRows.analyses);
+            yield* write.putMany("expresses", chunkRows.expresses);
+            yield* write.putMany("reacts_to", chunkRows.reactsTo);
+
+            turnsAnalyzed += analyses.length;
+            expressesEdges += chunkRows.expresses.length;
+            reactsToEdges += chunkRows.reactsTo.length;
+            yield* Effect.sync(() => Bun.gc(true));
+        }
+
+        // The signals accumulator only reaches its final firstSeen/lastSeen/
+        // confidence once every chunk has been folded in, so it writes once
+        // here rather than per chunk.
+        yield* write.putMany("semantic_signal", signalAccumToRows(signals));
+
+        return { turnsAnalyzed, signalsPromoted: signals.size, expressesEdges, reactsToEdges };
     });
 
 export class TurnAnalysisStageStats extends BaseStageStats.extend<TurnAnalysisStageStats>("TurnAnalysisStageStats")({

--- a/apps/axctl/src/ingest/turn-content-blocks.chunk.test.ts
+++ b/apps/axctl/src/ingest/turn-content-blocks.chunk.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `deriveAndPersistTurnContentBlocks` now fetches turns one fixed ROW CHUNK at a
+ * time and writes each chunk's content documents before fetching the next
+ * (#917): a single unbounded `SELECT ... FROM turn` (full `text` column) was
+ * one of the fetches behind the ~14 GB RSS segfault on a full
+ * `--reparse=claude` backfill. This suite pins the properties that MUST
+ * survive chunking against a REAL DuckDB, using an injected small `batchSize`
+ * so the fixture cheaply crosses more than one chunk boundary:
+ *
+ *  - one session can cross a row boundary and every turn is counted once
+ *  - the persisted `content_document`/`content_block`/`content_atom` rows are
+ *    byte-for-byte the same whether derived in one chunk or many
+ *  - a second (incremental) run over the same store is a no-op (idempotence)
+ */
+import { describe, expect } from "bun:test";
+import { Effect, Schema } from "effect";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { deriveAndPersistTurnContentBlocks, type TurnContentBlocksStats } from "./turn-content-blocks.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("turn content blocks chunking", { requireFts: true });
+
+// Small injected batch size splits each two-turn session across boundaries.
+const BATCH_SIZE = 3;
+const SESSION_COUNT = 7;
+const TURNS_PER_SESSION = 2;
+const RECENT = new Date();
+
+const seedSessionsAndTurns = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const sessions = Array.from({ length: SESSION_COUNT }, (_, i) => ({
+            id: `s${String(i).padStart(4, "0")}`,
+            source: "claude",
+            started_at: RECENT,
+        }));
+        yield* write.putMany("session", sessions);
+        const turns = sessions.flatMap((s) =>
+            Array.from({ length: TURNS_PER_SESSION }, (_, seq) => ({
+                id: `${s.id}-t${seq}`,
+                session: s.id,
+                agent_event: null,
+                seq: BigInt(seq + 1),
+                ts: RECENT,
+                role: seq === 0 ? "user" : "assistant",
+                text: `${s.id} turn ${seq} talks about src/${s.id}/${seq}.ts`,
+                text_excerpt: `${s.id} turn ${seq}`,
+            })));
+        yield* write.putMany("turn", turns);
+    });
+
+const DocumentRow = Schema.Struct({
+    id: Schema.String, source_ref: Schema.NullOr(Schema.String), content_hash: Schema.String,
+    blockset_hash: Schema.NullOr(Schema.String), title: Schema.NullOr(Schema.String),
+});
+const BlockRow = Schema.Struct({
+    id: Schema.String, document: Schema.String, kind: Schema.String, block_hash: Schema.String,
+    text_excerpt: Schema.NullOr(Schema.String),
+});
+const AtomRow = Schema.Struct({
+    id: Schema.String, block: Schema.String, document: Schema.String, kind: Schema.String,
+    value: Schema.String, normalized: Schema.NullOr(Schema.String),
+});
+
+const projectContentRows = (write: CacheWriteService) =>
+    Effect.gen(function* () {
+        const documents = yield* write.rows(DocumentRow, "SELECT id, source_ref, content_hash, blockset_hash, title FROM content_document WHERE source_kind = 'turn' ORDER BY id");
+        const blocks = yield* write.rows(BlockRow, "SELECT id, document, kind, block_hash, text_excerpt FROM content_block WHERE source_kind = 'turn' ORDER BY id");
+        const atoms = yield* write.rows(AtomRow, "SELECT id, block, document, kind, value, normalized FROM content_atom WHERE source_kind = 'turn' ORDER BY id");
+        return { documents, blocks, atoms };
+    });
+
+interface ContentRows {
+    readonly documents: readonly Schema.Schema.Type<typeof DocumentRow>[];
+    readonly blocks: readonly Schema.Schema.Type<typeof BlockRow>[];
+    readonly atoms: readonly Schema.Schema.Type<typeof AtomRow>[];
+}
+
+interface Run {
+    readonly stats: TurnContentBlocksStats;
+    readonly rows: ContentRows;
+}
+
+const runFixture = (dirPrefix: string, batchSize: number): Promise<Run> =>
+    runWithPlatform(Effect.gen(function* () {
+        let result: Run | undefined;
+        yield* publishCacheFixture(tempDir(dirPrefix), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* seedSessionsAndTurns(write);
+                const stats = yield* deriveAndPersistTurnContentBlocks(write, { sinceDays: undefined, batchSize });
+                const rows = yield* projectContentRows(write);
+                result = { stats, rows };
+            }));
+        if (result === undefined) return yield* Effect.die("fixture body did not run");
+        return result;
+    }));
+
+describe("deriveAndPersistTurnContentBlocks session chunking (#917)", () => {
+    dtest("visits every session and sums every turn across chunk boundaries", async () => {
+        const run = await runFixture("ax-turn-content-blocks-chunk-", BATCH_SIZE);
+        expect(run.stats.turns).toBe(SESSION_COUNT * TURNS_PER_SESSION);
+        expect(run.stats.documents).toBe(SESSION_COUNT * TURNS_PER_SESSION);
+        expect(run.rows.documents).toHaveLength(SESSION_COUNT * TURNS_PER_SESSION);
+    });
+
+    dtest("chunked and single-batch derives persist byte-identical content rows", async () => {
+        const chunked = await runFixture("ax-turn-content-blocks-chunked-", BATCH_SIZE);
+        const single = await runFixture("ax-turn-content-blocks-single-", SESSION_COUNT * 10);
+
+        expect(chunked.stats).toEqual(single.stats);
+        expect(chunked.rows.documents).toEqual(single.rows.documents);
+        expect(chunked.rows.blocks).toEqual(single.rows.blocks);
+        expect(chunked.rows.atoms).toEqual(single.rows.atoms);
+    });
+
+    dtest("a second incremental run over the same store is a no-op", async () => {
+        const dir = tempDir("ax-turn-content-blocks-idempotent-");
+        const runs = await runWithPlatform(Effect.gen(function* () {
+            let first: TurnContentBlocksStats | undefined;
+            let second: TurnContentBlocksStats | undefined;
+            yield* publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    yield* seedSessionsAndTurns(write);
+                    first = yield* deriveAndPersistTurnContentBlocks(write, { sinceDays: undefined, batchSize: BATCH_SIZE });
+                    second = yield* deriveAndPersistTurnContentBlocks(write, { sinceDays: undefined, batchSize: BATCH_SIZE });
+                }));
+            if (first === undefined || second === undefined) return yield* Effect.die("fixture body did not run");
+            return { first, second };
+        }));
+
+        expect(runs.first.documents).toBe(SESSION_COUNT * TURNS_PER_SESSION);
+        expect(runs.second.turns).toBe(SESSION_COUNT * TURNS_PER_SESSION);
+        expect(runs.second.documents).toBe(0);
+        expect(runs.second.blocks).toBe(0);
+        expect(runs.second.atoms).toBe(0);
+    });
+});

--- a/apps/axctl/src/ingest/turn-content-blocks.ts
+++ b/apps/axctl/src/ingest/turn-content-blocks.ts
@@ -8,6 +8,17 @@ import type { ContentDocumentInput } from "./content-blocks/types.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 
+/**
+ * How many turns one `fetchTurnRowBatch` round-trip pulls.
+ * A single unbounded `SELECT ... FROM turn` (with the full `text` column, not
+ * just `text_excerpt`) materialised the whole turn corpus in the Bun VM heap
+ * at once and was one of the fetches behind the ~14 GB RSS segfault on a full
+ * `--reparse=claude` backfill (#917, same root cause as #1021). Mirrors
+ * Turn content has no cross-turn state, so a fixed row limit also splits one
+ * very large session. The real corpus has a session with more than 49k turns.
+ */
+export const TURN_BATCH_SIZE = 5_000;
+
 export const TurnContentBlocksKey = Schema.Literal("turn-content-blocks");
 export type TurnContentBlocksKey = typeof TurnContentBlocksKey.Type;
 
@@ -89,23 +100,49 @@ export function buildTurnContentDocumentWrites(
         .filter((write): write is ContentDocumentWrite => write !== null);
 }
 
-const fetchTurnRows = (
+const TurnContentBlockRowSchema = Schema.Struct({
+    id: Schema.String, session: Schema.String, agent_event: Schema.NullOr(Schema.String),
+    seq: Schema.Number, role: Schema.NullOr(Schema.String), message_kind: Schema.NullOr(Schema.String),
+    intent_kind: Schema.NullOr(Schema.String), text: Schema.NullOr(Schema.String),
+    text_excerpt: Schema.NullOr(Schema.String), has_tool_use: Schema.NullOr(Schema.Boolean),
+    has_error: Schema.NullOr(Schema.Boolean), ts: TimestampColumn,
+});
+type FetchedTurnContentBlockRow = typeof TurnContentBlockRowSchema.Type;
+
+/** One stable keyset page. This bounds rows even when one session is very large. */
+const fetchTurnRowBatch = (
     write: CacheWriteService,
+    cursor: { readonly session: string; readonly seq: number; readonly id: string } | undefined,
     sinceDays: number | undefined,
-): Effect.Effect<readonly TurnContentBlockRow[], CacheReadError> =>
+    batchSize: number,
+): Effect.Effect<readonly FetchedTurnContentBlockRow[], CacheReadError> =>
     Effect.gen(function* () {
-        const Row = Schema.Struct({
-            id: Schema.String, session: Schema.NullOr(Schema.String), agent_event: Schema.NullOr(Schema.String),
-            seq: Schema.Number, role: Schema.NullOr(Schema.String), message_kind: Schema.NullOr(Schema.String),
-            intent_kind: Schema.NullOr(Schema.String), text: Schema.NullOr(Schema.String),
-            text_excerpt: Schema.NullOr(Schema.String), has_tool_use: Schema.NullOr(Schema.Boolean),
-            has_error: Schema.NullOr(Schema.Boolean), ts: TimestampColumn,
-        });
-        return yield* write.rows(Row, `
+        const predicates: string[] = [];
+        const params: Array<string | number> = [];
+        if (cursor !== undefined) {
+            predicates.push(`(
+                session > ?
+                OR (session = ? AND seq > CAST(? AS BIGINT))
+                OR (session = ? AND seq = CAST(? AS BIGINT) AND id > ?)
+            )`);
+            params.push(cursor.session, cursor.session, cursor.seq, cursor.session, cursor.seq, cursor.id);
+        }
+        if (sinceDays !== undefined) {
+            predicates.push("ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')");
+            params.push(sinceDays);
+        }
+        params.push(batchSize);
+        const sql = `
 SELECT id, session, agent_event, CAST(seq AS DOUBLE) AS seq, role, message_kind, intent_kind, text, text_excerpt, has_tool_use, has_error, ts
 FROM turn
-${sinceDays === undefined ? "" : "WHERE ts >= CAST(CURRENT_TIMESTAMP AS TIMESTAMP) - (CAST(? AS INTEGER) * INTERVAL '1 day')"}
-ORDER BY session, seq`, sinceDays === undefined ? [] : [sinceDays]);
+${predicates.length === 0 ? "" : `WHERE ${predicates.join(" AND ")}`}
+ORDER BY session, seq, id
+LIMIT CAST(? AS INTEGER)`;
+        return yield* write.rows(
+            TurnContentBlockRowSchema,
+            sql,
+            params,
+        );
     });
 
 /**
@@ -135,44 +172,55 @@ const loadExistingTurnContentHashes = (write: CacheWriteService): Effect.Effect<
 
 export const deriveAndPersistTurnContentBlocks = (
     write: CacheWriteService,
-    opts: { readonly sinceDays: number | undefined } = { sinceDays: undefined },
+    opts: { readonly sinceDays: number | undefined; readonly batchSize?: number } = { sinceDays: undefined },
 ): Effect.Effect<TurnContentBlocksStats, CacheReadError | CacheWriteError> =>
     Effect.gen(function* () {
         // Escape hatch: when the derivation logic itself changes, force a full
         // reset + re-derive of every turn content document.
         const full = process.env.AX_REDERIVE_CONTENT === "1";
-        const rows = yield* fetchTurnRows(write, opts.sinceDays);
+        const batchSize = Math.max(1, Math.floor(opts.batchSize ?? TURN_BATCH_SIZE));
 
         if (full) {
-            const writes = buildTurnContentDocumentWrites(rows);
             yield* write.exec("DELETE FROM content_atom WHERE source_kind = 'turn'");
             yield* write.exec("DELETE FROM content_block WHERE source_kind = 'turn'");
             yield* write.exec("DELETE FROM content_document WHERE source_kind = 'turn'");
-            for (const document of writes) yield* writeContentDocument(write, document);
-            const blocks = writes.reduce((sum, write) => sum + write.parsed.blocks.length, 0);
-            const atoms = writes.reduce((sum, write) => sum + write.parsed.atoms.length, 0);
-            return { turns: rows.length, documents: writes.length, blocks, atoms };
         }
+        // Incremental: only (re)derive turns whose content hash is new or
+        // changed vs. what is already stored. Content-document/block/atom ids
+        // are deterministic per turn, so each UPSERT lands in place (no
+        // blanket DELETE). Turns whose hash matches are skipped - already
+        // derived and output-equivalent. Turns are append-only, so changes
+        // are rare; this is a near-no-op on warm runs. In `full` mode every
+        // turn is rederived, so the hash map is never consulted.
+        const existing = full ? undefined : yield* loadExistingTurnContentHashes(write);
 
-        // Incremental: only (re)derive turns whose content hash is new or changed
-        // vs. what is already stored. Content-document/block/atom ids are
-        // deterministic per turn, so each UPSERT lands in place (no blanket
-        // DELETE). Turns whose hash matches are skipped - already derived and
-        // output-equivalent. Turns are append-only, so changes are rare; this is
-        // a near-no-op on warm runs.
-        const existing = yield* loadExistingTurnContentHashes(write);
-        const writes = buildTurnContentDocumentWrites(rows).filter(
-            (write) => existing.get(write.sourceRef) !== write.contentHash,
-        );
-        for (const document of writes) yield* writeContentDocument(write, document);
-        const blocks = writes.reduce((sum, write) => sum + write.parsed.blocks.length, 0);
-        const atoms = writes.reduce((sum, write) => sum + write.parsed.atoms.length, 0);
-        return {
-            turns: rows.length,
-            documents: writes.length,
-            blocks,
-            atoms,
-        };
+        let turns = 0;
+        let documents = 0;
+        let blocks = 0;
+        let atoms = 0;
+        let batches = 0;
+        let cursor: { readonly session: string; readonly seq: number; readonly id: string } | undefined;
+        while (true) {
+            const rows = yield* fetchTurnRowBatch(write, cursor, opts.sinceDays, batchSize);
+            if (rows.length === 0) break;
+            turns += rows.length;
+            const candidates = buildTurnContentDocumentWrites(rows);
+            const writes = existing === undefined
+                ? candidates
+                : candidates.filter((doc) => existing.get(doc.sourceRef) !== doc.contentHash);
+            for (const document of writes) yield* writeContentDocument(write, document);
+            documents += writes.length;
+            blocks += writes.reduce((sum, doc) => sum + doc.parsed.blocks.length, 0);
+            atoms += writes.reduce((sum, doc) => sum + doc.parsed.atoms.length, 0);
+            const last = rows[rows.length - 1]!;
+            cursor = { session: last.session, seq: last.seq, id: last.id };
+            batches += 1;
+            // DuckDB result objects become unreachable after each page, but a
+            // tight million-row scan can finish before JSC collects them.
+            // A periodic full collection keeps the page limit effective.
+            if (batches % 5 === 0) yield* Effect.sync(() => Bun.gc(true));
+        }
+        return { turns, documents, blocks, atoms };
     });
 
 export class TurnContentBlocksStageStats extends BaseStageStats.extend<TurnContentBlocksStageStats>("TurnContentBlocksStageStats")({


### PR DESCRIPTION
## Summary

- read turn content and turn analysis data in bounded batches
- spool signal writes into bulk NDJSON loads
- serialize reparse stages by default and collect completed stage data
- preserve explicit concurrency overrides

## Verification

- full copied-store `ax ingest --reparse=claude --progress=plain` completed in 603 seconds
- 1,090,001 turn content rows processed
- 377,816 run evidence rows processed
- `bun test`: 6,515 pass, 13 skip, 0 fail
- `bun run typecheck`
- storage and SQL guard checks

Fixes #917

---

_Generated with [ax](https://github.com/Necmttn/ax)._