### PR TITLE
fix: stabilize judgment integration test on Intel

### DIFF
--- a/apps/axctl/src/cli/judgment-daemonless.test.ts
+++ b/apps/axctl/src/cli/judgment-daemonless.test.ts
@@ -9,7 +9,12 @@ import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 const runCli = async (sidecarPath: string, args: string[]) => {
     const child = Bun.spawn(["bun", "apps/axctl/src/cli/index.ts", ...args], {
         cwd: process.cwd(),
-        env: { ...process.env, AX_DEV: "1", AX_SIDECAR_PATH: sidecarPath },
+        env: {
+            ...process.env,
+            AX_DEV: "1",
+            AX_NO_AUTO_INGEST: "1",
+            AX_SIDECAR_PATH: sidecarPath,
+        },
         stdout: "pipe",
         stderr: "pipe",
     });
@@ -61,7 +66,7 @@ describe("judgment commands without SurrealDB", () => {
         expect(improve.stdout).toContain("use-rg");
         expect(retro.stdout).toContain("manual");
         expect(dogfood.stdout).toContain("run-1");
-    });
+    }, 20_000);
 
     test("manual retro emit uses SQLite when the session and file are explicit", async () => {
         const root = mkdtempSync(join(tmpdir(), "ax-retro-emit-daemonless-"));


### PR DESCRIPTION
## Summary

- disable automatic ingest in the judgment CLI subprocess fixture
- allow 20 seconds for the three-process integration test
- keep the single-process retro test on the default limit

The release job proved the cause. The same multi-process test exceeded Bun’s 5-second default twice on macOS Intel. Linux, macOS ARM, and five focused local runs passed.

## Verification

- `bun test apps/axctl/src/cli/judgment-daemonless.test.ts` repeated five times
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check`

Fixes #1117

---

_Generated with [ax](https://github.com/Necmttn/ax)._
