### PR TITLE
fix: suppress installed hook proposals

### DIFF
--- a/apps/axctl/src/hooks/config.ts
+++ b/apps/axctl/src/hooks/config.ts
@@ -49,6 +49,8 @@ export interface ReadOptions {
     readonly repoRoot?: string | null | undefined;
 }
 
+export type ConfiguredReadOptions = Omit<ReadOptions, "withEvidence">;
+
 const resolveRepoRoot = (
     override: string | null | undefined,
 ): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
@@ -99,17 +101,13 @@ const writeParked = (
 ): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> =>
     writeFileAtomic(parkedPath(file), `${JSON.stringify(entries, null, 2)}\n`);
 
-/**
- * Read every declared hook across the selected providers/scopes/files.
- * When `withEvidence` is set, joins fired counts from `queryHookSummary`
- * (matched by exact command string).
- */
-export const readAllHooks = (
-    opts: ReadOptions = {},
+/** Read configured hooks only. This seam has no cache dependency. */
+export const readConfiguredHooks = (
+    opts: ConfiguredReadOptions = {},
 ): Effect.Effect<
-    ReadonlyArray<ConfiguredHookWithEvidence>,
+    ReadonlyArray<ConfiguredHook>,
     PlatformError | HookConfigParseError | HookConfigSchemaError,
-    HookProviderRegistry | FileSystem.FileSystem | Path.Path | CacheRead
+    HookProviderRegistry | FileSystem.FileSystem | Path.Path
 > =>
     Effect.gen(function* () {
         const registry = yield* HookProviderRegistry;
@@ -142,7 +140,20 @@ export const readAllHooks = (
             ? collected.filter((h) => h.event === opts.eventFilter)
             : collected;
 
-        if (!opts.withEvidence) return filtered;
+        return filtered;
+    });
+
+/** Read configured hooks and optionally join cache-derived fire evidence. */
+export const readAllHooks = (
+    opts: ReadOptions = {},
+): Effect.Effect<
+    ReadonlyArray<ConfiguredHookWithEvidence>,
+    PlatformError | HookConfigParseError | HookConfigSchemaError,
+    HookProviderRegistry | FileSystem.FileSystem | Path.Path | CacheRead
+> =>
+    Effect.gen(function* () {
+        const configured = yield* readConfiguredHooks(opts);
+        if (!opts.withEvidence) return configured;
 
         const summary = yield* queryHookSummary({ tail: 1000 });
         const firedByCommand = new Map<string, { count: number; lastSeen?: Date | string | undefined }>();
@@ -153,7 +164,7 @@ export const readAllHooks = (
                 lastSeen: row.last_seen ?? prev?.lastSeen,
             });
         }
-        return filtered.map((h) => {
+        return configured.map((h) => {
             const ev = firedByCommand.get(h.command);
             return ev ? { ...h, fired: ev.count, lastSeen: ev.lastSeen } : { ...h, fired: 0 };
         });

--- a/apps/axctl/src/hooks/hooks-config.test.ts
+++ b/apps/axctl/src/hooks/hooks-config.test.ts
@@ -13,6 +13,7 @@ import { HookProviderRegistry, HookProviderRegistryDefault, HookProviderRegistry
 import { deriveHookId, deriveOwner, axMarkerId, embedMarker } from "./providers/ownership.ts";
 import {
     readAllHooks,
+    readConfiguredHooks,
     addHook,
     removeHook,
     editHook,
@@ -343,6 +344,28 @@ describe("config orchestration", () => {
         expect(withEv[0]!.fired).toBe(7);
         void file;
         void program;
+    });
+
+    test("readConfiguredHooks needs no CacheRead service", async () => {
+        const root = mk();
+        const layer = Layer.mergeAll(fsLayers, HookProviderRegistryDefault);
+        const rows = await Effect.runPromise(
+            addHook({
+                provider: "claude",
+                scope: "project",
+                repoRoot: root,
+                input: { event: "PreToolUse", matcher: "Agent", command: "bun /x/route-dispatch.js" },
+            }).pipe(
+                Effect.flatMap(() => readConfiguredHooks({
+                    providerFilter: "claude",
+                    scopeFilter: "project",
+                    repoRoot: root,
+                })),
+                Effect.provide(layer),
+            ),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ event: "PreToolUse", matcher: "Agent", enabled: true });
     });
 
     test("add then remove leaves the file with no hooks", async () => {

--- a/apps/axctl/src/hooks/installed-guards.test.ts
+++ b/apps/axctl/src/hooks/installed-guards.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { hasActiveClaudeRouteDispatch } from "./installed-guards.ts";
+import type { ConfiguredHook } from "./providers/types.ts";
+
+const hook = (overrides: Partial<ConfiguredHook> = {}): ConfiguredHook => ({
+    id: "hook-1",
+    provider: "claude",
+    scope: "global",
+    file: "/home/me/.claude/settings.json",
+    event: "PreToolUse",
+    matcher: "Agent",
+    command: "bun /home/me/.ax/hooks/route-dispatch.js # ax:abc123",
+    enabled: true,
+    owner: "ax",
+    ...overrides,
+});
+
+describe("hasActiveClaudeRouteDispatch", () => {
+    test.each([
+        "bun /home/me/.ax/hooks/route-dispatch.js # ax:a",
+        "bun /home/me/.ax/hooks/dispatch.ts # ax:b",
+        "bun /home/me/.ax/hooks/dispatch-shim.js # ax:c",
+    ])("recognizes direct, dispatcher, and dispatcher-shim registrations", (command) => {
+        expect(hasActiveClaudeRouteDispatch([hook({ command })])).toBe(true);
+    });
+
+    test("recognizes Agent as one exact tool in a dispatcher matcher", () => {
+        expect(hasActiveClaudeRouteDispatch([hook({ matcher: "Edit|Agent|Write", command: "bun /x/dispatch.js" })])).toBe(true);
+        expect(hasActiveClaudeRouteDispatch([hook({ matcher: "Subagent", command: "bun /x/dispatch.js" })])).toBe(false);
+    });
+
+    test("does not use parked, non-Claude, wrong-event, or unrelated registrations", () => {
+        expect(hasActiveClaudeRouteDispatch([hook({ enabled: false })])).toBe(false);
+        expect(hasActiveClaudeRouteDispatch([hook({ provider: "codex" })])).toBe(false);
+        expect(hasActiveClaudeRouteDispatch([hook({ event: "PostToolUse" })])).toBe(false);
+        expect(hasActiveClaudeRouteDispatch([hook({ command: "bun /x/enforce-worktree.js" })])).toBe(false);
+    });
+});

--- a/apps/axctl/src/hooks/installed-guards.ts
+++ b/apps/axctl/src/hooks/installed-guards.ts
@@ -1,0 +1,19 @@
+import type { ConfiguredHook } from "./providers/types.ts";
+
+const ROUTE_DISPATCH_COMMAND = /(?:^|[/\\])(?:route-dispatch|dispatch|dispatch-shim)\.(?:[cm]?[jt]s)(?:["']|\s|$)/;
+const stripAxMarker = (command: string): string =>
+    command.replace(/\s*#\s*ax:[a-z0-9_-]+\s*$/, "");
+
+const matcherIncludesAgent = (matcher: string | null): boolean =>
+    matcher !== null && matcher.split("|").some((tool) => tool.trim() === "Agent");
+
+/** True when live Claude configuration runs route-dispatch for PreToolUse:Agent. */
+export const hasActiveClaudeRouteDispatch = (
+    hooks: ReadonlyArray<ConfiguredHook>,
+): boolean => hooks.some((hook) =>
+    hook.enabled &&
+    hook.provider === "claude" &&
+    hook.event === "PreToolUse" &&
+    matcherIncludesAgent(hook.matcher) &&
+    ROUTE_DISPATCH_COMMAND.test(stripAxMarker(hook.command)),
+);

--- a/apps/axctl/src/ingest/derive-proposals.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.test.ts
@@ -27,7 +27,10 @@ import {
     normalizeTitle,
     parseMetrics,
     migrateProposalDedupeSigs,
+    ROUTING_PROPOSAL_INSTALLED_REASON,
+    ROUTING_PROPOSAL_SIG,
     skillProposalFrequency,
+    supersedeInstalledRoutingProposal,
 } from "./derive-proposals.ts";
 import type { HarnessLearningCandidate } from "../project/types.ts";
 import type { ImageContextResult } from "../queries/image-context.ts";
@@ -499,6 +502,57 @@ describe("buildRoutingProposalWrites", () => {
     test("statement contains form hook and frequency", () => {
         const writes = buildRoutingProposalWrites(baseRoutingRow, new Set());
         expect(writes[0]!.row).toMatchObject({ form: "hook", frequency: baseRoutingRow.frequency });
+    });
+
+    test("writes an acceptable hook payload with every safety gate", () => {
+        const payload = buildRoutingProposalWrites(baseRoutingRow, new Set())
+            .find((write) => write.table === "hook_proposal");
+        expect(payload?.row).toMatchObject({
+            event_name: "PreToolUse",
+            target_tool: "Agent",
+            hook_command: "bun ~/.ax/hooks/route-dispatch.ts",
+            disable_command: "AX_ROUTE_DISPATCH=off",
+            failure_mode: "fail_open",
+        });
+        expect(payload?.row.recovery_path).toBeTruthy();
+        expect(payload?.row.smoke_test_command).toBeTruthy();
+    });
+});
+
+describe("installed route-dispatch proposal cleanup", () => {
+    test("supersedes only the matching open proposal with a machine reason", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-routing-proposal-"));
+        try {
+            const rows = await Effect.runPromise(Effect.gen(function* () {
+                const judgment = yield* Judgment;
+                yield* judgment.put("proposal", {
+                    id: "routing-open", form: "hook", title: "routing", hypothesis: "test",
+                    dedupe_sig: ROUTING_PROPOSAL_SIG, confidence: "high", status: "open",
+                });
+                yield* judgment.put("proposal", {
+                    id: "other-open", form: "hook", title: "other", hypothesis: "test",
+                    dedupe_sig: "hook__other", confidence: "low", status: "open",
+                });
+                expect(yield* supersedeInstalledRoutingProposal(judgment)).toBe(1);
+                return yield* judgment.rows(Schema.Struct({
+                    id: Schema.String,
+                    status: Schema.String,
+                    reject_reason: Schema.NullOr(Schema.String),
+                }), "SELECT id, status, reject_reason FROM proposal ORDER BY id");
+            }).pipe(
+                Effect.scoped,
+                Effect.provide(JudgmentLayer({
+                    sidecarPath: join(dir, "judgment.sqlite"),
+                    schemaSql: SIDECAR_SCHEMA_SQL,
+                })),
+            ));
+            expect(rows).toEqual([
+                { id: "other-open", status: "open", reject_reason: null },
+                { id: "routing-open", status: "superseded", reject_reason: ROUTING_PROPOSAL_INSTALLED_REASON },
+            ]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
     });
 });
 

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -42,6 +42,10 @@ import { fetchImageContext, type ImageContextResult } from "../queries/image-con
 import { fetchCacheLensCandidates, relativeCostDelta, type CacheLensCandidateRow } from "../queries/cache-bust.ts";
 import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveCandidate, type DirectiveTurnRow } from "./directives.ts";
 import { fetchWorkflowArcs, type ArcCandidate } from "../queries/workflow-sequences.ts";
+import { readConfiguredHooks } from "../hooks/config.ts";
+import { hasActiveClaudeRouteDispatch } from "../hooks/installed-guards.ts";
+import { HookProviderRegistryDefault } from "../hooks/providers/registry.ts";
+import type { ConfiguredHook } from "../hooks/providers/types.ts";
 
 export interface DeriveProposalsStats {
     readonly skillProposals: number;
@@ -315,6 +319,9 @@ export interface RoutingProposalRow {
     readonly sig: string;
 }
 
+export const ROUTING_PROPOSAL_TITLE = "Route mechanical subagent dispatches to cheaper models";
+export const ROUTING_PROPOSAL_INSTALLED_REASON = "route_dispatch_already_installed";
+
 /**
  * Derive a single routing-form proposal row from dispatch candidate analytics.
  *
@@ -333,7 +340,7 @@ export const deriveRoutingProposalRow = (input: {
 }): RoutingProposalRow | null => {
     if (input.candidateCount < 5 || input.totalEstSavingsUsd < 5) return null;
 
-    const title = "Route mechanical subagent dispatches to cheaper models";
+    const title = ROUTING_PROPOSAL_TITLE;
     const normTitle = normalizeTitle(title);
     const sig = dedupeSig("hook", normTitle);
 
@@ -366,12 +373,26 @@ export const deriveRoutingProposalRow = (input: {
 /**
  * Build cache write rows for a routing proposal. Mirrors
  * buildGuidanceProposalWrites: insert on first sight, update mutable
- * fields on re-derive. No typed payload table (hook form is self-contained).
+ * fields on re-derive. The typed payload carries all four safety gates, so
+ * `ax improve accept` can emit the existing manual task brief.
  */
 export const buildRoutingProposalWrites = (
     row: RoutingProposalRow,
     existingSigs: ReadonlySet<string> = new Set(),
-): ProposalWrite[] => [proposalWrite(row, "hook", { frequency: row.frequency }, existingSigs.has(row.sig))];
+): ProposalWrite[] => [
+    proposalWrite(row, "hook", { frequency: row.frequency }, existingSigs.has(row.sig)),
+    { store: "judgment", table: "hook_proposal", row: judgmentRow({
+        id: row.proposalKey,
+        proposal: row.proposalKey,
+        event_name: "PreToolUse",
+        target_tool: "Agent",
+        hook_command: "bun ~/.ax/hooks/route-dispatch.ts",
+        recovery_path: "Remove the route-dispatch hook registration from Claude settings.",
+        smoke_test_command: "ax hooks backtest ~/.ax/hooks/route-dispatch.ts --days=7",
+        disable_command: "AX_ROUTE_DISPATCH=off",
+        failure_mode: "fail_open",
+    }) },
+];
 
 // ---------------------------------------------------------------------------
 // Image context proposal (form='subagent') - isolate heavy visual context signal
@@ -683,6 +704,16 @@ const sha256Prefix = (value: string, length = 16): string => {
 
 export const dedupeSig = (form: string, normalizedTitle: string): string =>
     `${form}__${sha256Prefix(`${form}:${normalizedTitle}`)}`;
+
+export const ROUTING_PROPOSAL_SIG = dedupeSig("hook", normalizeTitle(ROUTING_PROPOSAL_TITLE));
+
+export const supersedeInstalledRoutingProposal = (
+    judgment: JudgmentService,
+): Effect.Effect<number, JudgmentError> =>
+    judgment.exec(
+        "UPDATE proposal SET status = 'superseded', reject_reason = ?, updated_at = ? WHERE dedupe_sig = ? AND status = 'open'",
+        [ROUTING_PROPOSAL_INSTALLED_REASON, new Date(), ROUTING_PROPOSAL_SIG],
+    );
 
 interface ProposalDedupeMigrationRow {
     readonly id: string;
@@ -1027,16 +1058,27 @@ FROM skill_candidate`),
         // nothing into the wrong store for a whole chunk without anyone noticing.
         // Any failure below fails the stage, loudly.
 
-        // Routing proposal (form='hook'): derive from dispatch candidate analytics.
+        // Routing proposal (form='hook'): installed CONFIGURATION is the source
+        // of truth. Silent Allow verdicts do not create hook-fire evidence.
         const sinceDays = opts.sinceDays ?? 14;
         const dispatchResult = yield* fetchDispatchCandidates(write, { sinceDays });
+        // Installed-state suppression is an optional local-config observation.
+        // A missing, unreadable, or invalid settings file must not stop ingest.
+        const configuredHooks = yield* readConfiguredHooks({ providerFilter: "claude" }).pipe(
+            Effect.provide(HookProviderRegistryDefault),
+            Effect.orElseSucceed((): ReadonlyArray<ConfiguredHook> => []),
+        );
+        const routingInstalled = hasActiveClaudeRouteDispatch(configuredHooks);
+        if (routingInstalled) {
+            yield* supersedeInstalledRoutingProposal(judgment);
+        }
         const routingRow = deriveRoutingProposalRow({
             candidateCount: dispatchResult.candidates.length,
             totalEstSavingsUsd: dispatchResult.total_est_savings_usd,
             sinceDays,
             topClasses: dispatchResult.top_classes,
         });
-        const routingWrites = routingRow
+        const routingWrites = routingRow && !routingInstalled
             ? buildRoutingProposalWrites(routingRow, existingSigs)
             : [];
 
@@ -1151,7 +1193,7 @@ WHERE p.form = 'guidance' AND g.section = ? AND p.status = 'open'`,
         return {
             skillProposals: skillRows.length,
             guidanceProposals: guidanceRows.length,
-            routingProposals: routingRow ? 1 : 0,
+            routingProposals: routingRow && !routingInstalled ? 1 : 0,
             imageContextProposals: imageContextRow ? 1 : 0,
             directiveProposals: directiveRows.length,
             workflowProposals: workflowRows.length,

--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -37,6 +37,13 @@ beforeEach(() => {
 });
 afterEach(() => {
   delete process.env.AX_SPEND_MODE;
+  delete process.env.AX_ROUTE_DISPATCH;
+});
+
+test("AX_ROUTE_DISPATCH=off disables the guard", async () => {
+  process.env.AX_ROUTE_DISPATCH = "off";
+  const v = await run({ description: "locate all usages" });
+  expect(v._tag).toBe("Allow");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -19,6 +19,8 @@
  * Mode is determined by AX_SPEND_MODE env override (conserve|splurge), else
  * by computeSpendMode reading the quota cache. Stale/missing cache → conserve
  * (fail-safe).
+ * Set `AX_ROUTE_DISPATCH=off` to disable this guard without removing its
+ * registration. The guard then returns Allow before it reads routing state.
  *
  * The routing-table schema, built-in defaults, and the fail-open read live in
  * ../routing-table.ts (ADR-0014) - the same module `ax routing compile|tune`
@@ -70,6 +72,8 @@ const hook = defineHook({
   // (R = never is assignable to the HookDefinition's R = GitEnv.)
   run: (event) =>
     Effect.sync(() => {
+      if (readEnv(event, "AX_ROUTE_DISPATCH") === "off") return { _tag: "Allow" } as const;
+
       const input = (event.tool?.input ?? {}) as Record<string, unknown>;
       const modelRaw = input.model;
       const explicit = typeof modelRaw === "string" && modelRaw.length > 0;

--- a/packages/hooks-sdk/src/shim-core.ts
+++ b/packages/hooks-sdk/src/shim-core.ts
@@ -29,6 +29,7 @@
  *  shim runs in the AGENT's process, so it forwards these into the payload. */
 export const FORWARDED_ENV_KEYS = [
     "ALLOW_MAIN_WRITE",
+    "AX_ROUTE_DISPATCH",
     "ALLOW_BRANCH_CHECKOUT",
     "ALLOW_DIRTY_MAIN_MUTATION",
     "AX_SPEND_MODE",


### PR DESCRIPTION
## Summary

- give mined hook proposals all four required safety gates
- suppress route-dispatch proposals from active Claude hook configuration
- supersede an existing open duplicate with a stable machine reason
- add AX_ROUTE_DISPATCH=off as a guard-level disable switch

## Verification

- 6,641 repository tests pass
- 170 focused tests pass after rebase
- root typecheck passes
- all three static checks pass

Fixes #1098

---

_Generated with [ax](https://github.com/Necmttn/ax)._

