### PR TITLE
fix: backfill produced edges on warm Git ingest

### DIFF
--- a/apps/axctl/src/ingest/git.stage.test.ts
+++ b/apps/axctl/src/ingest/git.stage.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it } from "bun:test";
 import { Schema } from "effect";
 import { GitKey, gitStage } from "./git.ts";
+import { ALL_STAGES } from "./stage/registry.ts";
 
 describe("gitStage", () => {
     it("declares the canonical key/deps/tags", () => {
         expect(Schema.decodeUnknownSync(GitKey)("git")).toBe("git");
         expect(gitStage.meta.key).toBe("git");
-        expect(gitStage.meta.deps).toEqual([]);
+        // #684: gitStage must wait for every session-writing provider stage
+        // that precedes it in ALL_STAGES, so a warm run (unchanged git
+        // watermark) still sees the sessions those stages just wrote before
+        // it correlates produced edges. The subagent parser also writes
+        // sessions. The runner only awaits deps present in the selected stage
+        // set, so listing all seven is safe even when a
+        // caller runs a stage subset that omits some of them.
+        const gitIndex = ALL_STAGES.findIndex((stage) => stage.meta.key === "git");
+        const precedingSessionWriters = ALL_STAGES
+            .slice(0, gitIndex)
+            .filter((stage) => stage.meta.writes.some((write) => write.table === "session" && write.mode === "parse"))
+            .map((stage) => stage.meta.key);
+        expect(gitStage.meta.deps).toEqual(precedingSessionWriters);
         expect(gitStage.meta.tags).toEqual(["ingest"]);
     });
 });

--- a/apps/axctl/src/ingest/git.test.ts
+++ b/apps/axctl/src/ingest/git.test.ts
@@ -1,9 +1,14 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer, PlatformError, Schema } from "effect";
 import { BunPath } from "@effect/platform-bun";
 import { FixturePlatform, publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { layerTestFileSystem } from "@ax/lib/testing/test-filesystem";
+import { cacheRow, tsParam } from "@ax/lib/duckdb/row";
+import { TimestampColumn } from "@ax/lib/duckdb/columns";
 import {
     buildSessionCheckoutWhere,
     buildSessionRepoWhere,
@@ -14,6 +19,28 @@ import {
     readRepoListFile,
     REPO_LIST_FILE,
 } from "./git.ts";
+
+async function git(repoPath: string, args: readonly string[]): Promise<string> {
+    const proc = Bun.spawn(["git", "-C", repoPath, ...args], { stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+    ]);
+    const code = await proc.exited;
+    if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
+    return stdout.trim();
+}
+
+async function createRepoWithOneCommit(): Promise<string> {
+    const repoPath = await mkdtemp(join(tmpdir(), "ax-git-warm-produced-"));
+    await git(repoPath, ["init", "-b", "main"]);
+    await git(repoPath, ["config", "user.name", "Test User"]);
+    await git(repoPath, ["config", "user.email", "test@example.com"]);
+    await writeFile(join(repoPath, "README.md"), "initial\n");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, ["commit", "-m", "initial"]);
+    return repoPath;
+}
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("git ingest", { requireFts: true });
 
@@ -91,5 +118,73 @@ describe("git ingest on real DuckDB", () => {
 
         expect(stats).toMatchObject({ repos: 1 });
         expect(rows).toEqual([{ root_path: repoRoot, checkout_count: 1 }]);
+    });
+
+    dtest("#684: correlates a session added after the watermark, on a warm (skipped) git run", async () => {
+        const repoPath = await createRepoWithOneCommit();
+        try {
+            let coldStats: unknown;
+            let warmStats: unknown;
+            let expectedCommitId = "";
+            let produced: readonly unknown[] = [];
+
+            await runWithPlatform(publishCacheFixture(tempDir("ax-git-warm-produced-"), dylibPath, (write) =>
+                Effect.gen(function* () {
+                    // Cold run: establishes the repository/checkout/commit rows
+                    // and the git watermark. No sessions exist yet.
+                    coldStats = yield* ingestGit(write, { repoPaths: [repoPath], sinceDays: 1 }).pipe(
+                        Effect.provide(FixturePlatform),
+                    );
+
+                    const commitRows = yield* write.rows(
+                        Schema.Struct({ id: Schema.String, ts: TimestampColumn }),
+                        "SELECT id, ts FROM commit LIMIT 1",
+                    );
+                    const commit = commitRows[0];
+                    if (!commit) throw new Error("expected a persisted commit after the cold run");
+                    expectedCommitId = commit.id;
+
+                    // Commit identity is repository-wide. A canonical commit
+                    // row can name another worktree checkout, so correlation
+                    // must match its repository and the session checkout.
+                    yield* write.exec("UPDATE commit SET checkout = ? WHERE id = ?", [
+                        "another-checkout",
+                        commit.id,
+                    ]);
+
+                    // A session added AFTER the cold run, whose window covers
+                    // the commit's ts. It has no `checkout` yet - that gets
+                    // set by the warm run's session-linking UPDATE, same as
+                    // any newly-ingested session would.
+                    const startedAt = new Date(commit.ts.getTime() - 60_000);
+                    const endedAt = new Date(commit.ts.getTime() + 60_000);
+                    yield* write.put("session", cacheRow({
+                        id: "warm-session-684", cwd: repoPath, source: "claude",
+                        started_at: tsParam(startedAt), ended_at: tsParam(endedAt),
+                    }));
+
+                    // Warm run: HEAD is unchanged, so the watermark must skip
+                    // the (expensive) git history walk - but the new session
+                    // still needs its `produced` edge to the existing commit.
+                    warmStats = yield* ingestGit(write, { repoPaths: [repoPath], sinceDays: 1 }).pipe(
+                        Effect.provide(FixturePlatform),
+                    );
+
+                    produced = yield* write.rows(
+                        Schema.Struct({ in_id: Schema.String, out_id: Schema.String }),
+                        "SELECT in_id, out_id FROM produced WHERE in_id = ?",
+                        ["warm-session-684"],
+                    );
+                }),
+            ));
+
+            expect(coldStats).toMatchObject({ repos: 1, commits: 1 });
+            // The fetch path stayed skipped: an unchanged HEAD yields no
+            // freshly-walked commits on the warm run.
+            expect(warmStats).toMatchObject({ repos: 1, commits: 0 });
+            expect(produced).toEqual([{ in_id: "warm-session-684", out_id: expectedCommitId }]);
+        } finally {
+            await rm(repoPath, { recursive: true, force: true });
+        }
     });
 });

