### PR TITLE
fix(ingest): surface child discovery errors

### DIFF
--- a/apps/axctl/src/ingest/derive-claude-subagents.stage.test.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.stage.test.ts
@@ -1,6 +1,19 @@
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { describe, expect, it } from "bun:test";
-import { Schema } from "effect";
-import { SubagentsKey, subagentsStage } from "./derive-claude-subagents.ts";
+import { Effect, Layer, Schema } from "effect";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    __testDiscoverClaudeSubagents,
+    SubagentsKey,
+    subagentsStage,
+} from "./derive-claude-subagents.ts";
+
+const BunFsLayer = Layer.merge(BunFileSystem.layer, BunPath.layer);
+
+const discover = (root: string) =>
+    Effect.runPromise(__testDiscoverClaudeSubagents(root).pipe(Effect.provide(BunFsLayer)));
 
 describe("subagentsStage", () => {
     it("declares the canonical key/deps/tags", () => {
@@ -8,5 +21,21 @@ describe("subagentsStage", () => {
         expect(subagentsStage.meta.key).toBe("subagents");
         expect(subagentsStage.meta.deps).toEqual(["claude", "codex"]);
         expect(subagentsStage.meta.tags).toEqual(["derive"]);
+    });
+
+    it("accepts a missing optional transcript root", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-subagent-missing-root-"));
+        expect(await discover(join(base, "missing"))).toEqual([]);
+    });
+
+    it("reports a regular file transcript root", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-subagent-file-root-"));
+        const root = join(base, "not-a-directory");
+        await writeFile(root, "data");
+
+        const error = await Effect.runPromise(
+            Effect.flip(__testDiscoverClaudeSubagents(root).pipe(Effect.provide(BunFsLayer))),
+        );
+        expect(error.reason._tag).not.toBe("NotFound");
     });
 });

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -7,7 +7,7 @@ import { edgeRowId } from "@ax/lib/stable-id";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 import { decodeJsonOrNull } from "@ax/lib/decode";
-import { isNotFound, orAbsent } from "@ax/lib/shared/fs-error";
+import { isNotFound, skipNotFound } from "@ax/lib/shared/fs-error";
 import {
     extractFileWithSessionId,
     upsertTurnsForSubagents,
@@ -59,26 +59,29 @@ const stringField = (row: Record<string, unknown>, key: string): string | null =
  */
 const discover = (
     transcriptsDir: string,
-): Effect.Effect<SubagentManifest[], never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<SubagentManifest[], PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const out: SubagentManifest[] = [];
-        // Original tolerance: any readdir failure (missing/unreadable) -> skip.
+        // A missing optional root, or a project/session dir with no `subagents/`
+        // subdir (the common case - most sessions spawn none), is NotFound and
+        // stays non-fatal. Every other PlatformError (the root is a regular
+        // file, a permission fault) propagates to the stage boundary (#796).
         const projectDirs = yield* fs
             .readDirectory(transcriptsDir)
-            .pipe(orAbsent<ReadonlyArray<string>>([]));
+            .pipe(skipNotFound<ReadonlyArray<string>>([]));
         for (const projectDir of projectDirs) {
             const fullProject = path.join(transcriptsDir, projectDir);
             const entries = yield* fs
                 .readDirectory(fullProject)
-                .pipe(orAbsent<ReadonlyArray<string>>([]));
+                .pipe(skipNotFound<ReadonlyArray<string>>([]));
             for (const entry of entries) {
                 if (entry.endsWith(".jsonl")) continue;
                 const subagentDir = path.join(fullProject, entry, "subagents");
                 const agentFiles = yield* fs
                     .readDirectory(subagentDir)
-                    .pipe(orAbsent<ReadonlyArray<string>>([]));
+                    .pipe(skipNotFound<ReadonlyArray<string>>([]));
                 for (const agentFile of agentFiles) {
                     if (!agentFile.endsWith(".jsonl")) continue;
                     if (!agentFile.startsWith("agent-")) continue;
@@ -91,14 +94,18 @@ const discover = (
         return out;
     });
 
+/** Exposes {@link discover}'s PlatformError policy for direct, DB-free testing. */
+export const __testDiscoverClaudeSubagents = discover;
+
 const parseManifest = (
     filePath: string,
     projectDir: string,
-): Effect.Effect<SubagentManifest | null, never, FileSystem.FileSystem> =>
+): Effect.Effect<SubagentManifest | null, PlatformError.PlatformError, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        // Original tolerance: any read failure -> null (file vanished/unreadable).
-        const text = yield* fs.readFileString(filePath).pipe(orAbsent<string | null>(null));
+        // The file vanishing between listing and read (NotFound) -> null;
+        // every other PlatformError propagates (#796).
+        const text = yield* fs.readFileString(filePath).pipe(skipNotFound<string | null>(null));
         if (text === null) return null;
         return buildManifest(text, filePath, projectDir);
     });
