### PR TITLE
fix: suppress universal taste pattern

### DIFF
--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -9,14 +9,6 @@ import { buildProfile } from "./render.ts";
 // SQL; a statement missing a route surfaces as an "out of results" mock
 // failure rather than a silent wrong answer.
 
-// `fetchContentTypeBreakdown` (queries/content-types.ts) reads the published
-// CacheRead snapshot, matched below by its own "has_content" fragment (a
-// different wave-3 chunk's convention, unchanged here).
-const contentTypeRows = [
-    { ct: "content_type:code", calls: 10, bytes: 800 },
-    { ct: "content_type:text", calls: 5, bytes: 200 },
-];
-
 // One entry per queries.ts CacheRead statement, keyed by a fragment of that
 // statement's own SQL text unique enough not to collide with any other
 // statement in this file (verified by hand against queries.ts; every key
@@ -166,17 +158,14 @@ const verdictRows = [
 const runProfile = <A, E>(
     effect: Effect.Effect<A, E, unknown>,
     proposals: ReadonlyArray<Record<string, unknown>> = proposalRows,
-    contentTypes: ReadonlyArray<Record<string, unknown>> = contentTypeRows,
     cacheOverrides: Readonly<Record<string, ReadonlyArray<Record<string, unknown>>>> = {},
 ) => Effect.runPromise(effect.pipe(Effect.provide(Layer.mergeAll(
-    // Dispatched by SQL text: content-type breakdown (`has_content`, a
-    // different wave-3 chunk's convention) first, then per-test overrides,
-    // then the default CACHE_ROUTES table built above. The pricing-catalog
-    // lookup inside fetchCostModels resolves when a row stores zero cost
-    // against real tokens - none of these fixtures do, so falling through to
-    // empty is the right answer for it.
+    // Dispatched by SQL text: per-test overrides first, then the default
+    // CACHE_ROUTES table built above. The pricing-catalog lookup inside
+    // fetchCostModels resolves when a row stores zero cost against real
+    // tokens - none of these fixtures do, so falling through to empty is the
+    // right answer for it.
     cacheReadTestLayer((sql) => {
-        if (sql.includes("has_content")) return contentTypes;
         for (const [key, rows] of Object.entries(cacheOverrides)) {
             if (sql.includes(key)) return rows;
         }
@@ -236,6 +225,7 @@ describe("buildProfile", () => {
         expect(p.rig.skills[0]!.runs).toBe(88);
         expect(p.rig.skills[0]!.downstream_share).toBeDefined();
         expect(p.rig.rules).toEqual({ count: 2 });
+        expect(p.taste!.patterns).toHaveLength(1);
         expect(p.taste!.patterns[0]!.name).toBe("stop-edit-loops-early");
         // activity
         expect(p.activity).toBeDefined();
@@ -303,14 +293,8 @@ describe("buildProfile", () => {
         expect(p.stats.models[0]).toEqual({ name: "fable", share: 100 / 142 });
     });
 
-    test("no proposals -> taste has only the mix pattern from content types", async () => {
+    test("no proposals -> taste omitted (no universal tool-output-mix pattern generated)", async () => {
         const p = await runProfile(buildProfile({ windowDays: 30, includeCost: true, env }), []);
-        expect(p.taste?.patterns).toHaveLength(1);
-        expect(p.taste?.patterns[0]?.category).toBe("tool-output-mix");
-    });
-
-    test("no proposals + no content types -> taste omitted", async () => {
-        const p = await runProfile(buildProfile({ windowDays: 30, includeCost: true, env }), [], []);
         expect(p.taste).toBeUndefined();
     });
 
@@ -320,7 +304,6 @@ describe("buildProfile", () => {
         const p = await runProfile(
             buildProfile({ windowDays: 30, includeCost: true, env }),
             proposalRows,
-            contentTypeRows,
             {
                 "count(*) AS sessions\nFROM session\nWHERE started_at IS NOT NULL": [],
                 "FROM session_token_usage\nWHERE ts IS NOT NULL": [],

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -11,7 +11,6 @@
  * `CacheRead`, so that is the whole of `buildProfile`'s data requirement.
  */
 import { Effect } from "effect";
-import { fetchContentTypeBreakdown } from "../queries/content-types.ts";
 import { fetchCostModels } from "../queries/cost-analytics.ts";
 import {
     fetchAcceptedProposals,
@@ -40,7 +39,7 @@ import { deriveGuardrailReceipts } from "./guardrails.ts";
 import { deriveInsights } from "./insights.ts";
 import { deriveRig } from "./rig.ts";
 import { computeStreak } from "./streak.ts";
-import { buildToolOutputMixPattern, deriveTastePatterns } from "./taste.ts";
+import { deriveTastePatterns } from "./taste.ts";
 import { decodeProfile, type Highlights, type ProfileV1 } from "./schema.ts";
 import { deriveWorkflowArcs } from "./workflow.ts";
 import { computeDownstreamShares } from "./downstream.ts";
@@ -74,8 +73,7 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
         // 22 windowedInvocations  23 windowedSessions
         // 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
-        // 27 contentTypeBreakdown
-        // 28 guardrailHookEvidence  29 guardrailVerdicts
+        // 27 guardrailHookEvidence  28 guardrailVerdicts
         const totals = yield* fetchTokenTotals({ windowDays });
         const daily = yield* fetchDailyActivity({ windowDays });
         const harnesses = yield* fetchHarnesses({ windowDays });
@@ -99,8 +97,6 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         // 24 deepSessions (outcome-density DEPTH numerator + non-subagent
         // denominator). Internally fans out: total-count -> produced -> landed-loc.
         const deep = yield* fetchDeepSessionCount({ windowDays });
-        // 27 content-type breakdown (appended last; keeps mock order in render.test.ts aligned)
-        const contentTypes = yield* fetchContentTypeBreakdown();
         const guardrailHookEvidence = yield* fetchGuardrailHookEvidence({ windowDays });
         const guardrailVerdicts = yield* fetchGuardrailVerdicts({ windowDays });
 
@@ -121,8 +117,6 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         });
 
         const patterns = deriveTastePatterns(proposals);
-        const mixPattern = buildToolOutputMixPattern(contentTypes, totals.sessions);
-        if (mixPattern !== null) patterns.push(mixPattern);
 
         // null when there is no data at all -> section omitted below.
         const insights = deriveInsights({

--- a/apps/axctl/src/profile/taste.test.ts
+++ b/apps/axctl/src/profile/taste.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildToolOutputMixPattern, deriveTastePatterns, parseConfidence, slugify } from "./taste.ts";
-import type { ContentTypeBreakdown } from "../queries/content-types.ts";
+import { deriveTastePatterns, parseConfidence, slugify } from "./taste.ts";
 import type { ProposalRow } from "./queries.ts";
 
 const row = (over: Partial<ProposalRow>): ProposalRow => ({
@@ -67,37 +66,5 @@ describe("deriveTastePatterns", () => {
         ]);
         expect(out).toHaveLength(1);
         expect(out[0]!.evidence.sessions).toBe(9);
-    });
-});
-
-describe("buildToolOutputMixPattern", () => {
-    const breakdown: ContentTypeBreakdown = {
-        rows: [
-            { category: "code", calls: 10, bytes: 800, estTokens: 200, tokenShare: 0.8 },
-            { category: "text", calls: 5, bytes: 200, estTokens: 50, tokenShare: 0.2 },
-        ],
-        totals: { calls: 15, bytes: 1000, estTokens: 250 },
-    };
-
-    test("builds a tool-output-mix pattern from the content breakdown", () => {
-        const p = buildToolOutputMixPattern(breakdown, 42);
-        expect(p?.category).toBe("tool-output-mix");
-        expect(p?.summary).toContain("code");
-    });
-
-    test("encodes lead share in summary", () => {
-        const p = buildToolOutputMixPattern(breakdown, 42);
-        expect(p?.summary).toContain("80%");
-    });
-
-    test("returns null when breakdown has no rows", () => {
-        const empty: ContentTypeBreakdown = { rows: [], totals: { calls: 0, bytes: 0, estTokens: 0 } };
-        expect(buildToolOutputMixPattern(empty, 10)).toBeNull();
-    });
-
-    test("evidence reflects the sessions argument", () => {
-        const p = buildToolOutputMixPattern(breakdown, 7);
-        expect(p?.evidence.sessions).toBe(7);
-        expect(p?.evidence.confidence).toBe(0.9);
     });
 });

--- a/apps/axctl/src/profile/taste.ts
+++ b/apps/axctl/src/profile/taste.ts
@@ -10,7 +10,6 @@
  * the publish path MUST scrub or require per-pattern confirmation before
  * this text leaves the machine.
  */
-import type { ContentTypeBreakdown } from "../queries/content-types.ts";
 import type { ProposalRow } from "./queries.ts";
 import type { TastePattern } from "./schema.ts";
 
@@ -47,25 +46,6 @@ const FORM_TO_CATEGORY: Record<string, ProseCategory> = {
 };
 
 const dayOf = (iso: string): string => iso.slice(0, 10);
-
-/**
- * Derive a tool-output-mix pattern from the global content-type breakdown.
- * Returns null when the breakdown is empty (taste section stays omitted).
- */
-export function buildToolOutputMixPattern(
-    breakdown: ContentTypeBreakdown,
-    sessions: number,
-) {
-    const top = breakdown.rows.slice(0, 3);
-    if (top.length === 0) return null;
-    const lead = top[0]!;
-    return {
-        category: "tool-output-mix" as const,
-        name: `${lead.category}-heavy context`,
-        summary: `Context is ${Math.round(lead.tokenShare * 100)}% ${lead.category} by tokens (${top.map((r) => r.category).join(", ")}).`,
-        evidence: { sessions, confidence: 0.9 },
-    };
-}
 
 export function deriveTastePatterns(rows: ReadonlyArray<ProposalRow>): TastePattern[] {
     const byName = new Map<string, { row: ProposalRow; pattern: TastePattern }>();


### PR DESCRIPTION
## Summary

- Remove the universal `tool-output-mix` pattern from new profile assembly.
- Keep the category in the profile schema for old profile compatibility.
- Keep proposal-derived taste patterns unchanged.
- Add a regression test that omits taste when no proposal pattern exists.

## Verification

- `bun test apps/axctl/src/profile`: 205 pass, 1 environment skip, 0 fail
- `bun run typecheck`: pass
- `bun run check:no-node-fs`: pass
- `bun run check:timestamp-cast`: pass
- `bun run check:raw-numeric-cast`: pass

Closes #1094

---

_Generated with [ax](https://github.com/Necmttn/ax)._
