### PR TITLE
ci: cache DuckDB release builds

### DIFF
--- a/.github/actions/provision-duckdb/action.yml
+++ b/.github/actions/provision-duckdb/action.yml
@@ -1,0 +1,107 @@
+name: Provision DuckDB build
+description: >-
+  Restore or build the platform DuckDB artifact used to embed axctl's native
+  dependency, always air-gap smoke the provisioned bytes, and save on a
+  genuine miss. Shared, byte-identical, between release-please.yml's
+  build-artifacts job (tag-scoped) and its prime-duckdb-cache job
+  (default-branch-scoped) - the two callers MUST compute the exact same
+  cache key, and factoring the key computation out here is what guarantees
+  that instead of relying on two hand-copies never drifting apart.
+inputs:
+  label:
+    description: Label for the timing line written to the step summary.
+    required: true
+outputs:
+  cache-hit:
+    description: "'true' if the cache was restored rather than built from scratch"
+    value: ${{ steps.duckdb-restore.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    # The key is scoped per (os, arch). It includes the native build recipe,
+    # this action's build flags, the smoke contract, and both DuckDB addon
+    # versions. A new smoke contract or addon must miss the old immutable
+    # cache. Otherwise, incompatible restored bytes can fail every later run
+    # without giving the build step a chance to replace them.
+    - name: Compute DuckDB cache key
+      id: duckdb-key
+      shell: bash
+      run: |
+        duckdb_versions="$(bun -e 'const catalog = (await Bun.file("package.json").json()).workspaces.catalog; process.stdout.write(`${catalog["@duckdb/node-api"]}-${catalog["@duckdb/node-bindings"]}`)')"
+        echo "value=duckdb-${{ runner.os }}-${{ runner.arch }}-${duckdb_versions}-${{ hashFiles('scripts/build-duckdb.sh', 'scripts/duckdb/extension_config_local.cmake', 'scripts/smoke-duckdb-dylib.ts', '.github/actions/provision-duckdb/action.yml') }}" >> "$GITHUB_OUTPUT"
+
+    - name: Start DuckDB provision timer
+      id: duckdb-timer
+      shell: bash
+      run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+    # GitHub Actions scopes a saved cache to the ref that created it (plus
+    # that ref's base branches, plus the repository's DEFAULT branch) and
+    # does NOT share a cache between two different tags. Restoring here
+    # picks up either this run's own ref scope or - critically for a
+    # release tag, which has no other tag to fall back to - a prior save
+    # made from the default branch by the prime-duckdb-cache job below.
+    # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+    - name: Restore DuckDB build
+      id: duckdb-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: dist/duckdb
+        key: ${{ steps.duckdb-key.outputs.value }}
+
+    - name: Install DuckDB build tools (Linux)
+      if: runner.os == 'Linux' && steps.duckdb-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
+
+    - name: Build DuckDB
+      if: steps.duckdb-restore.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        STATIC_LIBCPP: ${{ runner.os == 'Linux' && '1' || '' }}
+      run: scripts/build-duckdb.sh
+
+    - name: Resolve DuckDB library name
+      id: duckdb-lib
+      shell: bash
+      run: |
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          echo "name=libduckdb.dylib" >> "$GITHUB_OUTPUT"
+        else
+          echo "name=libduckdb.so" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Always smoke, restore or build - proves the bytes about to be embedded
+    # (or, from the prime job, the bytes about to be saved for the next
+    # release) still link fts/json statically, so a poisoned or truncated
+    # cache entry fails here with one clear error instead of downstream in
+    # the shipped binary.
+    - name: Air-gap smoke the provisioned DuckDB
+      shell: bash
+      run: |
+        set -euo pipefail
+        chmod +x dist/duckdb/duckdb
+        scripts/build-duckdb.sh --smoke-only dist/duckdb/duckdb
+        bun scripts/smoke-duckdb-dylib.ts dist/duckdb/${{ steps.duckdb-lib.outputs.name }}
+
+    # Saved only after the smoke passes and only on a genuine miss - a
+    # cache hit must never re-save, and a bad build must never become the
+    # cached answer for every later release.
+    - name: Save DuckDB build
+      if: steps.duckdb-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: dist/duckdb
+        key: ${{ steps.duckdb-key.outputs.value }}
+
+    - name: Record DuckDB provision duration
+      shell: bash
+      run: |
+        elapsed=$(( $(date +%s) - ${{ steps.duckdb-timer.outputs.start }} ))
+        status="miss"
+        if [ "${{ steps.duckdb-restore.outputs.cache-hit }}" = "true" ]; then
+          status="hit"
+        fi
+        receipt="DuckDB provision (${{ inputs.label }}): cache ${status}, ${elapsed}s"
+        echo "$receipt"
+        echo "$receipt" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,64 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
+  # Primes the DuckDB build cache from a TRUSTED default-branch (`main`) run
+  # so the next release tag gets a warm restore instead of a from-scratch
+  # build. GitHub Actions scopes a saved cache to the ref that created it
+  # plus the repository's default branch - it does NOT share a cache
+  # between two different tags - so build-artifacts' tag-scoped save (below)
+  # only ever helps a RETRY of that same tag, never the next release.
+  # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  #
+  # Gated on `releases_created` (release-please's own output, set only on the
+  # push where it actually cuts a release) so this doesn't run three
+  # expensive full-matrix runners on every ordinary main push - just the rare
+  # push that creates a release. That push's `release: published` event also
+  # triggers build-artifacts on the new tag concurrently, so this prime run
+  # may race it and lose the save on a shared first-ever cache miss; it isn't
+  # racing to help ITS OWN release, only to seed every release after this one.
+  # No release publishing happens here (build/smoke/save only), so the
+  # publish-race protection on build-artifacts/publish-artifacts is untouched.
+  prime-duckdb-cache:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    name: Prime DuckDB cache (${{ matrix.artifact }})
+    runs-on: ${{ matrix.runner }}
+    # Mirrors build-artifacts' cold-build headroom - a prime run misses the
+    # cache exactly like a build-artifacts run would on the same inputs.
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # Must match build-artifacts' matrix runners exactly - the cache key
+        # is a function of (runner.os, runner.arch), so priming a runner
+        # build-artifacts doesn't use would seed a key nothing ever reads.
+        include:
+          - runner: macos-14
+            artifact: axctl-darwin-arm64
+          - runner: macos-15-intel
+            artifact: axctl-darwin-x64
+          - runner: ubuntu-24.04
+            artifact: axctl-linux-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      # The dynamic library smoke imports @ax/lib through the workspace link.
+      # Install before both a cache-hit smoke and a cache-miss build.
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      # No CLI build, no packaging, no upload-artifact, no release publish -
+      # this job's only job is to leave a warm, smoke-verified cache entry
+      # behind under the default-branch scope.
+      - name: Provision DuckDB build
+        uses: ./.github/actions/provision-duckdb
+        with:
+          label: ${{ matrix.artifact }} (default-branch prime)
+
   # Artifacts build only on the `release: published` event (or manual dispatch
   # with a tag). The push run that creates the release via release-please must
   # NOT also build - when it did, its publish job raced the release-event run's
@@ -39,6 +97,9 @@ jobs:
     if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') }}
     name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.runner }}
