### PR TITLE
fix(profile): match guardrail evidence by command

### DIFF
--- a/apps/axctl/src/profile/guardrail-evidence.duckdb.test.ts
+++ b/apps/axctl/src/profile/guardrail-evidence.duckdb.test.ts
@@ -16,7 +16,7 @@ import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { fetchGuardrailHookEvidence } from "./queries.ts";
 import { deriveGuardrailReceipts } from "./guardrails.ts";
 
-const { dylibPath, dtest, tempDir } = await duckdbTestSetup("guardrail evidence");
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("guardrail evidence", { requireFts: true });
 
 const daysAgo = (d: number): Date => new Date(Date.now() - d * 24 * 60 * 60 * 1000);
 

--- a/apps/axctl/src/profile/guardrail-evidence.duckdb.test.ts
+++ b/apps/axctl/src/profile/guardrail-evidence.duckdb.test.ts
@@ -1,0 +1,134 @@
+/**
+ * End-to-end regression for #1086: `hook_command_invocation.hook_name` holds
+ * the harness EVENT label (e.g. "PreToolUse:Bash"), not the hook's identity -
+ * that lives in `command` (e.g. "bun ~/.ax/hooks/enforce-worktree.ts #
+ * ax:<id>"). Grouping evidence by `hook_name` collapsed every distinct guard
+ * into a handful of event buckets and made `ax profile show`'s guardrail
+ * receipts meaningless. This exercises the real query
+ * (`fetchGuardrailHookEvidence`) against a published DuckDB snapshot - so the
+ * window predicate actually runs - piped into `deriveGuardrailReceipts`, the
+ * pure aggregator that matches evidence back to installed hook files.
+ */
+import { describe, expect } from "bun:test";
+import { Effect } from "effect";
+import { publishCacheFixture, readFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { fetchGuardrailHookEvidence } from "./queries.ts";
+import { deriveGuardrailReceipts } from "./guardrails.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("guardrail evidence");
+
+const daysAgo = (d: number): Date => new Date(Date.now() - d * 24 * 60 * 60 * 1000);
+
+const fire = (
+    id: string,
+    ts: Date,
+    opts: {
+        readonly eventLabel: string;
+        readonly command: string;
+        readonly effect: string;
+        readonly providerStatus?: string;
+    },
+) => ({
+    id,
+    hook_event: `hook_event:${id}`,
+    session: "sess-1",
+    ts,
+    harness: "claude",
+    event_name: opts.eventLabel.split(":")[0],
+    hook_name: opts.eventLabel,
+    tool_call_id: null,
+    tool_call: null,
+    command: opts.command,
+    command_hash: `hash-${id}`,
+    provider_status: opts.providerStatus ?? "success",
+    effect: opts.effect,
+    exit_code: 0,
+    duration_ms: 10,
+    stdout_excerpt: null,
+    stderr_excerpt: null,
+    content_excerpt: null,
+    blocking_error_excerpt: null,
+});
+
+describe("guardrail hook evidence (real DuckDB window + prefix matching)", () => {
+    dtest("windows counts correctly and never cross-matches a prefix hook name", async () => {
+        const dir = tempDir("guardrail-evidence");
+        const fixture = await runWithPlatform(
+            publishCacheFixture(dir, dylibPath, (write) =>
+                Effect.gen(function* () {
+                    // Recent, blocked: counts toward "enforce-worktree".
+                    yield* write.put("hook_command_invocation", fire("hci:blocked", daysAgo(1), {
+                        eventLabel: "PreToolUse:Bash",
+                        command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:74da7418",
+                        effect: "blocked",
+                        providerStatus: "blocking_error",
+                    }));
+                    // Recent, allowed, SAME hook but a different install (fresh ax
+                    // marker) - must aggregate into the same bucket as the fire
+                    // above, not a second one.
+                    yield* write.put("hook_command_invocation", fire("hci:allowed", daysAgo(2), {
+                        eventLabel: "PreToolUse:Bash",
+                        command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:ab00cd11",
+                        effect: "allowed",
+                    }));
+                    // Recent, injected_context (warned) for a DIFFERENT hook whose
+                    // name is a superstring of the one above - must not fold into
+                    // "enforce-worktree".
+                    yield* write.put("hook_command_invocation", fire("hci:warned", daysAgo(1), {
+                        eventLabel: "PreToolUse:Write",
+                        command: "bun /Users/me/.ax/hooks/enforce-worktree-write.ts # ax:9c1a0b2e",
+                        effect: "injected_context",
+                    }));
+                    // Blocked, but OUTSIDE the window - must not count.
+                    yield* write.put("hook_command_invocation", fire("hci:old-blocked", daysAgo(60), {
+                        eventLabel: "PreToolUse:Bash",
+                        command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:74da7418",
+                        effect: "blocked",
+                        providerStatus: "blocking_error",
+                    }));
+                    // Recent, but the hook is not installed locally - must be
+                    // excluded from the derived receipts entirely.
+                    yield* write.put("hook_command_invocation", fire("hci:uninstalled", daysAgo(1), {
+                        eventLabel: "PreToolUse:Bash",
+                        command: "bun /Users/me/.ax/hooks/retired-guard.ts # ax:deadbeef",
+                        effect: "blocked",
+                        providerStatus: "blocking_error",
+                    }));
+                }),
+            ),
+        );
+        const layer = readFixture(fixture.snapshotPath, dylibPath);
+
+        const evidence = await Effect.runPromise(
+            fetchGuardrailHookEvidence({ windowDays: 14 }).pipe(Effect.provide(layer)),
+        );
+
+        // The 60-day-old fire is outside the 14-day window; everything else is in.
+        expect(evidence.reduce((sum, row) => sum + row.fires, 0)).toBe(4);
+        // hook_name is never surfaced as the grouping key - the row shape from
+        // the real query carries `command`, and no row's `command` is the bare
+        // event label a hook_name-keyed regression would have produced.
+        for (const row of evidence) {
+            expect(row.command).not.toBe("PreToolUse:Bash");
+            expect(row.command).not.toBe("PreToolUse:Write");
+        }
+
+        const receipts = deriveGuardrailReceipts({
+            hookFiles: ["enforce-worktree.ts", "enforce-worktree-write.ts"],
+            hookEvidence: evidence,
+            verdicts: [],
+        });
+
+        expect(receipts).not.toBeNull();
+        expect(receipts?.hooks).toEqual([
+            { name: "enforce-worktree", fires: 2, blocked: 1, warned: 0 },
+            { name: "enforce-worktree-write", fires: 1, blocked: 0, warned: 1 },
+        ]);
+
+        // The uninstalled hook's fires never leak into either bucket or inflate
+        // a phantom total.
+        const totalFires = (receipts?.hooks ?? []).reduce((sum, h) => sum + h.fires, 0);
+        expect(totalFires).toBe(3);
+    });
+});

--- a/apps/axctl/src/profile/guardrails.test.ts
+++ b/apps/axctl/src/profile/guardrails.test.ts
@@ -2,13 +2,63 @@ import { describe, expect, test } from "bun:test";
 import { deriveGuardrailReceipts } from "./guardrails.ts";
 
 describe("deriveGuardrailReceipts", () => {
-    test("matches hook evidence by normalized installed hook name", () => {
+    test("matches hook evidence by the installed hook script embedded in the command", () => {
         expect(deriveGuardrailReceipts({
             hookFiles: ["enforce-worktree.ts", "enforce-worktree-write.ts", "guard.test.ts"],
             hookEvidence: [
-                { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 10, blocked: 2, warned: 1 },
-                { hook_name: "enforce-worktree-write.js", fires: 3, blocked: 0, warned: 3 },
-                { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 99 },
+                // Recent fires against the real installed command, ax-marker included.
+                {
+                    command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:74da7418",
+                    fires: 10,
+                    blocked: 2,
+                    warned: 1,
+                },
+                // A sibling hook whose name shares a prefix - must NOT fold into
+                // "enforce-worktree" above.
+                {
+                    command: "bun /Users/me/.ax/hooks/enforce-worktree-write.ts # ax:9c1a0b2e",
+                    fires: 3,
+                    blocked: 0,
+                    warned: 3,
+                },
+                // A second install of the same hook (different ax marker id, e.g.
+                // after a reinstall) - aggregates into the same bucket.
+                {
+                    command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:ab00cd11",
+                    fires: 5,
+                    blocked: 1,
+                    warned: 0,
+                },
+                // Compiled-binary install (.js bundle instead of .ts) still matches
+                // the installed ".ts" name.
+                {
+                    command: "bun /Users/me/.ax/hooks/enforce-worktree.js # ax:5f5f5f5f",
+                    fires: 2,
+                    blocked: 0,
+                    warned: 0,
+                },
+                // Not installed locally - excluded rather than mis-bucketed.
+                {
+                    command: "bun /Users/me/.ax/hooks/uninstalled.ts # ax:deadbeef",
+                    fires: 99,
+                    blocked: 99,
+                    warned: 99,
+                },
+                // The same basename outside the installed hook directory is not
+                // evidence for the installed guard.
+                {
+                    command: "bun /Users/me/project/enforce-worktree.ts",
+                    fires: 50,
+                    blocked: 50,
+                    warned: 0,
+                },
+                // Multiple installed hook paths have ambiguous attribution.
+                {
+                    command: "bun /Users/me/.ax/hooks/enforce-worktree.ts /Users/me/.ax/hooks/enforce-worktree-write.ts",
+                    fires: 40,
+                    blocked: 40,
+                    warned: 0,
+                },
             ],
             verdicts: [
                 { verdict: "adopted", count: 4 },
@@ -19,7 +69,7 @@ describe("deriveGuardrailReceipts", () => {
             ],
         })).toEqual({
             hooks: [
-                { name: "enforce-worktree", fires: 10, blocked: 2, warned: 1 },
+                { name: "enforce-worktree", fires: 17, blocked: 3, warned: 1 },
                 { name: "enforce-worktree-write", fires: 3, blocked: 0, warned: 3 },
             ],
             verdicts: {
@@ -35,7 +85,7 @@ describe("deriveGuardrailReceipts", () => {
         expect(deriveGuardrailReceipts({
             hookFiles: [],
             hookEvidence: [
-                { hook_name: "uninstalled.ts", fires: 1, blocked: 1, warned: 0 },
+                { command: "bun /Users/me/.ax/hooks/uninstalled.ts # ax:deadbeef", fires: 1, blocked: 1, warned: 0 },
             ],
             verdicts: [],
         })).toBeNull();

--- a/apps/axctl/src/profile/guardrails.ts
+++ b/apps/axctl/src/profile/guardrails.ts
@@ -1,7 +1,7 @@
 import type { GuardrailReceipts } from "./schema.ts";
 
 export interface GuardrailHookEvidenceRow {
-    readonly hook_name: string;
+    readonly command: string;
     readonly fires: number;
     readonly blocked: number;
     readonly warned: number;
@@ -18,10 +18,14 @@ const hookNameFromFile = (file: string): string | null => {
     return name.length > 0 ? name : null;
 };
 
-const hookNameFromEvidence = (hookName: string): string => {
-    const base = hookName.split(/[\\/]/).at(-1) ?? hookName;
-    return base.replace(/\.(?:ts|js)$/, "");
-};
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Match only the installed hook path. The extension and following command
+// boundary prevent a short hook name from matching a longer sibling name.
+const commandRunsHook = (command: string, hookName: string): boolean =>
+    new RegExp(
+        `(?:^|[/\\\\])\\.ax[/\\\\]hooks[/\\\\]${escapeRegex(hookName)}\\.(?:ts|js)(?=$|[\\s"';&|)])`,
+    ).test(command);
 
 export function deriveGuardrailReceipts(input: {
     readonly hookFiles: ReadonlyArray<string>;
@@ -39,8 +43,11 @@ export function deriveGuardrailReceipts(input: {
     }
 
     for (const row of input.hookEvidence) {
-        const name = hookNameFromEvidence(row.hook_name);
-        if (!totals.has(name)) continue;
+        const matches = hookNames.filter((candidate) => commandRunsHook(row.command, candidate));
+        // A dispatcher command can contain multiple hook paths. Its attribution
+        // needs a separate rule, so this profile excludes ambiguous evidence.
+        if (matches.length !== 1) continue;
+        const name = matches[0];
         const prev = totals.get(name) ?? { fires: 0, blocked: 0, warned: 0 };
         totals.set(name, {
             fires: prev.fires + row.fires,

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -503,21 +503,21 @@ describe("fetchWindowedSessions", () => {
 });
 
 describe("fetchGuardrailHookEvidence", () => {
-    test("returns per-hook fire/block/warn counts from hook evidence", async () => {
+    test("returns per-command fire/block/warn counts from hook evidence", async () => {
         const cache = cacheRead({
             "FROM hook_command_invocation": [
-                { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
-                { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
+                { command: "bun ~/.ax/hooks/enforce-worktree.ts # ax:74da7418", fires: 12, blocked: 3, warned: 1 },
+                { command: "bun ~/.ax/hooks/dispatch.ts # ax:9c1a0b2e", fires: 8, blocked: 0, warned: 6 },
             ],
         });
         const rows = await runCache(fetchGuardrailHookEvidence({ windowDays: 14 }), cache.layer);
         expect(rows).toEqual([
-            { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
-            { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
+            { command: "bun ~/.ax/hooks/enforce-worktree.ts # ax:74da7418", fires: 12, blocked: 3, warned: 1 },
+            { command: "bun ~/.ax/hooks/dispatch.ts # ax:9c1a0b2e", fires: 8, blocked: 0, warned: 6 },
         ]);
         expect(cache.captured[0]).toContain("FROM hook_command_invocation");
         expect(cache.captured[0]).toContain("INTERVAL '1 day'");
-        expect(cache.captured[0]).toContain("GROUP BY hook_name");
+        expect(cache.captured[0]).toContain("GROUP BY command");
         expect(cache.captured[0]).toContain("effect = 'blocked'");
         expect(cache.captured[0]).toContain("'injected_context'");
     });

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -840,9 +840,14 @@ export const fetchWindowedSessions = Effect.fn("profile.fetchWindowedSessions")(
 
 // --- guardrail receipts -----------------------------------------------------
 
+// Grouped by \`command\` (the actual executable invocation, e.g.
+// "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:74da7418"), NOT
+// \`hook_name\` - hook_name holds the harness EVENT label (e.g.
+// "PreToolUse:Bash"), not the hook's identity, so grouping by it collapses
+// every distinct hook into a handful of event buckets. See #1086.
 const GUARDRAIL_HOOK_EVIDENCE_SQL = `
 SELECT
-    hook_name,
+    command,
     count(*) AS fires,
     SUM(CASE WHEN effect = 'blocked' OR provider_status = 'blocking_error' THEN 1 ELSE 0 END) AS blocked,
     SUM(CASE WHEN effect IN ('notified', 'injected_context', 'modified_input') THEN 1 ELSE 0 END) AS warned
@@ -850,7 +855,7 @@ FROM hook_command_invocation
 WHERE TRUE`;
 
 const GuardrailHookDbRow = Schema.Struct({
-    hook_name: Schema.String,
+    command: Schema.String,
     fires: NumberFromBigIntColumn,
     blocked: NumberFromBigIntColumn,
     warned: NumberFromBigIntColumn,
@@ -864,17 +869,17 @@ export const fetchGuardrailHookEvidence = Effect.fn("profile.fetchGuardrailHookE
             "guardrailHookEvidence",
             read.rows(
                 GuardrailHookDbRow,
-                `${GUARDRAIL_HOOK_EVIDENCE_SQL} ${within.sql} AND hook_name IS NOT NULL `
-                    + "GROUP BY hook_name ORDER BY fires DESC LIMIT 1000",
+                `${GUARDRAIL_HOOK_EVIDENCE_SQL} ${within.sql} AND command IS NOT NULL `
+                    + "GROUP BY command ORDER BY fires DESC LIMIT 1000",
                 within.params,
             ),
         );
         return rows.map((r) => ({
-            hook_name: r.hook_name,
+            command: r.command,
             fires: r.fires,
             blocked: r.blocked,
             warned: r.warned,
-        })).filter((r) => r.hook_name.length > 0) satisfies GuardrailHookEvidenceRow[];
+        })).filter((r) => r.command.length > 0) satisfies GuardrailHookEvidenceRow[];
     },
 );
 

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -139,11 +139,12 @@ const CACHE_ROUTES: Readonly<Record<string, ReadonlyArray<Record<string, unknown
             e: new Date("2026-06-12T10:30:00Z"),
         },
     ],
-    // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL)
+    // fetchGuardrailHookEvidence (GUARDRAIL_HOOK_EVIDENCE_SQL) - grouped by the
+    // real executed `command`, not the `hook_name` event label (#1086).
     "FROM hook_command_invocation": [
-        { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 412, blocked: 9, warned: 0 },
-        { hook_name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
-        { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 0 },
+        { command: "bun /Users/me/.ax/hooks/enforce-worktree.ts # ax:74da7418", fires: 412, blocked: 9, warned: 0 },
+        { command: "bun /Users/me/.ax/hooks/route-dispatch.ts # ax:9c1a0b2e", fires: 25, blocked: 0, warned: 12 },
+        { command: "bun /Users/me/.ax/hooks/uninstalled.ts # ax:deadbeef", fires: 99, blocked: 99, warned: 0 },
     ],
 };
 


### PR DESCRIPTION
Fixes #1086.

## Summary

- Group profile hook evidence by the recorded command.
- Match only installed scripts under .ax/hooks.
- Keep the existing profile window and effect counts.
- Exclude unmatched and ambiguous dispatcher commands.
- Add a published DuckDB regression test.

## Verification

- bun test apps/axctl/src/profile/ — 211 pass
- bun run typecheck — pass
- bun run check:no-node-fs — pass

Existing cache rows already contain command. No migration or reparse is required.

---

_Generated with [ax](https://github.com/Necmttn/ax)._

