### PR TITLE
fix: align cost command windows

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.test.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
     COST_SESSIONS_LEGEND,
+    costWindowHeader,
     renderCostModelsTable,
     renderCostSessionsTable,
     renderCostSplitTable,
 } from "./ax-cost.ts";
-import type {
-    CostModelsResult,
-    CostSessionsResult,
-    CostSplitResult,
+import {
+    COST_DEFAULT_WINDOW_DAYS,
+    type CostModelsResult,
+    type CostSessionsResult,
+    type CostSplitResult,
 } from "../../queries/cost-analytics.ts";
 
 describe("renderCostModelsTable", () => {
@@ -126,5 +128,18 @@ describe("renderCostSessionsTable", () => {
         expect(COST_SESSIONS_LEGEND).toContain("cost = est. USD");
         expect(COST_SESSIONS_LEGEND).toContain("out_tok = output");
         expect(COST_SESSIONS_LEGEND).toContain("cache_tok = cache-hit");
+    });
+});
+
+describe("costWindowHeader", () => {
+    test("states the requested day window", () => {
+        expect(costWindowHeader(14)).toBe("window: last 14 days");
+        expect(costWindowHeader(30)).toBe("window: last 30 days");
+    });
+
+    test("matches the shared default window used across ax cost subcommands", () => {
+        expect(costWindowHeader(COST_DEFAULT_WINDOW_DAYS)).toBe(
+            `window: last ${COST_DEFAULT_WINDOW_DAYS} days`,
+        );
     });
 });

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -33,6 +33,18 @@ import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
 
 // ---------------------------------------------------------------------------
+// Shared window header - printed first (before any table/no-data message) on
+// every human-readable `ax cost *` subcommand so the requested day window is
+// never ambiguous. JSON output is unaffected. Replaces the footer-only
+// "(N days)" mentions that used to be scattered (and sometimes absent, e.g.
+// `sessions` / `routability`) across the individual commands.
+// ---------------------------------------------------------------------------
+
+export function costWindowHeader(days: number): string {
+    return `window: last ${days} days`;
+}
+
+// ---------------------------------------------------------------------------
 // ax cost models [--days=N] [--json]
 // ---------------------------------------------------------------------------
 
@@ -82,6 +94,8 @@ const cmdCostModels = (input: {
             return;
         }
 
+        console.log(costWindowHeader(input.sinceDays));
+
         if (result.rows.length === 0) {
             console.log("(no session token usage in the requested window)");
             return;
@@ -89,7 +103,7 @@ const cmdCostModels = (input: {
 
         printNextLinks(buildCostModelsNext(result));
         console.log(renderCostModelsTable(result));
-        console.log(`\ntotal: ${usd(result.total_cost_usd)}  (${input.sinceDays} days)`);
+        console.log(`\ntotal: ${usd(result.total_cost_usd)}`);
     });
 
 const costModelsCommand = Command.make(
@@ -173,6 +187,8 @@ const cmdCostSessions = (input: {
             console.log(prettyPrint(result));
             return;
         }
+
+        console.log(costWindowHeader(input.sinceDays));
 
         if (result.rows.length === 0) {
             console.log("(no priced sessions in the requested window)");
@@ -276,6 +292,8 @@ const cmdCostSplit = (input: {
             return;
         }
 
+        console.log(costWindowHeader(input.sinceDays));
+
         if (result.rows.length === 0) {
             console.log("(no cost data in the requested window)");
             return;
@@ -283,7 +301,6 @@ const cmdCostSplit = (input: {
 
         printNextLinks(buildCostSplitNext(result));
         console.log(renderCostSplitTable(result));
-        console.log(`\n(${input.sinceDays} days)`);
     });
 
 const costSplitCommand = Command.make(
@@ -364,13 +381,14 @@ const cmdCostRoutability = (input: {
             return;
         }
 
+        console.log(costWindowHeader(input.days));
         console.log(renderRoutability(result));
     });
 
 const costRoutabilityCommand = Command.make(
     "routability",
     {
-        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+        days: Flag.integer("days").pipe(Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)),
         minRun: Flag.integer("min-run").pipe(Flag.withDefault(1)),
         json: jsonFlag,
     },
@@ -386,7 +404,7 @@ const costRoutabilityCommand = Command.make(
 ).pipe(
     Command.withDescription(
         "Estimate how much main-agent spend was routable to a cheaper subagent. " +
-        "--days=N (default 30)  --min-run=N (default 1)  --json",
+        "--days=N (default 14)  --min-run=N (default 1)  --json",
     ),
 );
 
@@ -409,6 +427,8 @@ const cmdCostImages = (input: {
             console.log(prettyPrint(result));
             return;
         }
+
+        console.log(costWindowHeader(input.sinceDays));
 
         if (result.rows.length === 0) {
             console.log("(no image content in the requested window)");
@@ -447,7 +467,6 @@ const cmdCostImages = (input: {
             `main-thread image context: ${mb(t.mainBytes)} MB (${integer(t.mainCalls)} calls) - persists + re-bills across turns`,
         );
         console.log(`subagent: ${mb(t.subagentBytes)} MB (${integer(t.subagentCalls)} calls) - isolated`);
-        console.log(`\n(${input.sinceDays} days)`);
     });
 
 const costImagesCommand = Command.make(
@@ -490,6 +509,8 @@ const cmdCostAttribution = (input: {
             console.log(prettyPrint(result));
             return;
         }
+
+        console.log(costWindowHeader(input.sinceDays));
 
         const cov = result.coverage;
         if (cov.attributedTurns === 0) {
@@ -541,7 +562,7 @@ const cmdCostAttribution = (input: {
             const mix = result.apiErrors.map((r) => `${r.status}×${integer(r.turns)}`).join(", ");
             console.log(`api errors: ${mix}`);
         }
-        console.log(`\n(${input.sinceDays} days; native = harness-stamped, cross-check vs invoked-edge inference)`);
+        console.log("\n(native = harness-stamped, cross-check vs invoked-edge inference)");
     });
 
 const costAttributionCommand = Command.make(
@@ -586,6 +607,8 @@ const cmdCostCache = (input: {
             console.log(prettyPrint(result));
             return;
         }
+
+        console.log(costWindowHeader(input.sinceDays));
 
         if (result.coverage.bustTurns === 0) {
             console.log("(no cache-bust events in the requested window)");
@@ -671,7 +694,7 @@ const cmdCostCache = (input: {
         if (trims.length > 0) console.log(`trimming: ${trims.join("; ")}`);
 
         console.log(
-            `\n(${input.sinceDays} days; a bust = a billing event whose prompt cache missed; ` +
+            "\n(a bust = a billing event whose prompt cache missed; " +
                 "cost = the cache-creation tokens that re-established it on that turn)",
         );
     });

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -872,7 +872,7 @@ const costRoutabilityTool: AxMcpTool = defineMcpTool({
             .int()
             .positive()
             .optional()
-            .describe("Window in days (default 30)."),
+            .describe("Window in days (default 14)."),
         min_run: z
             .number()
             .int()
@@ -881,7 +881,7 @@ const costRoutabilityTool: AxMcpTool = defineMcpTool({
             .describe("Min consecutive same-class turns for a span to count (default 1)."),
     },
     run: async (args, rt) => {
-        const days = args.days ?? 30;
+        const days = args.days ?? COST_DEFAULT_WINDOW_DAYS;
         const minRun = args.min_run ?? 1;
         const result = await rt.runPromise(fetchRoutability({ days, minRun }));
         return result;

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -55,7 +55,7 @@ const CostSplitAggRow = Schema.Struct({
 // Shared constants + SQL-boundary helpers
 // ---------------------------------------------------------------------------
 
-/** Default look-back window for all `ax cost *` subcommands (models / sessions / split). */
+/** Default look-back window for every `ax cost *` subcommand (CLI and MCP). */
 export const COST_DEFAULT_WINDOW_DAYS = 14;
 
 /**


### PR DESCRIPTION
## Summary

- Use the shared 14-day default for cost routability in the CLI and MCP.
- Print the selected window before every human-readable cost result.
- Remove duplicate footer window labels.
- Keep JSON result formatting unchanged.

## Verification

- `bun test apps/axctl/src/cli/commands/ax-cost.test.ts apps/axctl/src/mcp/tools.test.ts`: 17 pass
- `bun run typecheck`: pass
- `bun run check:no-node-fs`: pass
- `bun run check:timestamp-cast`: pass
- `bun run check:raw-numeric-cast`: pass

Closes #1092

---

_Generated with [ax](https://github.com/Necmttn/ax)._
