### PR TITLE
fix: harden snapshot clone publication

### DIFF
--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -538,10 +538,17 @@ export const runIngest = (
             Effect.catch((error): Effect.Effect<OtelRetentionOutcome> =>
                 Effect.succeed({ error: errorText(error) })),
         );
+        // FTS is NOT best-effort (#952): a failed rebuild here propagates and
+        // fails the whole run, same as every other unguarded `yield*` in this
+        // body - `withCacheWrite` publishes only on success (see seam.ts), so
+        // a failed FTS build correctly withholds the publish and leaves the
+        // previous snapshot in place, rather than shipping a snapshot whose
+        // index is stale or missing.
         yield* buildFtsIndexes(write);
         // Idempotent, version-gated seed - not a stage (nothing here is
-        // derived from transcripts); best-effort like FTS, a failure here
-        // must not fail the whole run (regex judgment path stays the floor).
+        // derived from transcripts); UNLIKE FTS above, a failure here is
+        // best-effort and must not fail the whole run (regex judgment path
+        // stays the floor).
         yield* seedClassifierWeights(write).pipe(Effect.ignore);
         return {
             runId,

--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -43,7 +43,13 @@ import { posixPath } from "../shared/path.ts";
 import { stageAndRename } from "../staged-rename.ts";
 import { loadNodeApiOver, type DuckDbNodeApi } from "./binding.ts";
 import { canonicalPath } from "./canonical-path.ts";
-import { cloneFile, statSnapshot, statsEqual, walIsQuiescent } from "./clone-file.ts";
+import {
+    clearPartialClone as clearPartialCloneFile,
+    cloneFile,
+    statSnapshot,
+    statsEqual,
+    walIsQuiescent,
+} from "./clone-file.ts";
 import { resolveDylibPath } from "./dylib.ts";
 import {
     DuckDbDecodeError,
@@ -742,22 +748,36 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
         const cloneDisabledByEnv = (): boolean =>
             (process.env.AX_SNAPSHOT_CLONE ?? "").trim().toLowerCase() === "off";
 
-        /** Best-effort: only ever called on a path where `cloneFile` already
-         *  wrote something to `tmp` and a LATER guard rejected it, so the
-         *  fallback about to run (`copyThrough` on the SAME `tmp`) doesn't
-         *  `ATTACH` onto a stale, half-trusted clone. Never fails - a removal
-         *  failure here just surfaces naturally as the fallback's own ATTACH
-         *  error against a non-empty path, which is a legible failure either
-         *  way. This is NOT the tmp-cleanup `stageAndRename`'s finalizer
-         *  already owns (that still runs unconditionally on every exit); it
-         *  exists only so the same `tmp` path can be reused a second time
-         *  within THIS one `stage` call. */
-        const clearPartialClone = (tmp: string): Effect.Effect<void> =>
-            fs.remove(tmp, { force: true, recursive: true }).pipe(
-                Effect.catch((err) =>
-                    Effect.logWarning(
-                        `ax duckdb: could not clear the partially-cloned temp file at ${tmp} before falling back to the logical copy: ${err.message}`,
-                    ),
+        /**
+         * Called on EVERY path where `cloneFile` has already started - a
+         * successful clone that a later guard rejected, AND a `cloneFile`
+         * call that itself reported `{ cloneable: false }` (`copyfile(3)`
+         * does not promise a failed clone wrote nothing at `tmp`; ENOSPC
+         * mid-clone can leave a truncated destination - #952) - so the
+         * fallback about to run (`copyThrough` on the SAME `tmp`) never
+         * `ATTACH`es onto a stale, partially-written clone.
+         *
+         * UNLIKE the earlier best-effort version, a removal failure here is
+         * NOT swallowed: it FAILS this Effect with a `SnapshotPublishError`,
+         * which aborts `attemptClone` and therefore the whole `stage` step -
+         * `stageAndRename` never reaches the rename, so the previous snapshot
+         * is left exactly as it was. Falling through to `logicalCopy` on a
+         * `tmp` that could not be cleared would ATTACH onto (or overwrite
+         * into) a path in an unknown, half-cloned state - a legible failure
+         * here is safer than a copy of uncertain provenance. This is NOT the
+         * tmp-cleanup `stageAndRename`'s finalizer already owns (that still
+         * runs unconditionally on every exit, best-effort); it exists only so
+         * the same `tmp` path can be reused a second time within THIS one
+         * `stage` call.
+         */
+        const clearPartialClone = (tmp: string): Effect.Effect<void, SnapshotPublishError> =>
+            clearPartialCloneFile(fs, tmp).pipe(
+                Effect.mapError(
+                    (err) =>
+                        new SnapshotPublishError({
+                            snapshotPath: targetPath,
+                            message: `could not clear the partially-cloned temp file at ${tmp} before falling back to the logical copy: ${err.message}`,
+                        }),
                 ),
             );
 
@@ -770,7 +790,7 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
          * `tmp` has been checkpoint-consistent, byte-cloned without a torn
          * read, and has itself opened read-only and answered a sanity query.
          *
-         * Safety protocol (all four must hold):
+         * Safety protocol (all five must hold):
          *  (a) `CHECKPOINT` succeeds on the connection that actually owns the
          *      live database - the writer's own `options.from` when given
          *      (RULING R14: a second handle on `livePath` cannot be trusted
@@ -785,13 +805,34 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
          *      after the clone syscall reports the identical size + mtime -
          *      the torn-copy tripwire: something else wrote to `livePath`
          *      while the clone ran, so its contents can no longer be trusted.
+         *      The stat is taken via `clone-file.ts`'s `statSnapshot`, which
+         *      carries the filesystem's raw nanosecond mtime rather than
+         *      `Date`'s whole-millisecond `getTime()` - a same-size rewrite
+         *      landing inside the SAME millisecond as the pre-clone stat is
+         *      otherwise invisible (#952).
+         *  (e) `<livePath>.wal` is RE-CHECKED for quiescence after the clone
+         *      syscall returns (#952) - (b) alone only covers the window
+         *      before the clone started; a commit on another handle that
+         *      lands entirely in the WAL (never touching the base file's
+         *      size/mtime) during the check->clone window would pass (c)'s
+         *      torn-copy tripwire undetected while still being missing from
+         *      the clone.
          *  (d) the staged clone at `tmp` opens read-only and answers
          *      `SELECT count(*) AS n FROM duckdb_tables()` with a positive
          *      count, closed again before this returns.
+         *
+         * Every rejection reached AFTER `cloneFile` has written to `tmp`
+         * clears it first (`clearPartialClone`) - including `!clone.cloneable`
+         * itself, since `copyfile(3)` does not promise a failed clone wrote
+         * nothing there. A `clearPartialClone` failure aborts the whole
+         * attempt rather than falling through to the logical copy.
          */
         const attemptClone = (
             tmp: string,
-        ): Effect.Effect<{ readonly mode: "clone" } | { readonly mode: "copy"; readonly reason: string }> =>
+        ): Effect.Effect<
+            { readonly mode: "clone" } | { readonly mode: "copy"; readonly reason: string },
+            SnapshotPublishError
+        > =>
             Effect.gen(function* () {
                 if (cloneDisabledByEnv()) {
                     return { mode: "copy", reason: "AX_SNAPSHOT_CLONE=off" } as const;
@@ -814,14 +855,14 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
                     } as const;
                 }
 
-                // (b) post-checkpoint WAL tripwire.
+                // (b) post-checkpoint WAL tripwire, before the clone starts.
                 const walQuiescent = yield* walIsQuiescent(fs, livePath);
                 if (!walQuiescent) {
                     return { mode: "copy", reason: "WAL is non-empty after checkpoint" } as const;
                 }
 
                 // (c) torn-copy tripwire, half one: stat before the clone.
-                const before = yield* Effect.result(statSnapshot(fs, livePath));
+                const before = yield* Effect.result(statSnapshot(livePath));
                 if (before._tag === "Failure") {
                     return {
                         mode: "copy",
@@ -831,11 +872,16 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
 
                 const clone = yield* cloneFile(livePath, tmp);
                 if (!clone.cloneable) {
+                    // #952: a failed clonefile(3) call is not guaranteed to
+                    // have left `tmp` empty (e.g. ENOSPC mid-clone can leave a
+                    // truncated destination) - clear it before falling
+                    // through to the logical copy on the same path.
+                    yield* clearPartialClone(tmp);
                     return { mode: "copy", reason: clone.reason ?? "clonefile syscall failed" } as const;
                 }
 
                 // (c) torn-copy tripwire, half two: stat after the clone.
-                const after = yield* Effect.result(statSnapshot(fs, livePath));
+                const after = yield* Effect.result(statSnapshot(livePath));
                 if (after._tag === "Failure") {
                     yield* clearPartialClone(tmp);
                     return {
@@ -848,6 +894,20 @@ const makeService = (api: DuckDbNodeApi, fs: FileSystem.FileSystem): DuckDbServi
                     return {
                         mode: "copy",
                         reason: "torn-copy tripwire: the live database's size/mtime changed during the clone",
+                    } as const;
+                }
+
+                // (e) #952: re-check the WAL AFTER the clone, before trusting
+                // it - (b) only guards the window BEFORE the clone started. A
+                // concurrent commit on another handle can land entirely in
+                // the WAL without moving the base file's size or mtime, which
+                // (c) cannot see at all.
+                const walQuiescentAfterClone = yield* walIsQuiescent(fs, livePath);
+                if (!walQuiescentAfterClone) {
+                    yield* clearPartialClone(tmp);
+                    return {
+                        mode: "copy",
+                        reason: "WAL is non-empty after the clone - a concurrent commit landed during the check->clone window",
                     } as const;
                 }
 

--- a/packages/lib/src/duckdb/clone-file.test.ts
+++ b/packages/lib/src/duckdb/clone-file.test.ts
@@ -12,10 +12,17 @@
 import { describe, expect, test } from "bun:test";
 import { BunFileSystem } from "@effect/platform-bun";
 import { Effect, FileSystem } from "effect";
-import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cloneFile, statsEqual, walIsQuiescent, type FileStatSnapshot } from "./clone-file.ts";
+import {
+    clearPartialClone,
+    cloneFile,
+    statSnapshot,
+    statsEqual,
+    walIsQuiescent,
+    type FileStatSnapshot,
+} from "./clone-file.ts";
 
 const withTempDir = async (body: (dir: string) => Promise<void>): Promise<void> => {
     const dir = mkdtempSync(join(tmpdir(), "ax-clone-file-"));
@@ -97,21 +104,55 @@ describe("cloneFile", () => {
 
 describe("statsEqual (torn-copy tripwire, pure half)", () => {
     test("true for identical size + mtime", () => {
-        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
-        const b: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
+        const a: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_000_000_000n };
+        const b: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_000_000_000n };
         expect(statsEqual(a, b)).toBe(true);
     });
 
     test("false when size differs", () => {
-        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
-        const b: FileStatSnapshot = { size: 2048, mtimeMs: 1_700_000_000_000 };
+        const a: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_000_000_000n };
+        const b: FileStatSnapshot = { size: 2048, mtimeNs: 1_700_000_000_000_000_000n };
         expect(statsEqual(a, b)).toBe(false);
     });
 
-    test("false when mtime differs", () => {
-        const a: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_000 };
-        const b: FileStatSnapshot = { size: 1024, mtimeMs: 1_700_000_000_001 };
+    test("false when mtime differs by a whole millisecond", () => {
+        const a: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_000_000_000n };
+        const b: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_001_000_000_000n };
         expect(statsEqual(a, b)).toBe(false);
+    });
+
+    /** #952: the whole point of carrying `mtimeNs` instead of `Date`'s
+     *  whole-millisecond `getTime()` - two mtimes that round to the SAME
+     *  millisecond (both `...123` ms) but differ at the sub-millisecond
+     *  (nanosecond) grain must still compare unequal, or an in-place rewrite
+     *  landing inside one millisecond window is invisible to the tripwire. */
+    test("false when mtimes differ only below whole-millisecond precision", () => {
+        const a: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_123_000_000n };
+        const b: FileStatSnapshot = { size: 1024, mtimeNs: 1_700_000_000_123_500_000n };
+        expect(statsEqual(a, b)).toBe(false);
+    });
+});
+
+describe("statSnapshot (precise mtime via statSync bigint)", () => {
+    test("captures size and a nanosecond-precision mtime as a bigint", async () => {
+        await withTempDir(async (dir) => {
+            const file = join(dir, "f.bin");
+            writeFileSync(file, "hello");
+
+            const snap = await Effect.runPromise(statSnapshot(file));
+
+            expect(snap.size).toBe(5);
+            expect(typeof snap.mtimeNs).toBe("bigint");
+            expect(snap.mtimeNs > 0n).toBe(true);
+        });
+    });
+
+    test("fails with a typed PreciseStatError when the path does not exist", async () => {
+        await withTempDir(async (dir) => {
+            const exit = await Effect.runPromiseExit(statSnapshot(join(dir, "missing.bin")));
+
+            expect(exit._tag).toBe("Failure");
+        });
     });
 });
 
@@ -160,6 +201,92 @@ describe("walIsQuiescent (post-checkpoint WAL tripwire)", () => {
             const quiescent = await runWithFs((fs) => walIsQuiescent(fs, live));
 
             expect(quiescent).toBe(false);
+        });
+    });
+
+    /**
+     * #952: the pre-clone WAL check alone only guards the window BEFORE the
+     * clone starts - a commit on another handle that lands entirely in the
+     * WAL during the check->clone window is invisible to it. The fix is to
+     * re-run this SAME primitive again after the clone; that is only a valid
+     * fix if the primitive is stateless and re-evaluates the file fresh on
+     * every call rather than caching its first answer, which is what this
+     * proves: calling it a second time, after new bytes land, flips the
+     * result from quiescent to not - exactly what a post-clone re-check
+     * needs to catch a race the pre-clone check missed.
+     */
+    test("re-checking after new bytes land on the WAL flips quiescent to non-quiescent (post-clone recheck, #952)", async () => {
+        await withTempDir(async (dir) => {
+            const live = join(dir, "live.duckdb");
+            writeFileSync(live, "stem");
+            writeFileSync(`${live}.wal`, "");
+
+            const beforeClone = await runWithFs((fs) => walIsQuiescent(fs, live));
+            expect(beforeClone).toBe(true);
+
+            // Simulates a commit on another handle landing in the WAL during
+            // the check -> clone window - the exact case the pre-clone check
+            // cannot see, and the post-clone recheck exists to catch.
+            writeFileSync(`${live}.wal`, "a-commit-that-landed-during-the-clone");
+
+            const afterClone = await runWithFs((fs) => walIsQuiescent(fs, live));
+            expect(afterClone).toBe(false);
+        });
+    });
+});
+
+describe("clearPartialClone (temp cleanup after a rejected clone attempt) (#952)", () => {
+    test("removes a partially-cloned temp file", async () => {
+        await withTempDir(async (dir) => {
+            const tmp = join(dir, "partial.duckdb");
+            writeFileSync(tmp, "partial-clone-bytes");
+
+            await runWithFs((fs) => clearPartialClone(fs, tmp).pipe(Effect.orDie));
+
+            expect(existsSync(tmp)).toBe(false);
+        });
+    });
+
+    test("is a no-op when there is nothing at the temp path (force semantics)", async () => {
+        await withTempDir(async (dir) => {
+            const tmp = join(dir, "never-existed.duckdb");
+
+            await runWithFs((fs) => clearPartialClone(fs, tmp).pipe(Effect.orDie));
+
+            expect(existsSync(tmp)).toBe(false);
+        });
+    });
+
+    /**
+     * The safety property #952 depends on: a caller (`publishSnapshot` in
+     * `client.ts`) that cannot clear a partial clone must STOP rather than
+     * fall through to a fallback of unknown provenance at the same path. A
+     * removal failure has to actually surface as a typed failure - not be
+     * swallowed - for that guarantee to hold.
+     */
+    test("fails with a typed ClearPartialCloneError when removal is denied, and leaves the file in place", async () => {
+        await withTempDir(async (dir) => {
+            const lockedDir = join(dir, "locked");
+            mkdirSync(lockedDir);
+            const tmp = join(lockedDir, "partial.duckdb");
+            writeFileSync(tmp, "partial-clone-bytes");
+            // Read+execute, no write: removing a file inside must fail.
+            chmodSync(lockedDir, 0o555);
+
+            try {
+                const exit = await Effect.runPromiseExit(
+                    Effect.gen(function* () {
+                        const fs = yield* FileSystem.FileSystem;
+                        return yield* clearPartialClone(fs, tmp);
+                    }).pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<void, unknown>,
+                );
+
+                expect(exit._tag).toBe("Failure");
+                expect(existsSync(tmp)).toBe(true);
+            } finally {
+                // Restore write access so withTempDir's own cleanup can remove it.
+                chmodSync(lockedDir, 0o755);
+            }
         });
     });
 });

--- a/packages/lib/src/duckdb/clone-file.ts
+++ b/packages/lib/src/duckdb/clone-file.ts
@@ -16,9 +16,8 @@
  * without anyone noticing. Every use of the node import is wrapped in
  * `Effect.try` and never escapes this module as an untyped throw.
  */
-import { copyFileSync, constants } from "node:fs";
-import { Effect, FileSystem, Option } from "effect";
-import type { PlatformError } from "effect/PlatformError";
+import { copyFileSync, constants, statSync } from "node:fs";
+import { Effect, FileSystem, Schema } from "effect";
 import { skipNotFound } from "../shared/fs-error.ts";
 
 /** Outcome of one `cloneFile` attempt. Never throws/fails - a failed clone
@@ -54,10 +53,12 @@ export const cloneFile = (src: string, dst: string): Effect.Effect<CloneOutcome>
         Effect.catch((reason) => Effect.succeed({ cloneable: false, reason } as const)),
     );
 
-/** The two stat fields the torn-copy tripwire compares. */
+/** The two stat fields the torn-copy tripwire compares. `mtimeNs` is the
+ *  filesystem's raw nanosecond mtime (not `Date`'s whole-millisecond
+ *  `getTime()`) - see {@link statSnapshot} for why the precision matters. */
 export interface FileStatSnapshot {
     readonly size: number;
-    readonly mtimeMs: number;
+    readonly mtimeNs: bigint;
 }
 
 /**
@@ -68,21 +69,38 @@ export interface FileStatSnapshot {
  * without touching a filesystem.
  */
 export const statsEqual = (a: FileStatSnapshot, b: FileStatSnapshot): boolean =>
-    a.size === b.size && a.mtimeMs === b.mtimeMs;
+    a.size === b.size && a.mtimeNs === b.mtimeNs;
 
-/** Torn-copy tripwire, effectful half: take a `{ size, mtimeMs }` snapshot of
- *  `path`. Fails (typed `PlatformError`) exactly when `fs.stat` fails -
- *  callers decide what a stat failure means for their fallback logic. */
-export const statSnapshot = (
-    fs: FileSystem.FileSystem,
-    path: string,
-): Effect.Effect<FileStatSnapshot, PlatformError> =>
-    fs.stat(path).pipe(
-        Effect.map((info) => ({
-            size: Number(info.size),
-            mtimeMs: Option.match(info.mtime, { onNone: () => 0, onSome: (d) => d.getTime() }),
-        })),
-    );
+/** A native `fs.statSync` call failed. Never an untyped throw - see the
+ *  module header on why `statSnapshot` reaches for `node:fs` at all. */
+export class PreciseStatError extends Schema.TaggedErrorClass<PreciseStatError>(
+    "PreciseStatError",
+)("PreciseStatError", {
+    path: Schema.String,
+    message: Schema.String,
+}) {}
+
+/**
+ * Torn-copy tripwire, effectful half: take a `{ size, mtimeNs }` snapshot of
+ * `path` via `statSync(path, { bigint: true })`. Effect's `FileSystem.stat`
+ * reports mtime as a `Date`, whose `getTime()` truncates to whole
+ * milliseconds - a same-size, in-place page rewrite that lands within the
+ * SAME millisecond as the pre-clone stat was therefore invisible to the
+ * tripwire (#952). `statSync`'s `bigint` mode reports the filesystem's actual
+ * nanosecond mtime, so two writes a fraction of a millisecond apart still
+ * compare unequal. This is the module's one permitted `node:fs` call outside
+ * `cloneFile` itself (see the header): the native call is wrapped in
+ * `Effect.try` so a stat failure is a typed error, never an uncaught throw -
+ * callers decide what a stat failure means for their fallback logic.
+ */
+export const statSnapshot = (path: string): Effect.Effect<FileStatSnapshot, PreciseStatError> =>
+    Effect.try({
+        try: (): FileStatSnapshot => {
+            const info = statSync(path, { bigint: true });
+            return { size: Number(info.size), mtimeNs: info.mtimeNs };
+        },
+        catch: (err) => new PreciseStatError({ path, message: errorMessage(err) }),
+    });
 
 /**
  * Post-checkpoint tripwire: `true` iff `<livePath>.wal` is absent or exactly
@@ -99,4 +117,36 @@ export const walIsQuiescent = (fs: FileSystem.FileSystem, livePath: string): Eff
         Effect.map((info) => Number(info.size) === 0),
         skipNotFound(true),
         Effect.orElseSucceed(() => false),
+    );
+
+/** `clearPartialClone` could not remove the temp path - see its docstring for
+ *  why this is a typed failure rather than a swallowed warning. */
+export class ClearPartialCloneError extends Schema.TaggedErrorClass<ClearPartialCloneError>(
+    "ClearPartialCloneError",
+)("ClearPartialCloneError", {
+    path: Schema.String,
+    message: Schema.String,
+}) {}
+
+/**
+ * Remove a temp path a `cloneFile` attempt has already written to, before a
+ * caller falls back to producing the SAME path a different way (a logical
+ * copy that the fallback then `ATTACH`es). Meant to be called on EVERY
+ * rejection reached once `cloneFile` has run - including a `{ cloneable:
+ * false }` outcome itself, since `copyfile(3)` does not promise a failed
+ * clone left `dst` untouched (ENOSPC mid-clone can leave a truncated file) -
+ * so the fallback never lands on, or is mistaken for, a stale partial clone.
+ *
+ * UNLIKE a swallowed best-effort cleanup, a removal failure here is a typed
+ * FAILURE, not a logged warning: the caller (`publishSnapshot` in
+ * `client.ts`) treats it as fatal and aborts the whole publish attempt
+ * rather than falling through to a fallback of unknown provenance at the
+ * same path - the previous snapshot is left exactly as it was (#952).
+ */
+export const clearPartialClone = (
+    fs: FileSystem.FileSystem,
+    tmp: string,
+): Effect.Effect<void, ClearPartialCloneError> =>
+    fs.remove(tmp, { force: true, recursive: true }).pipe(
+        Effect.mapError((err) => new ClearPartialCloneError({ path: tmp, message: err.message })),
     );

--- a/packages/lib/src/duckdb/seam.test.ts
+++ b/packages/lib/src/duckdb/seam.test.ts
@@ -205,6 +205,27 @@ describe("CacheWrite: the ingest lock IS the write capability", () => {
     });
 });
 
+describe("CacheWrite: writer path metadata (#952)", () => {
+    /**
+     * `writerOver` used to report `snapshotPath = target` (the PUBLISH
+     * destination) while its `reader` actually queried through `conn`, which
+     * is open on the LIVE database - `write.snapshotPath` told a caller a
+     * different file than the one every read on `write` actually goes
+     * through. A writer must report the path it reads, which is `livePath`.
+     */
+    dtest("write.snapshotPath reports the LIVE path being written, not the publish target", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-writer-path-");
+            const outcome = await run(asIngest(p, (write) => Effect.succeed(write.snapshotPath)));
+
+            expect(outcome._tag).toBe("completed");
+            const reported = outcome._tag === "completed" ? outcome.value : null;
+            expect(reported).toBe(p.livePath);
+            expect(reported).not.toBe(p.snapshotPath);
+        });
+    });
+});
+
 describe("CacheWrite: the semantics the DDL cannot express", () => {
     dtest("stamps skill.ingested_at even when the caller supplies its own value", async () => {
         await dylibEnv(async () => {
@@ -563,6 +584,45 @@ describe("CacheWrite: publish", () => {
     });
 
     /**
+     * #952: `buildFtsIndexes` runs at the tail of `ax ingest` UNGUARDED (no
+     * `Effect.ignore`) - a build failure must fail the whole ingest body, not
+     * be swallowed as best-effort, precisely so this guarantee holds: an
+     * index rebuild that dies partway through must not be able to publish a
+     * snapshot whose FTS state is inconsistent with its data. An unsafe
+     * identifier is a deterministic way to make `buildFtsIndexes` fail
+     * (`Effect.die`) without needing to fabricate a real rebuild fault.
+     */
+    dtest("a failing FTS build preserves the previous snapshot - FTS failures are fatal, not best-effort", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-fts-fatal-");
+            await run(asIngest(p, (write) => write.put("skill", { id: "s1", name: "good" })));
+            const before = readFileSync(p.snapshotPath);
+
+            const unsafeTarget: FtsTarget = { table: "turn; DROP TABLE turn", idColumn: "id", textColumn: "text_excerpt" };
+
+            const exit = await Effect.runPromiseExit(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("skill", { id: "s2", name: "doomed" });
+                        yield* buildFtsIndexes(write, [unsafeTarget]);
+                    }),
+                ).pipe(Effect.provide(Platform)) as Effect.Effect<unknown, unknown>,
+            );
+
+            expect(exit._tag).toBe("Failure");
+            expect(readFileSync(p.snapshotPath).equals(before)).toBe(true);
+
+            const found = await run(
+                Effect.gen(function* () {
+                    const read = yield* CacheRead;
+                    return yield* read.rows(SkillRow, "SELECT id, name, ingested_at FROM skill ORDER BY id");
+                }).pipe(Effect.provide(CacheReadLayer({ snapshotPath: p.snapshotPath }))),
+            );
+            expect(found.map((r) => r.name)).toEqual(["good"]);
+        });
+    });
+
+    /**
      * THE REGRESSION. "Publish only on success" is gated on `body` succeeding,
      * which means "the ingest succeeded" only while ingest is the sole caller of
      * this seam. It is not - the CLI stamps the `ingest_run` row from `onTimeout`
@@ -758,6 +818,78 @@ describe("CacheWrite: publishIntermediateSnapshot (#833)", () => {
                 ),
             );
 
+            expect(readFileSync(p.snapshotPath).equals(before)).toBe(true);
+        });
+    });
+
+    /**
+     * #952: the empty-publish guard used to `ATTACH ... AS ax_publish_guard
+     * (READ_ONLY)` / `DETACH ax_publish_guard` on the SHARED writer
+     * connection, under a FIXED alias name. A `DETACH` failure was silently
+     * ignored, so it left the alias attached - and every LATER guard
+     * evaluation on that SAME connection then failed its own `ATTACH`
+     * (duplicate alias), which the guard's `orElseSucceed(() => 0)` turned
+     * into "existing <= 0" - i.e. the guard silently stopped protecting data
+     * for the rest of that connection's lifetime.
+     *
+     * The fix opens a dedicated, throwaway connection per guard check instead
+     * of touching the writer's connection at all. This proves BOTH halves:
+     * (a) the writer's own connection never gets anything attached to it, and
+     * (b) two guard evaluations in a row on the SAME writer connection both
+     * still refuse correctly - the shape the old fixed-alias bug degraded.
+     */
+    dtest("checking the empty-publish guard never attaches anything onto the writer's connection, and a second check still works", async () => {
+        await dylibEnv(async () => {
+            const p = paths("ax-seam-guard-no-attach-");
+            await run(
+                asIngest(p, (write) =>
+                    Effect.gen(function* () {
+                        yield* write.put("session", { id: "sess-1" });
+                        yield* write.put("skill", { id: "s1", name: "good" });
+                    }),
+                ),
+            );
+            const before = readFileSync(p.snapshotPath);
+
+            const outcome = await run(
+                withIngestLock(
+                    {
+                        lockPath: p.lockPath,
+                        command: "seam-test-guard-no-attach",
+                        staleMs: 60_000,
+                        onBusy: () => Effect.succeed("busy" as const),
+                    },
+                    withCacheWrite(
+                        {
+                            livePath: join(p.dir, "live-empty.duckdb"),
+                            lockPath: p.lockPath,
+                            snapshotPath: p.snapshotPath,
+                            schemaSql: DDL,
+                            publish: false,
+                        },
+                        (write) =>
+                            Effect.gen(function* () {
+                                // Two guard evaluations in a row, on the SAME
+                                // connection - the second one degrading is
+                                // exactly the old bug's shape.
+                                yield* write.publishIntermediateSnapshot();
+                                yield* write.publishIntermediateSnapshot();
+                                return yield* write.rows(
+                                    Schema.Struct({ database_name: Schema.String }),
+                                    "SELECT database_name FROM duckdb_databases() WHERE NOT internal",
+                                );
+                            }),
+                    ),
+                ),
+            );
+
+            expect(outcome._tag).toBe("completed");
+            const databases = outcome._tag === "completed" ? outcome.value.map((r) => r.database_name) : [];
+            expect(databases).not.toContain("ax_publish_guard");
+            expect(databases).toHaveLength(1); // only the live database itself
+
+            // And both guard evaluations actually refused: the populated
+            // snapshot from run 1 is untouched.
             expect(readFileSync(p.snapshotPath).equals(before)).toBe(true);
         });
     });