+    # Recent cold-build durations ranged 12m22s-33m39s; 90m matches CI's own
+    # DuckDB cold-build guard and leaves headroom above the slowest observed run.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +141,27 @@ jobs:
       - run: bun test
 
       - run: bun run check:cli-reference
+
+      # DuckDB is a native dep with an expensive from-scratch build
+      # (scripts/build-duckdb.sh, mirrors CI's own `duckdb` job). Reusing a
+      # full built artifact - not a compiler cache - is what lets the
+      # restored bytes be air-gap smoked directly before build-axctl.ts's
+      # writeManifestReusingBuild() embeds them, the same trust proof CI
+      # runs on every fire.
+      #
+      # GitHub Actions caches are scoped per-ref (a saved cache is visible to
+      # the ref that made it, that ref's base branches, and the default
+      # branch - never to another tag), so a cache this job saves under a
+      # release tag is invisible to the NEXT release tag. The
+      # prime-duckdb-cache job below saves the identical key from `main` (a
+      # trusted default-branch run) so every later release tag gets a warm
+      # restore instead of a from-scratch build. The restore/build/smoke/save
+      # logic is factored into ./.github/actions/provision-duckdb so both
+      # jobs compute a byte-identical cache key by construction.
+      - name: Provision DuckDB build
+        uses: ./.github/actions/provision-duckdb
+        with:
+          label: ${{ matrix.artifact }}
 
       - run: bun scripts/build-axctl.ts apps/axctl/src/cli/index.ts dist/axctl
 

