### PR TITLE
test(ci): run gated DuckDB smoke cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
       # (scripts/bench/duckdb-bin.ts) both prefer this dir over anything else,
       # so no test can silently reach the upstream download.
       DUCKDB_DIST_DIR: ${{ github.workspace }}/dist/duckdb
+      # gatedTest reads these two directly (scripts/build-duckdb.test.ts) to
+      # decide whether the real binary/dylib smoke cases run or skip. Without
+      # them, DUCKDB_DIST_DIR alone leaves those two cases gated off even
+      # though the artifact is right there.
+      AX_DUCKDB_BIN: ${{ github.workspace }}/dist/duckdb/duckdb
+      AX_DUCKDB_DYLIB: ${{ github.workspace }}/dist/duckdb/libduckdb.so
       # Make a broken provisioning step FAIL rather than quietly skip every
       # FTS-dependent suite. CI green must mean the suites ran.
       AX_DUCKDB_REQUIRE_FTS: "1"

--- a/scripts/check-ci-duckdb.test.ts
+++ b/scripts/check-ci-duckdb.test.ts
@@ -119,6 +119,29 @@ describe("ci.yml provisions the custom DuckDB", () => {
         // rejects it, and duckdbBinPath falls through to PATH silently.
         expect(runScripts("verify")).toContain("chmod +x dist/duckdb/duckdb");
     });
+
+    test("verify wires the exact real-binary/dylib paths gatedTest reads", () => {
+        // scripts/build-duckdb.test.ts gates its two real smoke cases on
+        // AX_DUCKDB_BIN / AX_DUCKDB_DYLIB directly - DUCKDB_DIST_DIR alone
+        // leaves them gated off even though the artifact was downloaded.
+        const env = job("verify").env ?? {};
+        expect(env.AX_DUCKDB_BIN).toBe("${{ github.workspace }}/dist/duckdb/duckdb");
+        expect(env.AX_DUCKDB_DYLIB).toBe("${{ github.workspace }}/dist/duckdb/libduckdb.so");
+    });
+
+    test("verify still points DUCKDB_DIST_DIR at the same downloaded build", () => {
+        expect(job("verify").env?.DUCKDB_DIST_DIR).toBe("${{ github.workspace }}/dist/duckdb");
+    });
+
+    test("verify orders artifact download, chmod, then bun test", () => {
+        const steps = stepsOf("verify");
+        const download = steps.findIndex((s) => s.uses?.startsWith("actions/download-artifact"));
+        const chmod = steps.findIndex((s) => (s.run ?? "").includes("chmod +x dist/duckdb/duckdb"));
+        const bunTest = steps.findIndex((s) => (s.run ?? "").trim() === "bun test");
+        expect(download).toBeGreaterThanOrEqual(0);
+        expect(chmod).toBeGreaterThan(download);
+        expect(bunTest).toBeGreaterThan(chmod);
+    });
 });
 
 describe("every FTS-dependent suite declares requireFts", () => {


### PR DESCRIPTION
## Summary

- set the exact DuckDB shell and library paths in the CI verify job
- keep the shared dist directory for all other DuckDB test resolvers
- guard artifact download, executable repair, and test order with parsed workflow tests

## Verification

- 131 structural tests pass
- 24 custom DuckDB tests pass with both gated smoke cases required
- typecheck passes
- no-node-fs, timestamp-cast, and raw-numeric-cast guards pass

Fixes #774

---

_Generated with [ax](https://github.com/Necmttn/ax)._