--- a/packages/lib/src/duckdb/seam.ts
+++ b/packages/lib/src/duckdb/seam.ts
@@ -747,6 +747,7 @@ const ALLOW_EMPTY_PUBLISH_ENV = "AX_ALLOW_EMPTY_PUBLISH";
  */
 const publishWouldNotDestroyData = (
     fs: FileSystem.FileSystem,
+    db: DuckDbService,
     conn: DuckDbConnection,
     target: string,
 ): Effect.Effect<boolean> =>
@@ -761,7 +762,7 @@ const publishWouldNotDestroyData = (
         // means the count could not be read, which is not evidence of emptiness.
         if (incoming !== 0) return true;
 
-        const existing = yield* countSessionsIn(conn, target).pipe(Effect.orElseSucceed(() => 0));
+        const existing = yield* countSessionsIn(db, target).pipe(Effect.orElseSucceed(() => 0));
         if (existing <= 0) return true; // empty over empty: no loss either way
 
         yield* Effect.logError(
@@ -788,19 +789,29 @@ const sessionCount = (
         Effect.map((result) => Number(result.rows[0]?.n ?? 0)),
     );
 
-/** Sessions in ANOTHER database file, read-only, without disturbing it. The
- *  alias is unlikely to collide and is detached on every exit path. */
+/**
+ * Sessions in ANOTHER database file, read-only, without disturbing the
+ * writer's own connection. #952: this used to `ATTACH ... AS ax_publish_guard
+ * (READ_ONLY)` / `DETACH` on the SHARED writer connection - a fixed alias
+ * name, so a `DETACH` that failed (silently ignored) left it attached, and
+ * every LATER guard check on that same connection then failed its own
+ * `ATTACH` (duplicate alias), which `Effect.orElseSucceed(() => 0)` above
+ * turns into "existing <= 0" - the guard degrading to a silent no-op for the
+ * rest of that connection's lifetime. Opening a dedicated, throwaway
+ * connection has no shared state to poison and is closed on every exit path
+ * (`acquireUseRelease`), so a close failure here cannot carry forward either.
+ */
 const countSessionsIn = (
-    conn: DuckDbConnection,
+    db: DuckDbService,
     path: string,
-): Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError> =>
+): Effect.Effect<number, DuckDbQueryError | DuckDbUnsupportedTypeError | DuckDbOpenError> =>
     Effect.acquireUseRelease(
-        conn.exec(`ATTACH '${path.replace(/'/g, "''")}' AS ax_publish_guard (READ_ONLY)`),
-        () =>
-            conn.query("SELECT CAST(count(*) AS DOUBLE) AS n FROM ax_publish_guard.session").pipe(
+        db.open(path, { readOnly: true }),
+        (conn) =>
+            conn.query("SELECT CAST(count(*) AS DOUBLE) AS n FROM session").pipe(
                 Effect.map((result) => Number(result.rows[0]?.n ?? 0)),
             ),
-        () => conn.exec("DETACH ax_publish_guard").pipe(Effect.ignore),
+        (conn) => conn.close,
     );
 
 /**
@@ -866,7 +877,7 @@ const publishSnapshotNow = (
     target: string,
 ): Effect.Effect<void, CacheWriteError> =>
     Effect.gen(function* () {
-        const safe = yield* publishWouldNotDestroyData(fs, conn, target);
+        const safe = yield* publishWouldNotDestroyData(fs, db, conn, target);
         if (safe) {
             yield* db
                 .publishSnapshot(livePath, target, { from: conn })
@@ -883,8 +894,12 @@ const writerOver = (
 ): CacheWriteService => {
     // The writer owns exactly one connection for its whole lifetime, so
     // "borrowing" it is just calling with it - no identity check, no reopen: a
-    // writer must keep reading the LIVE database it is writing.
-    const reader = readerOver((use) => use(conn), target);
+    // writer must keep reading the LIVE database it is writing. #952: the
+    // reported `snapshotPath` must reflect that - `target` is the PUBLISH
+    // destination, not what this connection is actually open on, and a
+    // caller that reads `write.snapshotPath` to reason about what it is
+    // querying would be told the wrong file.
+    const reader = readerOver((use) => use(conn), livePath);
 
     /**
      * THE NUL CHOKE POINT (#790). Every write this seam issues - `exec`, `put`,


### PR DESCRIPTION
## Summary

- recheck WAL state after clone creation
- preserve nanosecond file timestamps for torn-copy detection
- stop publication when partial-clone cleanup fails
- isolate the empty-publish guard from the writer connection
- report the live path from CacheWrite
- keep FTS rebuild failures fatal

## Verification

- bun test: 6590 pass, 12 skip, 0 fail
- bun run typecheck
- bun run check:no-node-fs
- bun run check:timestamp-cast
- bun run check:raw-numeric-cast

Closes #952

---

_Generated with [ax](https://github.com/Necmttn/ax)._