--- a/scripts/build-duckdb.test.ts
+++ b/scripts/build-duckdb.test.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parse } from "yaml";
 
 const binTest = gatedTest({
     reason: "AX_DUCKDB_BIN is not set (no built duckdb binary to exercise)",
@@ -196,4 +197,222 @@ chmod +x "$2/build/release/duckdb"
             }
         },
     );
+});
+
+type WorkflowStep = {
+    id?: string;
+    name?: string;
+    run?: string;
+    uses?: string;
+    if?: string;
+    env?: Record<string, string>;
+    with?: Record<string, string>;
+};
+
+describe("provision-duckdb composite action restores/builds/smokes/saves the DuckDB build", () => {
+    const actionPath = join(repoRoot, ".github/actions/provision-duckdb/action.yml");
+    const action = parse(readFileSync(actionPath, "utf8")) as {
+        runs: { using: string; steps: WorkflowStep[] };
+        outputs?: Record<string, { value: string }>;
+    };
+    const steps = action.runs.steps;
+
+    const restoreStep = steps.find((s) => s.uses?.startsWith("actions/cache/restore"));
+    const saveStep = steps.find((s) => s.uses?.startsWith("actions/cache/save"));
+    const buildStep = steps.find((s) => (s.run ?? "").trim() === "scripts/build-duckdb.sh");
+    const smokeStep = steps.find((s) =>
+        (s.run ?? "").includes("bun scripts/smoke-duckdb-dylib.ts"),
+    );
+
+    test("is a composite action with the DuckDB steps to guard", () => {
+        // A parse/lookup mistake here would make every case below vacuously
+        // true - the same trap check-ci-duckdb.test.ts guards against.
+        expect(action.runs.using).toBe("composite");
+        expect(restoreStep).toBeDefined();
+        expect(saveStep).toBeDefined();
+        expect(buildStep).toBeDefined();
+        expect(smokeStep).toBeDefined();
+    });
+
+    test("the cache is scoped per platform and keyed on every DuckDB build and compatibility input", () => {
+        expect(restoreStep?.with?.path).toBe("dist/duckdb");
+        // The restore/save `key:` reference the computed value by step
+        // output, so the hashFiles inputs live in the step that computes it.
+        const keyStep = steps.find(
+            (s) => (s.run ?? "").includes("GITHUB_OUTPUT") && (s.run ?? "").includes("hashFiles"),
+        );
+        expect(keyStep?.id).toBeDefined();
+        expect(restoreStep?.with?.key).toContain(`steps.${keyStep?.id}.outputs`);
+
+        const key = keyStep?.run ?? "";
+        expect(key).toContain("runner.os");
+        expect(key).toContain("runner.arch");
+        expect(key).toContain("scripts/build-duckdb.sh");
+        expect(key).toContain("scripts/duckdb/extension_config_local.cmake");
+        expect(key).toContain("scripts/smoke-duckdb-dylib.ts");
+        expect(key).toContain(".github/actions/provision-duckdb/action.yml");
+        expect(key).toContain("@duckdb/node-api");
+        expect(key).toContain("@duckdb/node-bindings");
+        // Read only the two exact catalog versions. Hashing package.json or
+        // bun.lock would rebuild native DuckDB after unrelated dependency or
+        // release-version changes.
+        expect(key).toContain('Bun.file("package.json").json()');
+        expect(key).not.toContain("bun.lock");
+    });
+
+    test("save uses the identical key and path as restore", () => {
+        expect(saveStep?.with?.key).toBe(restoreStep?.with?.key);
+        expect(saveStep?.with?.path).toBe("dist/duckdb");
+    });
+
+    test("restores the cache, and builds on a miss, before the smoke step", () => {
+        const restoreIdx = steps.indexOf(restoreStep!);
+        const buildIdx = steps.indexOf(buildStep!);
+        const smokeIdx = steps.indexOf(smokeStep!);
+        expect(restoreIdx).toBeGreaterThanOrEqual(0);
+        expect(buildIdx).toBeGreaterThan(restoreIdx);
+        expect(buildIdx).toBeLessThan(smokeIdx);
+    });
+
+    test("only builds DuckDB from scratch on a cache miss", () => {
+        expect(buildStep?.if).toContain("cache-hit");
+        expect(buildStep?.if).toContain("!=");
+    });
+
+    test("passes STATIC_LIBCPP on Linux only, not on the macOS legs", () => {
+        const staticLibcpp = String(buildStep?.env?.STATIC_LIBCPP ?? "");
+        expect(staticLibcpp).toContain("runner.os == 'Linux'");
+        expect(staticLibcpp).toContain("'1'");
+    });
+
+    test("smokes both the restored shell and the correct dylib unconditionally - restore or build, never skipped on a hit", () => {
+        expect(smokeStep?.if).toBeUndefined();
+        expect(smokeStep?.run).toContain("chmod +x dist/duckdb/duckdb");
+        expect(smokeStep?.run).toContain("build-duckdb.sh --smoke-only");
+        expect(smokeStep?.run).toContain("smoke-duckdb-dylib.ts");
+    });
+
+    test("resolves the platform-specific library rather than hardcoding one extension", () => {
+        const fullText = readFileSync(actionPath, "utf8");
+        expect(fullText).toContain("libduckdb.dylib");
+        expect(fullText).toContain("libduckdb.so");
+        expect(smokeStep?.run).toMatch(/libduckdb\.(dylib|so)|duckdb-lib/);
+    });
+
+    test("saves only after the smoke passes, and never on a cache hit", () => {
+        const smokeIdx = steps.indexOf(smokeStep!);
+        const saveIdx = steps.indexOf(saveStep!);
+        expect(saveIdx).toBeGreaterThan(smokeIdx);
+        expect(saveStep?.if).toContain("cache-hit");
+        expect(saveStep?.if).toContain("!=");
+    });
+
+    test("records a provisioning timing receipt via a cross-step start value, labeled by the caller", () => {
+        const timerStep = steps.find(
+            (s) => (s.run ?? "").includes("GITHUB_OUTPUT") && (s.run ?? "").includes("date +%s"),
+        );
+        expect(timerStep?.id).toBeDefined();
+
+        const summaryStep = steps.find((s) => (s.run ?? "").includes("GITHUB_STEP_SUMMARY"));
+        expect(summaryStep).toBeDefined();
+        expect(summaryStep?.run).toContain(`steps.${timerStep?.id}.outputs`);
+        expect(summaryStep?.run).toContain("cache-hit");
+        expect(summaryStep?.run).toContain("inputs.label");
+        expect(summaryStep?.run).toContain('echo "$receipt"');
+        expect(steps.indexOf(summaryStep!)).toBeGreaterThan(steps.indexOf(smokeStep!));
+    });
+
+    test("exposes cache-hit as an output for callers to key logic off", () => {
+        expect(action.outputs?.["cache-hit"]?.value ?? "").toContain("duckdb-restore.outputs.cache-hit");
+    });
+});
+
+describe("release-please.yml: a trusted default-branch prime primes the same cache release tags restore from", () => {
+    const workflowPath = join(repoRoot, ".github/workflows/release-please.yml");
+    const workflow = parse(readFileSync(workflowPath, "utf8")) as {
+        jobs: Record<
+            string,
+            {
+                needs?: string | string[];
+                if?: string;
+                "timeout-minutes"?: number;
+                outputs?: Record<string, string>;
+                strategy?: { matrix?: { include?: Array<{ runner: string; artifact: string }> } };
+                steps?: WorkflowStep[];
+            }
+        >;
+    };
+    const releasePleaseJob = workflow.jobs["release-please"];
+    const primeJob = workflow.jobs["prime-duckdb-cache"];
+    const buildJob = workflow.jobs["build-artifacts"];
+    const publishJob = workflow.jobs["publish-artifacts"];
+    const provisionUses = "./.github/actions/provision-duckdb";
+
+    test("build-artifacts and prime-duckdb-cache both exist and invoke the identical composite action path", () => {
+        // Cache-key identity between the two jobs comes from literally calling
+        // the same action file, not from two hand-copied formulas that could
+        // drift apart - this is the structural guarantee that a key the prime
+        // job saves is the exact key a release tag will look up.
+        expect(buildJob).toBeDefined();
+        expect(primeJob).toBeDefined();
+        const buildProvisionStep = buildJob?.steps?.find((s) => s.uses === provisionUses);
+        const primeProvisionStep = primeJob?.steps?.find((s) => s.uses === provisionUses);
+        expect(buildProvisionStep).toBeDefined();
+        expect(primeProvisionStep).toBeDefined();
+    });
+
+    test("build-artifacts carries 90 minutes of timeout headroom above recent 12m-33m cold builds", () => {
+        expect(buildJob?.["timeout-minutes"]).toBe(90);
+    });
+
+    test("build-artifacts restores/builds via the composite action before the CLI binary build", () => {
+        const steps = buildJob?.steps ?? [];
+        const provisionIdx = steps.findIndex((s) => s.uses === provisionUses);
+        const buildAxctlIdx = steps.findIndex((s) => (s.run ?? "").includes("scripts/build-axctl.ts"));
+        expect(provisionIdx).toBeGreaterThanOrEqual(0);
+        expect(buildAxctlIdx).toBeGreaterThan(provisionIdx);
+    });
+
+    test("prime-duckdb-cache is gated on release-please's own releases_created output, not guessed from the event", () => {
+        expect(primeJob?.needs).toBe("release-please");
+        expect(primeJob?.if ?? "").toContain("needs.release-please.outputs.releases_created");
+        expect(primeJob?.if ?? "").toContain("== 'true'");
+        // A typo'd output name here would leave the condition permanently
+        // false and the prime job would silently never fire - pin it back to
+        // release-please's actual output wiring.
+        expect(releasePleaseJob?.outputs?.releases_created ?? "").toContain(
+            "steps.release.outputs.releases_created",
+        );
+    });
+
+    test("prime-duckdb-cache's matrix mirrors build-artifacts' matrix runners exactly, so it seeds the same (os, arch) cache keys build-artifacts will look up", () => {
+        const buildRunners = (buildJob?.strategy?.matrix?.include ?? []).map((m) => m.runner).sort();
+        const primeRunners = (primeJob?.strategy?.matrix?.include ?? []).map((m) => m.runner).sort();
+        expect(buildRunners.length).toBeGreaterThan(0);
+        expect(primeRunners).toEqual(buildRunners);
+    });
+
+    test("prime-duckdb-cache never publishes release artifacts - no CLI build, packaging, upload, or gh release calls", () => {
+        const primeText = JSON.stringify(primeJob?.steps ?? []);
+        expect(primeText).not.toContain("build-axctl.ts");
+        expect(primeText).not.toContain("upload-artifact");
+        expect(primeText).not.toContain("gh release");
+        expect(primeText).not.toContain("tar -czf");
+    });
+
+    test("prime-duckdb-cache installs workspace dependencies before the dynamic library smoke", () => {
+        const steps = primeJob?.steps ?? [];
+        const installIdx = steps.findIndex(
+            (s) => (s.run ?? "").trim() === "bun install --frozen-lockfile",
+        );
+        const provisionIdx = steps.findIndex((s) => s.uses === provisionUses);
+        expect(installIdx).toBeGreaterThanOrEqual(0);
+        expect(provisionIdx).toBeGreaterThan(installIdx);
+    });
+
+    test("the release publish-race protection is unchanged: publish-artifacts still gates on the release/tag-dispatch event only", () => {
+        expect(publishJob?.needs).toBe("build-artifacts");
+        expect(publishJob?.if ?? "").not.toContain("prime-duckdb-cache");
+        expect(publishJob?.if ?? "").toContain("github.event_name == 'release'");
+    });
 });


### PR DESCRIPTION
## Summary

- cache smoke-verified DuckDB release outputs by operating system, architecture, build recipe, smoke contract, and addon versions
- prime identical cache keys from trusted main runs so later release tags can restore them
- record cold or warm provision duration for every target and set a 90-minute timeout

## Verification

- `bun test ./scripts/build-duckdb.test.ts ./scripts/check-ci-duckdb.test.ts` (146 pass, 2 gated skips)
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

Fixes #776

---

_Generated with [ax](https://github.com/Necmttn/ax)._