@@ -130,16 +137,18 @@ const buildManifest = (
 }
 
 /**
- * Attempt to read `agent-<id>.meta.json` (sibling of the `.jsonl` file).
- * Returns partial/empty object on any failure – callers treat every field optional.
+ * Attempt to read `agent-<id>.meta.json` (sibling of the `.jsonl` file). A
+ * missing sidecar (NotFound - most agents write no meta file) returns a
+ * partial/empty object, since callers treat every field optional; every
+ * other PlatformError propagates (#796).
  */
 const readSubagentMeta = (
     jsonlPath: string,
-): Effect.Effect<SubagentMeta, never, FileSystem.FileSystem> =>
+): Effect.Effect<SubagentMeta, PlatformError.PlatformError, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const metaPath = jsonlPath.replace(/\.jsonl$/, ".meta.json");
-        const text = yield* fs.readFileString(metaPath).pipe(orAbsent<string | null>(null));
+        const text = yield* fs.readFileString(metaPath).pipe(skipNotFound<string | null>(null));
         if (text === null) return {};
         const parsed = decodeJsonOrNull(text);
         if (!isRecord(parsed)) return {};
@@ -260,13 +269,15 @@ export const deriveClaudeSubagents = (
             // its session/turns/tool_calls/spawned edge persist, so skipping is
             // output-equivalent. stat is cheap relative to the full re-parse +
             // DB writes below; we reuse it for the watermark write at the end.
-            // Original tolerance: bare stat (FOLLOWS) with any error -> null.
+            // The file vanishing between discovery and this stat (NotFound)
+            // -> null (no watermark write this run); every other PlatformError
+            // propagates (#796).
             const fileStat = yield* fs.stat(m.file).pipe(
                 Effect.map((info) => ({
                     mtimeMs: Option.getOrElse(info.mtime, () => new Date(0)).getTime(),
                     size: Number(info.size),
                 })),
-                orAbsent<{ mtimeMs: number; size: number } | null>(null),
+                skipNotFound<{ mtimeMs: number; size: number } | null>(null),
             );
             if (fileStat && wm.unchanged(m.file, fileStat.mtimeMs, fileStat.size)) {
                 skippedUnchanged += 1;

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -889,11 +889,8 @@ const makePiLikeStage = (
             failedFiles: 1,
             failedOpenError: error.message,
         });
-        // The directory walk recovers every PlatformError internally, and a
-        // per-file `readFileString` fault is now recorded + skipped by the
-        // per-file isolation seam (#261, see file-isolation.ts), so no
-        // A discovery or spool setup PlatformError reaches the stage boundary,
-        // which records failed-open stats. Database errors still abort the stage.
+        // The directory walk absorbs NotFound only. Other discovery and spool
+        // PlatformError values reach this boundary. Database errors still abort.
         return yield* ingest(write, { sinceDays, runId: ctx.runId }).pipe(
             Effect.map((result) => PiStageStats.make({
                 durationMs: Date.now() - t0,

--- a/apps/axctl/src/ingest/walk-jsonl.test.ts
+++ b/apps/axctl/src/ingest/walk-jsonl.test.ts
@@ -89,4 +89,30 @@ describe("walkJsonlFiles", () => {
         expect(await runStrict(missing, 0)).toEqual([]);
         expect(await runLenient(missing, 0)).toEqual([]);
     });
+
+    // #796: a regular file used as the configured root is not "absent" - it's
+    // a real misconfiguration, and the lenient walker used to swallow every
+    // filesystem error into `[]`, indistinguishable from "no sessions yet".
+    // Both walkers must surface a typed failure instead of a silent zero.
+    test("a regular file root propagates a typed failure for both walkers", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-walk-jsonl-regular-root-"));
+        const root = join(base, "not-a-directory.jsonl");
+        await writeFile(root, "{}\n");
+
+        const strictExit = await Effect.runPromiseExit(
+            walkJsonlFilesStrict(root, 0).pipe(Effect.provide(BunFsLayer)),
+        );
+        const lenientExit = await Effect.runPromiseExit(
+            walkJsonlFilesLenient(root, 0).pipe(Effect.provide(BunFsLayer)),
+        );
+
+        expect(strictExit._tag).toBe("Failure");
+        expect(lenientExit._tag).toBe("Failure");
+
+        // Not the vanished-entry/missing-root case - that one recovers to [].
+        const lenientError = await Effect.runPromise(
+            Effect.flip(walkJsonlFilesLenient(root, 0).pipe(Effect.provide(BunFsLayer))),
+        );
+        expect(lenientError.reason._tag).not.toBe("NotFound");
+    });
 });

--- a/apps/axctl/src/ingest/walk-jsonl.ts
+++ b/apps/axctl/src/ingest/walk-jsonl.ts
@@ -1,4 +1,3 @@
-import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { orAbsent, skipNotFound } from "@ax/lib/shared/fs-error";
 import { Effect, FileSystem, Option, Path, PlatformError } from "effect";
 
@@ -102,41 +101,50 @@ export const walkJsonlFilesStrict = (
     });
 
 /**
- * Pi semantics: classify entries without following symlinks and absorb every
- * PlatformError as "absent"; callers ignore `sizeBytes`.
+ * Classify one entry without following symbolic links. `readLink` failures
+ * are normal for non-links. The following stat reports other access errors.
+ */
+const classifyEntryNoFollow = (
+    fs: FileSystem.FileSystem,
+    full: string,
+): Effect.Effect<Option.Option<WalkEntry>, PlatformError.PlatformError> =>
+    Effect.gen(function* () {
+        const isLink = yield* fs.readLink(full).pipe(Effect.as(true), orAbsent(false));
+        if (isLink) return Option.none<WalkEntry>();
+
+        return yield* fs.stat(full).pipe(
+            Effect.map((stats) =>
+                stats.type === "Directory"
+                    ? Option.some<WalkEntry>({ kind: "directory" })
+                    : stats.type === "File"
+                      ? Option.some<WalkEntry>({
+                            kind: "file",
+                            mtimeMs: Option.getOrElse(stats.mtime, () => new Date(0)).getTime(),
+                            sizeBytes: Number(stats.size),
+                        })
+                      : Option.none<WalkEntry>(),
+            ),
+            skipNotFound(Option.none<WalkEntry>()),
+        );
+    });
+
+/**
+ * Pi semantics: classify entries without following symbolic links. Missing
+ * paths stay non-fatal. Other PlatformError values reach the stage boundary.
  */
 export const walkJsonlFilesLenient = (
     root: string,
     cutoffMs: number,
-): Effect.Effect<JsonlFileCandidate[], never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<JsonlFileCandidate[], PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
 
-        return yield* walkJsonlCore<never, FileSystem.FileSystem>({
+        return yield* walkJsonlCore<PlatformError.PlatformError, never>({
             root,
             cutoffMs,
             joinPath: (dir, entry) => path.join(dir, entry),
-            listDir: (dir) => fs.readDirectory(dir).pipe(orAbsent([] as string[])),
-            classifyEntry: (full) =>
-                classifyNoFollow(full).pipe(
-                    Effect.flatMap((kind) => {
-                        if (kind === "Directory") {
-                            return Effect.succeed(Option.some<WalkEntry>({ kind: "directory" }));
-                        }
-                        if (kind !== "File") return Effect.succeed(Option.none<WalkEntry>());
-
-                        return fs.stat(full).pipe(
-                            Effect.map((stats) =>
-                                Option.some<WalkEntry>({
-                                    kind: "file",
-                                    mtimeMs: Option.getOrElse(stats.mtime, () => new Date(0)).getTime(),
-                                    sizeBytes: Number(stats.size),
-                                }),
-                            ),
-                            orAbsent(Option.none<WalkEntry>()),
-                        );
-                    }),
-                ),
+            listDir: (dir) => fs.readDirectory(dir).pipe(skipNotFound([] as string[])),
+            classifyEntry: (full) => classifyEntryNoFollow(fs, full),
         });
     });


### PR DESCRIPTION
Fixes #796.

Pi, Omp, and Claude child discovery now handle missing paths only.

Other filesystem errors reach the existing stage boundary. The stage records a failed-open result.

The change keeps symbolic link behavior. It also keeps watermark order.

Tests cover missing roots and regular file roots.

Checks:

- 21 focused tests pass.
- Type checking passes.
- `check:no-node-fs` passes.
- `check:raw-numeric-cast` passes.
- `git diff --check` passes.

The Effect review finds no unsafe casts or broad error recovery. The code uses public Effect APIs.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
