### PR TITLE
fix: filter stale harness preambles from reads

### DIFF
--- a/apps/axctl/src/dashboard/recall.test.ts
+++ b/apps/axctl/src/dashboard/recall.test.ts
@@ -61,6 +61,8 @@ const turn = (
     seq,
     ts: T(ts),
     role,
+    message_kind: role === "user" ? "task" : "assistant",
+    intent_kind: role === "user" ? "organic_task" : "assistant",
     text,
     text_excerpt: text,
     has_tool_use: false,
@@ -298,6 +300,75 @@ describe("recall: turn source", () => {
         expect(second.hits.map((h) => h.turn_id)).toEqual(["turn:1"]);
         expect(second.truncated).toBe(false);
     });
+});
+
+describe("recall: user-turn compat filter (#1095)", () => {
+    dtest(
+        "excludes a stale message_kind='task' user preamble hit, keeps assistant + unknown-source hits, and keeps page/count in agreement",
+        async () => {
+            const res = await withRecall("ax-recall-compat-", (w) =>
+                Effect.gen(function* () {
+                    yield* w.putMany("session", [
+                        session("session:a", { project: "ax" }),
+                        // A source the classifier has no rule table for at all -
+                        // must stay unfiltered.
+                        session("session:c", { project: "oc", source: "opencode" }),
+                    ]);
+                    yield* w.putMany("turn", [
+                        // A pre-classifier-fix row: the ingest classifier had not
+                        // yet learned this harness-wrapper shape when the row was
+                        // written, so `message_kind` was stamped 'task'. It still
+                        // carries the query term and must NOT surface as a user
+                        // hit.
+                        turn(
+                            "turn:preamble",
+                            "session:a",
+                            1,
+                            "<recommended_plugins> here is a list of plugins mentioning duckdb",
+                            "2026-08-10T10:00:00.000Z",
+                        ),
+                        // The genuine ask, same session and source.
+                        turn(
+                            "turn:real",
+                            "session:a",
+                            2,
+                            "please fix the duckdb spool bug",
+                            "2026-08-10T11:00:00.000Z",
+                        ),
+                        // An assistant turn that happens to quote the same wrapper
+                        // text - the filter is user-only, so this must survive.
+                        turn(
+                            "turn:assistant-echo",
+                            "session:a",
+                            3,
+                            "<recommended_plugins> duckdb reference",
+                            "2026-08-10T12:00:00.000Z",
+                            "assistant",
+                        ),
+                        // Same wrapper shape, but a source outside the classifier's
+                        // coverage - unknown-source behavior stays unchanged.
+                        turn(
+                            "turn:unknown-source",
+                            "session:c",
+                            1,
+                            "<recommended_plugins> duckdb notes for opencode",
+                            "2026-08-10T13:00:00.000Z",
+                        ),
+                    ]);
+                }),
+                { q: "duckdb" },
+            );
+
+            const ids = res.hits.map((h) => h.turn_id);
+            expect(ids).not.toContain("turn:preamble");
+            expect(ids).toContain("turn:real");
+            expect(ids).toContain("turn:assistant-echo");
+            expect(ids).toContain("turn:unknown-source");
+            // total_counts must describe exactly the rows that came back - not a
+            // different set (see `promptsWhere`'s docstring on the same hazard).
+            expect(res.total_counts.turn).toBe(ids.length);
+        },
+    );
 });
 
 describe("recall: session prefilters", () => {

--- a/apps/axctl/src/dashboard/session-summary.test.ts
+++ b/apps/axctl/src/dashboard/session-summary.test.ts
@@ -22,4 +22,39 @@ describe("session summary", () => {
         const summary = await readThroughFixture(fixture, dylibPath, fetchSessionSummary("session:s1"));
         expect(summary).toMatchObject({ session_id: "s1", task: "Build it", last_assistant: "Done", turns: 2, tokens: 100, cost_usd: 0.5, model: "m1", tools: [{ name: "Read", count: 1 }] });
     });
+
+    dtest("a stale message_kind='task' harness preamble never wins first_ask/task over the real ask (#1095)", async () => {
+        const ts = new Date("2026-08-15T00:00:00Z");
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-session-summary-preamble-"), dylibPath, (db) => Effect.gen(function* () {
+            yield* db.put("session", { id: "s2", source: "claude", started_at: ts });
+            yield* db.putMany("turn", [
+                // Every row below carries a STALE message_kind='task' - stamped
+                // before the classifier learned these harness-wrapper shapes.
+                { id: "t1", session: "s2", seq: 1, ts, role: "user", message_kind: "task", intent_kind: "organic_task", text_excerpt: "<recommended_plugins> Here is a list of plugins available for this session" },
+                { id: "t2", session: "s2", seq: 2, ts, role: "user", message_kind: "task", intent_kind: "organic_task", text_excerpt: "<local-command-stdout>Login interrupted</local-command-stdout>" },
+                { id: "t3", session: "s2", seq: 3, ts, role: "user", message_kind: "task", intent_kind: "organic_task", text_excerpt: "Build the ingest fix" },
+            ]);
+        })));
+        const summary = await readThroughFixture(fixture, dylibPath, fetchSessionSummary("session:s2"));
+        expect(summary.first_ask).toBe("Build the ingest fix");
+        expect(summary.task).toBe("Build the ingest fix");
+    });
+
+    dtest("a session with no genuine task has no summary (#1095)", async () => {
+        const ts = new Date("2026-08-15T00:00:00Z");
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-session-summary-no-task-"), dylibPath, (db) => Effect.gen(function* () {
+            yield* db.put("session", { id: "s3", source: "claude", started_at: ts });
+            // Every user turn is a stale-classified harness wrapper - there is no
+            // genuine ask, and no session_health.task_label either.
+            yield* db.putMany("turn", [
+                { id: "t1", session: "s3", seq: 1, ts, role: "user", message_kind: "task", intent_kind: "organic_task", text_excerpt: "<recommended_plugins> plugin list" },
+                { id: "t2", session: "s3", seq: 2, ts, role: "user", message_kind: "task", intent_kind: "organic_task", text_excerpt: "<local-command-stdout>done</local-command-stdout>" },
+            ]);
+        })));
+        const summary = await readThroughFixture(fixture, dylibPath, fetchSessionSummary("session:s3"));
+        // No unrestricted "any user turn" fallback (#1095): reporting nothing is
+        // correct here, not a plausible-looking wrapper preamble.
+        expect(summary.first_ask).toBeNull();
+        expect(summary.task).toBeNull();
+    });
 });

