### PR TITLE
fix(install): secure the otlpd plist

### DIFF
--- a/apps/axctl/src/cli/install-otlpd-plist.test.ts
+++ b/apps/axctl/src/cli/install-otlpd-plist.test.ts
@@ -1,20 +1,138 @@
 import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import {
+    escapeXmlText,
     otlpdPlist,
     resolveOtlpdPlistDecision,
     resolveTelemetryConsent,
     telemetryConsentConflict,
 } from "./install.ts";
 
+/** Best-effort well-formedness check via whichever validator is on PATH. */
+function assertWellFormedXml(xml: string): void {
+    const plutil = spawnSync("plutil", ["-lint", "-"], { input: xml, encoding: "utf8" });
+    if (plutil.error === undefined && plutil.status !== null) {
+        expect(plutil.status).toBe(0);
+        return;
+    }
+    const xmllint = spawnSync("xmllint", ["--noout", "-"], { input: xml, encoding: "utf8" });
+    if (xmllint.error === undefined && xmllint.status !== null) {
+        expect(xmllint.status).toBe(0);
+    }
+}
+
 describe("otlpd install wiring", () => {
     it("builds a standalone LaunchAgent for ax otlpd", () => {
         const plist = otlpdPlist("/Users/test/.local/bin/ax");
 
         expect(plist).toContain("<string>com.necmttn.ax-otlpd</string>");
-        expect(plist).toContain('exec "/Users/test/.local/bin/ax" otlpd');
         expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
         expect(plist).toContain("otlpd.out");
         expect(plist).toContain("otlpd.err");
+    });
+
+    it("uses direct ProgramArguments - no shell, no bash -lc wrapper", () => {
+        const plist = otlpdPlist("/Users/test/.local/bin/ax");
+
+        expect(plist).not.toContain("/bin/bash");
+        expect(plist).not.toContain("-lc");
+        expect(plist).not.toContain("exec ");
+        expect(plist).toMatch(
+            /<key>ProgramArguments<\/key>\s*<array>\s*<string>\/Users\/test\/\.local\/bin\/ax<\/string>\s*<string>otlpd<\/string>\s*<\/array>/,
+        );
+    });
+
+    it("keeps working for the source-checkout bin\\/axctl wrapper path", () => {
+        const plist = otlpdPlist("/Users/test/repo/apps/axctl/bin/axctl");
+
+        expect(plist).toMatch(
+            /<key>ProgramArguments<\/key>\s*<array>\s*<string>\/Users\/test\/repo\/apps\/axctl\/bin\/axctl<\/string>\s*<string>otlpd<\/string>\s*<\/array>/,
+        );
+        assertWellFormedXml(plist);
+    });
+
+    it("keeps working for the compiled-binary execPath", () => {
+        const plist = otlpdPlist("/Users/test/.local/bin/axctl");
+
+        expect(plist).toMatch(
+            /<key>ProgramArguments<\/key>\s*<array>\s*<string>\/Users\/test\/\.local\/bin\/axctl<\/string>\s*<string>otlpd<\/string>\s*<\/array>/,
+        );
+        assertWellFormedXml(plist);
+    });
+
+    it("escapes an ampersand in binPath so the plist stays well-formed", () => {
+        const plist = otlpdPlist("/Users/a&b/bin/ax");
+
+        expect(plist).toContain("<string>/Users/a&amp;b/bin/ax</string>");
+        expect(plist).not.toContain("/Users/a&b/bin/ax");
+        assertWellFormedXml(plist);
+    });
+
+    it("escapes a less-than sign in binPath so the plist stays well-formed", () => {
+        const plist = otlpdPlist("/Users/a<b/bin/ax");
+
+        expect(plist).toContain("<string>/Users/a&lt;b/bin/ax</string>");
+        expect(plist).not.toContain("<b/bin/ax<");
+        assertWellFormedXml(plist);
+    });
+
+    it("escapes quotes in binPath", () => {
+        const plist = otlpdPlist(`/Users/a"b'c/bin/ax`);
+
+        expect(plist).toContain("<string>/Users/a&quot;b&apos;c/bin/ax</string>");
+        assertWellFormedXml(plist);
+    });
+
+    it("carries shell metacharacters through as inert literal text, never as a command", () => {
+        const dangerous = "/Users/$(rm -rf /);`id`|bin/ax";
+        const plist = otlpdPlist(dangerous);
+
+        // No shell wrapper exists to interpret these - they must appear as
+        // plain escaped XML text inside a single <string> element.
+        expect(plist).toContain(escapeXmlText(dangerous));
+        expect(plist).not.toContain("/bin/bash");
+        assertWellFormedXml(plist);
+    });
+
+    it("escapes an optional AX_OTLP_SPOOL_DIR env value", () => {
+        const prev = process.env.AX_OTLP_SPOOL_DIR;
+        process.env.AX_OTLP_SPOOL_DIR = "/Users/spool&<dir>";
+        try {
+            const plist = otlpdPlist("/Users/test/.local/bin/ax");
+            expect(plist).toContain("<key>AX_OTLP_SPOOL_DIR</key>");
+            expect(plist).toContain("<string>/Users/spool&amp;&lt;dir&gt;</string>");
+            assertWellFormedXml(plist);
+        } finally {
+            if (prev === undefined) delete process.env.AX_OTLP_SPOOL_DIR;
+            else process.env.AX_OTLP_SPOOL_DIR = prev;
+        }
+    });
+
+    it("omits AX_OTLP_SPOOL_DIR entirely when unset", () => {
+        const prev = process.env.AX_OTLP_SPOOL_DIR;
+        delete process.env.AX_OTLP_SPOOL_DIR;
+        try {
+            const plist = otlpdPlist("/Users/test/.local/bin/ax");
+            expect(plist).not.toContain("AX_OTLP_SPOOL_DIR");
+        } finally {
+            if (prev === undefined) delete process.env.AX_OTLP_SPOOL_DIR;
+            else process.env.AX_OTLP_SPOOL_DIR = prev;
+        }
+    });
+});
+
+describe("escapeXmlText", () => {
+    it("escapes ampersand first so entities are not double-escaped", () => {
+        expect(escapeXmlText("a & b")).toBe("a &amp; b");
+    });
+    it("escapes less-than and greater-than", () => {
+        expect(escapeXmlText("<tag>")).toBe("&lt;tag&gt;");
+    });
+    it("escapes double and single quotes", () => {
+        expect(escapeXmlText(`"quoted" 'single'`)).toBe("&quot;quoted&quot; &apos;single&apos;");
+    });
+    it("leaves plain text untouched", () => {
+        expect(escapeXmlText("/Users/test/.local/bin/ax")).toBe("/Users/test/.local/bin/ax");
     });
 });
 

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -50,15 +50,40 @@ const BIN_DIR = posixPath.join(HOME, ".local", "bin");
 const OTLPD_LABEL = "com.necmttn.ax-otlpd";
 const OTLPD_PLIST = posixPath.join(LAUNCH_AGENTS_DIR, `${OTLPD_LABEL}.plist`);
 
