### PR TITLE
fix: share derive deadline across pending stages

### DIFF
--- a/apps/axctl/src/ingest/stage/derive-budget.test.ts
+++ b/apps/axctl/src/ingest/stage/derive-budget.test.ts
@@ -23,6 +23,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: now + 900_000,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         })).toEqual({ _tag: "capped", capMs: 300_000 });
     });
 
@@ -33,6 +34,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: now + 100_000,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         })).toEqual({ _tag: "capped", capMs: 70_000 });
     });
 
@@ -42,6 +44,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: now + 30_000,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         });
         expect(budget._tag).toBe("skip");
     });
@@ -52,6 +55,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: now - 1,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         })._tag).toBe("skip");
     });
 
@@ -61,6 +65,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: null,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         })).toEqual({ _tag: "capped", capMs: 300_000 });
     });
 
@@ -70,6 +75,7 @@ describe("deriveStageBudget", () => {
             deadlineMs: null,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
         })).toEqual({ _tag: "uncapped" });
     });
 
@@ -79,6 +85,62 @@ describe("deriveStageBudget", () => {
             deadlineMs: now + 100_000,
             nowMs: now,
             reserveMs: 30_000,
+            remainingDeriveStages: 1,
+        })).toEqual({ _tag: "capped", capMs: 70_000 });
+    });
+
+    test("no deadline: remainingDeriveStages > 1 still uncaps (infinity / N is infinity)", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 0,
+            deadlineMs: null,
+            nowMs: now,
+            reserveMs: 30_000,
+            remainingDeriveStages: 5,
+        })).toEqual({ _tag: "uncapped" });
+    });
+
+    test("two remaining derive stages split the time-to-deadline evenly", () => {
+        // 200s left, minus a 30s reserve => 170s to split two ways => 85s each,
+        // not the 170s a single starter would have claimed under the old code.
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 200_000,
+            nowMs: now,
+            reserveMs: 30_000,
+            remainingDeriveStages: 2,
+        })).toEqual({ _tag: "capped", capMs: 85_000 });
+    });
+
+    test("four remaining derive stages each get a quarter of the time to the deadline", () => {
+        // 400s left, minus a 30s reserve => 370s split four ways => 92.5s each.
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 400_000,
+            nowMs: now,
+            reserveMs: 30_000,
+            remainingDeriveStages: 4,
+        })).toEqual({ _tag: "capped", capMs: 92_500 });
+    });
+
+    test("the static cap still bounds a stage's share even with many remaining stages", () => {
+        // Plenty of time to the deadline, but only 2 remaining stages share it -
+        // each would get more than the static cap, so the static cap wins.
+        expect(deriveStageBudget({
+            staticCapMs: 60_000,
+            deadlineMs: now + 900_000,
+            nowMs: now,
+            reserveMs: 30_000,
+            remainingDeriveStages: 2,
+        })).toEqual({ _tag: "capped", capMs: 60_000 });
+    });
+
+    test("a non-positive remainingDeriveStages is treated as 1, never divides by zero", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 100_000,
+            nowMs: now,
+            reserveMs: 30_000,
+            remainingDeriveStages: 0,
         })).toEqual({ _tag: "capped", capMs: 70_000 });
     });
 });

