### PR TITLE
fix: repair cache indexes after upgrades

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -16,6 +16,7 @@ import { runIngest, withIngestRunFinish, type RunIngestResult } from "../../inge
 import { resolveIngestDeadlineSeconds } from "../../ingest/deadline.ts";
 import { snapshotPath } from "@ax/lib/duckdb/client";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
+import { cmdIngestRepairIndexes, formatIndexRepairResult } from "../../ingest/repair-indexes.ts";
 import type { OtelRetentionResult } from "../../otel/retention.ts";
 import { ingestLockOptions, withIngestLock } from "@ax/lib/ingest-lock";
 import { StageRegistry, type IngestStageError, type StageRegistryShape } from "../../ingest/stage/registry.ts";
@@ -737,6 +738,22 @@ const ingestReapCommand = Command.make(
     ),
 );
 
+const ingestRepairIndexesCommand = Command.make(
+    "repair-indexes",
+    { dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)) },
+    ({ dryRun }) =>
+        Effect.gen(function* () {
+            const result = yield* cmdIngestRepairIndexes({ dryRun });
+            console.log(formatIndexRepairResult(result));
+        }),
+).pipe(
+    Command.withDescription(
+        "Rebuild explicit secondary indexes on the live cache (#1084) - e.g. after an upgrade left " +
+            "one missing. Primary-key and UNIQUE-constraint-backed indexes are out of scope (see the " +
+            "command's own output). Use --dry-run to preview without touching the catalog.",
+    ),
+);
+
 export const ingestCommand = Command.make(
     "ingest",
     {
@@ -809,7 +826,7 @@ export const ingestCommand = Command.make(
             "watermark and re-read inputs ax already ingested - needed to backfill evidence a " +
             "parser fix newly recovers.",
     ),
-    Command.withSubcommands([ingestHereCommand, ingestReapCommand]),
+    Command.withSubcommands([ingestHereCommand, ingestReapCommand, ingestRepairIndexesCommand]),
 );
 
 // Shared flag specs + handlers for the derive verbs. They back BOTH the flat

--- a/apps/axctl/src/ingest/repair-indexes.test.ts
+++ b/apps/axctl/src/ingest/repair-indexes.test.ts
@@ -1,0 +1,549 @@
+/**
+ * `ax ingest repair-indexes` (#1084), against a REAL DuckDB.
+ *
+ * Covers: discovery is limited to explicit secondary indexes (never a
+ * primary-key or constraint-backed index, which never appear in
+ * `duckdb_indexes()` for this DuckDB build in the first place - see the
+ * module header); one-index-at-a-time rebuild with compensation after failure;
+ * dry-run touches no catalog state; and the publish gate gets tripped by any
+ * failure and satisfied only when every discovered index repaired cleanly.
+ */
+import { describe, expect, test } from "bun:test";
+import { Effect, FileSystem, Layer, type Result } from "effect";
+import { AxConfigTest } from "@ax/lib/config";
+import { withIngestLock } from "@ax/lib/ingest-lock";
+import { withCacheWrite, type CacheWriteError, type CacheWriteService } from "@ax/lib/duckdb/seam";
+import { FixturePlatform, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import {
+    INDEX_REPAIR_SCOPE_NOTE,
+    cmdIngestRepairIndexes,
+    formatIndexRepairResult,
+    listRepairableIndexes,
+    planPublish,
+    repairIndexList,
+    repairOneIndex,
+    runIndexRepair,
+    type RepairableIndex,
+} from "./repair-indexes.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("repair-indexes");
+
+const FIXTURE_DDL = `
+CREATE TABLE IF NOT EXISTS widget (
+    id VARCHAR PRIMARY KEY,
+    a VARCHAR UNIQUE,
+    b BIGINT,
+    CONSTRAINT widget_b_named_uq UNIQUE (b)
+);
+CREATE INDEX IF NOT EXISTS widget_b_idx ON widget(b);
+CREATE UNIQUE INDEX IF NOT EXISTS widget_a_c_uq ON widget(a, id);
+`;
+
+interface Paths {
+    readonly dir: string;
+    readonly livePath: string;
+    readonly lockPath: string;
+    readonly snapshotPath: string;
+}
+
+const paths = (prefix: string): Paths => {
+    const dir = tempDir(prefix);
+    return {
+        dir,
+        livePath: `${dir}/live.duckdb`,
+        lockPath: `${dir}/ingest.lock`,
+        snapshotPath: `${dir}/snapshot.duckdb`,
+    };
+};
+
+/** Open the fixture live db under the ingest lock and run `body`. Mirrors
+ *  the real command's own explicit schema handling so tests can seed data
+ *  (schemaSql = FIXTURE_DDL) or exercise repair with schema application
+ *  disabled (schemaSql = null), exactly as the command does. `publish`
+ *  mirrors `CacheWriteOptions.publish` - default `false` so a test opts in
+ *  only when it actually means to exercise `withCacheWrite`'s on-success
+ *  publish gate. `body`'s error type is left for Effect to infer rather than
+ *  pinned to `CacheWriteError`, since some callers below exercise the
+ *  module's own typed errors (`IndexRestoreFailedError`,
+ *  `IndexRepairIncompleteError`), which are not `CacheWriteError`s. */
+const openFixture = <A, E>(
+    p: Paths,
+    schemaSql: string | null,
+    body: (write: CacheWriteService) => Effect.Effect<A, E, never>,
+    publish = false,
+): Promise<A> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const outcome = yield* withIngestLock(
+                {
+                    lockPath: p.lockPath,
+                    command: "repair-indexes-test",
+                    staleMs: 60_000,
+                    onBusy: () => Effect.die("the ingest lock was busy in a single-process test"),
+                },
+                withCacheWrite(
+                    {
+                        livePath: p.livePath,
+                        lockPath: p.lockPath,
+                        snapshotPath: p.snapshotPath,
+                        schemaSql,
+                        publish,
+                        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                    },
+                    body,
+                ),
+            );
+            if (outcome._tag !== "completed") {
+                throw new Error(`ingest run did not complete: ${outcome._tag}`);
+            }
+            return outcome.value;
+        }),
+    );
+
+/** Like `openFixture`, but captures the write body's success/failure OUTSIDE
+ *  `withCacheWrite` via `Effect.result`, exactly where `cmdIngestRepairIndexes`
+ *  itself catches `IndexRepairIncompleteError` - so these tests observe the
+ *  SAME thing `withCacheWrite` observed when deciding whether to publish,
+ *  rather than a body that already swallowed its own failure. */
+const openFixtureResult = <A, E>(
+    p: Paths,
+    schemaSql: string | null,
+    body: (write: CacheWriteService) => Effect.Effect<A, E, never>,
+    publish: boolean,
+): Promise<Result.Result<A, E | CacheWriteError>> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const outcome = yield* withIngestLock(
+                {
+                    lockPath: p.lockPath,
+                    command: "repair-indexes-test",
+                    staleMs: 60_000,
+                    onBusy: () => Effect.die("the ingest lock was busy in a single-process test"),
+                },
+                withCacheWrite(
+                    {
+                        livePath: p.livePath,
+                        lockPath: p.lockPath,
+                        snapshotPath: p.snapshotPath,
+                        schemaSql,
+                        publish,
+                        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                    },
+                    body,
+                ).pipe(Effect.result),
+            );
+            if (outcome._tag !== "completed") {
+                throw new Error(`ingest run did not complete: ${outcome._tag}`);
+            }
+            return outcome.value;
+        }),
+    );
+
+const seedWidgets = (write: CacheWriteService) =>
+    write.exec(
+        "INSERT INTO widget (id, a, b) VALUES ('w1', 'alpha', 1), ('w2', 'beta', 2), ('w3', 'gamma', 3)",
+    );
+
+const indexNames = (rows: ReadonlyArray<{ readonly indexName: string }>): readonly string[] =>
+    [...rows].map((r) => r.indexName).sort();
+
+describe("listRepairableIndexes", () => {
+    dtest("lists only explicit secondary indexes - never the primary key or the named UNIQUE constraint", async () => {
+        const p = paths("ax-ridx-list-");
+        const found = await openFixture(p, FIXTURE_DDL, (write) => listRepairableIndexes(write));
+
+        expect(indexNames(found)).toEqual(["widget_a_c_uq", "widget_b_idx"]);
+        const byName = new Map(found.map((f) => [f.indexName, f]));
+        expect(byName.get("widget_a_c_uq")?.isUnique).toBe(true);
+        expect(byName.get("widget_b_idx")?.isUnique).toBe(false);
+        expect(byName.get("widget_a_c_uq")?.createSql).toContain("CREATE UNIQUE INDEX");
+        // Never a PK or the table-level named UNIQUE constraint on `b`.
+        expect(found.some((f) => f.indexName === "widget_b_named_uq")).toBe(false);
+        expect(found.some((f) => f.tableName === "widget" && f.indexName.includes("pkey"))).toBe(false);
+    });
+});
+
+describe("repairOneIndex", () => {
+    dtest("rebuilds a non-unique index and it still works", async () => {
+        const p = paths("ax-ridx-one-nonunique-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+
+        const outcome = await openFixture(p, null, (write) =>
+            repairOneIndex(write, {
+                indexName: "widget_b_idx",
+                tableName: "widget",
+                isUnique: false,
+                createSql: "CREATE INDEX widget_b_idx ON widget(b);",
+            }),
+        );
+        expect(outcome).toEqual({ indexName: "widget_b_idx", tableName: "widget", status: "repaired" });
+
+        const after = await openFixture(p, null, (write) =>
+            Effect.all([
+                write.raw("SELECT sql FROM duckdb_indexes() WHERE index_name = 'widget_b_idx'"),
+                write.raw("SELECT count(*) AS n FROM widget WHERE b = 2"),
+            ]),
+        );
+        expect(after[0].rows[0]?.["sql"]).toBe("CREATE INDEX widget_b_idx ON widget(b);");
+        expect(Number(after[1].rows[0]?.["n"])).toBe(1);
+    });
+
+    dtest("rebuilds a unique index and it still works", async () => {
+        const p = paths("ax-ridx-one-unique-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+
+        const outcome = await openFixture(p, null, (write) =>
+            repairOneIndex(write, {
+                indexName: "widget_a_c_uq",
+                tableName: "widget",
+                isUnique: true,
+                createSql: "CREATE UNIQUE INDEX widget_a_c_uq ON widget(a, id);",
+            }),
+        );
+        expect(outcome.status).toBe("repaired");
+
+        // The uniqueness constraint is genuinely back in force: a duplicate
+        // insert must fail.
+        const rejected = await openFixture(p, null, (write) =>
+            write.exec("INSERT INTO widget (id, a, b) VALUES ('w1', 'alpha', 99)").pipe(
+                Effect.map(() => "inserted" as const),
+                Effect.catch(() => Effect.succeed("rejected" as const)),
+            ),
+        );
+        expect(rejected).toBe("rejected");
+    });
+
+    dtest("a recreation failure restores the original index and leaves rows untouched", async () => {
+        const p = paths("ax-ridx-one-fail-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+        const before = await openFixture(p, null, (write) =>
+            write.raw("SELECT sql FROM duckdb_indexes() WHERE index_name = 'widget_b_idx'"),
+        );
+
+        const outcome = await openFixture(p, null, (write) =>
+            repairOneIndex(write, {
+                indexName: "widget_b_idx",
+                tableName: "widget",
+                isUnique: false,
+                // Deliberately bad: references a column that does not exist,
+                // so CREATE INDEX fails after the DROP. The compensating
+                // action must restore the captured original definition.
+                createSql: "CREATE INDEX widget_b_idx ON widget(does_not_exist);",
+            }),
+        );
+        expect(outcome.status).toBe("failed");
+        expect(outcome.error).toContain("does_not_exist");
+
+        const after = await openFixture(p, null, (write) =>
+            Effect.all([
+                write.raw("SELECT sql FROM duckdb_indexes() WHERE index_name = 'widget_b_idx'"),
+                write.raw("SELECT count(*) AS n FROM widget"),
+            ]),
+        );
+        expect(after[0].rows[0]?.["sql"]).toBe(before.rows[0]?.["sql"]);
+        expect(Number(after[1].rows[0]?.["n"])).toBe(3);
+    });
+});
+
+describe("planPublish", () => {
+    const outcome = (status: "repaired" | "failed" | "would-repair"): { status: typeof status } => ({ status });
+
+    test("publishes when at least one index was repaired and none failed", () => {
+        expect(planPublish([outcome("repaired"), outcome("repaired")])).toBe(true);
+    });
+
+    test("refuses when any index failed, even alongside successes", () => {
+        expect(planPublish([outcome("repaired"), outcome("failed")])).toBe(false);
+    });
+
+    test("refuses when nothing needed repairing (no-op run)", () => {
+        expect(planPublish([])).toBe(false);
+    });
+
+    test("refuses for a dry-run's would-repair outcomes", () => {
+        expect(planPublish([outcome("would-repair"), outcome("would-repair")])).toBe(false);
+    });
+});
+
+describe("repairIndexList: dry-run changes no catalog state", () => {
+    dtest("dry-run reports would-repair for every discovered index and mutates nothing", async () => {
+        const p = paths("ax-ridx-dryrun-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+        const before = await openFixture(p, null, (write) =>
+            write.raw("SELECT index_name, sql FROM duckdb_indexes() WHERE table_name = 'widget' ORDER BY index_name"),
+        );
+
+        const indexes: readonly RepairableIndex[] = await openFixture(p, null, (write) =>
+            listRepairableIndexes(write),
+        );
+        const result = await openFixture(p, null, (write) => repairIndexList(write, indexes, true));
+
+        expect(result.dryRun).toBe(true);
+        expect(result.repaired).toBe(0);
+        expect(result.failed).toBe(0);
+        expect(indexNames(result.outcomes)).toEqual(["widget_a_c_uq", "widget_b_idx"]);
+        expect(result.outcomes.every((o) => o.status === "would-repair")).toBe(true);
+
+        const after = await openFixture(p, null, (write) =>
+            write.raw("SELECT index_name, sql FROM duckdb_indexes() WHERE table_name = 'widget' ORDER BY index_name"),
+        );
+        expect(after.rows).toEqual(before.rows);
+
+        // No snapshot published either - dry-run touches nothing.
+        const fs = await runWithPlatform(
+            Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                return yield* fs.exists(p.snapshotPath);
+            }),
+        );
+        expect(fs).toBe(false);
+    });
+});
+
+describe("repairIndexList: publish gating", () => {
+    // `repairIndexList` itself never publishes anything (#1084 review: the
+    // old implementation reached for `CacheWriteService.publishIntermediateSnapshot()`,
+    // a narrow escape hatch reserved for ingest's cold-start path - see the
+    // module header). Publishing is `withCacheWrite`'s own on-success gate,
+    // so these tests open with `publish: true` and prove the gate by whether
+    // `repairIndexList`'s body SUCCEEDS or FAILS.
+    dtest("publishes when every discovered index repairs cleanly", async () => {
+        const p = paths("ax-ridx-allok-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+        const indexes: readonly RepairableIndex[] = await openFixture(p, null, (write) =>
+            listRepairableIndexes(write),
+        );
+
+        const result = await openFixture(p, null, (write) => repairIndexList(write, indexes, false), true);
+        expect(result.repaired).toBe(2);
+        expect(result.failed).toBe(0);
+
+        const fs = await runWithPlatform(
+            Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                return yield* fs.exists(p.snapshotPath);
+            }),
+        );
+        expect(fs).toBe(true);
+    });
+
+    dtest("does NOT publish when one index fails to rebuild - even if others succeeded", async () => {
+        const p = paths("ax-ridx-onefail-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+        const real: readonly RepairableIndex[] = await openFixture(p, null, (write) =>
+            listRepairableIndexes(write),
+        );
+        const broken: readonly RepairableIndex[] = real.map((idx) =>
+            idx.indexName === "widget_b_idx"
+                ? { ...idx, createSql: "CREATE INDEX widget_b_idx ON widget(does_not_exist);" }
+                : idx,
+        );
+
+        // `repairIndexList` fails its own body (IndexRepairIncompleteError)
+        // when the pass is not a clean sweep - exactly what stops
+        // `withCacheWrite`'s on-success publish from firing even though
+        // `publish: true` is set below. Observe that failure the same way
+        // `withCacheWrite` did (outside its own body), via `openFixtureResult`.
+        const outcome = await openFixtureResult(p, null, (write) => repairIndexList(write, broken, false), true);
+        expect(outcome._tag).toBe("Failure");
+        if (outcome._tag !== "Failure") throw new Error("expected repairIndexList to fail");
+        expect(outcome.failure._tag).toBe("IndexRepairIncompleteError");
+        if (outcome.failure._tag !== "IndexRepairIncompleteError") throw new Error("expected IndexRepairIncompleteError");
+        expect(outcome.failure.result.repaired).toBe(1);
+        expect(outcome.failure.result.failed).toBe(1);
+
+        const fs = await runWithPlatform(
+            Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                return yield* fs.exists(p.snapshotPath);
+            }),
+        );
+        expect(fs).toBe(false);
+
+        // The failed index's ORIGINAL definition survives - restored, not
+        // left dropped - even though this run never published.
+        const catalog = await openFixture(p, null, (write) =>
+            write.raw("SELECT sql FROM duckdb_indexes() WHERE index_name = 'widget_b_idx'"),
+        );
+        expect(catalog.rows[0]?.["sql"]).toBe("CREATE INDEX widget_b_idx ON widget(b);");
+    });
+
+    dtest("does NOT publish when nothing was discovered to repair (no-op run)", async () => {
+        const p = paths("ax-ridx-noop-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+
+        const outcome = await openFixtureResult(p, null, (write) => repairIndexList(write, [], false), true);
+        expect(outcome._tag).toBe("Failure");
+        if (outcome._tag !== "Failure") throw new Error("expected repairIndexList to fail");
+        expect(outcome.failure._tag).toBe("IndexRepairIncompleteError");
+        if (outcome.failure._tag !== "IndexRepairIncompleteError") throw new Error("expected IndexRepairIncompleteError");
+        expect(outcome.failure.result.repaired).toBe(0);
+        expect(outcome.failure.result.failed).toBe(0);
+        expect(outcome.failure.result.outcomes.length).toBe(0);
+
+        const fs = await runWithPlatform(
+            Effect.gen(function* () {
+                const fs = yield* FileSystem.FileSystem;
+                return yield* fs.exists(p.snapshotPath);
+            }),
+        );
+        expect(fs).toBe(false);
+    });
+
+    dtest(
+        "a compensating-restore failure propagates as IndexRestoreFailedError, leaves the index dropped, " +
+            "and blocks publish",
+        async () => {
+            const p = paths("ax-ridx-restore-fail-");
+            await openFixture(p, FIXTURE_DDL, seedWidgets);
+            const indexes: readonly RepairableIndex[] = await openFixture(p, null, (write) =>
+                listRepairableIndexes(write),
+            );
+            const target = indexes.find((idx) => idx.indexName === "widget_a_c_uq");
+            if (target === undefined) throw new Error("fixture is missing widget_a_c_uq");
+            const originalSql = target.createSql;
+            const broken: readonly RepairableIndex[] = indexes.map((idx) =>
+                idx.indexName === "widget_a_c_uq"
+                    ? { ...idx, createSql: "CREATE UNIQUE INDEX widget_a_c_uq ON widget(a, does_not_exist);" }
+                    : idx,
+            );
+
+            const outcome = await openFixtureResult(
+                p,
+                null,
+                (write) => {
+                    // Sabotage ONLY the compensating restore: right as
+                    // `repairOneIndex` re-runs the captured original
+                    // definition (verbatim SQL match, so neither the bad
+                    // CREATE nor the DROP is affected), sneak in a
+                    // primary-key-violating duplicate `id` row first, so the
+                    // restore's own exec call fails outright before it ever
+                    // reaches the real CREATE UNIQUE INDEX statement.
+                    const sabotaged: CacheWriteService = {
+                        ...write,
+                        exec: (sql, params) =>
+                            sql === originalSql
+                                ? write
+                                      .exec("INSERT INTO widget (id, a, b) VALUES ('w1', 'alpha', 99)")
+                                      .pipe(Effect.flatMap(() => write.exec(sql, params)))
+                                : write.exec(sql, params),
+                    };
+                    return repairIndexList(sabotaged, broken, false);
+                },
+                true,
+            );
+
+            expect(outcome._tag).toBe("Failure");
+            if (outcome._tag === "Failure") {
+                expect(outcome.failure._tag).toBe("IndexRestoreFailedError");
+                if (outcome.failure._tag === "IndexRestoreFailedError") {
+                    expect(outcome.failure.indexName).toBe("widget_a_c_uq");
+                }
+            }
+
+            // The catalog is left WITHOUT the index at all - the DROP
+            // succeeded, and BOTH the sabotaged CREATE and the compensating
+            // restore failed. This is exactly why it must be fatal rather
+            // than a per-index "failed" outcome.
+            const catalog = await openFixture(p, null, (write) =>
+                write.raw("SELECT sql FROM duckdb_indexes() WHERE index_name = 'widget_a_c_uq'"),
+            );
+            expect(catalog.rows.length).toBe(0);
+
+            const fs = await runWithPlatform(
+                Effect.gen(function* () {
+                    const fs = yield* FileSystem.FileSystem;
+                    return yield* fs.exists(p.snapshotPath);
+                }),
+            );
+            expect(fs).toBe(false);
+        },
+    );
+});
+
+describe("runIndexRepair", () => {
+    dtest("discovers and repairs every explicit secondary index end to end", async () => {
+        const p = paths("ax-ridx-e2e-");
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+
+        const result = await openFixture(p, null, (write) => runIndexRepair(write, { dryRun: false }));
+        expect(result.repaired).toBe(2);
+        expect(result.failed).toBe(0);
+        expect(indexNames(result.outcomes)).toEqual(["widget_a_c_uq", "widget_b_idx"]);
+    });
+});
+
+describe("formatIndexRepairResult", () => {
+    test("states the primary/constraint scope boundary in every mode", () => {
+        expect(formatIndexRepairResult({ dryRun: true, outcomes: [], repaired: 0, failed: 0 })).toContain(
+            INDEX_REPAIR_SCOPE_NOTE,
+        );
+        expect(
+            formatIndexRepairResult({
+                dryRun: false,
+                outcomes: [{ indexName: "x", tableName: "t", status: "repaired" }],
+                repaired: 1,
+                failed: 0,
+            }),
+        ).toContain(INDEX_REPAIR_SCOPE_NOTE);
+    });
+
+    test("says the snapshot was not published when a repair failed", () => {
+        const text = formatIndexRepairResult({
+            dryRun: false,
+            outcomes: [
+                { indexName: "ok", tableName: "t", status: "repaired" },
+                { indexName: "bad", tableName: "t", status: "failed", error: "boom" },
+            ],
+            repaired: 1,
+            failed: 1,
+        });
+        expect(text).toContain("snapshot NOT published");
+        expect(text).toContain("FAILED  t.bad - boom");
+    });
+
+    test("dry-run states every discovered index would be repaired, not 0/N", () => {
+        const text = formatIndexRepairResult({
+            dryRun: true,
+            outcomes: [
+                { indexName: "a", tableName: "t", status: "would-repair" },
+                { indexName: "b", tableName: "t", status: "would-repair" },
+            ],
+            repaired: 0,
+            failed: 0,
+        });
+        expect(text).toContain("would repair 2/2 explicit secondary index(es)");
+        expect(text).not.toContain("would repair 0/2");
+    });
+});
+
+describe("cmdIngestRepairIndexes: the CLI composition", () => {
+    dtest("acquires the lock, opens with schema disabled, and repairs against AxConfig's dataDir", async () => {
+        // Seeded at the SAME filenames `cmdIngestRepairIndexes` itself
+        // resolves from `AxConfig.paths.dataDir` (`ax-live.duckdb` /
+        // `ingest.lock` / `ax-snapshot.duckdb` - see `maintenanceCacheWriteOptions`
+        // in cli/commands/ingest.ts, the same convention every other
+        // dataDir-rooted maintenance write uses) - NOT the generic
+        // `live.duckdb`/`snapshot.duckdb` names the other describe blocks in
+        // this file use for their own directly-supplied `CacheWriteOptions`.
+        const dir = tempDir("ax-ridx-cli-");
+        const p: Paths = {
+            dir,
+            livePath: `${dir}/ax-live.duckdb`,
+            lockPath: `${dir}/ingest.lock`,
+            snapshotPath: `${dir}/ax-snapshot.duckdb`,
+        };
+        await openFixture(p, FIXTURE_DDL, seedWidgets);
+
+        const result = await Effect.runPromise(
+            cmdIngestRepairIndexes({ dryRun: false }).pipe(
+                Effect.provide(
+                    AxConfigTest({ paths: { dataDir: p.dir } }).pipe(Layer.provideMerge(FixturePlatform)),
+                ),
+            ),
+        );
+        expect(result.repaired).toBe(2);
+        expect(result.failed).toBe(0);
+    });
+});

