### PR TITLE
test(duckdb): prove CI smokes run without network

### DIFF
--- a/.github/actions/provision-duckdb/action.yml
+++ b/.github/actions/provision-duckdb/action.yml
@@ -76,13 +76,27 @@ runs:
     # release) still link fts/json statically, so a poisoned or truncated
     # cache entry fails here with one clear error instead of downstream in
     # the shipped binary.
+    #
+    # On Linux this runs inside a real network namespace (`sudo unshare
+    # --net`), not just the dead-port proxy env vars build-duckdb.sh also
+    # sets - those are defense only, since DuckDB's extension downloader does
+    # not honor them. Bun is resolved to an absolute path BEFORE the sudo
+    # call, since root's PATH (secure_path) does not carry it. macOS has no
+    # `unshare` syscall, so it runs the identical combined smoke directly.
     - name: Air-gap smoke the provisioned DuckDB
       shell: bash
       run: |
         set -euo pipefail
         chmod +x dist/duckdb/duckdb
-        scripts/build-duckdb.sh --smoke-only dist/duckdb/duckdb
-        bun scripts/smoke-duckdb-dylib.ts dist/duckdb/${{ steps.duckdb-lib.outputs.name }}
+        shell_path="$PWD/dist/duckdb/duckdb"
+        lib_path="$PWD/dist/duckdb/${{ steps.duckdb-lib.outputs.name }}"
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          bun_bin=$(command -v bun)
+          sudo unshare --net env BUN_BIN="$bun_bin" \
+            scripts/build-duckdb.sh --smoke-artifacts "$shell_path" "$lib_path"
+        else
+          scripts/build-duckdb.sh --smoke-artifacts "$shell_path" "$lib_path"
+        fi
 
     # Saved only after the smoke passes and only on a genuine miss - a
     # cache hit must never re-save, and a bad build must never become the

--- a/.github/workflows/build-duckdb.yml
+++ b/.github/workflows/build-duckdb.yml
@@ -38,14 +38,37 @@ jobs:
         with:
           bun-version: "1.3.10"
 
+      # The dynamic library smoke (both here and in the isolated re-smoke
+      # below) imports @ax/lib through the workspace link.
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
       - name: Install Linux build tools
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
 
+      # The build (make) itself is never isolated - only the post-build smoke
+      # below is.
       - name: Build and run air-gap smoke
         env:
           STATIC_LIBCPP: ${{ matrix.static_libcpp }}
         run: scripts/build-duckdb.sh
