### PR TITLE
test: scope DuckDB integration timeout

### DIFF
--- a/packages/lib/src/testing/duckdb-dylib.test.ts
+++ b/packages/lib/src/testing/duckdb-dylib.test.ts
@@ -8,11 +8,39 @@ import {
     releaseDownloadSentinel,
     decideFtsGate,
     probeFtsCapable,
+    REAL_DUCKDB_TEST_TIMEOUT_MS,
     repoRootFrom,
     requireFtsFromEnv,
     resolveTestDylib,
     vendorDir,
+    withRealDuckDbTimeout,
 } from "./duckdb-dylib.ts";
+
+describe("real DuckDB test timeout", () => {
+    test("adds the real-database limit when a case has no explicit limit", () => {
+        let received: number | object | undefined;
+        const dtest = withRealDuckDbTimeout((_label, _fn, options) => {
+            received = options;
+        });
+
+        dtest("case", () => undefined);
+
+        expect(received).toBe(REAL_DUCKDB_TEST_TIMEOUT_MS);
+    });
+
+    test("preserves an explicit numeric or object limit", () => {
+        const received: Array<number | object | undefined> = [];
+        const dtest = withRealDuckDbTimeout((_label, _fn, options) => {
+            received.push(options);
+        });
+        const options = { timeout: 12_000, retry: 1 };
+
+        dtest("numeric", () => undefined, 15_000);
+        dtest("object", () => undefined, options);
+
+        expect(received).toEqual([15_000, options]);
+    });
+});
 
 describe("resolveTestDylib", () => {
     test("either resolves to a real file on disk or explains why it cannot", async () => {

--- a/packages/lib/src/testing/duckdb-dylib.ts
+++ b/packages/lib/src/testing/duckdb-dylib.ts
@@ -20,7 +20,7 @@
  * (which scans runtime sources) does not apply and an Effect `FileSystem`
  * would only add ceremony to something that runs before any layer exists.
  */
-import { afterAll, test } from "bun:test";
+import { afterAll, test, type TestOptions } from "bun:test";
 import { Effect, type Layer } from "effect";
 import { closeSync, existsSync, mkdirSync, mkdtempSync, openSync, rmSync, statSync } from "node:fs";
 import { arch, platform, tmpdir } from "node:os";
@@ -29,6 +29,23 @@ import { DuckDb, DuckDbLayer, type DuckDbService } from "../duckdb/client.ts";
 import type { DuckDbDylibError } from "../duckdb/errors.ts";
 
 export const DUCKDB_VERSION = "v1.5.5";
+
+/**
+ * Real DuckDB cases open native connections, apply the full DDL, and often
+ * publish FTS indexes. Bun's five-second unit-test default measures shared CI
+ * runner load for this work. Keep the larger limit on `dtest` only, so ordinary
+ * unit tests still fail quickly.
+ */
+export const REAL_DUCKDB_TEST_TIMEOUT_MS = 30_000;
+
+export type DuckDbTest = (
+    label: string,
+    fn: () => void | Promise<unknown>,
+    options?: number | TestOptions,
+) => void;
+
+export const withRealDuckDbTimeout = (baseTest: DuckDbTest): DuckDbTest =>
+    (label, fn, options = REAL_DUCKDB_TEST_TIMEOUT_MS) => baseTest(label, fn, options);
 
 export type TestDylib =
     | { readonly ok: true; readonly path: string }
@@ -337,7 +354,7 @@ export interface DuckDbTestSetup {
      *  dylib is available - registering at module load (not inside a
      *  `beforeAll`) so bun reports a real SKIP status instead of a silent
      *  PASS on a dylib-less box. */
-    readonly dtest: typeof test;
+    readonly dtest: DuckDbTest;
     /** `DuckDbLayer(dylibPath)`, or `null` when no dylib is available. Only
      *  ever consumed through `withDuckDb` below - exposed too for a suite
      *  that needs to `Effect.provide` it directly. */
@@ -395,7 +412,7 @@ export const duckdbTestSetup = async (
     }
 
     const layer = dylibPath !== null ? DuckDbLayer(dylibPath) : null;
-    const dtest = test.skipIf(dylibPath === null);
+    const dtest = withRealDuckDbTimeout(test.skipIf(dylibPath === null));
 
     // Publish the resolved path into the environment.
     //


### PR DESCRIPTION
Closes #1069.

## Cause

All real DuckDB cases used `dtest`, but `dtest` inherited Bun’s five-second unit-test limit. Shared CI load pushed valid database work past that limit.

## Change

- Give `dtest` a 30-second default limit.

- Keep ordinary unit tests at Bun’s five-second default.

- Preserve every explicit numeric or object test option.

## Verification

- The 32-process stress loop fails before this change and passes after it.

- 17 helper tests pass.

- 21 focused helper and segment tests pass.

- Type checking passes across 504 `dtest` call sites.

- The full suite passes 6,545 tests with zero failures.

- Storage and source guards pass.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
