### PR TITLE
test: cover ingest deadline wiring

### DIFF
--- a/apps/axctl/src/cli/commands/ingest-deadline-wiring.test.ts
+++ b/apps/axctl/src/cli/commands/ingest-deadline-wiring.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { withIngestLock } from "@ax/lib/ingest-lock";
+import { TraceSink } from "@ax/lib/live-traces/Sink";
+import { ProcessServiceLive } from "@ax/lib/process";
+import { Effect, Exit, Layer } from "effect";
+import { FIRST_RUN_INGEST_TIMEOUT_SECONDS } from "../../ingest/deadline.ts";
+import { runIngest, type RunIngestOptions } from "../../ingest/run.ts";
+import { StageRegistryLive } from "../../ingest/stage/registry.ts";
+import {
+    cmdIngest,
+    resolveIngestCommandTiming,
+    type IngestCommandDeps,
+} from "./ingest.ts";
+
+const NOW_MS = Date.parse("2026-08-26T00:00:00Z");
+
+const restoreEnv = (name: string, value: string | undefined): void => {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+};
+
+describe("ingest command deadline wiring", () => {
+    test("one timing decision supplies both the derive deadline and lock timeout", () => {
+        const firstRun = resolveIngestCommandTiming({
+            configuredSeconds: 900,
+            knobExplicitlySet: false,
+            firstRun: true,
+            nowMs: NOW_MS,
+        });
+        expect(firstRun.lockOptions.timeoutSeconds).toBe(FIRST_RUN_INGEST_TIMEOUT_SECONDS);
+        expect(firstRun.runOptions.deadlineMs).toBe(
+            NOW_MS + firstRun.lockOptions.timeoutSeconds * 1000,
+        );
+
+        const explicit = resolveIngestCommandTiming({
+            configuredSeconds: 37,
+            knobExplicitlySet: true,
+            firstRun: true,
+            nowMs: NOW_MS,
+        });
+        expect(explicit.lockOptions.timeoutSeconds).toBe(37);
+        expect(explicit.runOptions.deadlineMs).toBe(NOW_MS + 37_000);
+    });
+
+    test("the real cmdIngest boundary forwards first-run and explicit deadlines", async () => {
+        const previousSnapshot = process.env.AX_DUCKDB_SNAPSHOT;
+        const previousTimeout = process.env.AX_INGEST_TIMEOUT_SECONDS;
+        const dirs: string[] = [];
+
+        const capture = async (
+            configuredSeconds: number,
+            explicitTimeout: string | undefined,
+        ): Promise<{
+            readonly runOptions: RunIngestOptions;
+            readonly lockTimeoutSeconds: number | undefined;
+        }> => {
+            const dataDir = mkdtempSync(join(tmpdir(), "ax-ingest-deadline-wiring-"));
+            dirs.push(dataDir);
+            process.env.AX_DUCKDB_SNAPSHOT = join(dataDir, "missing-snapshot.duckdb");
+            if (explicitTimeout === undefined) delete process.env.AX_INGEST_TIMEOUT_SECONDS;
+            else process.env.AX_INGEST_TIMEOUT_SECONDS = explicitTimeout;
+
+            const observed: RunIngestOptions[] = [];
+            const fakeRunIngest: typeof runIngest = (options) => {
+                observed.push(options);
+                return Effect.die(new Error("stop after deadline capture"));
+            };
+            let lockTimeoutSeconds: number | undefined;
+            const captureLock: typeof withIngestLock = (options, work) => {
+                lockTimeoutSeconds = options.timeoutSeconds;
+                return withIngestLock(options, work);
+            };
+            const deps: IngestCommandDeps = {
+                nowMs: () => NOW_MS,
+                runIngest: fakeRunIngest,
+                withIngestLock: captureLock,
+            };
+            const platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+            const layer = Layer.mergeAll(
+                platform,
+                ProcessServiceLive,
+                StageRegistryLive([]),
+                Layer.mock(TraceSink, { emit: () => undefined }),
+                AxConfigTest({
+                    paths: { dataDir },
+                    knobs: { ingestTimeoutSeconds: configuredSeconds },
+                }).pipe(Layer.provide(platform)),
+            );
+
+            const exit = await Effect.runPromiseExit(
+                cmdIngest([], {}, deps).pipe(Effect.provide(layer)),
+            );
+            expect(Exit.isFailure(exit)).toBe(true);
+            expect(observed).toHaveLength(1);
+            return { runOptions: observed[0]!, lockTimeoutSeconds };
+        };
+
+        try {
+            const firstRun = await capture(900, undefined);
+            expect(firstRun.runOptions.deadlineMs).toBe(
+                NOW_MS + FIRST_RUN_INGEST_TIMEOUT_SECONDS * 1000,
+            );
+            expect(firstRun.lockTimeoutSeconds).toBe(FIRST_RUN_INGEST_TIMEOUT_SECONDS);
+
+            const explicit = await capture(37, "37");
+            expect(explicit.runOptions.deadlineMs).toBe(NOW_MS + 37_000);
+            expect(explicit.lockTimeoutSeconds).toBe(37);
+        } finally {
+            restoreEnv("AX_DUCKDB_SNAPSHOT", previousSnapshot);
+            restoreEnv("AX_INGEST_TIMEOUT_SECONDS", previousTimeout);
+            for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -12,8 +12,17 @@ import { posixPath } from "@ax/lib/shared/path";
 import { DUCKDB_SCHEMA_SQL } from "@ax/schema/duckdb-ddl";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { duckdbAssetPathOption } from "../../duckdb-embed-wiring.ts";
-import { runIngest, withIngestRunFinish, type RunIngestResult } from "../../ingest/run.ts";
-import { resolveIngestDeadlineSeconds } from "../../ingest/deadline.ts";
+import {
+    runIngest,
+    withIngestRunFinish,
+    type RunIngestOptions,
+    type RunIngestResult,
+} from "../../ingest/run.ts";
+import {
+    resolveIngestDeadlineSeconds,
+    type IngestDeadlineDecision,
+    type IngestDeadlineInput,
+} from "../../ingest/deadline.ts";
 import { snapshotPath } from "@ax/lib/duckdb/client";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
 import { cmdIngestRepairIndexes, formatIndexRepairResult } from "../../ingest/repair-indexes.ts";
@@ -181,6 +190,45 @@ interface IngestCommandOpts {
     readonly claudeProject?: string;
 }
 
+/** One resolved clock value, projected to both consumers that must agree.
+ * Keeping the two option fragments together prevents the derive deadline and
+ * outer lock timeout from drifting apart. */
+export interface IngestCommandTiming {
+    readonly decision: IngestDeadlineDecision;
+    readonly runOptions: Pick<RunIngestOptions, "deadlineMs">;
+    readonly lockOptions: { readonly timeoutSeconds: number };
+}
+
+/** Resolve the CLI deadline once, then prepare the exact option fragments sent
+ * to `runIngest` and `withIngestLock`. Exported for boundary tests. */
+export const resolveIngestCommandTiming = (
+    input: IngestDeadlineInput & { readonly nowMs: number },
+): IngestCommandTiming => {
+    const decision = resolveIngestDeadlineSeconds(input);
+    return {
+        decision,
+        runOptions: decision.seconds > 0
+            ? { deadlineMs: input.nowMs + decision.seconds * 1000 }
+            : {},
+        lockOptions: { timeoutSeconds: decision.seconds },
+    };
+};
+
+/** Narrow command dependency seam. Production uses the real ingest runner;
+ * tests substitute only this expensive boundary while retaining the real
+ * command, filesystem probe, deadline resolution, and lock orchestration. */
+export interface IngestCommandDeps {
+    readonly nowMs: () => number;
+    readonly runIngest: typeof runIngest;
+    readonly withIngestLock: typeof withIngestLock;
+}
+
+const liveIngestCommandDeps: IngestCommandDeps = {
+    nowMs: Date.now,
+    runIngest,
+    withIngestLock,
+};
+
 /**
  * Blob GC deletes any bucket blob no `session` row references. That is only
  * safe when the run built a COMPLETE reference set - i.e. a truly GLOBAL
@@ -324,7 +372,11 @@ const runMaintenanceHalf = <A, E, R>(
 // Exported for `ax segment import` (#902): after loading a segment it triggers
 // the wide-window re-derive through this exact path, so the lock, deadline,
 // verdicts, and maintenance summary behave like any other ingest.
-export const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
+export const cmdIngest = (
+    args: string[],
+    opts: IngestCommandOpts = {},
+    deps: IngestCommandDeps = liveIngestCommandDeps,
+) =>
     Effect.gen(function* () {
         const commandName = opts.command ?? "ingest";
         const cfg = yield* AxConfig;
@@ -335,15 +387,16 @@ export const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // every first ingest used to fail (#830). "First run" = no published
         // snapshot yet; `fs.exists` is fail-open to false, so a filesystem
         // hiccup degrades to today's behaviour rather than granting hours.
-        const deadline = resolveIngestDeadlineSeconds({
+        const timing = resolveIngestCommandTiming({
             configuredSeconds: cfg.knobs.ingestTimeoutSeconds,
             knobExplicitlySet: (process.env.AX_INGEST_TIMEOUT_SECONDS ?? "").trim().length > 0,
             firstRun: !(yield* (yield* FileSystem.FileSystem)
                 .exists(snapshotPath())
                 .pipe(Effect.orElseSucceed(() => true))),
+            nowMs: deps.nowMs(),
         });
-        const timeoutSeconds = deadline.seconds;
-        if (deadline.upgraded) yield* Effect.logInfo(`ingest: ${deadline.reason}`);
+        const timeoutSeconds = timing.lockOptions.timeoutSeconds;
+        if (timing.decision.upgraded) yield* Effect.logInfo(`ingest: ${timing.decision.reason}`);
         // The runId is minted HERE (not inside runIngest) so the timeout and
         // failure paths below can address the `ingest_run` row.
         const runId = runIdFor(commandName);
@@ -377,7 +430,7 @@ export const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // for why these must not publish a snapshot.
         const cacheWriteOptions = maintenanceCacheWriteOptions(cfg.paths.dataDir, lockPath);
 
-        const work = runIngest({
+        const work = deps.runIngest({
             command: commandName,
             args,
             cwd: opts.cwd ?? process.cwd(),
@@ -392,7 +445,7 @@ export const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             // Computed from the same `timeoutSeconds` knob the lock uses; the
             // lock's own clock starts a hair after this, so the deadline reads
             // slightly early - the derive reserve absorbs that.
-            ...(timeoutSeconds > 0 ? { deadlineMs: Date.now() + timeoutSeconds * 1000 } : {}),
+            ...timing.runOptions,
         });
 
         // Best-effort maintenance, still under the lock, but NOT subject to
@@ -454,10 +507,10 @@ export const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // lock to age into a cooldown - interrupting the fiber doesn't prove
         // DuckDB stopped work, so the next ingest must hold off until
         // the lock goes stale rather than charging a still-busy DB.
-        const outcome = yield* withIngestLock(
+        const outcome = yield* deps.withIngestLock(
             {
                 ...ingestLockOptions(path, cfg.paths.dataDir, commandName, timeoutSeconds),
-                timeoutSeconds,
+                ...timing.lockOptions,
                 onBusy: (holder) =>
                     Effect.sync(() =>
                         process.stderr.write(


### PR DESCRIPTION
## Summary

- resolve the CLI deadline once
- send the same timeout to runIngest and withIngestLock
- test first-run expansion and explicit timeout wiring through cmdIngest

## Verification

- bun test: 6,659 pass, 13 skip, 0 fail
- bun run typecheck
- bun run check:no-node-fs
- bun run check:timestamp-cast
- bun run check:raw-numeric-cast

Fixes #723

---

_Generated with [ax](https://github.com/Necmttn/ax)._
