### PR TITLE
fix(runs): handle pre-ledger snapshots

### DIFF
--- a/apps/axctl/src/queries/run-evidence.duckdb.test.ts
+++ b/apps/axctl/src/queries/run-evidence.duckdb.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `fetchRunEvidence` (#578) against a REAL published DuckDB snapshot that
+ * predates the run-evidence ledger tables (#675).
+ *
+ * The normal DuckDB upgrade path applies the current DDL to the live cache,
+ * but a snapshot PUBLISHED before that DDL landed - or restored from an older
+ * backup - still lacks `run_evidence_event` and `run_evidence_ref`. Before
+ * this fix, `ax runs evidence` read that snapshot directly and every one of
+ * its four queries failed with a raw `DuckDbQueryError` ("table does not
+ * exist"). The fix adds an explicit catalog check that short-circuits to the
+ * SAME zero-event `RunEvidenceResult` shape a session with no rows already
+ * produces - so the renderer's existing empty-state branch handles it with no
+ * changes.
+ *
+ * This suite proves that against a genuine snapshot file (no mocked seam):
+ * publish the fixture with the CURRENT schema (which creates both tables),
+ * then `DROP TABLE` them directly on the snapshot to reproduce a pre-ledger
+ * publish, and read through the real `CacheRead` layer.
+ */
+import { describe, expect } from "bun:test";
+import { Effect, FileSystem, type Path } from "effect";
+import { openDuckDbService } from "@ax/lib/duckdb/client";
+import { publishCacheFixture, readFixture, runWithPlatform, type CacheFixture } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { RUN_EVIDENCE_BACKINGS, RUN_EVIDENCE_KINDS } from "@ax/lib/shared/run-evidence";
+import { fetchRunEvidence, RUN_EVIDENCE_COVERED_KINDS } from "./run-evidence.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("run evidence pre-ledger", { requireFts: true });
+
+const SESSION = "019e2531-b552-7b53-a029-c780adbb6560";
+
+/**
+ * Publish a fixture with the CURRENT schema (both ledger tables exist), then
+ * drop the ledger tables directly on the published snapshot file - a real
+ * pre-ledger publish, not a synthetic empty-table stand-in.
+ */
+const publishPreLedgerFixture = (dir: string): Effect.Effect<CacheFixture, unknown, FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        const fixture = yield* publishCacheFixture(dir, dylibPath, () => Effect.void);
+        const fs = yield* FileSystem.FileSystem;
+        const opened = yield* openDuckDbService(fs, dylibPath === null ? {} : { assetPath: dylibPath });
+        const conn = yield* opened.db.open(fixture.snapshotPath, { readOnly: false });
+        yield* conn.exec("DROP TABLE run_evidence_ref");
+        yield* conn.exec("DROP TABLE run_evidence_event");
+        yield* conn.close;
+        opened.close();
+        return fixture;
+    });
+
+describe("fetchRunEvidence over a pre-ledger published snapshot (#675)", () => {
+    dtest("returns the empty RunEvidenceResult instead of failing", async () => {
+        const dir = tempDir("run-evidence-pre-ledger");
+        const fixture = await runWithPlatform(publishPreLedgerFixture(dir));
+
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+        const result = await Effect.runPromise(
+            fetchRunEvidence({ sessionId: `session:\`${SESSION}\``, timelineLimit: 7 }).pipe(Effect.provide(layer)),
+        );
+
+        // Bare session id, even though the ledger never ran - the catalog
+        // check short-circuits AFTER `toBareSessionId`, not before it.
+        expect(result.session_id).toBe(SESSION);
+
+        // Zero totals, empty timeline and refs.
+        expect(result.total).toBe(0);
+        expect(result.timeline).toEqual([]);
+        expect(result.ref_total).toBe(0);
+        expect(result.by_ref_kind).toEqual([]);
+        expect(result.objective).toBeNull();
+        expect(result.repo).toBeNull();
+
+        // The full taxonomy is present at zero - the same honest-zeros
+        // contract a populated-but-empty session gets, not a truncated list.
+        expect(result.by_kind).toEqual(
+            RUN_EVIDENCE_KINDS.map((key) => ({ key, count: 0 })),
+        );
+        expect(result.by_backing).toEqual(
+            RUN_EVIDENCE_BACKINGS.map((key) => ({ key, count: 0 })),
+        );
+        expect(result.covered_kinds).toEqual([...RUN_EVIDENCE_COVERED_KINDS]);
+
+        // The requested timeline limit is still reported honestly.
+        expect(result.timeline_limit).toBe(7);
+    });
+
+    dtest("still fails on an unrelated query error once the ledger tables exist", async () => {
+        const dir = tempDir("run-evidence-unrelated-error");
+        const fixture = await runWithPlatform(
+            Effect.gen(function* () {
+                const built = yield* publishCacheFixture(dir, dylibPath, () => Effect.void);
+                const fs = yield* FileSystem.FileSystem;
+                const opened = yield* openDuckDbService(fs, dylibPath === null ? {} : { assetPath: dylibPath });
+                const conn = yield* opened.db.open(built.snapshotPath, { readOnly: false });
+                // Both ledger tables exist (the catalog check passes), but a
+                // column the read queries select is gone - a real schema-drift
+                // failure that must NOT be swallowed by the new short-circuit.
+                // DuckDB refuses to ALTER a table while any index on it
+                // exists ("entries that depend on it"), so the table's own
+                // indexes have to go first.
+                yield* conn.exec("DROP INDEX run_evidence_event_session");
+                yield* conn.exec("DROP INDEX run_evidence_event_kind");
+                yield* conn.exec("DROP INDEX run_evidence_event_source");
+                yield* conn.exec("DROP INDEX run_evidence_event_observed");
+                yield* conn.exec("ALTER TABLE run_evidence_event DROP COLUMN summary");
+                yield* conn.close;
+                opened.close();
+                return built;
+            }),
+        );
+
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+        const failure = await Effect.runPromise(
+            Effect.flip(fetchRunEvidence({ sessionId: SESSION }).pipe(Effect.provide(layer))),
+        );
+
+        expect(failure._tag).toBe("DuckDbQueryError");
+    });
+});

--- a/apps/axctl/src/queries/run-evidence.ts
+++ b/apps/axctl/src/queries/run-evidence.ts
@@ -15,7 +15,7 @@
  */
 import { Effect, Schema } from "effect";
 import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns";
-import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
+import { CacheRead, type CacheReadError, type CacheReadService } from "@ax/lib/duckdb/seam";
 import { toBareSessionId } from "@ax/lib/shared/session-id";
 import {
     RUN_EVIDENCE_BACKINGS,
@@ -90,6 +90,83 @@ const TimelineDbRow = Schema.Struct({ ts: TimestampColumn, kind: Schema.String, 
 const RefGroupDbRow = Schema.Struct({ ref_kind: Schema.String, n: NumberFromBigIntColumn });
 const HeadDbRow = Schema.Struct({ kind: Schema.String, summary: Schema.NullOr(Schema.String) });
 
+/** The two tables the ledger needs. A snapshot published before #578's DDL
+ *  landed (or one restored from an older backup) has neither - see the
+ *  catalog check below. */
+const RUN_EVIDENCE_TABLES = ["run_evidence_event", "run_evidence_ref"] as const;
+
+const TableCountDbRow = Schema.Struct({ n: NumberFromBigIntColumn });
+
+/**
+ * Whether BOTH ledger tables exist in the published snapshot. Checked via
+ * `information_schema.tables` (the same catalog-probe shape `fts.ts` uses for
+ * `information_schema.schemata`) rather than by running the ledger queries and
+ * inspecting the error: a missing-table `DuckDbQueryError` and any OTHER
+ * `DuckDbQueryError` on these tables (a bad column, a corrupt row) look
+ * identical from the outside, and only the explicit check lets this function
+ * treat "no ledger yet" as an honest zero-event result while still letting
+ * every other query failure surface as a real `CacheReadError`.
+ */
+const ledgerTablesPresent = (cache: CacheReadService): Effect.Effect<boolean, CacheReadError> =>
+    Effect.gen(function* () {
+        const rows = yield* cache.rows(
+            TableCountDbRow,
+            "SELECT count(*) AS n FROM information_schema.tables WHERE table_schema = 'main' AND table_name IN (?, ?)",
+            [...RUN_EVIDENCE_TABLES],
+        );
+        return (rows[0]?.n ?? 0) >= RUN_EVIDENCE_TABLES.length;
+    });
+
+interface RunEvidenceQueryRows {
+    readonly bareId: string;
+    readonly limit: number;
+    readonly groups: ReadonlyArray<GroupRow>;
+    readonly timelineRows: ReadonlyArray<{
+        readonly ts: Date;
+        readonly kind: string;
+        readonly backing: string;
+        readonly source_table: string;
+        readonly summary: string | null;
+    }>;
+    readonly refGroups: ReadonlyArray<{ readonly ref_kind?: string | null; readonly n?: number | null }>;
+    readonly heads: ReadonlyArray<{ readonly kind: string; readonly summary: string | null }>;
+}
+
+/** Pure assembly of {@link RunEvidenceResult} from decoded rows. Called with
+ *  every array empty when the ledger tables are absent - the SAME shape a
+ *  session with zero rows produces, which is the shape the renderer already
+ *  handles (see `renderRunEvidence`'s `total === 0` branch). */
+const buildRunEvidenceResult = ({ bareId, limit, groups, timelineRows, refGroups, heads }: RunEvidenceQueryRows): RunEvidenceResult => {
+    const headOf = (kind: string): string | null =>
+        heads.find((h) => h.kind === kind)?.summary ?? null;
+
+    const total = groups.reduce((acc, r) => acc + (typeof r.n === "number" ? r.n : 0), 0);
+    const byKind = tallyByTaxonomy(groups, "kind", RUN_EVIDENCE_KINDS)
+        .sort((a, b) => b.count - a.count);
+    const byBacking = tallyByTaxonomy(groups, "backing", RUN_EVIDENCE_BACKINGS);
+
+    const refTotal = refGroups.reduce((acc, r) => acc + (typeof r.n === "number" ? r.n : 0), 0);
+    const byRefKind = refGroups
+        .filter((r): r is { ref_kind: string; n: number } => typeof r.ref_kind === "string")
+        .map((r) => ({ key: r.ref_kind, count: typeof r.n === "number" ? r.n : 0 }))
+        .sort((a, b) => b.count - a.count);
+
+    return {
+        session_id: bareId,
+        generated_at: new Date().toISOString(),
+        objective: headOf("objective"),
+        repo: headOf("repo_state"),
+        total,
+        by_kind: byKind,
+        by_backing: byBacking,
+        timeline: timelineRows.map((row) => ({ ...row, ts: row.ts.toISOString() })),
+        ref_total: refTotal,
+        by_ref_kind: byRefKind,
+        covered_kinds: [...RUN_EVIDENCE_COVERED_KINDS],
+        timeline_limit: limit,
+    } satisfies RunEvidenceResult;
+};
+
 const tallyByTaxonomy = (
     rows: ReadonlyArray<GroupRow>,
     field: "kind" | "backing",
@@ -116,6 +193,11 @@ export const fetchRunEvidence = (input: RunEvidenceInput): Effect.Effect<
         const sessionRef = bareId;
         const limit = Math.max(1, Math.floor(input.timelineLimit ?? RUN_EVIDENCE_TIMELINE_LIMIT));
 
+        const ledgerReady = yield* ledgerTablesPresent(cache);
+        if (!ledgerReady) {
+            return buildRunEvidenceResult({ bareId, limit, groups: [], timelineRows: [], refGroups: [], heads: [] });
+        }
+
         const groups = yield* cache.rows(
             GroupDbRow,
             "SELECT kind, backing, count(*) AS n FROM run_evidence_event WHERE session = ? GROUP BY kind, backing",
@@ -137,36 +219,8 @@ export const fetchRunEvidence = (input: RunEvidenceInput): Effect.Effect<
             "SELECT kind, summary FROM run_evidence_event WHERE session = ? AND kind IN ('objective', 'repo_state') ORDER BY ts DESC",
             [sessionRef],
         );
-        const headOf = (kind: string): string | null =>
-            heads.find((h) => h.kind === kind)?.summary ?? null;
 
-        const rows = groups;
-        const total = rows.reduce((acc, r) => acc + (typeof r.n === "number" ? r.n : 0), 0);
-        const byKind = tallyByTaxonomy(rows, "kind", RUN_EVIDENCE_KINDS)
-            .sort((a, b) => b.count - a.count);
-        const byBacking = tallyByTaxonomy(rows, "backing", RUN_EVIDENCE_BACKINGS);
-
-        const refRows = refGroups;
-        const refTotal = refRows.reduce((acc, r) => acc + (typeof r.n === "number" ? r.n : 0), 0);
-        const byRefKind = refRows
-            .filter((r): r is { ref_kind: string; n: number } => typeof r.ref_kind === "string")
-            .map((r) => ({ key: r.ref_kind, count: typeof r.n === "number" ? r.n : 0 }))
-            .sort((a, b) => b.count - a.count);
-
-        return {
-            session_id: bareId,
-            generated_at: new Date().toISOString(),
-            objective: headOf("objective"),
-            repo: headOf("repo_state"),
-            total,
-            by_kind: byKind,
-            by_backing: byBacking,
-            timeline: timelineRows.map((row) => ({ ...row, ts: row.ts.toISOString() })),
-            ref_total: refTotal,
-            by_ref_kind: byRefKind,
-            covered_kinds: [...RUN_EVIDENCE_COVERED_KINDS],
-            timeline_limit: limit,
-        } satisfies RunEvidenceResult;
+        return buildRunEvidenceResult({ bareId, limit, groups, timelineRows, refGroups, heads });
     });
 
 const nonZero = (counts: ReadonlyArray<RunEvidenceCount>): string =>


### PR DESCRIPTION
## Summary

- check the published snapshot catalog before run evidence reads
- return the existing empty result when ledger tables are absent
- preserve all unrelated DuckDB query failures
- add real snapshot regression tests

## Verification

- focused tests: 11 pass
- `bun run typecheck`
- `bun run check:raw-numeric-cast`
- `git diff --check`

Fixes #675

---

_Generated with [ax](https://github.com/Necmttn/ax)._