### PR TITLE
fix(cli): await large JSON output

### DIFF
--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -44,7 +44,7 @@ import { buildSessionsNext, buildSessionShowNext } from "../../nav/next-links.ts
 import { resolveStudioTarget } from "../banner.ts";
 import { resolvePwdCacheRepository, resolvePwdIdentity, type PwdIdentity } from "../../pwd.ts";
 import { printNextLinks } from "../next-format.ts";
-import { catchDbErrorAndExit, stderrExit, wantsJsonFlag } from "../output.ts";
+import { catchDbErrorAndExit, stderrExit, wantsJsonFlag, writeJsonStdout } from "../output.ts";
 import { renderCompareTable, renderCompareJson } from "../session-compare-format.ts";
 import { renderSessionMarkdown, renderSessionJson } from "../session-show-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -489,7 +489,7 @@ const cmdSessionShow = (input: {
         const next = buildSessionShowNext(payload, studio);
 
         if (useJson) {
-            console.log(renderSessionJson(payload, { metrics, next }));
+            yield* Effect.promise(() => writeJsonStdout(renderSessionJson(payload, { metrics, next })));
         } else {
             printNextLinks(next);
             console.log(renderSessionMarkdown(payload, { metrics, next }));

--- a/apps/axctl/src/cli/json-output.test.ts
+++ b/apps/axctl/src/cli/json-output.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for #688: a large `--json` payload piped into a slow
+ * downstream reader (e.g. `| jq`) must arrive complete. `console.log`/a bare
+ * `process.stdout.write(...)` resolve before the OS pipe drains, so a
+ * process that exits right after can truncate the write mid-stream under
+ * real backpressure. `writeJsonStdout` (cli/output.ts) fixes this by
+ * awaiting the stream's write-completion callback before returning.
+ *
+ * The reader in this test deliberately paces its reads with a delay so the
+ * OS pipe buffer fills and the child process genuinely observes
+ * backpressure (`write()` returning `false`) instead of racing a fast
+ * consumer that would mask the bug.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const OUTPUT_MODULE = new URL("./output.ts", import.meta.url).pathname;
+
+describe("writeJsonStdout backpressure (#688)", () => {
+    test("a slow reader receives the exact, complete JSON payload and the writer exits 0", async () => {
+        const payload = JSON.stringify({ big: "x".repeat(230 * 1024) });
+        const payloadBytes = Buffer.byteLength(payload, "utf8");
+        expect(payloadBytes).toBeGreaterThan(218 * 1024);
+
+        const dir = await mkdtemp(path.join(tmpdir(), "ax-json-output-"));
+        const fixturePath = path.join(dir, "slow-reader-fixture.ts");
+        // A minimal standalone script exercising exactly the production
+        // write path (`writeJsonStdout`), then exiting immediately - the
+        // worst case for a fire-and-forget write, since there is no other
+        // pending work to keep the process alive until the pipe drains.
+        const fixture = `
+import { writeJsonStdout } from ${JSON.stringify(OUTPUT_MODULE)};
+const payload = ${JSON.stringify(payload)};
+await writeJsonStdout(payload);
+process.exit(0);
+`;
+        await writeFile(fixturePath, fixture);
+
+        try {
+            const proc = Bun.spawn(["bun", fixturePath], {
+                stdout: "pipe",
+                stderr: "inherit",
+            });
+            const reader = proc.stdout.getReader();
+            const chunks: Uint8Array[] = [];
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) chunks.push(value);
+                // Slow reader: pace reads so the pipe buffer fills and the
+                // writer must actually wait out backpressure, not just win
+                // a race against a fast consumer.
+                await new Promise((resolve) => setTimeout(resolve, 15));
+            }
+            const exitCode = await proc.exited;
+            const received = Buffer.concat(chunks).toString("utf8");
+            const expected = `${payload}\n`;
+
+            expect(exitCode).toBe(0);
+            expect(received.length).toBe(expected.length);
+            expect(received).toBe(expected);
+            expect(JSON.parse(received)).toEqual(JSON.parse(payload));
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    }, 20_000);
+});

--- a/apps/axctl/src/cli/output.ts
+++ b/apps/axctl/src/cli/output.ts
@@ -38,6 +38,25 @@ export const catchDbErrorAndExit =
             ),
         ) as Effect.Effect<A, never, R>;
 
+/**
+ * Write a JSON payload to stdout, resolving only once the underlying stream
+ * has flushed those bytes - not merely queued them. `console.log`/a bare
+ * `process.stdout.write(...)` return before a slow downstream reader (e.g.
+ * `| jq`) drains the pipe; if the process exits right after, the write can
+ * be truncated mid-stream (#688). `Writable#write`'s callback is the stable
+ * Node/Bun-compatible completion signal - it fires only once this chunk has
+ * been handled, including any backpressure wait - so awaiting it is enough.
+ * Never ends/closes stdout.
+ */
+export function writeJsonStdout(json: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        process.stdout.write(`${json}\n`, (err) => {
+            if (err) reject(err);
+            else resolve();
+        });
+    });
+}
+
 /** Report a typed DuckDB cache read failure at a CLI handler boundary. */
 export const catchCacheReadErrorAndExit =
     (prefix: string) =>


### PR DESCRIPTION
Fixes #688.

The session JSON path now waits for stdout to complete its write. It no longer uses a fire-and-forget `console.log`.

The writer does not close stdout. Other JSON commands stay unchanged.

A subprocess test sends more than 218 KB through a slow pipe. It verifies the exit code, exact output, and valid JSON.

Checks:

- 59 focused tests pass.
- Type checking passes.
- `check:no-node-fs` passes.
- `git diff --check` passes.

The current Bun version did not reproduce the old truncation. The new test verifies the required output contract.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
