### PR TITLE
fix: restrict blob GC to known file names

### DIFF
--- a/packages/lib/src/blob-gc.test.ts
+++ b/packages/lib/src/blob-gc.test.ts
@@ -273,6 +273,42 @@ describe("gcFileBuckets", () => {
         }).pipe(Effect.provide(layer))));
     });
 
+    dtest("ignores unrelated files and nested layouts", async () => {
+        const referenced = await referencedFrom(
+            [filePointer("transcripts", "keep.jsonl")],
+            "ax-blobgc-known-names-",
+        );
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            const nested = path.join(transcripts, "nested");
+            yield* fs.makeDirectory(nested, { recursive: true });
+            yield* fs.writeFileString(path.join(transcripts, "keep.jsonl"), "keep");
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl.partial"), "remove");
+            yield* fs.writeFileString(path.join(transcripts, ".DS_Store"), "keep");
+            yield* fs.writeFileString(path.join(transcripts, "metadata.json"), "keep");
+            yield* fs.writeFileString(path.join(nested, "orphan.jsonl"), "keep");
+
+            const result = yield* gcFileBuckets(root, {
+                isGlobalIngest: true,
+                referenced,
+                minAgeMs: 0,
+            });
+
+            expect(result).toEqual({ scanned: 3, removed: 2, failed: 0, skipped: false });
+            expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(false);
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl.partial"))).toBe(false);
+            expect(yield* fs.exists(path.join(transcripts, ".DS_Store"))).toBe(true);
+            expect(yield* fs.exists(path.join(transcripts, "metadata.json"))).toBe(true);
+            expect(yield* fs.exists(path.join(nested, "orphan.jsonl"))).toBe(true);
+        }).pipe(Effect.provide(PlatformLayer))));
+    });
+
     dtest("a per-file remove failure is counted and does not abort the rest of GC", async () => {
         const referenced = await referencedFrom(
             [filePointer("transcripts", "keep.jsonl")],

--- a/packages/lib/src/blob-gc.ts
+++ b/packages/lib/src/blob-gc.ts
@@ -6,6 +6,11 @@ import { orAbsent, skipNotFound } from "./shared/fs-error.ts";
 
 const FILE_BUCKETS = ["transcripts", "codex_artifacts"] as const;
 
+// Blob writers use blobName(..., ".jsonl") and may leave the atomic-copy
+// sibling when a process stops. Do not treat unrelated bucket files as blobs.
+const isGcCandidate = (name: string): boolean =>
+    name.endsWith(".jsonl") || name.endsWith(".jsonl.partial");
+
 /** Never delete a blob written more recently than this - guards the window
  *  where a blob has just landed on disk (e.g. serve's live ingest, still
  *  mid-write) but its `session` row referencing it hasn't been upserted yet. */
@@ -151,6 +156,7 @@ export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
             skipNotFound<ReadonlyArray<string>>([]),
         );
         for (const entry of entries) {
+            if (!isGcCandidate(entry)) continue;
             const filePath = path.join(bucketDir, entry);
             const info = yield* fs.stat(filePath).pipe(skipNotFound(null));
             if (info === null || info.type !== "File") continue;


### PR DESCRIPTION
## Summary

- Process only `.jsonl` blobs and `.jsonl.partial` copy files.
- Preserve unrelated files in managed bucket directories.
- Keep nested layouts unchanged.
- Add a real file system and DuckDB regression test.

## Checks

- `DUCKDB_DIST_DIR=/Users/necmttn/Projects/ax/dist/duckdb bun test packages/lib/src/blob-gc.test.ts packages/lib/src/blob-store.test.ts`
- `bun run typecheck`
- `bun run check:no-node-fs`
- `git diff --check`

Fixes #780

---

_Generated with [ax](https://github.com/Necmttn/ax)._
