### PR TITLE
test(release): accept nonzero invalid-argument status

### DIFF
--- a/scripts/build-duckdb.test.ts
+++ b/scripts/build-duckdb.test.ts
@@ -136,7 +136,8 @@ describe("custom DuckDB build", () => {
             encoding: "utf8",
         });
 
-        expect(result.status).toBe(2);
+        expect(result.status).not.toBeNull();
+        expect(result.status).not.toBe(0);
         expect(result.stderr).toContain("usage:");
         expect(result.stderr).toContain("--smoke-artifacts <duckdb-shell> <libduckdb>");
     });


### PR DESCRIPTION
Closes #1081.

## Summary

- require a real nonzero child status for the invalid `--smoke-artifacts` call
- keep the stable usage-text assertions
- permit macOS runners to return status 1 instead of status 2

## Verification

- `bun test scripts/build-duckdb.test.ts` — 26 pass, 2 gated skips
- `bun run typecheck`
- `git diff --check`

---

_Generated with [ax](https://github.com/Necmttn/ax)._