--- a/apps/axctl/src/ingest/repair-indexes.ts
+++ b/apps/axctl/src/ingest/repair-indexes.ts
@@ -1,0 +1,413 @@
+/**
+ * `ax ingest repair-indexes` (#1084): rebuild secondary indexes on the live
+ * cache after an upgrade left one missing or stale.
+ *
+ * SCOPE: only EXPLICIT secondary indexes - the rows `duckdb_indexes()`
+ * reports for this DuckDB build. A primary key or a table-level `CONSTRAINT
+ * ... UNIQUE (...)` never appears there: DuckDB enforces those through the
+ * table's own constraint machinery, not a separate catalog index, so there is
+ * nothing this command could rebuild for them even if asked - see
+ * {@link INDEX_REPAIR_SCOPE_NOTE}, and `cache-bust-event-upgrade.test.ts` for
+ * the upgrade defect this command exists to let an operator recover from
+ * without a full reingest.
+ *
+ * Each index repairs as its OWN recoverable unit of work: DROP the existing
+ * index, then re-run its own `CREATE [UNIQUE] INDEX` statement (read back
+ * verbatim from `duckdb_indexes().sql`, so it reproduces the exact original
+ * definition). This is NOT a real SQL `BEGIN`/`COMMIT` transaction, despite
+ * that being the obvious way to write this: measured against this DuckDB
+ * build, wrapping a same-name `DROP INDEX` + `CREATE INDEX` pair in one
+ * explicit transaction crashes the native client outright (`libc++abi: Pure
+ * virtual function called!`) - reproduced with `BEGIN TRANSACTION` alone
+ * around the pair, on both a failing and a succeeding `CREATE`, and confirmed
+ * absent the moment either the transaction wrapper or the same-name reuse is
+ * removed. So `repairOneIndex` reads the index's CURRENT definition before
+ * touching anything, drops it, and on a `CREATE` failure re-runs that
+ * captured definition as a COMPENSATING action standing in for a rollback
+ * the native binding cannot execute - this is NOT a SQL transaction rollback,
+ * and it does not offer transactional guarantees. If that compensating
+ * restore itself fails, the catalog is left in a state this module cannot
+ * reconcile (the index dropped, neither the new nor the original definition
+ * in place), and `repairOneIndex` propagates {@link IndexRestoreFailedError}
+ * rather than reporting a per-index outcome - see there for why that must be
+ * fatal to the whole run.
+ *
+ * PUBLISH GATING mirrors the seam's own maintenance-write rule (see
+ * `CacheWriteOptions.publish` in `@ax/lib/duckdb/seam`): this command opens
+ * the live cache with the DDL disabled (it must be usable against a cache an
+ * upgrade already left in a broken state - see `withCacheWrite`'s
+ * `schemaSql: null` case). A dry-run passes `publish: false` outright, since
+ * it never touches the catalog. A real repair uses `withCacheWrite`'s own
+ * on-success publish - NOT `CacheWriteService.publishIntermediateSnapshot()`,
+ * which is a narrow escape hatch reserved for ingest's cold-start path (see
+ * its own doc comment) and is not a sanctioned caller here. Instead,
+ * `repairIndexList` fails its own body with the typed
+ * {@link IndexRepairIncompleteError} whenever the pass was not a clean sweep
+ * (nothing discovered, or at least one index failed) - a failed body is
+ * exactly what stops `withCacheWrite` from publishing. `cmdIngestRepairIndexes`
+ * handles that ONE typed error outside `withCacheWrite`. An empty pass returns
+ * a successful no-op result. A pass with failed repairs remains a typed CLI
+ * failure. Every other error (`IndexRestoreFailedError`, or any
+ * `CacheWriteError`) propagates unchanged. The live cache itself is never
+ * deleted or rebuilt from scratch by any of this.
+ */
+import { Effect, Schema } from "effect";
+import { AxConfig } from "@ax/lib/config";
+import {
+    withCacheWrite,
+    type CacheReadError,
+    type CacheReadService,
+    type CacheWriteError,
+    type CacheWriteService,
+} from "@ax/lib/duckdb/seam";
+import { withIngestLock } from "@ax/lib/ingest-lock";
+import { posixPath } from "@ax/lib/shared/path";
+import { duckdbAssetPathOption } from "../duckdb-embed-wiring.ts";
+
+export const INDEX_REPAIR_SCOPE_NOTE =
+    "scope: explicit secondary indexes only - primary-key and UNIQUE-constraint-backed indexes " +
+    "are enforced by the table itself, never appear in duckdb_indexes(), and are unsupported here.";
+
+export interface RepairableIndex {
+    readonly indexName: string;
+    readonly tableName: string;
+    readonly isUnique: boolean;
+    /** The index's own `CREATE [UNIQUE] INDEX ...` statement, verbatim from
+     *  `duckdb_indexes().sql` - reproducing it is what "repair" means. */
+    readonly createSql: string;
+}
+
+export interface IndexRepairOutcome {
+    readonly indexName: string;
+    readonly tableName: string;
+    readonly status: "repaired" | "failed" | "would-repair";
+    readonly error?: string | undefined;
+}
+
+export interface IndexRepairResult {
+    readonly dryRun: boolean;
+    readonly outcomes: readonly IndexRepairOutcome[];
+    readonly repaired: number;
+    readonly failed: number;
+}
+
+/** A compensating restore (re-running an index's captured original
+ *  definition) itself failed after a DROP and a failed CREATE. Unlike a
+ *  per-index `"failed"` outcome - where the DROP never ran, or it did and the
+ *  restore put the catalog back - this leaves the catalog in a state this
+ *  module cannot reconcile: the index is gone, and neither the attempted new
+ *  definition nor the original one is in place. It is FATAL rather than a
+ *  reported outcome for exactly that reason: it propagates out of
+ *  `repairOneIndex` uncaught, past `repairIndexList`, and fails the
+ *  `withCacheWrite` body - so the run can never publish over it. */
+export class IndexRestoreFailedError extends Schema.TaggedErrorClass<IndexRestoreFailedError>(
+    "IndexRestoreFailedError",
+)("IndexRestoreFailedError", {
+    indexName: Schema.String,
+    tableName: Schema.String,
+    createError: Schema.String,
+    restoreError: Schema.String,
+    message: Schema.String,
+}) {}
+
+/** Raised from `repairIndexList`'s write body whenever a non-dry-run pass was
+ *  not a clean sweep - nothing was discovered to repair, or at least one
+ *  index came back `"failed"`. Failing the body is what stops
+ *  `withCacheWrite`'s on-success publish from firing; it carries the
+ *  already-computed {@link IndexRepairResult} so `cmdIngestRepairIndexes` can
+ *  catch it OUTSIDE `withCacheWrite` and still hand the CLI a result to
+ *  format, without that catch masking any other `CacheWriteError`. */
+export class IndexRepairIncompleteError extends Schema.TaggedErrorClass<IndexRepairIncompleteError>(
+    "IndexRepairIncompleteError",
+)("IndexRepairIncompleteError", {
+    message: Schema.String,
+    result: Schema.Struct({
+        dryRun: Schema.Boolean,
+        outcomes: Schema.Array(
+            Schema.Struct({
+                indexName: Schema.String,
+                tableName: Schema.String,
+                status: Schema.Literals(["repaired", "failed", "would-repair"]),
+                error: Schema.optional(Schema.String),
+            }),
+        ),
+        repaired: Schema.Number,
+        failed: Schema.Number,
+    }),
+}) {}
+
+export class IndexRepairBusyError extends Schema.TaggedErrorClass<IndexRepairBusyError>(
+    "IndexRepairBusyError",
+)("IndexRepairBusyError", {
+    holderCommand: Schema.String,
+    message: Schema.String,
+}) {}
+
+const RepairableIndexRow = Schema.Struct({
+    index_name: Schema.String,
+    table_name: Schema.String,
+    is_unique: Schema.Boolean,
+    sql: Schema.String,
+});
+
+const IndexSqlRow = Schema.Struct({ sql: Schema.String });
+
+/** Quote a catalog identifier without restricting valid quoted names. */
+const quoteIdentifier = (name: string): string => `"${name.replaceAll('"', '""')}"`;
+
+const writeErrorMessage = (error: CacheWriteError): string => error.message;
+
+/** Every explicit secondary index on the live cache, read straight off the
+ *  catalog. Never a primary key or a named UNIQUE constraint - see the module
+ *  header for why those cannot appear here in the first place. */
+export const listRepairableIndexes = (
+    read: CacheReadService,
+): Effect.Effect<readonly RepairableIndex[], CacheReadError> =>
+    read
+        .rows(
+            RepairableIndexRow,
+            "SELECT index_name, table_name, is_unique, sql FROM duckdb_indexes() " +
+                "WHERE NOT is_primary AND sql IS NOT NULL ORDER BY index_name",
+        )
+        .pipe(
+            Effect.map((rows) =>
+                rows.map((row): RepairableIndex => ({
+                    indexName: row.index_name,
+                    tableName: row.table_name,
+                    isUnique: row.is_unique,
+                    createSql: row.sql,
+                })),
+            ),
+        );
+
+/** After a CREATE fails, re-run the index's captured `originalSql` to put the
+ *  catalog back where it was. If that restore itself fails, the outcome is no
+ *  longer representable as a per-index `"failed"` result - fail fatally with
+ *  {@link IndexRestoreFailedError} instead (see its own doc comment). */
+const restoreAfterFailedCreate = (
+    write: CacheWriteService,
+    index: RepairableIndex,
+    originalSql: unknown,
+    createError: CacheWriteError,
+): Effect.Effect<IndexRepairOutcome, IndexRestoreFailedError> =>
+    Effect.gen(function* () {
+        if (typeof originalSql !== "string") {
+            return {
+                indexName: index.indexName,
+                tableName: index.tableName,
+                status: "failed" as const,
+                error: writeErrorMessage(createError),
+            };
+        }
+
+        const restored = yield* Effect.result(write.exec(originalSql));
+        if (restored._tag === "Failure") {
+            return yield* new IndexRestoreFailedError({
+                indexName: index.indexName,
+                tableName: index.tableName,
+                createError: writeErrorMessage(createError),
+                restoreError: writeErrorMessage(restored.failure),
+                message:
+                    `repair-indexes: ${index.tableName}.${index.indexName} - index creation failed and the compensating ` +
+                    "restore of its original definition ALSO failed. The catalog is left without this index and " +
+                    "this run's publish is blocked - investigate the live cache directly before retrying.",
+            });
+        }
+
+        return {
+            indexName: index.indexName,
+            tableName: index.tableName,
+            status: "failed" as const,
+            error: writeErrorMessage(createError),
+        };
+    });
+
+/**
+ * Rebuild one index: DROP it, then re-run its own `createSql`. Not a real SQL
+ * transaction - see the module header for why that crashes the native
+ * client. If the DROP itself fails, nothing has changed and the failure is
+ * reported as a per-index `"failed"` outcome. If the CREATE fails AFTER a
+ * successful DROP, the index's definition as read BEFORE this call
+ * (`originalSql`) is re-run to put the catalog back where it was; if THAT
+ * restore also fails, this propagates {@link IndexRestoreFailedError} rather
+ * than reporting an outcome. Every other failure reports `"failed"` instead
+ * of propagating, so one bad index never aborts the rest of the pass.
+ */
+export const repairOneIndex = (
+    write: CacheWriteService,
+    index: RepairableIndex,
+): Effect.Effect<IndexRepairOutcome, IndexRestoreFailedError> =>
+    Effect.gen(function* () {
+        const before = yield* write.rows(IndexSqlRow, "SELECT sql FROM duckdb_indexes() WHERE index_name = ?", [
+            index.indexName,
+        ]);
+        const originalSql = before[0]?.sql;
+
+        yield* write.exec(`DROP INDEX ${quoteIdentifier(index.indexName)}`);
+
+        return yield* write.exec(index.createSql).pipe(
+            Effect.as({
+                indexName: index.indexName,
+                tableName: index.tableName,
+                status: "repaired" as const,
+            }),
+            Effect.catch((createError) => restoreAfterFailedCreate(write, index, originalSql, createError)),
+        );
+    }).pipe(
+        // Only IndexRestoreFailedError (raised above) is fatal - every other
+        // failure along this path (the lookup query, the DROP itself) is a
+        // normal per-index outcome, never a reason to abort the whole pass.
+        Effect.catchIf(
+            (error): error is CacheWriteError => error._tag !== "IndexRestoreFailedError",
+            (error) =>
+                Effect.succeed({
+                    indexName: index.indexName,
+                    tableName: index.tableName,
+                    status: "failed" as const,
+                    error: writeErrorMessage(error),
+                }),
+        ),
+    );
+
+/** Publish only when there was something to repair and every one of them
+ *  repaired cleanly - never for a dry-run's `would-repair` outcomes, never
+ *  for a no-op empty run, and never alongside even one failure. */
+export const planPublish = (outcomes: ReadonlyArray<Pick<IndexRepairOutcome, "status">>): boolean =>
+    outcomes.length > 0 && outcomes.every((o) => o.status === "repaired");
+
+/** Repair (or, in dry-run, merely report) every index in `indexes`. A
+ *  dry-run always succeeds. A real pass succeeds ONLY when
+ *  {@link planPublish} would say yes to the result it just computed;
+ *  otherwise it fails the whole effect with {@link IndexRepairIncompleteError}
+ *  carrying that same result, so `withCacheWrite`'s on-success publish never
+ *  fires over a no-op or partially-failed run. */
+export const repairIndexList = (
+    write: CacheWriteService,
+    indexes: readonly RepairableIndex[],
+    dryRun: boolean,
+): Effect.Effect<IndexRepairResult, IndexRestoreFailedError | IndexRepairIncompleteError> =>
+    Effect.gen(function* () {
+        if (dryRun) {
+            const outcomes: IndexRepairOutcome[] = indexes.map((index) => ({
+                indexName: index.indexName,
+                tableName: index.tableName,
+                status: "would-repair" as const,
+            }));
+            return { dryRun: true, outcomes, repaired: 0, failed: 0 };
+        }
+
+        const outcomes: IndexRepairOutcome[] = [];
+        for (const index of indexes) {
+            outcomes.push(yield* repairOneIndex(write, index));
+        }
+
+        const result: IndexRepairResult = {
+            dryRun: false,
+            outcomes,
+            repaired: outcomes.filter((o) => o.status === "repaired").length,
+            failed: outcomes.filter((o) => o.status === "failed").length,
+        };
+
+        if (!planPublish(outcomes)) {
+            return yield* new IndexRepairIncompleteError({
+                result,
+                message: formatIndexRepairResult(result),
+            });
+        }
+        return result;
+    });
+
+/** Discover, then repair (or preview) every explicit secondary index. */
+export const runIndexRepair = (
+    write: CacheWriteService,
+    opts: { readonly dryRun: boolean },
+): Effect.Effect<IndexRepairResult, CacheReadError | IndexRestoreFailedError | IndexRepairIncompleteError> =>
+    Effect.gen(function* () {
+        const indexes = yield* listRepairableIndexes(write);
+        return yield* repairIndexList(write, indexes, opts.dryRun);
+    });
+
+export const formatIndexRepairResult = (result: IndexRepairResult): string => {
+    const verb = result.dryRun ? "would repair" : "repaired";
+    // A dry-run's `repaired` counter is always 0 (nothing is actually
+    // touched) - the count worth showing is how many indexes were
+    // DISCOVERED, i.e. every outcome, all of which are "would-repair".
+    const count = result.dryRun ? result.outcomes.length : result.repaired;
+    const lines: string[] = [
+        `ingest repair-indexes: ${verb} ${count}/${result.outcomes.length} explicit secondary index(es)` +
+            (result.failed > 0 ? `, ${result.failed} FAILED` : "") +
+            (result.dryRun ? " (dry-run)" : ""),
+    ];
+    for (const outcome of result.outcomes) {
+        if (outcome.status === "failed") {
+            lines.push(`  FAILED  ${outcome.tableName}.${outcome.indexName} - ${outcome.error ?? "unknown error"}`);
+        }
+    }
+    if (!result.dryRun) {
+        lines.push(
+            result.failed > 0
+                ? "  snapshot NOT published - fix the failed index(es) and re-run."
+                : result.outcomes.length > 0
+                  ? "  snapshot published."
+                  : "  nothing to repair - snapshot NOT published.",
+        );
+    }
+    lines.push(`  ${INDEX_REPAIR_SCOPE_NOTE}`);
+    return lines.join("\n");
+};
+
+/**
+ * `ax ingest repair-indexes` end to end: acquire the ingest lock, open the
+ * live cache with schema application disabled (this command must work even
+ * when the live cache is in whatever broken state an upgrade left it in),
+ * repair every discovered index, and publish only on a clean sweep.
+ *
+ * Dry-run opens with `publish: false` outright. A real repair opens with
+ * `withCacheWrite`'s normal on-success publish and relies on
+ * `runIndexRepair` failing its own body (via `IndexRepairIncompleteError`)
+ * whenever the pass was not a clean sweep - that failed body is what blocks
+ * the publish. The catch below is scoped to that ONE typed error and applies
+ * OUTSIDE `withCacheWrite`. An empty pass becomes a successful no-op result.
+ * A real repair failure remains typed, so the CLI exits nonzero.
+ * `IndexRestoreFailedError` and every other `CacheWriteError` also propagate.
+ */
+export const cmdIngestRepairIndexes = (opts: { readonly dryRun: boolean }) =>
+    Effect.gen(function* () {
+        const cfg = yield* AxConfig;
+        const dataDir = cfg.paths.dataDir;
+        const lockPath = posixPath.join(dataDir, "ingest.lock");
+
+        const outcome = yield* withIngestLock(
+            {
+                lockPath,
+                command: "ingest repair-indexes",
+                staleMs: 60_000,
+                onBusy: (holder) =>
+                    Effect.fail(
+                        new IndexRepairBusyError({
+                            holderCommand: holder.command,
+                            message: `ingest repair-indexes: another ingest holds the cache lock (${holder.command})`,
+                        }),
+                    ),
+            },
+            withCacheWrite(
+                {
+                    livePath: posixPath.join(dataDir, "ax-live.duckdb"),
+                    lockPath,
+                    snapshotPath: posixPath.join(dataDir, "ax-snapshot.duckdb"),
+                    schemaSql: null,
+                    publish: !opts.dryRun,
+                    ...duckdbAssetPathOption(),
+                },
+                (write) => runIndexRepair(write, { dryRun: opts.dryRun }),
+            ).pipe(
+                Effect.catchTag("IndexRepairIncompleteError", (error) =>
+                    error.result.failed === 0 ? Effect.succeed(error.result) : Effect.fail(error),
+                ),
+            ),
+        );
+        if (outcome._tag !== "completed") {
+            return yield* Effect.die(`ingest repair-indexes did not complete: ${outcome._tag}`);
+        }
+        return outcome.value;
+    });