--- a/apps/axctl/src/ingest/git.ts
+++ b/apps/axctl/src/ingest/git.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import { Effect, FileSystem, Path, type PlatformError, Schema } from "effect";
 import { runCommand } from "@ax/lib/process";
 import { cacheRow, tsParam } from "@ax/lib/duckdb/row";
+import { TimestampColumn } from "@ax/lib/duckdb/columns";
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { watermarkRow } from "@ax/lib/duckdb/watermark";
 import { commitRowId, edgeRowId, stableId } from "@ax/lib/stable-id";
@@ -439,6 +440,46 @@ export function deriveRepositoryDisplayName(
     return remoteName && remoteName.length > 0 ? remoteName : posixPath.basename(repoPath);
 }
 
+/**
+ * session -> produced -> commit correlation, decoupled from the `commits`
+ * batch a single `writeRepo` call just walked (#684). A warm run with an
+ * unchanged git watermark passes `commits=[]` to `writeRepo` - but a session
+ * added since the last walk can still cover an ALREADY-persisted commit's ts,
+ * and that pairing was previously never correlated because the produced-edge
+ * write lived inside the `commits.length === 0` early return. This instead
+ * joins every commit already persisted for this repository against every
+ * session already linked to it, entirely inside DuckDB (no cross-store join -
+ * both tables live in the same cache). `edgeRowId` keeps ids stable and
+ * `putMany`'s `ON CONFLICT ("id") DO UPDATE` makes re-running this fully
+ * idempotent, so it is safe to call unconditionally on every `writeRepo`
+ * call - skipped-history or not - rather than reasoning about which commits
+ * were freshly walked.
+ */
+const correlateProducedEdges = (
+    write: CacheWriteService,
+    repositoryId: string,
+    checkoutId: string,
+): Effect.Effect<number, CacheWriteError> =>
+    Effect.gen(function* () {
+        const pairs = yield* write.rows(
+            Schema.Struct({ session_id: Schema.String, commit_id: Schema.String, ts: TimestampColumn }),
+            `SELECT s.id AS session_id, c.id AS commit_id, c.ts AS ts
+FROM commit c
+JOIN session s ON s.checkout = ?
+WHERE c.repository = ?
+  AND s.started_at <= c.ts
+  AND (s.ended_at IS NULL OR s.ended_at >= c.ts)`,
+            [checkoutId, repositoryId],
+        );
+        if (pairs.length === 0) return 0;
+        yield* write.putMany("produced", pairs.map((p) => cacheRow({
+            id: edgeRowId("produced", p.session_id, p.commit_id), in_id: p.session_id,
+            out_id: p.commit_id, repository: repositoryId, checkout: checkoutId,
+            ts: tsParam(p.ts), source: "git", kind: "commit",
+        })));
+        return pairs.length;
+    });
+
 const writeRepo = Effect.fn("git.writeRepo")(
     function* (
         write: CacheWriteService,
@@ -469,14 +510,16 @@ const writeRepo = Effect.fn("git.writeRepo")(
         yield* write.exec(`UPDATE session SET repository = ?, checkout = ? WHERE ${sessionClause.sql}`,
             [repositoryId, checkoutId, ...sessionClause.params]);
 
-        if (commits.length === 0)
+        if (commits.length === 0) {
+            const produced = yield* correlateProducedEdges(write, repositoryId, checkoutId);
             return {
                 commits: 0,
                 files: 0,
-                produced: 0,
+                produced,
                 touched: 0,
                 sessions: linkedSessions,
             } satisfies WriteStats;
+        }
 
         // 1. Bulk-upsert commits. If a previous ingest wrote this repo+sha
         // under the legacy local key, reuse that record id to satisfy the
@@ -509,9 +552,10 @@ const writeRepo = Effect.fn("git.writeRepo")(
         }
         yield* write.putMany("file", fileRows);
 
-        // 3. Write commit -> touched -> file rows. Touched is checkout-scoped
-        //    evidence, so re-runs delete only this checkout's rows before they
-        //    write fresh rows. Sibling worktree evidence is preserved.
+        // 3. Write commit -> touched -> file rows. Touched is
+        //    checkout-scoped evidence, so re-runs delete only this
+        //    checkout's rows before they write fresh rows. Sibling
+        //    worktree evidence is preserved.
         let touchedCount = 0;
         for (const c of commits) {
             if (c.files.length === 0) continue;
@@ -527,25 +571,9 @@ const writeRepo = Effect.fn("git.writeRepo")(
             yield* write.putMany("touched", rows);
         }
 
-        // 4. session -> produced -> commit. For each commit, find sessions whose
-        //    cwd starts with the repo path AND whose [started_at, ended_at]
-        //    range covers the commit ts. The per-commit query avoids loading
-        //    the session table into JavaScript.
-        let producedCount = 0;
-        for (const c of commits) {
-            const cid = commitIds.get(c.sha) ?? commitRowId(repo.repositoryKey, c.sha);
-            const sel = yield* write.rows(Schema.Struct({ id: Schema.String }),
-                "SELECT id FROM session WHERE checkout = ? AND started_at <= ? AND (ended_at IS NULL OR ended_at >= ?)",
-                [checkoutId, new Date(c.ts), new Date(c.ts)]);
-            const sessions = sel;
-            if (sessions.length > 0) {
-                yield* write.putMany("produced", sessions.map((s) => cacheRow({
-                    id: edgeRowId("produced", s.id, cid), in_id: s.id, out_id: cid,
-                    repository: repositoryId, checkout: checkoutId, ts: tsParam(c.ts), source: "git", kind: "commit",
-                })));
-            }
-            producedCount += sessions.length;
-        }
+        // 4. session -> produced -> commit. A session that appears after the
+        //    commit was persisted still gets correlated on the next warm run.
+        const producedCount = yield* correlateProducedEdges(write, repositoryId, checkoutId);
 
         return {
             commits: commits.length,
@@ -763,7 +791,14 @@ export type GitKey = typeof GitKey.Type;
 /**
  * Git stage - ingests Repository commits + touched files.
  *
- * Depends on: (none - leaf)
+ * Depends on: every session-writing provider stage that precedes it in
+ * `ALL_STAGES` (providers plus the subagent parser) - #684. `writeRepo`
+ * links `session.checkout`/`session.repository` and correlates `produced`
+ * edges against whatever sessions already exist at that point, so it must
+ * run after those stages write their sessions, not concurrently with them.
+ * The runner only awaits deps present in the selected stage set
+ * (`runner.ts`'s `runStage`), so this is safe even when a caller runs a
+ * stage subset that omits some of them.
  * Consumed by: {@link SignalsKey}
  * Tags: ingest
  */
@@ -780,7 +815,7 @@ export const gitStage: StageDef<
 > = {
     meta: StageMeta.make({
         key: "git",
-        deps: [],
+        deps: ["claude", "codex", "pi", "omp", "opencode", "cursor", "subagents"],
         tags: ["ingest"],
         writes: [
             { table: "repository", mode: "parse" },


### PR DESCRIPTION
## Summary

- Run Git after selected session provider stages.
- Correlate sessions against stored repository commits on warm runs.
- Keep the unchanged-repository history skip.
- Support canonical commits stored with a sibling worktree checkout.
- Add real DuckDB coverage for a session added after the Git watermark.

## Cause

The original Pi `cwd` claim did not match the local corpus. The provider-neutral Git path was the confirmed fault. An unchanged watermark linked the session checkout, then returned before `produced` correlation.

## Checks

- `DUCKDB_DIST_DIR=/Users/necmttn/Projects/ax/dist/duckdb bun test apps/axctl/src/ingest/git.test.ts apps/axctl/src/ingest/git.stage.test.ts`
- `DUCKDB_DIST_DIR=/Users/necmttn/Projects/ax/dist/duckdb bun test apps/axctl/src/ingest/stage/table-writes.test.ts apps/axctl/src/ingest/table-writes.behavior.test.ts`
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

Fixes #684

---

_Generated with [ax](https://github.com/Necmttn/ax)._