--- a/apps/axctl/src/ingest/stage/derive-budget.ts
+++ b/apps/axctl/src/ingest/stage/derive-budget.ts
@@ -1,17 +1,22 @@
 /**
  * How long may a derive stage run, given the pass's own deadline? (#697)
  *
- * The static watchdog (`AX_STAGE_TIMEOUT_SECONDS`, #671) caps ONE derive at
- * 300s but knows nothing about the run's wall-clock budget
+ * The static hung cap (`AX_STAGE_HUNG_SECONDS`, #671, demoted by #837) bounds
+ * ONE derive's wall clock but knows nothing about the run's wall-clock budget
  * (`AX_INGEST_TIMEOUT_SECONDS`, 900s). Under a backlog the provider stages eat
- * most of the budget, then each derive starts a fresh 300s clock and pushes the
+ * most of the budget, then each derive starts a fresh clock and pushes the
  * pass past the outer cap. The outer timeout is not a soft landing: it
  * deliberately LEAVES the ingest lock as a cooldown (see ingest-lock.ts), so
  * the watcher's next fires skip and a human is left re-running ingest by hand.
  *
- * So a derive gets `min(staticCap, timeLeftBeforeDeadline - reserve)`, and is
- * skipped outright once only the reserve remains. The reserve is what the run
- * needs to finalize its own `ingest_run` row and exit clean.
+ * A single starting derive getting the ENTIRE remaining budget was itself a
+ * bug (#721): a heavy stage could consume all of it and starve every derive
+ * still waiting on its deps. So a derive gets
+ * `min(staticCap, (timeLeftBeforeDeadline - reserve) / remainingDeriveStages)`
+ * - its even share of what is left, divided across every derive stage that
+ * has not yet settled (including itself) - and is skipped outright once only
+ * the reserve remains. The reserve is what the run needs to finalize its own
+ * `ingest_run` row and exit clean.
  *
  * This bounds the pass. It does NOT make a heavy derive finish - that wants
  * chunked/resumable derive (#689).
@@ -41,13 +46,23 @@ export const deriveReserveMs = (env: NodeJS.ProcessEnv = process.env): number =>
  * Budget for the derive stage about to start. `staticCapMs <= 0` disables the
  * static cap; `deadlineMs === null` means the caller has no wall-clock budget
  * (tests, `--derive-only` invocations without a timeout), in which case this
- * degrades to exactly today's static-cap behaviour.
+ * degrades to exactly today's static-cap behaviour regardless of
+ * `remainingDeriveStages` (dividing infinity by any positive count is still
+ * infinity).
+ *
+ * `remainingDeriveStages` is the count of derive stages - across the whole
+ * pipeline - that have not yet settled, INCLUDING the one asking for a
+ * budget right now. The time left before the deadline (minus the reserve) is
+ * divided evenly across that count, so one heavy starter cannot claim the
+ * whole remaining budget and starve derives still waiting on their deps
+ * (#721). Values `<= 1` behave exactly like today's single-stage math.
  */
 export const deriveStageBudget = (input: {
     readonly staticCapMs: number;
     readonly deadlineMs: number | null;
     readonly nowMs: number;
     readonly reserveMs: number;
+    readonly remainingDeriveStages: number;
 }): DeriveStageBudget => {
     const untilDeadline = input.deadlineMs === null
         ? Number.POSITIVE_INFINITY
@@ -59,7 +74,9 @@ export const deriveStageBudget = (input: {
                 "or run 'ax ingest --derive-only' to catch derives up)",
         };
     }
+    const stageCount = Math.max(1, Math.floor(input.remainingDeriveStages));
+    const shareOfDeadline = untilDeadline / stageCount;
     const staticCap = input.staticCapMs > 0 ? input.staticCapMs : Number.POSITIVE_INFINITY;
-    const capMs = Math.min(staticCap, untilDeadline);
+    const capMs = Math.min(staticCap, shareOfDeadline);
     return Number.isFinite(capMs) ? { _tag: "capped", capMs } : { _tag: "uncapped" };
 };

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -801,4 +801,49 @@ describe("runPipeline derive budget (#697)", () => {
         );
         expect(stats.map((s) => s.summary).sort()).toEqual(["claude ok", "outcomes ok"]);
     });