--- a/packages/lib/src/duckdb/cache-bust-event-upgrade.test.ts
+++ b/packages/lib/src/duckdb/cache-bust-event-upgrade.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #1084: a cache written by a pre-#1055 axctl already has
+ * `cache_bust_event.corroborated_cost_usd` plus its two secondary indexes
+ * (`cache_bust_event_ts`, `cache_bust_event_session_seq`). The current DDL's
+ * `ALTER TABLE cache_bust_event DROP COLUMN IF EXISTS corroborated_cost_usd`
+ * ran on EVERY write-connection open (`withCacheWrite` applies `schemaSql`
+ * unconditionally), and `ts` sits after `corroborated_cost_usd` in column
+ * order - so DuckDB refused the ALTER while either index still existed, and
+ * bricked every DB-backed command against an upgraded cache.
+ *
+ * Real database only, on purpose: the property under test is "does the DDL
+ * apply cleanly against an old ON-DISK shape", which a text-only parse of
+ * schema.duckdb.sql cannot see.
+ */
+import { describe, expect } from "bun:test";
+import { Effect } from "effect";
+import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
+import { withIngestLock } from "../ingest-lock.ts";
+import { runWithPlatform } from "../testing/cache-fixture.ts";
+import { duckdbTestSetup } from "../testing/duckdb-dylib.ts";
+import { withCacheWrite, type CacheWriteError, type CacheWriteService } from "./seam.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("cache_bust_event upgrade");
+
+/** The pre-#1055 on-disk shape: `corroborated_cost_usd` plus both indexes,
+ *  exactly as an axctl before that PR would have left it. Minimal - just
+ *  enough of the real table for the ALTER/DROP INDEX interaction under test. */
+const OLD_CACHE_BUST_EVENT_DDL = `
+CREATE TABLE IF NOT EXISTS cache_bust_event (
+    id VARCHAR PRIMARY KEY,
+    session VARCHAR NOT NULL,
+    turn VARCHAR NOT NULL,
+    seq BIGINT NOT NULL,
+    source VARCHAR NOT NULL,
+    model VARCHAR,
+    reason VARCHAR NOT NULL,
+    attribution_skill VARCHAR,
+    attribution_agent VARCHAR,
+    cache_creation_input_tokens BIGINT,
+    bust_cost_usd DOUBLE,
+    corroborated_cost_usd DOUBLE,
+    ts TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS cache_bust_event_ts ON cache_bust_event(ts);
+CREATE INDEX IF NOT EXISTS cache_bust_event_session_seq ON cache_bust_event(session, seq);
+`;
+
+interface Paths {
+    readonly dir: string;
+    readonly livePath: string;
+    readonly lockPath: string;
+}
+
+const paths = (prefix: string): Paths => {
+    const dir = tempDir(prefix);
+    return { dir, livePath: `${dir}/live.duckdb`, lockPath: `${dir}/ingest.lock` };
+};
+
+/** Open the live db under the ingest lock and apply `schemaSql`, then run
+ *  `body`. `schemaSql: null` skips DDL application, mirroring the seam's own
+ *  `withCacheWrite` contract (see `CacheWriteOptions.schemaSql`). */
+const openWith = <A>(
+    p: Paths,
+    schemaSql: string | null,
+    body: (write: CacheWriteService) => Effect.Effect<A, CacheWriteError, never>,
+): Promise<A> =>
+    runWithPlatform(
+        Effect.gen(function* () {
+            const outcome = yield* withIngestLock(
+                {
+                    lockPath: p.lockPath,
+                    command: "cache-bust-event-upgrade-test",
+                    staleMs: 60_000,
+                    onBusy: () => Effect.die("the ingest lock was busy in a single-process test"),
+                },
+                withCacheWrite(
+                    {
+                        livePath: p.livePath,
+                        lockPath: p.lockPath,
+                        // No snapshot publish needed - these cases only assert
+                        // against the live database the DDL was applied to.
+                        publish: false,
+                        schemaSql,
+                        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                    },
+                    body,
+                ),
+            );
+            if (outcome._tag !== "completed") {
+                throw new Error(`ingest run did not complete: ${outcome._tag}`);
+            }
+            return outcome.value;
+        }),
+    );
+
+describe("schema upgrade: cache_bust_event column removal vs pre-existing indexes (#1084)", () => {
+    dtest("the full DDL applies cleanly against a pre-#1055 on-disk shape, preserving rows", async () => {
+        const p = paths("ax-cache-bust-upgrade-");
+
+        // Build the OLD shape and seed a sentinel row, exactly as an
+        // already-ingested cache would have it.
+        await openWith(p, OLD_CACHE_BUST_EVENT_DDL, (write) =>
+            write.exec(
+                "INSERT INTO cache_bust_event (id, session, turn, seq, source, reason, corroborated_cost_usd, ts) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ["sentinel-1", "session-1", "turn-1", 1, "claude", "cache_miss_expired", 0.42, new Date()],
+            ),
+        );
+
+        // Upgrading: open the SAME live database with the CURRENT full DDL.
+        // This must not throw the "index depends on a column after it" Catalog
+        // Error every other DB-backed command hit on an upgraded cache.
+        const rows = await openWith(p, DUCKDB_SCHEMA_SQL, (write) =>
+            write.raw(
+                "SELECT id, session, bust_cost_usd, ts FROM cache_bust_event WHERE id = 'sentinel-1'",
+            ),
+        );
+
+        // The dropped column is gone from the live schema...
+        expect(rows.rows.length).toBe(1);
+        expect(rows.rows[0]?.["session"]).toBe("session-1");
+        expect("corroborated_cost_usd" in (rows.rows[0] ?? {})).toBe(false);
+
+        // ...and the two secondary indexes exist again, recreated.
+        const indexes = await openWith(p, null, (write) =>
+            write.raw(
+                "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'cache_bust_event' ORDER BY index_name",
+            ),
+        );
+        expect(indexes.rows.map((r) => r["index_name"])).toEqual([
+            "cache_bust_event_session_seq",
+            "cache_bust_event_ts",
+        ]);
+
+        // A second application of the full DDL against the now-upgraded
+        // database must also succeed (idempotency) and must not lose the row.
+        const second = await openWith(p, DUCKDB_SCHEMA_SQL, (write) =>
+            write.raw("SELECT count(*) AS n FROM cache_bust_event WHERE id = 'sentinel-1'"),
+        );
+        expect(Number(second.rows[0]?.["n"])).toBe(1);
+    });
+});

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -1309,6 +1309,17 @@ CREATE TABLE IF NOT EXISTS cache_bust_event (
     bust_cost_usd DOUBLE,
     ts TIMESTAMP NOT NULL
 );
