### PR TITLE
fix: define capped profile spans

### DIFF
--- a/apps/axctl/src/cli/commands/profile.test.ts
+++ b/apps/axctl/src/cli/commands/profile.test.ts
@@ -74,3 +74,40 @@ describe("formatProfile guardrail receipts", () => {
         expect(out).toContain("1 no longer needed (resolved or never fired)");
     });
 });
+
+describe("formatProfile insight labels", () => {
+    test("defines capped spans and session-start peak hour", () => {
+        const out = formatProfile({
+            v: 1,
+            github: "octocat",
+            generated_at: "2026-08-26T00:00:00Z",
+            window_days: 30,
+            stats: {
+                sessions: 3,
+                active_days: 2,
+                streak_days: 1,
+                tokens: { prompt: 1, completion: 1, total: 2 },
+                models: [],
+                harnesses: ["claude"],
+            },
+            rig: { skills: [], hooks: [], routing_table: false },
+            insights: {
+                hours_total: 26,
+                longest_session_minutes: 1440,
+                deep_session_share: 0,
+                peak_hour_utc: 6,
+                busiest_day: { date: "2026-08-25", sessions: 2 },
+                max_parallel_sessions: 2,
+                subagents_spawned: 0,
+                commits: 0,
+                tools_top: [],
+            },
+        });
+
+        expect(out).toContain("26.0h capped session spans");
+        expect(out).toContain("longest capped span: 24h+");
+        expect(out).toContain("peak session-start hour: 06:00 UTC");
+        expect(out).not.toContain("26.0h total");
+        expect(out).not.toContain("peak hour:");
+    });
+});

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -217,10 +217,10 @@ export function formatProfile(p: ProfileV1): string {
         lines.push("");
         lines.push("insights:");
         lines.push(
-            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${formatLongestSession(ins.longest_session_minutes)}  ·  landed clean: ${deepPct}%`,
+            `  ${ins.hours_total.toFixed(1)}h capped session spans  ·  longest capped span: ${formatLongestSession(ins.longest_session_minutes)}  ·  landed clean: ${deepPct}%`,
         );
         lines.push(
-            `  peak hour: ${String(ins.peak_hour_utc).padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,
+            `  peak session-start hour: ${String(ins.peak_hour_utc).padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,
         );
         if (ins.tool_calls !== undefined && ins.tool_calls > 0) {
             const verifPct = ins.verification_calls !== undefined

--- a/apps/axctl/src/profile/insights.ts
+++ b/apps/axctl/src/profile/insights.ts
@@ -47,9 +47,11 @@ export interface InsightsInput {
 }
 
 export interface InsightsResult {
+    /** Sum of per-session spans, each capped at 24h - not a measure of active/working time. */
     readonly hours_total: number;
     readonly longest_session_minutes: number;
     readonly deep_session_share: number;
+    /** UTC hour with the most session STARTS in the window - not the hour with the most turns/activity. */
     readonly peak_hour_utc: number;
     readonly busiest_day: { readonly date: string; readonly sessions: number };
     readonly max_parallel_sessions: number;

--- a/apps/site/app/components/profile-dossier.test.tsx
+++ b/apps/site/app/components/profile-dossier.test.tsx
@@ -1,27 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import type { ProfileInsights } from "@ax/lib/shared/community";
-import { buildInsightCards } from "./profile-dossier";
 
-const insights: ProfileInsights = {
-    hours_total: 26,
-    longest_session_minutes: 1440,
-    deep_session_share: 0,
-    peak_hour_utc: 6,
-    busiest_day: { date: "2026-08-25", sessions: 2 },
-    max_parallel_sessions: 2,
-    subagents_spawned: 0,
-    commits: 0,
-    tools_top: [],
-};
+// Repo-root `bun test` cannot resolve this component's `~/` import chain.
+// Follow the site source-contract convention used by the adjacent dossier tests.
+const src = await Bun.file(new URL("./profile-dossier.tsx", import.meta.url)).text();
 
 describe("buildInsightCards duration labels", () => {
     test("defines capped session spans and session-start peak hour", () => {
-        const cards = buildInsightCards(insights, []);
-        const subtitle = (question: string) => cards.find((card) => card.q === question)?.s;
-
-        expect(subtitle("Longest capped span?")).toContain("capped session span");
-        expect(subtitle("Longest capped span?")).toContain("capped at 24h");
-        expect(subtitle("Peak session-start hour?")).toContain("peak session-start hour");
-        expect(subtitle("Total capped session spans?")).toBe("sum of per-session spans, each capped at 24h");
+        expect(src).toContain('q: "Longest capped span?"');
+        expect(src).toContain('s: "longest capped session span - each session is capped at 24h');
+        expect(src).toContain('q: "Peak session-start hour?"');
+        expect(src).toContain('s: "peak session-start hour - most sessions kick off around here"');
+        expect(src).toContain('q: "Total capped session spans?"');
+        expect(src).toContain('s: "sum of per-session spans, each capped at 24h"');
     });
 });

--- a/apps/site/app/components/profile-dossier.test.tsx
+++ b/apps/site/app/components/profile-dossier.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import type { ProfileInsights } from "@ax/lib/shared/community";
+import { buildInsightCards } from "./profile-dossier";
+
+const insights: ProfileInsights = {
+    hours_total: 26,
+    longest_session_minutes: 1440,
+    deep_session_share: 0,
+    peak_hour_utc: 6,
+    busiest_day: { date: "2026-08-25", sessions: 2 },
+    max_parallel_sessions: 2,
+    subagents_spawned: 0,
+    commits: 0,
+    tools_top: [],
+};
+
+describe("buildInsightCards duration labels", () => {
+    test("defines capped session spans and session-start peak hour", () => {
+        const cards = buildInsightCards(insights, []);
+        const subtitle = (question: string) => cards.find((card) => card.q === question)?.s;
+
+        expect(subtitle("Longest capped span?")).toContain("capped session span");
+        expect(subtitle("Longest capped span?")).toContain("capped at 24h");
+        expect(subtitle("Peak session-start hour?")).toContain("peak session-start hour");
+        expect(subtitle("Total capped session spans?")).toBe("sum of per-session spans, each capped at 24h");
+    });
+});

--- a/apps/site/app/components/profile-dossier.tsx
+++ b/apps/site/app/components/profile-dossier.tsx
@@ -299,7 +299,7 @@ export function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsS
                 <Vital num={fmtInt(p.stats.sessions)} label="sessions" />
                 <Vital num={fmtCompact(p.stats.tokens.total)} label="tokens" />
                 {p.stats.cost_usd !== undefined && <Vital num={`~${fmtMoney(p.stats.cost_usd)}`} label="est. spend" />}
-                {ins && <Vital num={fmtCompact(ins.hours_total)} unit="hrs" label="in the loop" />}
+                {ins && <Vital num={fmtCompact(ins.hours_total)} unit="hrs" label="capped spans" />}
                 <Vital num={`${fmtInt(p.stats.active_days)}/${fmtInt(p.window_days)}`} label="days active" />
                 <Vital num={`${fmtInt(p.stats.streak_days)}d`} label="streak" />
             </div>
@@ -1074,16 +1074,16 @@ export function buildInsightCards(
             viz: signalStrength(ins.max_parallel_sessions, 10),
         },
         {
-            q: "Longest single run?",
+            q: "Longest capped span?",
             a: fmtDuration(ins.longest_session_minutes),
-            s: "one session, end to end, without letting go",
+            s: "longest capped session span - each session is capped at 24h, so this reads 24h for any longer, possibly multi-day, run",
             // share of a 12-hour marathon, against a 6-hour "deep run" goal line
             viz: bulletCount(ins.longest_session_minutes, 12 * 60),
         },
         {
-            q: "When are you most alive?",
+            q: "Peak session-start hour?",
             a: <>{fmtHour(ins.peak_hour_utc)}<small> UTC</small></>,
-            s: "the hour the graph lights up",
+            s: "peak session-start hour - most sessions kick off around here",
             viz: cometPct(Math.max(0, ins.peak_hour_utc) / 23),
         },
         {
@@ -1112,9 +1112,9 @@ export function buildInsightCards(
                 : bulletCount(ins.commits, 100),
         },
         {
-            q: "Time in the loop?",
+            q: "Total capped session spans?",
             a: <>{fmtCompact(ins.hours_total)}<small> hrs</small></>,
-            s: "of recorded agent time on the clock",
+            s: "sum of per-session spans, each capped at 24h",
         },
     ];
 

--- a/apps/site/app/components/profile-duel.tsx
+++ b/apps/site/app/components/profile-duel.tsx
@@ -106,7 +106,7 @@ function vitalRows(a: ProfileV1, b: ProfileV1): VitalCompare[] {
     }
     if (a.insights || b.insights) {
         rows.push({
-            label: "hours in loop",
+            label: "capped span hours",
             a: a.insights ? `${fmtCompact(a.insights.hours_total)} hrs` : "-",
             b: b.insights ? `${fmtCompact(b.insights.hours_total)} hrs` : "-",
             aNum: a.insights?.hours_total ?? null,

--- a/apps/site/app/lib/radar.test.ts
+++ b/apps/site/app/lib/radar.test.ts
@@ -185,7 +185,7 @@ describe("profileToAxes - raws", () => {
         expect(a.raws.RIGOR.label).toBe("2.9% verification share");
         expect(a.raws.DELEGATION.label).toBe("0.87 subagents/session");
         expect(a.raws.BREADTH.label).toBe("84 skills · 12 repos");
-        expect(a.raws.ENDURANCE.label).toBe("2.3K hrs");
+        expect(a.raws.ENDURANCE.label).toBe("2.3K capped span hrs");
     });
 
     it("carries comparable numerics matching the axis direction", () => {

--- a/apps/site/app/lib/radar.ts
+++ b/apps/site/app/lib/radar.ts
@@ -68,7 +68,7 @@ export const RADAR_AXES_META: readonly AxisMeta[] = [
     { key: "RIGOR", label: "RIGOR", note: "verification share of tool calls" },
     { key: "DELEGATION", label: "DELEG", note: "subagents per session" },
     { key: "BREADTH", label: "BREADTH", note: "distinct skills × repos" },
-    { key: "ENDURANCE", label: "ENDURE", note: "hours in the loop" },
+    { key: "ENDURANCE", label: "ENDURE", note: "capped session-span hours" },
 ];
 
 /* ---------- compare query helpers ---------- */
@@ -250,7 +250,7 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
             [1000, 80],
             [3000, 100],
         ]);
-        enduranceRaw = { label: `${fmtCompact.format(ins.hours_total)} hrs`, value: ins.hours_total };
+        enduranceRaw = { label: `${fmtCompact.format(ins.hours_total)} capped span hrs`, value: ins.hours_total };
     } else {
         missing.push("ENDURANCE");
     }
@@ -361,7 +361,7 @@ function blurbFor(top: RadarAxisKey, second: RadarAxisKey, p: ProfileV1): string
                     ? `${fmtCompact.format(ins.distinct_skills)} distinct skills`
                     : "the width of your rig";
             case "ENDURANCE":
-                return ins ? `${fmtCompact.format(ins.hours_total)} hours in the loop` : "your hours on the clock";
+                return ins ? `${fmtCompact.format(ins.hours_total)} capped session-span hours` : "your capped session spans";
         }
     };
     return `The stars are flattered, but it's ${fact(top)} and ${fact(second)} that wrote this chart.`;


### PR DESCRIPTION
## Summary

- Label profile duration totals as capped session spans.
- Label the peak hour as the session-start hour.
- Correct the same labels in profile cards, vitals, comparisons, and radar text.
- Keep existing numeric fields and calculations unchanged.

## Verification

- Focused CLI, profile, dossier, duel, and radar tests: 69 pass
- Root typecheck: pass
- Site typecheck: pass
- `check:no-node-fs`: pass
- `check:timestamp-cast`: pass
- `check:raw-numeric-cast`: pass

Closes #1093

---

_Generated with [ax](https://github.com/Necmttn/ax)._
