### PR TITLE
fix: cap skill taste commit credit

### DIFF
--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -26,6 +26,7 @@ import {
 import { fetchSkillBloat } from "../../queries/skill-bloat.ts";
 import { fetchSkillLoaded } from "../../queries/skill-loaded.ts";
 import { fetchSkillStats } from "../../queries/skill-stats.ts";
+import { computeTasteScore, TASTE_SCORE_FORMULA, TASTE_SCORE_LEGEND } from "../../queries/skill-taste-score.ts";
 import { fetchUnusedSkills, formatLastUsed } from "../../queries/unused-skills.ts";
 import { skillsConfigSubcommands } from "../../skills/cli.ts";
 import { printNextLinks } from "../next-format.ts";
@@ -520,15 +521,16 @@ export const cmdTaste = (input: TasteInput) =>
         // (negative), corrections within 3 turns of invocation in the same
         // session (negative - user pushed back), commits produced by sessions
         // that invoked this skill (positive - led to a real change), and
-        // proposed-but-not-invoked (negative - assistant suggested it but
-        // never fired, wasted suggestion).
+        // proposal edges into the skill (negative).
         //
         // `corrections` counts invocations where the next user turn within 3
         // seq steps in the same session triggered a corrected_by edge.
-        // `commits_after` counts `produced` edges from sessions that invoked
-        // this skill (proxy for "skill use led to a commit").
+        // `commits_after` counts DISTINCT `produced` edges from sessions that
+        // invoked this skill - a same-session correlation, not "after this
+        // invocation" despite the field name (kept for compatibility).
         // `proposals` counts proposed edges into this skill.
-        // taste_score = inv_total - 2*corrections + commits_after - 0.5*proposals
+        // taste_score is an ALL-TIME composite (see TASTE_SCORE_FORMULA in
+        // queries/skill-taste-score.ts, shared with the triage dashboard).
         //
         // PERF (issue #31): The previous form ran 4-5 correlated subqueries
         // per skill (`WHERE out = $parent.id AND <pred>`), each forcing the
@@ -623,7 +625,7 @@ GROUP BY i.out_id`,
                 corrections,
                 proposals,
                 commits_after: commitsAfter,
-                taste_score: invTotal - 2 * corrections + commitsAfter - 0.5 * proposals,
+                taste_score: computeTasteScore({ total: invTotal, corrections, cmts: commitsAfter, proposals }),
             });
         }
         // Sort to mirror the original ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC.
@@ -667,6 +669,10 @@ GROUP BY i.out_id`,
             );
         }
         console.log(`\n(${rows.length} / ${totalRows} skills shown)`);
+        console.log(`\n${TASTE_SCORE_FORMULA} (all-time, not a 30-day score)`);
+        for (const l of TASTE_SCORE_LEGEND) {
+            console.log(`  ${l.key.padEnd(6)} ${l.desc}`);
+        }
     });
 
 interface PairsInput {
@@ -790,7 +796,7 @@ const tasteCommand = Command.make(
     },
     ({ limit, includeTools }) => cmdTaste({ limit, includeTools }),
 ).pipe(Command.withDescription(
-    "Rank named skills by usage, corrections, proposals, and produced commits. " +
+    "Rank named skills by an all-time composite score: " + TASTE_SCORE_FORMULA + ". " +
     "Synthetic provider tools are hidden by default; use --include-tools to rank them too.",
 ));
 

