### PR TITLE
fix: classify Codex exec results by status header

### DIFF
--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -918,6 +918,117 @@ describe("Codex transcript extraction", () => {
         expect(toolTurn).toMatchObject({ role: "tool_call" });
     });
 
+    test("exec custom_tool_call output as an input_text array is decoded to plain text and not flagged as an error", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-09T14:00:00.000Z",
+                payload: {
+                    id: "codex-exec-array",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-09T14:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T14:00:01.000Z",
+                payload: {
+                    type: "custom_tool_call",
+                    status: "completed",
+                    name: "exec",
+                    call_id: "call-exec-ok",
+                    input: "bun test error-handling.test.ts",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T14:00:02.000Z",
+                payload: {
+                    type: "custom_tool_call_output",
+                    call_id: "call-exec-ok",
+                    output: [
+                        {
+                            type: "input_text",
+                            text:
+                                "Script completed\n" +
+                                "Wall time 0.2 seconds\n" +
+                                "Output:\n",
+                        },
+                        {
+                            type: "input_text",
+                            text:
+                                "tests/error-handling.test.ts .... 12 passed, 0 failed\n" +
+                                "0 \"not found\" warnings",
+                        },
+                    ],
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        const call = extracted.toolCalls.find((c) => c.callId === "call-exec-ok");
+        expect(call).toBeDefined();
+        if (!call) return;
+        expect(call.toolName).toBe("exec");
+        expect(call.hasError).toBe(false);
+        expect(call.errorText).toBeNull();
+        expect(call.outputExcerpt ?? "").toContain("12 passed, 0 failed");
+        expect(call.outputExcerpt ?? "").not.toContain('"type":"input_text"');
+        expect(call.outputExcerpt ?? "").not.toContain("[{");
+    });
+
+    test("exec custom_tool_call Script failed output as an input_text array remains an error", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-09T14:10:00.000Z",
+                payload: {
+                    id: "codex-exec-array-fail",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-09T14:10:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T14:10:01.000Z",
+                payload: {
+                    type: "custom_tool_call",
+                    status: "completed",
+                    name: "exec",
+                    call_id: "call-exec-fail",
+                    input: "bun test error-handling.test.ts",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T14:10:02.000Z",
+                payload: {
+                    type: "custom_tool_call_output",
+                    call_id: "call-exec-fail",
+                    output: [
+                        {
+                            type: "input_text",
+                            text:
+                                "Script failed in 0.1 seconds:\n" +
+                                "tests/error-handling.test.ts .... 1 failed\n" +
+                                "Wall time: 0.1 seconds",
+                        },
+                    ],
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        const call = extracted.toolCalls.find((c) => c.callId === "call-exec-fail");
+        expect(call).toBeDefined();
+        if (!call) return;
+        expect(call.hasError).toBe(true);
+    });
+
     test("extracts function calls, matched outputs, synthetic skill relations, and update_plan snapshots", () => {
         const execOutput =
             "Chunk ID: abc\nWall time: 0.2000 seconds\nProcess exited with code 1\nOriginal token count: 30\nOutput:\nfatal: not a git repository\n";

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -146,7 +146,14 @@ export interface CodexTurnTokenUsage {
 }
 
 function outputText(input: unknown): string | null {
-    return typeof input === "string" ? input : jsonText(input);
+    if (typeof input === "string") return input;
+    if (Array.isArray(input)) {
+        const flattened = textFromContent(input, { acceptedTypes: RESPONSES_TEXT_TYPES });
+        if (flattened !== null) return flattened;
+    }
+    // Unknown shapes (plain objects, empty/no-text arrays) fall back to a
+    // JSON dump so callers still get something to scan/store.
+    return jsonText(input);
 }
 
 function codexMessageRecord(payload: Record<string, unknown>): Record<string, unknown> | null {

--- a/apps/axctl/src/ingest/tool-calls.test.ts
+++ b/apps/axctl/src/ingest/tool-calls.test.ts
@@ -53,4 +53,56 @@ describe("tool call normalization", () => {
             hasError: true,
         });
     });
+
+    test("Script completed output is not flagged an error even when it mentions failed/error-handling/not found", () => {
+        const result = parseCodexFunctionOutput(
+            "Script completed in 0.2 seconds:\n" +
+                "tests/error-handling.test.ts .... 12 passed, 0 failed\n" +
+                "0 \"not found\" warnings\n" +
+                "Wall time: 0.2 seconds",
+        );
+        expect(result.hasError).toBe(false);
+        expect(result.exitCode).toBeNull();
+        expect(result.durationMs).toBe(200);
+    });
+
+    test("Script failed output remains an error", () => {
+        const result = parseCodexFunctionOutput(
+            "Script failed in 0.1 seconds:\nTraceback...\nWall time: 0.1 seconds",
+        );
+        expect(result.hasError).toBe(true);
+    });
+
+    test("Script running with cell ID is a pending, non-error result", () => {
+        const result = parseCodexFunctionOutput(
+            "Script running with cell ID abc-123. Check back later for output.",
+        );
+        expect(result.hasError).toBe(false);
+        expect(result.exitCode).toBeNull();
+    });
+
+    test("legacy exit code 0 with error-ish words in output remains a success", () => {
+        const result = parseCodexFunctionOutput(
+            "Process exited with code 0\nOutput:\n1 test failed but was retried and passed\n",
+        );
+        expect(result.hasError).toBe(false);
+        expect(result.exitCode).toBe(0);
+    });
+
+    test("legacy nonzero exit code remains an error", () => {
+        const result = parseCodexFunctionOutput(
+            "Process exited with code 1\nOutput:\nall good here\n",
+        );
+        expect(result.hasError).toBe(true);
+        expect(result.exitCode).toBe(1);
+    });
+
+    test("parses Wall time with and without a colon", () => {
+        expect(
+            parseCodexFunctionOutput("Script completed\nWall time: 0.2 seconds").durationMs,
+        ).toBe(200);
+        expect(
+            parseCodexFunctionOutput("Script completed\nWall time 0.2 seconds").durationMs,
+        ).toBe(200);
+    });
 });

--- a/apps/axctl/src/ingest/tool-calls.ts
+++ b/apps/axctl/src/ingest/tool-calls.ts
@@ -177,16 +177,39 @@ export function parseCodexFunctionOutput(
 ): ParsedFunctionOutput {
     const text = (output ?? "").replace(/\r\n/g, "\n");
     const exitCode = parseIntegerMatch(text.match(/Process exited with code\s+(-?\d+)/i));
-    const durationSeconds = parseFloatMatch(text.match(/Wall time:\s*([0-9]+(?:\.[0-9]+)?)\s*seconds/i));
+    const durationSeconds = parseFloatMatch(
+        text.match(/Wall time:?\s*([0-9]+(?:\.[0-9]+)?)\s*seconds/i),
+    );
     const outputBody = text.match(/(?:^|\n)Output:\n([\s\S]*)$/)?.[1] ?? text;
     const outputExcerpt = boundExcerpt(outputBody.trim());
+    const explicitStatus = explicitResultStatus(text);
 
     return {
         exitCode,
         durationMs: durationSeconds === null ? null : Math.round(durationSeconds * 1000),
         outputExcerpt,
-        hasError: exitCode !== null ? exitCode !== 0 : looksLikeError(outputExcerpt),
+        hasError: explicitStatus !== null
+            ? explicitStatus === "error"
+            : exitCode !== null
+            ? exitCode !== 0
+            : looksLikeError(outputExcerpt),
     };
+}
+
+/**
+ * Codex exec results (the "run a script" tool) open with an explicit status
+ * header - "Script completed"/"Script failed"/"Script running with cell ID
+ * ..." (still pending, e.g. a background cell). That header is authoritative:
+ * a completed script's own output commonly contains words like "failed" or
+ * "not found" (test names, log lines) that would otherwise trip
+ * `looksLikeError`'s text scan.
+ */
+function explicitResultStatus(text: string): "success" | "error" | "pending" | null {
+    const header = text.trimStart();
+    if (/^Script completed\b/i.test(header)) return "success";
+    if (/^Script failed\b/i.test(header)) return "error";
+    if (/^Script running with cell ID\b/i.test(header)) return "pending";
+    return null;
 }
 
 function extractCommandTokens(command: string | null | undefined): string[] | null {


### PR DESCRIPTION
Closes #1085.

## Summary

- decode current Codex `custom_tool_call_output` text arrays
- use explicit `Script completed`, `Script failed`, and pending headers
- preserve legacy process exit code handling
- ignore error words in output when an explicit success header exists

## Existing caches

Existing Codex rows keep their old classification until a reparse.

Run:

```sh
ax ingest --reparse=codex
```

A full signals rebuild then removes stale false friction rows.

## Verification

- focused suite: 110 pass, 0 fail, 518 checks
- type checks: pass
- `check:no-node-fs`: pass
- complete suite: 6,614 pass, 13 skip
- three unrelated CLI tests timed out during the complete run
- the timed-out file passed alone: 8 pass, 0 fail

No schema, writer, friction query, or time-window change is included.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