+/**
+ * Escapes a value for safe use as literal XML text content in a plist
+ * (property list). `&` must escape first, or the entities inserted for the
+ * other characters would themselves be re-escaped. Every dynamic value
+ * interpolated into `otlpdPlist` (paths, env values) MUST go through this -
+ * an unescaped `&`/`<` breaks the XML, and a raw `<string>` boundary lets
+ * attacker-controlled input (e.g. an env var) inject sibling plist keys.
+ */
+export function escapeXmlText(value: string): string {
+    return value
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&apos;");
+}
+
 // The otlpd spool dir is decoupled from AX_DATA_DIR (see spool-server.ts
 // defaultOtlpSpoolDir) - forward AX_OTLP_SPOOL_DIR into the LaunchAgent's env
 // when the installer's own env carries an override, not AX_DATA_DIR.
 const otlpdSpoolDirEnv = (): string => process.env.AX_OTLP_SPOOL_DIR
     ? `
     <key>AX_OTLP_SPOOL_DIR</key>
-    <string>${process.env.AX_OTLP_SPOOL_DIR}</string>`
+    <string>${escapeXmlText(process.env.AX_OTLP_SPOOL_DIR)}</string>`
     : "";
 
+// ProgramArguments runs binPath directly (no shell) - both the source
+// checkout's bin/axctl (a `#!/usr/bin/env bash` wrapper, executable) and the
+// compiled binary's execPath are directly exec()-able by launchd, so no
+// `/bin/bash -lc "exec \"...\" otlpd"` indirection is needed. That wrapper
+// used to interpolate binPath into a double-quoted shell string unescaped -
+// a path containing shell metacharacters could inject commands. Passing
+// binPath and "otlpd" as separate ProgramArguments entries removes the
+// shell entirely, so there is nothing left to inject into.
 export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -67,9 +92,8 @@ export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" enco
   <string>${OTLPD_LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/bin/bash</string>
-    <string>-lc</string>
-    <string>exec "${binPath}" otlpd</string>
+    <string>${escapeXmlText(binPath)}</string>
+    <string>otlpd</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -79,13 +103,13 @@ export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" enco
     <key>Crashed</key><true/>
   </dict>
   <key>StandardOutPath</key>
-  <string>${LOG_DIR}/otlpd.out</string>
+  <string>${escapeXmlText(LOG_DIR)}/otlpd.out</string>
   <key>StandardErrorPath</key>
-  <string>${LOG_DIR}/otlpd.err</string>
+  <string>${escapeXmlText(LOG_DIR)}/otlpd.err</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpdSpoolDirEnv()}
+    <string>${escapeXmlText(HOME)}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpdSpoolDirEnv()}
   </dict>
   <key>ThrottleInterval</key>
   <integer>5</integer>


### PR DESCRIPTION
Fixes #772.

The otlpd plist now escapes every dynamic XML text value.

The plist also executes the ax path directly. It no longer uses `bash -lc` or an interpolated shell command.

Tests cover XML characters, shell characters, both executable path forms, and the optional spool path.

Checks:

- 30 focused tests pass.
- The full CLI test directory passes with 728 tests and two gated skips.
- Type checking passes.
- `check:no-node-fs` passes.
- `git diff --check` passes.
- Generated plist files pass `plutil -lint`.

Telemetry consent behavior does not change.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