--- a/apps/axctl/src/cli/skills-family-daemonless.test.ts
+++ b/apps/axctl/src/cli/skills-family-daemonless.test.ts
@@ -86,6 +86,9 @@ describe("ax skills family - direct-call against a published cache", () => {
         expect(out).toContain("composto");
         // tdd has no invocations/proposals - issue #47's zero-score inclusion.
         expect(out).toContain("tdd");
+        expect(out).toContain("score = total - 2×corr + min(cmts, total) - 0.5×prop");
+        expect(out).toContain("clean  invocations with no tool/turn error - display only");
+        expect(out).toContain("cmts   commits correlated with a session that invoked this skill");
     }, 60_000);
 
     dtest("pairs reads skill_paired joined to skill, not Surreal", async () => {

--- a/apps/axctl/src/dashboard/triage.ts
+++ b/apps/axctl/src/dashboard/triage.ts
@@ -6,6 +6,7 @@ import { Judgment, TextColumn, TimestampColumn, type JudgmentError } from "@ax/l
 import { stableId } from "@ax/lib/stable-id";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 import { countField } from "@ax/lib/shared/row-fields";
+import { computeTasteScore } from "../queries/skill-taste-score.ts";
 import type {
     SkillRow,
     SkillTriageEntry,
@@ -80,9 +81,10 @@ const recordArrayField = (row: Record<string, unknown>, key: string): string[] =
 
 // Local DuckDB translations of queries/skill-summary.ts (chunk 2b's, not yet
 // ported - same "copy the shape, don't import" pattern used elsewhere in
-// this migration, so this module never depends on queries/ for its read
-// path). taste_score = total_inv - 2*corrections + commits_after -
-// 0.5*proposals (computed in enrichSummaryRow, unchanged).
+// this migration, so this module never depends on queries/ for its SQL read
+// path). taste_score itself is computed via the shared, all-time
+// computeTasteScore helper (queries/skill-taste-score.ts) in enrichSummaryRow
+// below - not duplicated here.
 const SKILL_SUMMARY_SQL = `
 SELECT
     sk.name AS name,
@@ -148,7 +150,7 @@ SELECT
     0 AS corrections,
     (SELECT count(*) FROM proposed p WHERE p.out_id = sk.id) AS proposals,
     0 AS commits_after,
-    -0.5 * (SELECT count(*) FROM proposed p WHERE p.out_id = sk.id) AS taste_score
+    0 AS taste_score
 FROM skill sk
 WHERE NOT EXISTS (SELECT 1 FROM invoked iv WHERE iv.out_id = sk.id)
     AND EXISTS (SELECT 1 FROM proposed p WHERE p.out_id = sk.id)
@@ -262,7 +264,7 @@ const enrichSummaryRow = (
         ...raw,
         last_project: lastProjectBySkill.get(name) ?? null,
         commits_after: commitsAfter,
-        taste_score: totalInv - 2 * corrections + commitsAfter - 0.5 * proposals,
+        taste_score: computeTasteScore({ total: totalInv, corrections, cmts: commitsAfter, proposals }),
     };
 };
 
@@ -433,8 +435,17 @@ export const fetchSkillTriage = (): Effect.Effect<
             });
         }
         for (const raw of proposedOnly) {
-            const row = coerceRow(raw);
-            if (!row.name || seen.has(row.name)) continue;
+            const coerced = coerceRow(raw);
+            if (!coerced.name || seen.has(coerced.name)) continue;
+            const row: SkillRow = {
+                ...coerced,
+                taste_score: computeTasteScore({
+                    total: coerced.total_inv,
+                    corrections: coerced.corrections,
+                    cmts: coerced.commits_after,
+                    proposals: coerced.proposals,
+                }),
+            };
             const rec = recommendForSkill(row);
             rows.push({
                 ...row,

--- a/apps/axctl/src/queries/skill-taste-score.test.ts
+++ b/apps/axctl/src/queries/skill-taste-score.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { commitCredit, computeTasteScore, TASTE_SCORE_FORMULA, TASTE_SCORE_LEGEND } from "./skill-taste-score.ts";
+
+describe("commitCredit", () => {
+    test("passes cmts through unchanged when it does not exceed total", () => {
+        expect(commitCredit(3, 10)).toBe(3);
+    });
+
+    test("caps cmts at total when cmts exceeds total", () => {
+        expect(commitCredit(50, 2)).toBe(2);
+    });
+
+    test("is zero when total is zero, regardless of cmts", () => {
+        expect(commitCredit(7, 0)).toBe(0);
+    });
+});
+
+describe("computeTasteScore", () => {
+    test("matches the documented formula for an uncapped mid-range skill", () => {
+        // score = total - 2*corr + min(cmts, total) - 0.5*prop
+        //       = 20 - 2*2 + 5 - 0.5*4 = 20 - 4 + 5 - 2 = 19
+        const score = computeTasteScore({ total: 20, corrections: 2, cmts: 5, proposals: 4 });
+        expect(score).toBe(19);
+    });
+
+    test("caps commit credit at total so a commit-heavy session cannot dominate", () => {
+        // Without the cap this would be 1 - 0 + 500 - 0 = 501.
+        // With the cap: commit_credit = min(500, 1) = 1, so score = 1 - 0 + 1 - 0 = 2.
+        const score = computeTasteScore({ total: 1, corrections: 0, cmts: 500, proposals: 0 });
+        expect(score).toBe(2);
+    });
+
+    test("corrections apply a double-weight negative term", () => {
+        const score = computeTasteScore({ total: 10, corrections: 3, cmts: 0, proposals: 0 });
+        expect(score).toBe(10 - 2 * 3);
+    });
+
+    test("proposals-only (never invoked) skill scores negative", () => {
+        const score = computeTasteScore({ total: 0, corrections: 0, cmts: 0, proposals: 6 });
+        expect(score).toBe(-3);
+    });
+
+    test("score can go negative when corrections outweigh everything else", () => {
+        const score = computeTasteScore({ total: 2, corrections: 5, cmts: 0, proposals: 2 });
+        expect(score).toBe(2 - 10 + 0 - 1);
+    });
+});
+
+describe("TASTE_SCORE_FORMULA / TASTE_SCORE_LEGEND", () => {
+    test("formula string documents the cap explicitly", () => {
+        expect(TASTE_SCORE_FORMULA).toContain("min(cmts, total)");
+    });
+
+    test("legend documents every column the formula or table uses", () => {
+        const keys = TASTE_SCORE_LEGEND.map((l) => l.key);
+        expect(keys).toEqual(["total", "clean", "corr", "prop", "cmts"]);
+    });
+
+    test("legend calls out that clean does not affect score", () => {
+        const clean = TASTE_SCORE_LEGEND.find((l) => l.key === "clean");
+        expect(clean?.desc.toLowerCase()).toContain("does not affect score");
+    });
+});

--- a/apps/axctl/src/queries/skill-taste-score.ts
+++ b/apps/axctl/src/queries/skill-taste-score.ts
@@ -1,0 +1,47 @@
+/**
+ * The `ax skills taste` composite score formula, shared by the CLI
+ * (`cli/commands/skills.ts`) and the studio triage dashboard
+ * (`dashboard/triage.ts`) so the two consumers cannot drift apart on what
+ * "score" means.
+ *
+ * The score is an ALL-TIME composite (not a 30-day metric - `inv_30d` is a
+ * separate display column, never a formula input) and `clean` (error-free
+ * invocations) does not feed into it at all. See TASTE_SCORE_LEGEND for what
+ * every column means.
+ *
+ * `cmts` is commit correlation, not comments and not "commits after
+ * invocation": it is the count of DISTINCT `produced` (commit) edges from
+ * every session that invoked this skill, with no ordering constraint between
+ * the invocation and the commit within that session. A single commit-heavy
+ * session can push `cmts` far past a skill's own `total`, so the formula caps
+ * its contribution at `total` (commit_credit = min(cmts, total)) - otherwise
+ * one prolific session could dominate the score for a skill invoked once.
+ * The raw, uncapped `cmts` stays visible as its own column.
+ */
+
+export interface TasteScoreInputs {
+    /** all-time invocations of the skill */
+    readonly total: number;
+    /** invocations followed by a same-session correction within 3 turns */
+    readonly corrections: number;
+    /** raw correlated-commit count (see module doc) - NOT capped */
+    readonly cmts: number;
+    /** proposal edges into this skill */
+    readonly proposals: number;
+}
+
+export const TASTE_SCORE_FORMULA = "score = total - 2×corr + min(cmts, total) - 0.5×prop";
+
+export const TASTE_SCORE_LEGEND: ReadonlyArray<{ readonly key: string; readonly desc: string }> = [
+    { key: "total", desc: "all-time invocations (formula input)" },
+    { key: "clean", desc: "invocations with no tool/turn error - display only, does not affect score" },
+    { key: "corr", desc: "invocations followed by a same-session correction within 3 turns (formula input, x2 weight)" },
+    { key: "prop", desc: "proposal edges into this skill (formula input, x0.5 weight)" },
+    { key: "cmts", desc: "commits correlated with a session that invoked this skill, not necessarily after invocation - raw value shown, capped at total in the formula (commit_credit = min(cmts, total))" },
+];
+
+/** commit_credit = min(cmts, total) - the capped contribution `cmts` makes to the score. */
+export const commitCredit = (cmts: number, total: number): number => Math.min(cmts, total);
+
+export const computeTasteScore = (inputs: TasteScoreInputs): number =>
+    inputs.total - 2 * inputs.corrections + commitCredit(inputs.cmts, inputs.total) - 0.5 * inputs.proposals;

--- a/apps/axctl/src/tui/hooks/useSkills.ts
+++ b/apps/axctl/src/tui/hooks/useSkills.ts
@@ -3,11 +3,14 @@ import { Effect } from "effect";
 import { flushSync } from "@opentui/react";
 import { daysAgoExpr } from "@ax/lib/duckdb/clause";
 import type { CacheReadService } from "@ax/lib/duckdb/seam";
+import { computeTasteScore } from "../../queries/skill-taste-score.ts";
 
 // Local copy of dashboard/triage.ts's fetchSkillTriage SKILL_SUMMARY_SQL -
 // the TUI hot path and the web dashboard's triage view compute the same
-// skill-summary shape, but each surface carries its own local copy rather
-// than cross-importing between dashboard/ and tui/.
+// skill-summary shape, but each surface carries its own local copy of the SQL
+// rather than cross-importing between dashboard/ and tui/. The taste_score
+// formula itself (a pure, dependency-free helper) is NOT duplicated - both
+// surfaces, plus the CLI, share queries/skill-taste-score.ts.
 
 const SKILL_SUMMARY_SQL = `
 SELECT
@@ -266,7 +269,7 @@ const enrichSkillRow = (
     const proposals = Number(row.proposals ?? 0);
     return {
         ...row,
-        taste_score: totalInv - 2 * corrections + commitsAfter - 0.5 * proposals,
+        taste_score: computeTasteScore({ total: totalInv, corrections, cmts: commitsAfter, proposals }),
         // Preserve the extra field for callers that already tolerate it,
         // without adding it to the public SkillRow interface.
         last_project: lastProjectBySkill.get(row.name) ?? null,

--- a/docs/language.md
+++ b/docs/language.md
@@ -132,8 +132,12 @@ The outcome locked at a checkpoint. Five values:
 
 ### ax-score
 
-The composite taste metric for skills, computed across recency,
-frequency, and clean-run rate. Exposed by `axctl skills taste`.
+The composite taste metric for skills: an ALL-TIME score (not a 30-day
+or recency-weighted metric) computed from invocations, same-session
+corrections, correlated commits, and proposal-edge counts.
+Clean-run rate does not affect the score. Exact formula and column
+legend are printed by `axctl skills taste`
+(`apps/axctl/src/queries/skill-taste-score.ts`).
 
 ### ax-signal
 


### PR DESCRIPTION
## Summary

- cap commit credit at total invocations
- print the score formula and every column meaning
- share one score helper across CLI, dashboard, and TUI

## Verification

- 33 focused tests pass
- root typecheck passes
- all three static checks pass

Fixes #1096

---

_Generated with [ax](https://github.com/Necmttn/ax)._