+-- DROP the two secondary indexes before the ALTER (#1084): a cache upgraded
+-- from a pre-#1055 version already has them, `ts` sits AFTER
+-- corroborated_cost_usd in column order, and DuckDB refuses "Cannot drop
+-- this column: an index depends on a column after it!" while either index
+-- still exists. A fresh database has neither index yet, so the DROPs are
+-- no-ops there. The CREATE INDEX IF NOT EXISTS lines below restore both on
+-- every open (upgraded or fresh) - cheap on this table's size, and it keeps
+-- this block self-contained instead of depending on migration order staying
+-- undisturbed elsewhere in the file.
+DROP INDEX IF EXISTS cache_bust_event_ts;
+DROP INDEX IF EXISTS cache_bust_event_session_seq;
 ALTER TABLE cache_bust_event DROP COLUMN IF EXISTS corroborated_cost_usd;
 CREATE INDEX IF NOT EXISTS cache_bust_event_ts ON cache_bust_event(ts);
 CREATE INDEX IF NOT EXISTS cache_bust_event_session_seq ON cache_bust_event(session, seq);


### PR DESCRIPTION
## Summary

- drop the two `cache_bust_event` indexes before the removed-column migration
- recreate both indexes and preserve existing cache rows
- add `ax ingest repair-indexes [--dry-run]` for explicit secondary indexes
- block snapshot publication after any repair or restore failure
- report that primary-key and constraint indexes remain outside this repair scope

## DuckDB constraint

DuckDB crashes the native client when the same index name is dropped and recreated inside one explicit transaction. The repair command uses a tested compensating restore instead. A restore failure is fatal and blocks publication.

## Verification

- full suite: 6,598 pass, 13 skip, 0 fail
- focused migration and repair tests: 19 pass, 0 fail
- write-contract tests: 13 pass, 0 fail
- `bunx tsc --noEmit -p apps/axctl/tsconfig.json`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `bun run check:table-coverage`
- `bun run check:cli-reference`

Closes #1084.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