--- a/apps/axctl/src/dashboard/session-summary.ts
+++ b/apps/axctl/src/dashboard/session-summary.ts
@@ -3,6 +3,7 @@ import { CacheRead, type CacheReadError } from "@ax/lib/duckdb";
 import { NumberFromBigIntColumn } from "@ax/lib/duckdb/columns";
 import { toBareSessionId } from "@ax/lib/shared/session-id";
 import type { SessionSummary } from "@ax/lib/shared/dashboard-types";
+import { userTurnCompatClause } from "../queries/user-turn-compat.ts";
 
 // DB-ONLY session summary for the canvas detail card. Deliberately avoids
 // `locateTranscript` + the full JSONL read/parse that `fetchSessionInspect`
@@ -11,9 +12,21 @@ import type { SessionSummary } from "@ax/lib/shared/dashboard-types";
 // token usage, spawn edges. ~ms per query, run concurrently.
 
 // real first ask: a 'task'-kind user turn (skips AGENTS.md/CLAUDE.md context
-// injections that also carry role='user'). Falls back to any user turn.
-const FIRST_USER_SQL = `SELECT text_excerpt, seq FROM turn WHERE session = ? AND role = 'user' AND message_kind = 'task' ORDER BY seq ASC LIMIT 1`;
-const FIRST_USER_FALLBACK_SQL = `SELECT text_excerpt, seq FROM turn WHERE session = ? AND role = 'user' ORDER BY seq ASC LIMIT 1`;
+// injections that also carry role='user') that ALSO passes the source-aware
+// wrapper-text compat filter (#1095) - a stale `message_kind='task'` row from
+// before the classifier learned a harness-wrapper shape (e.g.
+// `<recommended_plugins>`, `<local-command-stdout>`) must not win the summary.
+// No fallback to "any user turn" here on purpose (#1095): that fallback is
+// what let an unfiltered wrapper preamble stand in as `first_ask`/`task` when
+// no genuine task turn existed - a session with no real ask now reports
+// neither rather than a plausible-looking wrong one.
+// `textExpr` targets `text_excerpt`, matching what the ingest classifier
+// itself sees (`classifyUserText` never reads the full `text` column).
+const firstUserCompat = userTurnCompatClause({ sourceExpr: "s.source", textExpr: "t.text_excerpt" });
+const FIRST_USER_SQL = `SELECT t.text_excerpt AS text_excerpt, t.seq AS seq
+    FROM turn t JOIN session s ON s.id = t.session
+    WHERE t.session = ? AND t.role = 'user' AND t.message_kind = 'task' ${firstUserCompat.sql}
+    ORDER BY t.seq ASC LIMIT 1`;
 // session_health.task_label is the boilerplate-filtered, organic-task-detected
 // label the canvas already shows - prefer it when present.
 const TASK_LABEL_SQL = `SELECT task_label FROM session_health WHERE session = ? LIMIT 1`;