+
+    it("concurrency 1: two independent hanging derive stages both time out - the first no longer starves the second (#721)", async () => {
+        // Regression for the fix: `deriveStageBudget` used to hand a STARTING
+        // derive the ENTIRE time left before the deadline. With
+        // AX_PIPELINE_CONCURRENCY=1, hang-a would run first, burn the whole
+        // window until the hung detector fired, and by the time hang-b
+        // finally got its permit no time was left - it read `skip`, not
+        // `timeout`, and never even ran. Dividing the remaining budget across
+        // every still-unsettled derive stage means each independent hang
+        // below gets its own even share instead, so both hit the wall-clock
+        // hung detector and both are recorded `timeout`.
+        const savedConcurrency = process.env.AX_PIPELINE_CONCURRENCY;
+        process.env.AX_PIPELINE_CONCURRENCY = "1";
+        try {
+            const rec = outcomeRecorder();
+            const started = Date.now();
+            const stats = await Effect.runPromise(
+                runPipeline(
+                    [hangs("hang-a", ["derive"]), hangs("hang-b", ["derive"])],
+                    ctx,
+                    {
+                        deadlineMs: started + 300,
+                        reserveMs: 0,
+                        recordStageOutcome: rec.recordStageOutcome,
+                    },
+                ) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+            );
+
+            expect(stats).toHaveLength(2);
+            expect(rec.seen).toHaveLength(2);
+            const statusByKey = new Map(rec.seen.map((r) => [r.key, r.status]));
+            // THE load-bearing assertion: both stages settle `timeout`, never
+            // `skipped` - the old code let hang-a claim the whole window and
+            // left hang-b with nothing.
+            expect(statusByKey.get("hang-a")).toBe("timeout");
+            expect(statusByKey.get("hang-b")).toBe("timeout");
+            expect(stats.every((s) => s.summary === "timed out (hung detector)")).toBe(true);
+            // Generous: this only guards against the pipeline hanging outright,
+            // not the precise per-stage split.
+            expect(Date.now() - started).toBeLessThan(5_000);
+        } finally {
+            if (savedConcurrency === undefined) delete process.env.AX_PIPELINE_CONCURRENCY;
+            else process.env.AX_PIPELINE_CONCURRENCY = savedConcurrency;
+        }
+    });
 });

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -193,8 +193,11 @@ export const topoLayers = <S extends BaseStageStats, R, E>(
  *  `opts.deadlineMs` is the run's wall-clock deadline (epoch ms). Derive stages
  *  are budgeted against it so the pass ends cleanly instead of being killed by
  *  the outer ingest timeout (#697); omit it and derives keep only their static
- *  `AX_STAGE_TIMEOUT_SECONDS` cap. `opts.reserveMs` overrides the finalization
- *  reserve (env default) - tests pass 0.
+ *  `AX_STAGE_HUNG_SECONDS` cap. The time left before the deadline is divided
+ *  across every derive stage that has not yet settled, so one heavy starter
+ *  cannot claim the whole remaining budget and starve derives still waiting on
+ *  their deps (#721). `opts.reserveMs` overrides the finalization reserve (env
+ *  default) - tests pass 0.
  *
  *  `opts.recordStageOutcome` lets the caller record the two outcomes only the
  *  RUNNER knows about, which the stage's own `Exit` cannot express: a watchdog
@@ -235,6 +238,24 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
         const hungCapMs = deriveStageHungSeconds() * 1000;
         const deadlineMs = opts.deadlineMs ?? null;
         const reserveMs = opts.reserveMs ?? deriveReserveMs();
+
+        // Count of derive stages that have not yet SETTLED (succeeded, failed,
+        // timed out, or been skipped for want of budget) - including ones still
+        // waiting on their deps. `deriveStageBudget` divides the time left
+        // before the deadline across this count so one heavy starter cannot
+        // claim the whole remaining budget and starve derives still queued
+        // behind it (#721). A starting stage reads the count BEFORE it
+        // decrements its own entry, so two derives starting in the same tick
+        // both see the conservative (not-yet-decremented) total - neither has
+        // settled yet, so neither should shrink the other's share. Plain
+        // `let`, not a Ref: every read/write below happens synchronously
+        // inside `Effect.sync`/`Effect.suspend` bodies with no `yield*` in
+        // between, so there is no interleaving window for another fiber to
+        // observe a half-updated count.
+        let remainingDeriveStages = stages.filter((s) => s.meta.tags.includes("derive")).length;
+        const settleDeriveStage = Effect.sync(() => {
+            remainingDeriveStages = Math.max(0, remainingDeriveStages - 1);
+        });
 
         const runStage = (s: StageDef<S, R, E>) =>
             Effect.gen(function* () {
@@ -277,6 +298,7 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                             deadlineMs,
                             nowMs: Date.now(),
                             reserveMs,
+                            remainingDeriveStages,
                         });
                         if (budget._tag === "skip") {
                             const reason = `skipped - ${budget.reason}`;
@@ -380,7 +402,15 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                                     ),
                             }),
                         );
-                    });
+                    }).pipe(
+                        // Decrement exactly once per derive stage, on every
+                        // settle path - skip, self-time timeout, hung timeout,
+                        // failure, or success alike - so the next stage's
+                        // budget read (#721) reflects one fewer stage still
+                        // competing for the remaining wall time. `ensuring`
+                        // fires on both success and failure exits.
+                        Effect.ensuring(settleDeriveStage),
+                    );
                 const tracked = Effect.sync(() => {
                     inFlight.add(s.meta.key);
                 }).pipe(


### PR DESCRIPTION
## Summary

- divide the usable derive deadline across all unsettled derive stages
- preserve the final reserve and keep ingest stages exempt
- keep skip and timeout receipts accurate
- add pure budget tests and a two-stage runner regression

## Verification

- `bun test apps/axctl/src/ingest/stage`
- runner test repeated five times
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

Fixes #721

---

_Generated with [ax](https://github.com/Necmttn/ax)._
