### PR TITLE
fix: update Codex docs drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
 
       - run: bun run check:doc-catalog
 
+      - run: bun run check:harness-docs
+
       - run: bun run check:no-node-fs
 
       - run: bun run check:record-select

--- a/scripts/check-harness-docs-drift.test.ts
+++ b/scripts/check-harness-docs-drift.test.ts
@@ -20,45 +20,48 @@ describe("parseClaudeDocsIndex", () => {
 });
 
 describe("parseCodexDocsIndex", () => {
-    test("extracts Codex Source sections and preserves nested slugs", () => {
+    test("extracts learn.chatgpt.com markdown doc links and preserves nested slugs", () => {
         const index = [
-            "# Advanced configuration",
-            "Source: https://developers.openai.com/codex/config-advanced.md",
+            "## Config File",
+            "- [Advanced Configuration](https://learn.chatgpt.com/docs/config-file/config-advanced.md): More advanced configuration options for Codex local clients",
             "",
-            "# Sandboxing",
-            "Source: https://developers.openai.com/codex/concepts/sandboxing.md",
+            "## Agent Configuration",
+            "- [Rules](https://learn.chatgpt.com/docs/agent-configuration/rules.md): Control which commands Codex can run outside the sandbox",
+            "- [Subagents](https://learn.chatgpt.com/docs/agent-configuration/subagents.md): Use subagents in ChatGPT and Codex",
             "",
-            "Raw current-format link: https://developers.openai.com/codex/hooks.md",
-            "Source: https://example.com/codex/permissions.md",
-            "Source: https://developers.openai.com/codex/config-advanced.md",
+            "## Extend",
+            "- [Model Context Protocol](https://learn.chatgpt.com/docs/extend/mcp.md): Give Codex access to third-party tools and context",
         ].join("\n");
 
         expect(parseCodexDocsIndex(index)).toEqual([
-            { slug: "config-advanced", title: "config-advanced" },
-            { slug: "concepts/sandboxing", title: "sandboxing" },
-            { slug: "hooks", title: "hooks" },
+            { slug: "config-file/config-advanced", title: "Advanced Configuration" },
+            { slug: "agent-configuration/rules", title: "Rules" },
+            { slug: "agent-configuration/subagents", title: "Subagents" },
+            { slug: "extend/mcp", title: "Model Context Protocol" },
         ]);
     });
 
-    test("extracts current full-export links and heading-only watched pages", () => {
+    test("strips query strings and dedupes repeated links to the same slug", () => {
         const index = [
-            "# Agent approvals & security",
-            "See [sandboxing](https://developers.openai.com/codex/concepts/sandboxing).",
-            "",
-            "# Codex App Server",
-            "Use app-server when embedding Codex.",
-            "",
-            '<a href="/codex/sdk">Codex SDK</a>',
-            "Raw URL: https://developers.openai.com/codex/hooks",
+            "## Cli",
+            "- [Command line options](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli): Options and flags for the Codex terminal client",
+            "- [Slash commands in Codex CLI](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli): Control Codex during interactive sessions",
         ].join("\n");
 
         expect(parseCodexDocsIndex(index)).toEqual([
-            { slug: "concepts/sandboxing", title: "sandboxing" },
-            { slug: "hooks", title: "hooks" },
-            { slug: "sdk", title: "sdk" },
-            { slug: "agent-approvals-security", title: "Agent approvals & security" },
-            { slug: "app-server", title: "Codex App Server" },
+            { slug: "developer-commands", title: "Command line options" },
         ]);
+    });
+
+    test("ignores the old developers.openai.com host and non-markdown links", () => {
+        const index = [
+            "- [Old host](https://developers.openai.com/codex/hooks.md): stale link from the retired index",
+            "- [Community](https://developers.openai.com/community/codex-for-oss): not a docs page",
+            "- [Combined docs](https://learn.chatgpt.com/docs/llms-full.txt): not a single doc page",
+            "- [Current](https://learn.chatgpt.com/docs/hooks.md): Run scripts or MCP tools during the Codex lifecycle",
+        ].join("\n");
+
+        expect(parseCodexDocsIndex(index)).toEqual([{ slug: "hooks", title: "Current" }]);
     });
 });
 

--- a/scripts/check-harness-docs-drift.ts
+++ b/scripts/check-harness-docs-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 const CLAUDE_DOCS_INDEX_URL = "https://code.claude.com/docs/llms.txt";
-const CODEX_DOCS_INDEX_URL = "https://developers.openai.com/codex/llms-full.txt";
+const CODEX_DOCS_INDEX_URL = "https://developers.openai.com/codex/llms.txt";
 
 const CLAUDE_WATCHED_SLUGS = [
     "monitoring-usage",
@@ -23,37 +23,25 @@ const CLAUDE_WATCHED_SLUGS = [
 ] as const;
 
 const CODEX_WATCHED_SLUGS = [
-    "config-advanced",
+    "config-file/config-advanced",
     "agent-approvals-security",
-    "concepts/sandboxing",
+    "sandboxing",
     "permissions",
     "hooks",
-    "mcp",
-    "skills",
-    "rules",
+    "extend/mcp",
+    "build-skills",
+    "agent-configuration/rules",
     "plugins",
-    "concepts/subagents",
-    "subagents",
+    "agent-configuration/subagents",
     "app-server",
-    "sdk",
+    "codex-sdk",
     "github-action",
     "cloud",
 ] as const;
 
 const CLAUDE_DOC_URL_RE = /\bhttps:\/\/code\.claude\.com\/docs\/en\/([A-Za-z0-9][A-Za-z0-9/_-]*?)\.md\b/g;
-const CODEX_SOURCE_RE = /^Source:\s+https:\/\/developers\.openai\.com\/codex\/([A-Za-z0-9][A-Za-z0-9/_-]*?)\.md\s*$/gm;
 const CODEX_MARKDOWN_LINK_RE =
-    /\[([^\]]+)\]\(https:\/\/developers\.openai\.com\/codex\/([A-Za-z0-9][A-Za-z0-9/_-]*?)(?:\.md)?(?:#[^)]+)?\)/g;
-const CODEX_ABSOLUTE_URL_RE =
-    /\bhttps:\/\/developers\.openai\.com\/codex\/([A-Za-z0-9][A-Za-z0-9/_-]*?)(?:\.md)?(?=[#)\s"'<]|$)/g;
-const CODEX_RELATIVE_HREF_RE = /\bhref="\/codex\/([A-Za-z0-9][A-Za-z0-9/_-]*?)(?:#[^"]*)?"/g;
-
-const CODEX_HEADING_SLUG_ALIASES = new Map<string, string>([
-    ["Agent approvals & security", "agent-approvals-security"],
-    ["Advanced Configuration", "config-advanced"],
-    ["Codex App Server", "app-server"],
-    ["Codex SDK", "sdk"],
-]);
+    /\[([^\]]+)\]\(https:\/\/learn\.chatgpt\.com\/docs\/([A-Za-z0-9][A-Za-z0-9/_-]*?)\.md(?:\?[^)#]*)?(?:#[^)]+)?\)/g;
 
 export interface DocsEntry {
     readonly slug: string;
@@ -102,36 +90,10 @@ export function parseClaudeDocsIndex(content: string): DocsEntry[] {
 export function parseCodexDocsIndex(content: string): DocsEntry[] {
     const entries: DocsEntry[] = [];
     const seen = new Set<string>();
-
-    let sourceMatch: RegExpExecArray | null;
-    while ((sourceMatch = CODEX_SOURCE_RE.exec(content)) !== null) {
-        const slug = sourceMatch[1] as string;
-        addEntry(entries, seen, slug, slugTitle(slug));
-    }
-
     let linkMatch: RegExpExecArray | null;
     while ((linkMatch = CODEX_MARKDOWN_LINK_RE.exec(content)) !== null) {
         addEntry(entries, seen, linkMatch[2] as string, linkMatch[1] as string);
     }
-
-    let absoluteMatch: RegExpExecArray | null;
-    while ((absoluteMatch = CODEX_ABSOLUTE_URL_RE.exec(content)) !== null) {
-        const slug = absoluteMatch[1] as string;
-        addEntry(entries, seen, slug, slugTitle(slug));
-    }
-
-    let hrefMatch: RegExpExecArray | null;
-    while ((hrefMatch = CODEX_RELATIVE_HREF_RE.exec(content)) !== null) {
-        const slug = hrefMatch[1] as string;
-        addEntry(entries, seen, slug, slugTitle(slug));
-    }
-
-    for (const [title, slug] of CODEX_HEADING_SLUG_ALIASES) {
-        if (content.includes(`\n# ${title}\n`) || content.startsWith(`# ${title}\n`)) {
-            addEntry(entries, seen, slug, title);
-        }
-    }
-
     return entries;
 }
 


### PR DESCRIPTION
## Summary

- Read the current curated Codex documentation index.
- Parse canonical `learn.chatgpt.com` Markdown links.
- Update watched topics to their current canonical slugs.
- Remove obsolete full-export parser branches.
- Add the live drift check to the CI verify job.

## Checks

- `bun test scripts/check-harness-docs-drift.test.ts`
- `bun run check:harness-docs`
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

The live check finds 191 Claude pages and 141 Codex pages. No watched page is missing.

Fixes #708

---

_Generated with [ax](https://github.com/Necmttn/ax)._