+
+      # Additional proof, Linux-only, that the artifact just built survives a
+      # real network namespace (`sudo unshare --net`), not just the dead-port
+      # proxy env vars build-duckdb.sh's own smoke also sets - those are
+      # defense only, since DuckDB's extension downloader does not honor
+      # them. `unshare --net` is a Linux-only syscall; Bun is resolved to an
+      # absolute path BEFORE the sudo call, since root's PATH (secure_path)
+      # does not carry it.
+      - name: Air-gap smoke under a network namespace (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          bun_bin=$(command -v bun)
+          sudo unshare --net env BUN_BIN="$bun_bin" \
+            scripts/build-duckdb.sh --smoke-artifacts \
+            "$PWD/dist/duckdb/duckdb" "$PWD/dist/duckdb/libduckdb.so"
 
       - name: Upload DuckDB artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,21 @@ jobs:
       # Re-run on a cache HIT too: this is what proves the restored bytes still
       # link fts statically, so a poisoned or truncated cache entry fails here
       # with one clear error instead of downstream as N mystery test failures.
+      #
+      # Runs inside a real Linux network namespace (`sudo unshare --net`), not
+      # just the dead-port proxy env vars build-duckdb.sh also sets - those
+      # proxy vars are defense only, since the DuckDB extension downloader
+      # does not honor them. `unshare --net` is a Linux-only syscall; Bun is
+      # resolved to an absolute path BEFORE the sudo call, since root's PATH
+      # (secure_path) does not carry it.
       - name: Air-gap smoke the provisioned artifact
         run: |
           set -euo pipefail
           chmod +x dist/duckdb/duckdb
-          scripts/build-duckdb.sh --smoke-only dist/duckdb/duckdb
-          bun scripts/smoke-duckdb-dylib.ts dist/duckdb/libduckdb.so
+          bun_bin=$(command -v bun)
+          sudo unshare --net env BUN_BIN="$bun_bin" \
+            scripts/build-duckdb.sh --smoke-artifacts \
+            "$PWD/dist/duckdb/duckdb" "$PWD/dist/duckdb/libduckdb.so"
 
       # Saved only after the smoke passes, so a bad build never becomes the
       # cached answer for every later run.

--- a/scripts/build-duckdb.sh
+++ b/scripts/build-duckdb.sh
@@ -6,6 +6,10 @@ build_root=${DUCKDB_BUILD_ROOT:-"$repo_root/dist/duckdb-build"}
 source_dir="$build_root/src"
 dist_dir=${DUCKDB_DIST_DIR:-"$repo_root/dist/duckdb"}
 config_template="$repo_root/scripts/duckdb/extension_config_local.cmake"
+# A caller running the dylib smoke inside a `sudo unshare --net` process runs
+# under root's PATH, which does not carry Bun - the caller resolves Bun's
+# absolute path first (e.g. `command -v bun`) and passes it through here.
+bun_bin=${BUN_BIN:-bun}
 # Pinned to the v1.5.5 tag's commit sha, not the tag name - a tag can be
 # force-moved on the remote, and a cached checkout could silently drift onto
 # a re-tagged commit without this. Resolve a new sha with:
@@ -79,7 +83,7 @@ smoke_duckdb_dylib() {
     HTTPS_PROXY=http://127.0.0.1:9 \
     ALL_PROXY=http://127.0.0.1:9 \
     NO_PROXY='' \
-        bun "$repo_root/scripts/smoke-duckdb-dylib.ts" "$dylib_path"
+        "$bun_bin" "$repo_root/scripts/smoke-duckdb-dylib.ts" "$dylib_path"
 }
 
 if [[ ${1:-} == "--smoke-only" ]]; then
@@ -91,8 +95,21 @@ if [[ ${1:-} == "--smoke-only" ]]; then
     exit 0
 fi
 
+# Runs both smokes as one unit, so a caller that needs them isolated together
+# (e.g. inside a single `sudo unshare --net` process) can do so with one call
+# instead of orchestrating two separately-isolated invocations.
+if [[ ${1:-} == "--smoke-artifacts" ]]; then
+    if [[ $# -ne 3 ]]; then
+        echo "usage: $0 --smoke-artifacts <duckdb-shell> <libduckdb>" >&2
+        exit 2
+    fi
+    smoke_duckdb "$2"
+    smoke_duckdb_dylib "$3"
+    exit 0
+fi
+
 if [[ $# -ne 0 ]]; then
-    echo "usage: $0 [--smoke-only <duckdb-shell>]" >&2
+    echo "usage: $0 [--smoke-only <duckdb-shell>] [--smoke-artifacts <duckdb-shell> <libduckdb>]" >&2
     exit 2
 fi
 

--- a/scripts/build-duckdb.test.ts
+++ b/scripts/build-duckdb.test.ts
@@ -5,6 +5,7 @@ import {
     accessSync,
     chmodSync,
     constants,
+    existsSync,
     mkdirSync,
     mkdtempSync,
     readFileSync,
@@ -46,6 +47,98 @@ describe("custom DuckDB build", () => {
         expect(script).toContain("match_bm25");
         expect(script).toContain("json_extract");
         expect(script).toContain("smoke-duckdb-dylib.ts");
+        // The dynamic-library smoke must call a resolvable Bun binary, not a
+        // hardcoded `bun` that only exists on the invoking user's PATH - a
+        // `sudo unshare --net` caller runs under root's PATH, which does not
+        // carry Bun.
+        expect(script).toContain("bun_bin=${BUN_BIN:-bun}");
+        expect(script).toContain('"$bun_bin" "$repo_root/scripts/smoke-duckdb-dylib.ts"');
+        expect(script).not.toMatch(/[^"]bun "\$repo_root\/scripts\/smoke-duckdb-dylib\.ts"/);
+        // A combined mode lets a caller run both smokes as a single unit
+        // (e.g. inside one `sudo unshare --net` process) instead of two
+        // separate invocations that would each need their own isolation.
+        expect(script).toContain("--smoke-artifacts");
+        expect(script).toContain("usage: $0 --smoke-only <duckdb-shell>");
+        expect(script).toContain("usage: $0 --smoke-artifacts <duckdb-shell> <libduckdb>");
+    });
+
+    test("--smoke-artifacts runs both the shell and dylib smokes, and honors BUN_BIN over PATH", () => {
+        const workDir = mkdtempSync(join(tmpdir(), "ax-duckdb-smoke-artifacts-"));
+        try {
+            const shellPath = join(workDir, "fake-duckdb-shell");
+            writeFileSync(
+                shellPath,
+                "#!/bin/sh\nprintf '%s\\n' 'fts=1:hello static world' 'json=42' \"shell-home=$HOME\"\n",
+            );
+            chmodSync(shellPath, 0o755);
+
+            const dylibPath = join(workDir, "fake-libduckdb.so");
+            writeFileSync(dylibPath, "placeholder");
+
+            // A real `bun` planted early on PATH must NOT be the one invoked -
+            // only BUN_BIN's absolute path should run.
+            const wrongBinDir = join(workDir, "wrong-bin");
+            mkdirSync(wrongBinDir);
+            const wrongBun = join(wrongBinDir, "bun");
+            writeFileSync(wrongBun, "#!/bin/sh\nprintf '%s\\n' 'WRONG BUN INVOKED'\nexit 1\n");
+            chmodSync(wrongBun, 0o755);
+
+            const honoredBunDir = join(workDir, "honored-bin");
+            mkdirSync(honoredBunDir);
+            const honoredBun = join(honoredBunDir, "bun-marker");
+            writeFileSync(
+                honoredBun,
+                "#!/bin/sh\nprintf '%s\\n' \"dylib-home=$HOME\" 'DuckDB dynamic library air-gap smoke passed'\n",
+            );
+            chmodSync(honoredBun, 0o755);
+
+            const parentHome = join(workDir, "parent-home");
+            mkdirSync(parentHome);
+
+            const result = spawnSync(
+                join(repoRoot, "scripts/build-duckdb.sh"),
+                ["--smoke-artifacts", shellPath, dylibPath],
+                {
+                    cwd: repoRoot,
+                    encoding: "utf8",
+                    env: {
+                        ...process.env,
+                        PATH: `${wrongBinDir}:${process.env.PATH ?? ""}`,
+                        BUN_BIN: honoredBun,
+                        HOME: parentHome,
+                    },
+                },
+            );
+
+            expect(result.status).toBe(0);
+            expect(result.stdout).toContain("DuckDB air-gap smoke passed");
+            expect(result.stdout).toContain("DuckDB dynamic library air-gap smoke passed");
+            expect(result.stdout).not.toContain("WRONG BUN INVOKED");
+            expect(result.stderr).not.toContain("WRONG BUN INVOKED");
+
+            const shellHome = result.stdout.match(/^shell-home=(.+)$/m)?.[1];
+            const dylibHome = result.stdout.match(/^dylib-home=(.+)$/m)?.[1];
+            expect(shellHome).toBeDefined();
+            expect(dylibHome).toBeDefined();
+            expect(shellHome).not.toBe(parentHome);
+            expect(dylibHome).not.toBe(parentHome);
+            expect(shellHome).not.toBe(dylibHome);
+            expect(existsSync(shellHome!)).toBe(false);
+            expect(existsSync(dylibHome!)).toBe(false);
+        } finally {
+            rmSync(workDir, { recursive: true, force: true });
+        }
+    });
+
+    test("--smoke-artifacts requires exactly a duckdb-shell and a libduckdb argument", () => {
+        const result = spawnSync(join(repoRoot, "scripts/build-duckdb.sh"), ["--smoke-artifacts", "one-arg-only"], {
+            cwd: repoRoot,
+            encoding: "utf8",
+        });
+
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain("usage:");
+        expect(result.stderr).toContain("--smoke-artifacts <duckdb-shell> <libduckdb>");
     });
 
     test("passes STATIC_LIBCPP from CI to the DuckDB make process", () => {
@@ -139,6 +232,42 @@ chmod +x "$2/build/release/duckdb"
         expect(workflow).toContain("actions/upload-artifact@v4");
     });
 
+    test("installs workspace dependencies before the build, and isolates the post-build smoke under a Linux-only network namespace", () => {
+        const workflowPath = join(repoRoot, ".github/workflows/build-duckdb.yml");
+        const workflow = parse(readFileSync(workflowPath, "utf8")) as {
+            jobs: Record<string, { steps: WorkflowStep[] }>;
+        };
+        const steps = workflow.jobs.build.steps;
+
+        const installIdx = steps.findIndex(
+            (s) => (s.run ?? "").trim() === "bun install --frozen-lockfile",
+        );
+        const buildIdx = steps.findIndex(
+            (s) => (s.run ?? "").includes("scripts/build-duckdb.sh") && !(s.run ?? "").includes("--"),
+        );
+        expect(installIdx).toBeGreaterThanOrEqual(0);
+        expect(buildIdx).toBeGreaterThan(installIdx);
+
+        // The build (make) itself must never run inside the network
+        // namespace - only an ADDITIONAL post-build smoke, Linux-only since
+        // `unshare --net` is a Linux syscall with no macOS equivalent.
+        const isolatedSmokeIdx = steps.findIndex((s) => (s.run ?? "").includes("sudo unshare --net"));
+        expect(isolatedSmokeIdx).toBeGreaterThan(buildIdx);
+        const isolatedSmoke = steps[isolatedSmokeIdx];
+        expect(isolatedSmoke?.if).toBe("runner.os == 'Linux'");
+        expect(isolatedSmoke?.run).toContain("--smoke-artifacts");
+        expect(isolatedSmoke?.run).toContain("BUN_BIN=");
+
+        // Bun must be resolved to an absolute path BEFORE the sudo call - a
+        // `command -v bun` issued inside the sudo'd process would see root's
+        // PATH, which does not carry Bun.
+        const runLines = (isolatedSmoke?.run ?? "").split("\n");
+        const resolveIdx = runLines.findIndex((l) => l.includes("command -v bun"));
+        const sudoIdx = runLines.findIndex((l) => l.includes("sudo unshare --net"));
+        expect(resolveIdx).toBeGreaterThanOrEqual(0);
+        expect(sudoIdx).toBeGreaterThan(resolveIdx);
+    });
+
     // Collapsed from the former AX_DUCKDB_SHELL knob onto the one CLI-binary
     // env name (AX_DUCKDB_BIN) - see scripts/bench/duckdb-bin.ts. This test
     // needs to name a SPECIFIC just-built shell to smoke, not "find any
@@ -220,9 +349,7 @@ describe("provision-duckdb composite action restores/builds/smokes/saves the Duc
     const restoreStep = steps.find((s) => s.uses?.startsWith("actions/cache/restore"));
     const saveStep = steps.find((s) => s.uses?.startsWith("actions/cache/save"));
     const buildStep = steps.find((s) => (s.run ?? "").trim() === "scripts/build-duckdb.sh");
-    const smokeStep = steps.find((s) =>
-        (s.run ?? "").includes("bun scripts/smoke-duckdb-dylib.ts"),
-    );
+    const smokeStep = steps.find((s) => (s.run ?? "").includes("--smoke-artifacts"));
 
     test("is a composite action with the DuckDB steps to guard", () => {
         // A parse/lookup mistake here would make every case below vacuously
@@ -288,8 +415,7 @@ describe("provision-duckdb composite action restores/builds/smokes/saves the Duc
     test("smokes both the restored shell and the correct dylib unconditionally - restore or build, never skipped on a hit", () => {
         expect(smokeStep?.if).toBeUndefined();
         expect(smokeStep?.run).toContain("chmod +x dist/duckdb/duckdb");
-        expect(smokeStep?.run).toContain("build-duckdb.sh --smoke-only");
-        expect(smokeStep?.run).toContain("smoke-duckdb-dylib.ts");
+        expect(smokeStep?.run).toContain("build-duckdb.sh --smoke-artifacts");
     });
 
     test("resolves the platform-specific library rather than hardcoding one extension", () => {
@@ -297,6 +423,26 @@ describe("provision-duckdb composite action restores/builds/smokes/saves the Duc
         expect(fullText).toContain("libduckdb.dylib");
         expect(fullText).toContain("libduckdb.so");
         expect(smokeStep?.run).toMatch(/libduckdb\.(dylib|so)|duckdb-lib/);
+    });
+
+    test("Linux smokes under a real network namespace with an absolute, pre-sudo-resolved Bun; macOS runs the combined smoke directly (no unshare)", () => {
+        const run = smokeStep?.run ?? "";
+        expect(run).toContain("sudo unshare --net");
+        expect(run).toContain("BUN_BIN=");
+        expect(run).toContain("runner.os");
+        expect(run).toContain("Linux");
+
+        const lines = run.split("\n");
+        const resolveIdx = lines.findIndex((l) => l.includes("command -v bun"));
+        const sudoIdx = lines.findIndex((l) => l.includes("sudo unshare --net"));
+        expect(resolveIdx).toBeGreaterThanOrEqual(0);
+        expect(sudoIdx).toBeGreaterThan(resolveIdx);
+
+        // macOS has no `unshare` syscall - its leg must still run the
+        // combined smoke, just without namespace isolation, and never fall
+        // back to a weaker smoke when Linux's isolation "fails".
+        const nonLinuxRunsCombinedSmoke = /else|macOS/.test(run) && run.includes("--smoke-artifacts");
+        expect(nonLinuxRunsCombinedSmoke).toBe(true);
     });
 
     test("saves only after the smoke passes, and never on a cache hit", () => {

--- a/scripts/check-ci-duckdb.test.ts
+++ b/scripts/check-ci-duckdb.test.ts
@@ -53,7 +53,40 @@ describe("ci.yml provisions the custom DuckDB", () => {
     test("the artifact is air-gap smoked, so a poisoned cache cannot pass as a build", () => {
         // The smoke sets autoload/autoinstall off, which is what makes it a
         // proof of STATIC linkage rather than of a populated ~/.duckdb.
-        expect(runScripts("duckdb")).toContain("scripts/smoke-duckdb-dylib.ts");
+        expect(runScripts("duckdb")).toContain("--smoke-artifacts");
+    });
+
+    test("the unconditional post-restore smoke runs both artifacts inside one real network namespace, not just proxy env vars", () => {
+        const steps = stepsOf("duckdb");
+        const smokeStep = steps.find((s) => (s.run ?? "").includes("--smoke-artifacts"));
+        expect(smokeStep).toBeDefined();
+        expect(smokeStep?.if).toBeUndefined();
+
+        const run = smokeStep?.run ?? "";
+        expect(run).toContain("sudo unshare --net");
+        expect(run).toContain("BUN_BIN=");
+        expect(run).toContain("dist/duckdb/duckdb");
+        expect(run).toContain("dist/duckdb/libduckdb.so");
+    });
+
+    test("the post-restore smoke resolves Bun to an absolute path before the sudo call, since root's PATH does not carry Bun", () => {
+        const steps = stepsOf("duckdb");
+        const smokeStep = steps.find((s) => (s.run ?? "").includes("--smoke-artifacts"));
+        const lines = (smokeStep?.run ?? "").split("\n");
+        const resolveIdx = lines.findIndex((l) => l.includes("command -v bun"));
+        const sudoIdx = lines.findIndex((l) => l.includes("sudo unshare --net"));
+        expect(resolveIdx).toBeGreaterThanOrEqual(0);
+        expect(sudoIdx).toBeGreaterThan(resolveIdx);
+    });
+
+    test("chmod still runs before the isolated smoke", () => {
+        const steps = stepsOf("duckdb");
+        const smokeStep = steps.find((s) => (s.run ?? "").includes("--smoke-artifacts"));
+        const lines = (smokeStep?.run ?? "").split("\n");
+        const chmodIdx = lines.findIndex((l) => l.includes("chmod +x dist/duckdb/duckdb"));
+        const sudoIdx = lines.findIndex((l) => l.includes("sudo unshare --net"));
+        expect(chmodIdx).toBeGreaterThanOrEqual(0);
+        expect(sudoIdx).toBeGreaterThan(chmodIdx);
     });
 
     test("installs workspace dependencies before the build runs its library smoke", () => {
@@ -69,7 +102,7 @@ describe("ci.yml provisions the custom DuckDB", () => {
     test("the build is cached, and saved only after the smoke passes", () => {
         const steps = stepsOf("duckdb");
         const restore = steps.findIndex((s) => s.uses?.startsWith("actions/cache/restore"));
-        const smoke = steps.findIndex((s) => (s.run ?? "").includes("smoke-duckdb-dylib.ts"));
+        const smoke = steps.findIndex((s) => (s.run ?? "").includes("--smoke-artifacts"));
         const save = steps.findIndex((s) => s.uses?.startsWith("actions/cache/save"));
         expect(restore).toBeGreaterThanOrEqual(0);
         expect(smoke).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Closes #775

## Change

- Run Linux DuckDB artifact checks inside a network namespace.
- Run the shell and dynamic library checks in one isolated process.
- Resolve the Bun path before sudo changes the environment.
- Keep the direct combined check on macOS.
- Install workspace dependencies before the manual build workflow.
- Verify temporary home directories, cache order, and workflow order.

## Verification

- bun test scripts/build-duckdb.test.ts scripts/check-ci-duckdb.test.ts: 158 pass, 0 fail, 0 skip with real artifacts.
- Combined shell and dynamic library check: pass.
- bun run typecheck: pass.
- bash -n scripts/build-duckdb.sh: pass.
- Repository guards: pass.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