@@ -48,9 +61,8 @@ export const fetchSessionSummary = (
     Effect.gen(function* () {
         const bare = toBareSessionId(sessionId);
         const db = yield* CacheRead;
-        const [fu, fuFallback, label, la, corr, tc, tok, sub, tools] = yield* Effect.all([
-            db.rows(ExcerptRow, FIRST_USER_SQL, [bare]),
-            db.rows(ExcerptRow, FIRST_USER_FALLBACK_SQL, [bare]),
+        const [fu, label, la, corr, tc, tok, sub, tools] = yield* Effect.all([
+            db.rows(ExcerptRow, FIRST_USER_SQL, [bare, ...firstUserCompat.params]),
             db.rows(LabelRow, TASK_LABEL_SQL, [bare]),
             db.rows(ExcerptRow, LAST_ASSISTANT_SQL, [bare]),
             db.rows(ExcerptRow, CORRECTION_SQL, [bare]),
@@ -60,7 +72,7 @@ export const fetchSessionSummary = (
             db.rows(ToolRow, TOOLS_SQL, [bare]),
         ], { concurrency: "unbounded" });
 
-        const firstAsk = excerpt(fu[0]) ?? excerpt(fuFallback[0]);
+        const firstAsk = excerpt(fu[0]);
         const taskLabelRaw = label[0]?.task_label;
         const taskLabel = typeof taskLabelRaw === "string" && taskLabelRaw.trim().length > 0
             ? taskLabelRaw.replace(/\s+/g, " ").trim() : null;

--- a/apps/axctl/src/dashboard/sessions-query.test.ts
+++ b/apps/axctl/src/dashboard/sessions-query.test.ts
@@ -80,6 +80,59 @@ describe("listSessionsHere", () => {
         expect(rows[0]?.first_user_message).toBe("fix the ingest bug");
     });
 
+    dtest("a stale message_kind='task' harness preamble never outranks the real ask (#1095)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-preamble-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", { id: "sp", repository: "r1", source: "claude", project: "p", cwd: "/w/ax", started_at: daysAgo(1) });
+                // Every row below is stamped message_kind='task' - a STALE
+                // classification from before the classifier learned these
+                // harness-wrapper shapes (#1095: message_kind is stamped at
+                // ingest and a re-parse is never assumed to have happened).
+                yield* w.putMany("turn", [
+                    { id: "p1", session: "sp", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "<recommended_plugins> Here is a list of plugins available for this session", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "p2", session: "sp", seq: 2, ts: daysAgo(1), role: "user", text_excerpt: "<command-message>fleet-ship</command-message>", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "p3", session: "sp", seq: 3, ts: daysAgo(1), role: "user", text_excerpt: "<local-command-stdout>Login interrupted</local-command-stdout>", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "p4", session: "sp", seq: 4, ts: daysAgo(1), role: "user", text_excerpt: "some environment info: <environment_context>cwd=/w/ax</environment_context>", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "p5", session: "sp", seq: 5, ts: daysAgo(1), role: "user", text_excerpt: "fix the ingest bug for real this time", message_kind: "task", intent_kind: "organic_task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(fixture, dylibPath, listSessionsHere({ repositoryId: "r1" }));
+        expect(rows[0]?.first_user_message).toBe("fix the ingest bug for real this time");
+    });
+
+    dtest("returns no summary when every candidate is a stale preamble (#1095)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-preamble-only-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", { id: "sq", repository: "r1", source: "codex", project: "p", cwd: "/w/ax", started_at: daysAgo(1) });
+                yield* w.putMany("turn", [
+                    { id: "q1", session: "sq", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "<recommended_plugins> plugin list", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "q2", session: "sq", seq: 2, ts: daysAgo(1), role: "user", text_excerpt: "<local-command-stdout>done</local-command-stdout>", message_kind: "task", intent_kind: "organic_task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(fixture, dylibPath, listSessionsHere({ repositoryId: "r1" }));
+        expect(rows[0]?.first_user_message).toBeNull();
+    });
+
+    dtest("keeps similar human text and an attachment with typed text (#1095)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-human-marker-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.putMany("session", [
+                    { id: "sh", repository: "r1", source: "claude", project: "p", cwd: "/w/ax", started_at: daysAgo(1) },
+                    { id: "si", repository: "r1", source: "claude", project: "p", cwd: "/w/ax", started_at: daysAgo(1) },
+                ]);
+                yield* w.putMany("turn", [
+                    { id: "h1", session: "sh", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "How should I display <recommended_plugins> output?", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "h2", session: "si", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "[Image: source: /tmp/a.png] Please fix this layout", message_kind: "task", intent_kind: "organic_task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(fixture, dylibPath, listSessionsHere({ repositoryId: "r1" }));
+        expect(rows.find((row) => row.id === "sh")?.first_user_message).toBe("How should I display <recommended_plugins> output?");
+        expect(rows.find((row) => row.id === "si")?.first_user_message).toBe("[Image: source: /tmp/a.png] Please fix this layout");
+    });
+
     dtest("respects a custom --days window", async () => {
         const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-here-days-"), dylibPath, FIXTURE));
 
@@ -109,6 +162,20 @@ describe("listSessionsAround", () => {
 
         expect(rows.map((r) => r.id)).toEqual(["s2"]);
     });
+
+    dtest("a stale message_kind='task' harness preamble never outranks the real ask (#1095)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-around-preamble-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", { id: "sr", source: "claude", project: "p", started_at: daysAgo(1) });
+                yield* w.putMany("turn", [
+                    { id: "r1", session: "sr", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "<recommended_plugins> plugin list", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "r2", session: "sr", seq: 2, ts: daysAgo(1), role: "user", text_excerpt: "fix the ingest bug", message_kind: "task", intent_kind: "organic_task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(fixture, dylibPath, listSessionsAround({ date: daysAgo(1), days: 3 }));
+        expect(rows.find((r) => r.id === "sr")?.first_user_message).toBe("fix the ingest bug");
+    });
 });
 
 describe("listSessionsNear", () => {
@@ -134,5 +201,23 @@ describe("listSessionsNear", () => {
         );
 
         expect(rows.map((r) => r.id).sort()).toEqual(["s1", "s2"]);
+    });
+
+    dtest("a stale message_kind='task' harness preamble never outranks the real ask (#1095)", async () => {
+        const fixture = await runWithPlatform(publishCacheFixture(tempDir("ax-sessions-near-preamble-"), dylibPath, (w) =>
+            Effect.gen(function* () {
+                yield* w.put("session", { id: "sn", repository: "r1", source: "claude", project: "p", started_at: daysAgo(1) });
+                yield* w.putMany("turn", [
+                    { id: "n1", session: "sn", seq: 1, ts: daysAgo(1), role: "user", text_excerpt: "<recommended_plugins> plugin list", message_kind: "task", intent_kind: "organic_task" },
+                    { id: "n2", session: "sn", seq: 2, ts: daysAgo(1), role: "user", text_excerpt: "fix the ingest bug", message_kind: "task", intent_kind: "organic_task" },
+                ]);
+            })));
+
+        const rows = await readThroughFixture(
+            fixture,
+            dylibPath,
+            listSessionsNear({ from: daysAgo(2), to: daysAgo(0), repositoryId: "r1" }),
+        );
+        expect(rows.find((r) => r.id === "sn")?.first_user_message).toBe("fix the ingest bug");
     });
 });

--- a/apps/axctl/src/dashboard/sessions-query.ts
+++ b/apps/axctl/src/dashboard/sessions-query.ts
@@ -19,6 +19,7 @@ import { CacheRead } from "@ax/lib/duckdb/seam";
 import { sessionIdsByPrefixCacheQuery } from "../queries/session-detail-cache.ts";
 import { runCacheQuery } from "@ax/lib/duckdb/query";
 import { toBareSessionId } from "@ax/lib/shared/session-id";
+import { userTurnCompatPredicate } from "../queries/user-turn-compat.ts";
 
 // ---------------------------------------------------------------------------
 // Row shape
@@ -67,6 +68,22 @@ const toSessionRow = (row: typeof SessionEnrichedRow.Type): SessionRow => ({
 });
 
 /**
+ * The source-aware compat predicate that keeps a STALE `message_kind='task'`
+ * harness-wrapper row (e.g. `<recommended_plugins>`, pre-classifier-fix rows,
+ * #1095) from outranking a genuine task turn below - computed once since it
+ * does not depend on `where`.
+ *
+ * `textExpr` targets `text_excerpt`, not the full `text` column: the ingest
+ * classifier (`classifyUserText`, `ingest/normalized/message-kind.ts`) itself
+ * only ever sees the excerpt, and this projection selects `text_excerpt` -
+ * `text` is not even joined in here.
+ */
+const firstUserCompat = userTurnCompatPredicate({
+    sourceExpr: "s2.source",
+    textExpr: "t2.text_excerpt",
+});
+
+/**
  * The one session projection every list variant shares: turn count and the
  * first user-role turn's excerpt, both joined in rather than fanned out.
  * `where` is appended after `WHERE TRUE` on the outer `session s` scan.
@@ -87,20 +104,25 @@ const fetchSessions = (where: Clause): Effect.Effect<SessionRow[], never, CacheR
                           -- (Codex records the AGENTS.md/CLAUDE.md system prompt as
                           -- the first user turn, classified message_kind='context';
                           -- it dominated the summary column and made the listing
-                          -- useless for Codex). Fall back to the earliest user turn
-                          -- when no task turn is classified (null message_kind, or a
-                          -- pre-reingest session).
-                          SELECT session, text_excerpt,
+                          -- useless for Codex) AND over a STALE task-classified
+                          -- harness-wrapper row (#1095: message_kind is stamped at
+                          -- ingest, so a row written before the classifier learned a
+                          -- wrapper shape keeps 'task' forever without a re-parse).
+                          -- Fall back to the earliest COMPATIBLE user turn when
+                          -- no task turn is classified. If every user row is a
+                          -- wrapper, the left join returns no summary.
+                          SELECT t2.session AS session, t2.text_excerpt AS text_excerpt,
                                  row_number() OVER (
-                                     PARTITION BY session
-                                     ORDER BY COALESCE(message_kind = 'task', FALSE) DESC, seq ASC
+                                     PARTITION BY t2.session
+                                     ORDER BY COALESCE(t2.message_kind = 'task', FALSE) DESC, t2.seq ASC
                                  ) AS rn
-                          FROM turn
-                          WHERE role = 'user'
+                          FROM turn t2
+                          JOIN session s2 ON s2.id = t2.session
+                          WHERE t2.role = 'user' AND ${firstUserCompat.sql}
                       ) fu ON fu.session = s.id AND fu.rn = 1
                       WHERE TRUE ${where.sql}
                       ORDER BY s.started_at DESC`,
-                params: where.params,
+                params: [...firstUserCompat.params, ...where.params],
             },
             "sessions-query.list",
         ),

--- a/apps/axctl/src/queries/prompts.ts
+++ b/apps/axctl/src/queries/prompts.ts
@@ -32,10 +32,12 @@ import { NumberFromBigIntColumn, TimestampColumn } from "@ax/lib/duckdb/columns"
 import { cacheFirst, cacheRows } from "@ax/lib/duckdb/query";
 import { andAll, NO_CLAUSE, withinDaysClause, type Clause } from "@ax/lib/duckdb/clause";
 import {
-    FULL_CONTEXT_RULES,
-    PI_CONTEXT_RULES,
-    type UserTextRules,
-} from "../ingest/normalized/message-kind.ts";
+    escapeLike,
+    legacyInjectionClause,
+    userTurnCompatClause,
+} from "./user-turn-compat.ts";
+
+export { escapeLike, legacyInjectionClause };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -102,93 +104,10 @@ export const promptsWhere = (input: PromptsInput): Clause =>
             params: [],
         },
         withinDaysClause("t.ts", input.sinceDays),
-        legacyInjectionClauseBySource(),
+        userTurnCompatClause(),
         scopeClause(input.scope),
         queryClause(input.query),
     ]);
-
-/**
- * A read-time repeat of the classifier's rules, DERIVED FROM THE SAME TABLES.
- *
- * WHY IT IS NEEDED AT ALL: `message_kind` is stamped at INGEST, so every row
- * written before the classifier learned a shape keeps the old kind. Re-parsing a
- * year of transcripts to correct history is expensive and not something a read
- * command may assume has happened, so without this the command would print
- * `<task-notification>` blocks at anyone whose store predates the fix - which is
- * everyone, on the day it ships.
- *
- * WHY IT IS NOT DUPLICATION: it is GENERATED from `UserTextRules`, not
- * hand-copied. A rule added to the classifier hardens the future ingest AND this
- * legacy read path in the same edit, and there is no second list to forget. That
- * distinction is the whole reason the rules are exported data rather than a
- * `switch`. Hand-copying them here was the first plan and would have recreated
- * exactly the divergence the classifier fix existed to remove.
- *
- * This clause becomes redundant once every row has been re-parsed. It is cheap,
- * it is generated, and "redundant" is the correct end state - do not delete it
- * on the strength of one machine's store being current.
- */
-export const legacyInjectionClause = (rules: UserTextRules): Clause => {
-    // `control` is included: an interrupt marker is not a typed request either.
-    const prefixes = [...rules.control, ...rules.contextStartsWith];
-    const parts: string[] = [];
-    const params: (string | number)[] = [];
-
-    for (const prefix of prefixes) {
-        parts.push("AND t.text NOT LIKE ? ESCAPE '\\'");
-        params.push(`${escapeLike(prefix)}%`);
-    }
-    for (const needle of rules.contextIncludes) {
-        parts.push("AND t.text NOT LIKE ? ESCAPE '\\'");
-        params.push(`%${escapeLike(needle)}%`);
-    }
-    for (const marker of rules.attachmentMarkers) {
-        // The marker-only test, in SQL: strip every marker and require something
-        // to be left. Mirrors `isOnlyAttachmentMarkers`, from the same RegExp.
-        parts.push(
-            "AND trim(regexp_replace(replace(t.text, chr(10), ' '), ?, '', 'g')) <> ''",
-        );
-        params.push(marker.source);
-    }
-
-    return parts.length === 0 ? NO_CLAUSE : { sql: parts.join(" "), params };
-};
-
-/**
- * Apply the legacy classifier guard only to sources that use that classifier.
- *
- * The normalized ingest parsers use FULL_CONTEXT_RULES for Claude and Codex,
- * PI_CONTEXT_RULES for Pi and Omp, and no context classifier for other sources.
- * Keep that source split here so a prefix measured for one harness cannot remove
- * a real prompt from another harness. Unknown sources stay unfiltered as well.
- */
-const legacyInjectionClauseBySource = (): Clause => {
-    const full = legacyInjectionClause(FULL_CONTEXT_RULES);
-    const pi = legacyInjectionClause(PI_CONTEXT_RULES);
-    const fullBody = full.sql.slice("AND ".length);
-    const piBody = pi.sql.slice("AND ".length);
-
-    return {
-        sql:
-            "AND (" +
-            "s.source NOT IN ('claude', 'codex', 'pi', 'omp')" +
-            " OR (s.source IN ('claude', 'codex') AND " + fullBody + ")" +
-            " OR (s.source IN ('pi', 'omp') AND " + piBody + ")" +
-            ")",
-        params: [...full.params, ...pi.params],
-    };
-};
-
-/**
- * Escape the LIKE metacharacters in a literal prefix.
- *
- * Necessary, not decorative: `<recommended_plugins>` contains `_`, which LIKE
- * reads as "any single character". Unescaped it would also exclude a human
- * prompt that happened to differ in that position - a silent over-filter, which
- * is the failure shape this whole change is about.
- */
-export const escapeLike = (literal: string): string =>
-    literal.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 
 /**
  * Scope to a directory SUBTREE, not one exact path: agents run in worktrees

--- a/apps/axctl/src/queries/recall.test.ts
+++ b/apps/axctl/src/queries/recall.test.ts
@@ -26,6 +26,7 @@ import {
     turnPageQuery,
     type TurnFilters,
 } from "./recall.ts";
+import { userTurnCompatClause } from "./user-turn-compat.ts";
 
 const BASE: TurnFilters = { q: "duckdb" };
 
@@ -54,11 +55,19 @@ describe("no query carries a literal value", () => {
         sessionsForContentTypesQuery([NASTY, "image"]),
     ];
 
-    test("no single quote appears in any generated SQL", () => {
+    // The one hardcoded exception (#1095): `userTurnCompatClause`'s source
+    // enum (`'claude'`, `'codex'`, `'pi'`, `'omp'`), its `'user'` role guard,
+    // and its `<> ''` marker-only check are CLOSED-SET literals from the
+    // shared classifier rule tables, never from caller input - so they cannot
+    // carry the hostile string, unlike every other literal this suite guards
+    // against.
+    const COMPAT_CLAUSE_SQL = userTurnCompatClause({ roleExpr: "t.role" }).sql;
+
+    test("no single quote appears in any generated SQL, besides the closed-set user-turn compat filter", () => {
         for (const q of queries()) {
             // The skill queries carry `ESCAPE '\'`, the one legitimate literal
             // in this family - it is part of the LIKE operator, not a value.
-            const withoutEscape = q.sql.replaceAll("ESCAPE '\\'", "");
+            const withoutEscape = q.sql.replaceAll(COMPAT_CLAUSE_SQL, "").replaceAll("ESCAPE '\\'", "");
             expect(withoutEscape).not.toContain("'");
         }
     });
@@ -87,12 +96,22 @@ describe("page and count queries agree about what matches", () => {
         expect(turnCountQuery(ALL_FILTERS).sql.match(/match_bm25/g)).toHaveLength(1);
     });
 
-    test("an unfiltered query binds the query text four times (3 snippet + 1 score), plus pagination", () => {
+    test("an unfiltered query binds the query text four times (3 snippet + 1 score), then the user-turn compat filter, then pagination", () => {
         // #921: the match-centered snippet binds `q` three times (position x2,
         // substr start) ahead of match_bm25's one - the same subquery serves
-        // page and count, so both carry all four.
-        expect(turnCountQuery(BASE).params).toEqual(["duckdb", "duckdb", "duckdb", "duckdb"]);
-        expect(turnPageQuery(BASE, 0, 50).params).toEqual(["duckdb", "duckdb", "duckdb", "duckdb", 50, 0]);
+        // page and count, so both carry all four. #1095 then appends the
+        // source-aware user-turn compatibility filter's own params (unconditional,
+        // like `promptsWhere`'s), so the trailing count is derived from that
+        // clause rather than hand-counted here.
+        const compatParams = userTurnCompatClause({ roleExpr: "t.role" }).params;
+        const countParams = turnCountQuery(BASE).params;
+        expect(countParams.slice(0, 4)).toEqual(["duckdb", "duckdb", "duckdb", "duckdb"]);
+        expect(countParams.slice(4)).toEqual([...compatParams]);
+
+        const pageParams = turnPageQuery(BASE, 0, 50).params;
+        expect(pageParams.slice(0, 4)).toEqual(["duckdb", "duckdb", "duckdb", "duckdb"]);
+        expect(pageParams.slice(4, 4 + compatParams.length)).toEqual([...compatParams]);
+        expect(pageParams.slice(-2)).toEqual([50, 0]);
     });
 
     test("the BM25 score is filtered outside the subquery, not used as a boolean", () => {
@@ -101,6 +120,18 @@ describe("page and count queries agree about what matches", () => {
         for (const q of [turnPageQuery(BASE, 0, 5), turnCountQuery(BASE)]) {
             expect(q.sql).toContain("score IS NOT NULL");
         }
+    });
+});
+
+describe("user-turn compat filter (#1095)", () => {
+    // Full behavioral coverage (does it actually drop a stale-`task` wrapper
+    // hit while keeping assistant/genuine-user hits?) lives in the real-DuckDB
+    // test `../dashboard/recall.test.ts`. This just pins that the filter is
+    // wired in and guarded to user-authored rows.
+    test("guards the legacy filter to user-authored rows, never assistant ones", () => {
+        const sql = turnCountQuery(BASE).sql;
+        expect(sql).toContain("t.role <> 'user'");
+        expect(sql).toContain("s.source NOT IN ('claude', 'codex', 'pi', 'omp')");
     });
 });
 

--- a/apps/axctl/src/queries/recall.ts
+++ b/apps/axctl/src/queries/recall.ts
@@ -43,6 +43,7 @@ import {
 } from "@ax/lib/duckdb/clause";
 import { TimestampColumn } from "@ax/lib/duckdb/columns";
 import { COMMIT_FTS_TARGET, matchBm25Sql, TURN_FTS_TARGET, type FtsTarget } from "@ax/lib/duckdb/fts";
+import { userTurnCompatClause } from "./user-turn-compat.ts";
 
 /** Re-exported FROM the fts module (#921) so the reader can never drift from
  *  the target `buildFtsIndexes` actually indexes. Turn search covers the FULL
@@ -86,6 +87,11 @@ const turnWhere = (filters: TurnFilters): Clause =>
         sinceClause("t.ts", filters.since),
         filters.sessionIds ? inClause("t.session", filters.sessionIds) : NO_CLAUSE,
         eqClause("s.repository", filters.repositoryId),
+        // Stale `message_kind='task'` rows from before the classifier learned a
+        // harness-wrapper shape (#1095) must not surface as a "task" hit for a
+        // USER turn. Guarded by `roleExpr` so an assistant hit - which can
+        // legitimately echo the same wrapper text - is never excluded by it.
+        userTurnCompatClause({ roleExpr: "t.role" }),
     ]);
 
 /**

--- a/apps/axctl/src/queries/user-turn-compat.test.ts
+++ b/apps/axctl/src/queries/user-turn-compat.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import {
+    escapeLike,
+    legacyInjectionClause,
+    userTurnCompatClause,
+    userTurnCompatPredicate,
+} from "./user-turn-compat.ts";
+import {
+    FULL_CONTEXT_RULES,
+    IMAGE_ATTACHMENT_MARKERS,
+    PI_CONTEXT_RULES,
+    type UserTextRules,
+} from "../ingest/normalized/message-kind.ts";
+
+/** Count the positional placeholders a fragment binds. */
+const placeholders = (sql: string): number => (sql.match(/\?/g) ?? []).length;
+
+const TOTAL_RULE_PARAMS =
+    FULL_CONTEXT_RULES.control.length +
+    FULL_CONTEXT_RULES.contextStartsWith.length +
+    FULL_CONTEXT_RULES.contextIncludes.length +
+    FULL_CONTEXT_RULES.attachmentMarkers.length +
+    PI_CONTEXT_RULES.control.length +
+    PI_CONTEXT_RULES.contextStartsWith.length +
+    PI_CONTEXT_RULES.contextIncludes.length +
+    PI_CONTEXT_RULES.attachmentMarkers.length;
+
+describe("legacyInjectionClause", () => {
+    test("is DERIVED from the rule tables, so one edit hardens every caller", () => {
+        const c = legacyInjectionClause(FULL_CONTEXT_RULES);
+        const expected =
+            FULL_CONTEXT_RULES.control.length +
+            FULL_CONTEXT_RULES.contextStartsWith.length +
+            FULL_CONTEXT_RULES.contextIncludes.length +
+            FULL_CONTEXT_RULES.attachmentMarkers.length;
+        expect(placeholders(c.sql)).toBe(expected);
+        expect(c.params).toHaveLength(expected);
+        expect(c.params).toContain("<task-notification>%");
+        expect(c.params).toContain("<command-message>%");
+        // Default text expression, unless the caller overrides it.
+        expect(c.sql).toContain("t.text NOT LIKE");
+    });
+
+    test("accepts a caller-supplied text expression, for aliases other than `t`", () => {
+        const c = legacyInjectionClause(FULL_CONTEXT_RULES, "t2.text");
+        expect(c.sql).toContain("t2.text NOT LIKE");
+        expect(c.sql).not.toContain(" t.text ");
+    });
+
+    test("prefixes anchor, includes float, markers use the regex form", () => {
+        const rules: UserTextRules = {
+            control: ["<ctl>"],
+            contextStartsWith: ["<ctx>"],
+            contextIncludes: ["<mid>"],
+            attachmentMarkers: IMAGE_ATTACHMENT_MARKERS,
+        };
+        const c = legacyInjectionClause(rules);
+        expect(c.params[0]).toBe("<ctl>%");
+        expect(c.params[1]).toBe("<ctx>%");
+        expect(c.params[2]).toBe("%<mid>%");
+        expect(c.params[3]).toBe(IMAGE_ATTACHMENT_MARKERS[0]!.source);
+        expect(c.sql).toContain("regexp_replace");
+    });
+
+    test("empty rules contribute nothing rather than a dangling AND", () => {
+        const c = legacyInjectionClause({
+            control: [],
+            contextStartsWith: [],
+            contextIncludes: [],
+            attachmentMarkers: [],
+        });
+        expect(c.sql).toBe("");
+        expect(c.params).toEqual([]);
+    });
+});
+
+describe("escapeLike", () => {
+    test("escapes the LIKE metacharacters", () => {
+        expect(escapeLike("<recommended_plugins>")).toBe("<recommended\\_plugins>");
+        expect(escapeLike("100%")).toBe("100\\%");
+    });
+});
+
+describe("userTurnCompatPredicate", () => {
+    test("defaults to t.text / s.source and covers both rule tables", () => {
+        const p = userTurnCompatPredicate();
+        expect(placeholders(p.sql)).toBe(TOTAL_RULE_PARAMS);
+        expect(p.params).toHaveLength(TOTAL_RULE_PARAMS);
+        expect(p.sql).toContain("s.source NOT IN ('claude', 'codex', 'pi', 'omp')");
+        expect(p.sql).toContain("s.source IN ('claude', 'codex')");
+        expect(p.sql).toContain("s.source IN ('pi', 'omp')");
+        // The full-only prefix is bound once for FULL_CONTEXT_RULES, never for pi.
+        expect(p.params.filter((v) => v === "Base directory for this skill:%")).toHaveLength(1);
+        // No leading AND - this is a raw boolean expression, embeddable in a
+        // CASE/ORDER BY, not just a WHERE-clause fragment.
+        expect(p.sql.startsWith("AND")).toBe(false);
+    });
+
+    test("honors caller-supplied source/text expressions", () => {
+        const p = userTurnCompatPredicate({ sourceExpr: "s2.source", textExpr: "t2.text" });
+        expect(p.sql).toContain("s2.source NOT IN");
+        expect(p.sql).toContain("t2.text NOT LIKE");
+        expect(p.sql).not.toContain("s.source");
+    });
+
+    test("unknown sources take the unconditional true branch", () => {
+        // `NOT IN (...)` is the FIRST disjunct - an unrecognized source can
+        // never be excluded by either rule table.
+        const p = userTurnCompatPredicate();
+        expect(p.sql.startsWith("(")).toBe(true);
+        expect(p.sql).toMatch(/^\(\S+ NOT IN/);
+    });
+});
+
+describe("userTurnCompatClause", () => {
+    test("prepends AND with no role guard by default", () => {
+        const c = userTurnCompatClause();
+        expect(c.sql.startsWith("AND (")).toBe(true);
+        expect(c.sql).not.toContain("<> 'user'");
+        expect(c.params).toHaveLength(TOTAL_RULE_PARAMS);
+    });
+
+    test("wraps with a role guard so non-user rows are always kept", () => {
+        const c = userTurnCompatClause({ roleExpr: "t.role" });
+        expect(c.sql).toBe(`AND (t.role <> 'user' OR ${userTurnCompatPredicate().sql})`);
+        // The guard itself binds no parameter - only the predicate's rule params.
+        expect(c.params).toEqual(userTurnCompatPredicate().params);
+    });
+
+    test("placeholder count always equals parameter count", () => {
+        for (const c of [
+            userTurnCompatClause(),
+            userTurnCompatClause({ roleExpr: "t.role" }),
+            userTurnCompatClause({ sourceExpr: "s2.source", textExpr: "t2.text", roleExpr: "t2.role" }),
+        ]) {
+            expect(placeholders(c.sql)).toBe(c.params.length);
+        }
+    });
+});

--- a/apps/axctl/src/queries/user-turn-compat.ts
+++ b/apps/axctl/src/queries/user-turn-compat.ts
@@ -1,0 +1,138 @@
+/**
+ * Source-aware "is this a genuine typed user turn, or harness-injected
+ * wrapper text" compatibility filter - extracted out of `queries/prompts.ts`
+ * (#1095) so every surface that ranks or filters user turns shares ONE
+ * definition instead of re-deriving it.
+ *
+ * WHY THIS EXISTS AT ALL, AND WHY IT IS GENERATED, NOT HAND-WRITTEN. See
+ * `legacyInjectionClause` below - the short version is that `message_kind` is
+ * stamped at INGEST, so a row written before the classifier learned a wrapper
+ * shape keeps the stale kind forever unless the file is re-parsed. A read
+ * command may not assume that has happened. Deriving the filter FROM
+ * `FULL_CONTEXT_RULES` / `PI_CONTEXT_RULES` (`ingest/normalized/message-kind.ts`)
+ * means a rule added to the classifier hardens every read surface below in the
+ * same edit - there is no second list to keep in sync.
+ *
+ * WHY THE SQL EXPRESSIONS ARE CONFIGURABLE. Each caller joins `turn`/`session`
+ * under different aliases (`t`/`s` in most places, `t2`/`s2` inside a
+ * correlated subquery in `dashboard/sessions-query.ts`), and not every caller
+ * has already restricted itself to `role = 'user'` before this filter runs
+ * (`ax recall` searches both roles in one statement). Rather than one filter
+ * per caller, the column names and the user-role guard are parameters.
+ */
+import {
+    FULL_CONTEXT_RULES,
+    PI_CONTEXT_RULES,
+    type UserTextRules,
+} from "../ingest/normalized/message-kind.ts";
+import { NO_CLAUSE, type Clause } from "@ax/lib/duckdb/clause";
+
+/**
+ * Escape the LIKE metacharacters in a literal prefix.
+ *
+ * Necessary, not decorative: `<recommended_plugins>` contains `_`, which LIKE
+ * reads as "any single character". Unescaped it would also exclude a human
+ * prompt that happened to differ in that position - a silent over-filter, which
+ * is the failure shape this whole module is about.
+ */
+export const escapeLike = (literal: string): string =>
+    literal.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+
+/**
+ * A read-time repeat of the classifier's rules, DERIVED FROM THE SAME TABLES.
+ *
+ * `textExpr` lets a caller point the filter at whichever column carries the
+ * full turn text under its own aliasing (`t.text` is the default and covers
+ * every current caller).
+ *
+ * This clause becomes redundant once every row has been re-parsed. It is cheap,
+ * it is generated, and "redundant" is the correct end state - do not delete it
+ * on the strength of one machine's store being current.
+ */
+export const legacyInjectionClause = (
+    rules: UserTextRules,
+    textExpr = "t.text",
+): Clause => {
+    // `control` is included: an interrupt marker is not a typed request either.
+    const prefixes = [...rules.control, ...rules.contextStartsWith];
+    const parts: string[] = [];
+    const params: (string | number)[] = [];
+
+    for (const prefix of prefixes) {
+        parts.push(`AND ${textExpr} NOT LIKE ? ESCAPE '\\'`);
+        params.push(`${escapeLike(prefix)}%`);
+    }
+    for (const needle of rules.contextIncludes) {
+        parts.push(`AND ${textExpr} NOT LIKE ? ESCAPE '\\'`);
+        params.push(`%${escapeLike(needle)}%`);
+    }
+    for (const marker of rules.attachmentMarkers) {
+        // The marker-only test, in SQL: strip every marker and require something
+        // to be left. Mirrors `isOnlyAttachmentMarkers`, from the same RegExp.
+        parts.push(
+            `AND trim(regexp_replace(replace(${textExpr}, chr(10), ' '), ?, '', 'g')) <> ''`,
+        );
+        params.push(marker.source);
+    }
+
+    return parts.length === 0 ? NO_CLAUSE : { sql: parts.join(" "), params };
+};
+
+export interface UserTurnCompatExprs {
+    /** SQL expression for the turn's full text column. Default `t.text`. */
+    readonly textExpr?: string;
+    /** SQL expression for the owning session's `source` column. Default `s.source`. */
+    readonly sourceExpr?: string;
+    /**
+     * SQL expression for the turn's `role` column. When given, the whole
+     * predicate is guarded so it only constrains USER rows -
+     * `(roleExpr <> 'user' OR <source-aware filter>)` - so non-user rows (e.g.
+     * assistant hits in `ax recall`) are always kept. Omit when the caller has
+     * already restricted the surrounding query to `role = 'user'`.
+     */
+    readonly roleExpr?: string;
+}
+
+/**
+ * The boolean predicate itself (no leading `AND`, no role guard) - for callers
+ * that need to embed it inside a larger expression, e.g. an `ORDER BY` CASE
+ * that DEPRIORITIZES a stale wrapper turn rather than excluding it outright
+ * (`dashboard/sessions-query.ts`'s "first user message" ranking).
+ *
+ * Apply the legacy classifier guard only to sources that use that classifier.
+ * The normalized ingest parsers use FULL_CONTEXT_RULES for Claude and Codex,
+ * PI_CONTEXT_RULES for Pi and Omp, and no context classifier for other
+ * sources. Keep that source split here so a prefix measured for one harness
+ * cannot remove a real prompt from another harness. Unknown sources stay
+ * unfiltered as well.
+ */
+export const userTurnCompatPredicate = (exprs: UserTurnCompatExprs = {}): Clause => {
+    const textExpr = exprs.textExpr ?? "t.text";
+    const sourceExpr = exprs.sourceExpr ?? "s.source";
+    const full = legacyInjectionClause(FULL_CONTEXT_RULES, textExpr);
+    const pi = legacyInjectionClause(PI_CONTEXT_RULES, textExpr);
+    const fullBody = full.sql.slice("AND ".length);
+    const piBody = pi.sql.slice("AND ".length);
+
+    return {
+        sql:
+            `(${sourceExpr} NOT IN ('claude', 'codex', 'pi', 'omp')` +
+            ` OR (${sourceExpr} IN ('claude', 'codex') AND ${fullBody})` +
+            ` OR (${sourceExpr} IN ('pi', 'omp') AND ${piBody}))`,
+        params: [...full.params, ...pi.params],
+    };
+};
+
+/**
+ * `userTurnCompatPredicate`, ready to append to a `WHERE` clause built from
+ * `andAll(...)` (leading `AND`, optionally guarded by `roleExpr`).
+ */
+export const userTurnCompatClause = (exprs: UserTurnCompatExprs = {}): Clause => {
+    const predicate = userTurnCompatPredicate(exprs);
+    return {
+        sql: exprs.roleExpr
+            ? `AND (${exprs.roleExpr} <> 'user' OR ${predicate.sql})`
+            : `AND ${predicate.sql}`,
+        params: predicate.params,
+    };
+};


### PR DESCRIPTION
Fixes #1095

## Summary

- reuse the source-aware harness preamble filter across read surfaces
- exclude stale preamble rows from session lists and summaries
- preserve assistant rows, unknown sources, and user text that only resembles a marker
- keep recall page and count queries in agreement

## Verification

- 80 focused tests pass with the project DuckDB build
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

---

_Generated with [ax](https://github.com/Necmttn/ax)._