### PR TITLE
perf: benchmark DuckDB index efficacy

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,3 +57,9 @@ jobs:
         env:
           AX_DUCKDB_BIN: ${{ steps.duckdb.outputs.bin }}
         run: bun test scripts/bench
+
+      - name: Compare DuckDB index variants
+        if: steps.duckdb.outputs.skip != 'true'
+        env:
+          AX_DUCKDB_BIN: ${{ steps.duckdb.outputs.bin }}
+        run: bun scripts/bench/index-efficacy.ts

--- a/docs/development.md
+++ b/docs/development.md
@@ -147,6 +147,16 @@ scripts/bench-empty-db.sh --since=90
 
 Artifacts land under `~/.local/share/ax/benchmarks/<db>/`.
 
+Compare DuckDB point lookups with no index, a composite index, and a
+single-column index:
+
+```bash
+AX_DUCKDB_BIN=dist/duckdb/duckdb bun scripts/bench/index-efficacy.ts
+```
+
+The comparison uses DuckDB v1.5.5 and reports raw samples, medians, and speed
+ratios. It stops when row checks fail or measurements are unstable.
+
 ## CLI reference
 
 Full surface in [`docs/insights-cli-reference.md`](insights-cli-reference.md).

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -90,12 +90,12 @@ describe("edge tables", () => {
 
     test("every relation table is indexed on both sides", () => {
         // A composite index does NOT serve a leftmost-prefix seek the way a
-        // B-tree would: measured on duckdb v1.5.5 (2M rows, 500k distinct
-        // keys, 200 sequential `WHERE in_id = ?` point lookups), a composite
-        // (in_id, out_id, args) index cost 2.10s user - statistically the
-        // same as NO index at all (2.17s user) - while a single-column
-        // (in_id) ART index cost 0.12s user. Only a single-column index is
-        // actually served, so require one per side.
+        // B-tree would: `scripts/bench/index-efficacy.ts` measures DuckDB v1.5.5
+        // with 2M rows, 500k distinct
+        // keys, and 200 separate `WHERE in_id = ?` point lookups. Stable runs
+        // show the composite (in_id, out_id, args) index tracks no index, while
+        // the single-column (in_id) ART index is materially faster. Require a
+        // single-column index per side.
         const indexes = parseDuckdbIndexes();
         const uncovered = relationTables
             // `plays_role` is a relation that moved to the sidecar; SQLite serves

--- a/scripts/bench/index-efficacy.test.ts
+++ b/scripts/bench/index-efficacy.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, test } from "bun:test";
+import { gatedTest } from "@ax/lib/testing/gated-test";
+import { duckdbBinPath } from "./duckdb-bin.ts";
+import {
+    ExplainNotAllowedError,
+    InvalidIndexEfficacyConfigError,
+    VARIANTS,
+    assertNoExplain,
+    buildDatasetSql,
+    buildIndexSql,
+    buildLookupKeys,
+    buildLookupSql,
+    detectOrderDrift,
+    iqrRatio,
+    main,
+    median,
+    parseDuckdbVersion,
+    parseIndexEfficacyConfig,
+    parseLookupCsv,
+    quantile,
+    rotateVariants,
+    validateLookupRows,
+} from "./index-efficacy.ts";
+
+describe("parseIndexEfficacyConfig", () => {
+    test("defaults to the #786 spec: 2M rows, 500k distinct, 200 lookups, 1+7 runs", () => {
+        const config = parseIndexEfficacyConfig({});
+        expect(config.rows).toBe(2_000_000);
+        expect(config.distinctInIds).toBe(500_000);
+        expect(config.rowsPerInId).toBe(4);
+        expect(config.lookupCount).toBe(200);
+        expect(config.warmRuns).toBe(1);
+        expect(config.measuredRuns).toBe(7);
+        expect(config.requiredDuckdbVersion).toBe("1.5.5");
+    });
+
+    test("every knob is overridable from env", () => {
+        const config = parseIndexEfficacyConfig({
+            AX_BENCH_INDEX_ROWS: "40",
+            AX_BENCH_INDEX_DISTINCT: "10",
+            AX_BENCH_INDEX_LOOKUPS: "5",
+            AX_BENCH_INDEX_WARM_RUNS: "0",
+            AX_BENCH_INDEX_MEASURED_RUNS: "2",
+        });
+        expect(config).toEqual({
+            rows: 40,
+            distinctInIds: 10,
+            rowsPerInId: 4,
+            lookupCount: 5,
+            warmRuns: 0,
+            measuredRuns: 2,
+            requiredDuckdbVersion: "1.5.5",
+        });
+    });
+
+    test("rejects a non-integer override with the offending name+value", () => {
+        expect(() => parseIndexEfficacyConfig({ AX_BENCH_INDEX_ROWS: "2.5" })).toThrow(
+            InvalidIndexEfficacyConfigError,
+        );
+        try {
+            parseIndexEfficacyConfig({ AX_BENCH_INDEX_ROWS: "abc" });
+            throw new Error("expected throw");
+        } catch (err) {
+            expect(String(err)).toContain("AX_BENCH_INDEX_ROWS");
+            expect(String(err)).toContain("abc");
+        }
+    });
+
+    test("rejects rows that are not an exact multiple of distinct in_ids", () => {
+        expect(() =>
+            parseIndexEfficacyConfig({
+                AX_BENCH_INDEX_ROWS: "10",
+                AX_BENCH_INDEX_DISTINCT: "3",
+            }),
+        ).toThrow(InvalidIndexEfficacyConfigError);
+    });
+
+    test("rejects a lookup count greater than the distinct in_id space", () => {
+        expect(() =>
+            parseIndexEfficacyConfig({
+                AX_BENCH_INDEX_ROWS: "40",
+                AX_BENCH_INDEX_DISTINCT: "10",
+                AX_BENCH_INDEX_LOOKUPS: "11",
+            }),
+        ).toThrow(InvalidIndexEfficacyConfigError);
+    });
+
+    test("rejects fewer than 1 measured run", () => {
+        expect(() =>
+            parseIndexEfficacyConfig({ AX_BENCH_INDEX_MEASURED_RUNS: "0" }),
+        ).toThrow(InvalidIndexEfficacyConfigError);
+    });
+});
+
+describe("median", () => {
+    test("returns the middle value for an odd-length sample", () => {
+        expect(median([3, 1, 2])).toBe(2);
+    });
+
+    test("averages the two middle values for an even-length sample", () => {
+        expect(median([1, 2, 3, 4])).toBe(2.5);
+    });
+
+    test("throws on an empty sample set rather than returning NaN/undefined", () => {
+        expect(() => median([])).toThrow(InvalidIndexEfficacyConfigError);
+    });
+});
+
+describe("quantile / iqrRatio", () => {
+    test("quantile(0.5) agrees with median", () => {
+        expect(quantile([1, 2, 3, 4], 0.5)).toBe(median([1, 2, 3, 4]));
+    });
+
+    test("iqrRatio is 0 for identical samples", () => {
+        expect(iqrRatio([5, 5, 5, 5, 5])).toBe(0);
+    });
+
+    test("iqrRatio grows with spread", () => {
+        const tight = iqrRatio([9.9, 10, 10, 10, 10.1]);
+        const wide = iqrRatio([5, 8, 10, 12, 15]);
+        expect(wide).toBeGreaterThan(tight);
+    });
+});
+
+describe("detectOrderDrift", () => {
+    test("false when position medians are close", () => {
+        expect(detectOrderDrift([1.0, 1.05, 0.98])).toBe(false);
+    });
+
+    test("true when position medians diverge past the threshold", () => {
+        expect(detectOrderDrift([1.0, 2.0, 1.1])).toBe(true);
+    });
+
+    test("false when all positions are zero", () => {
+        expect(detectOrderDrift([0, 0, 0])).toBe(false);
+    });
+});
+
+describe("rotateVariants (order rotation)", () => {
+    test("run 0 is the identity order", () => {
+        expect(rotateVariants(VARIANTS, 0)).toEqual(["none", "composite", "single"]);
+    });
+
+    test("rotates by one position per run", () => {
+        expect(rotateVariants(VARIANTS, 1)).toEqual(["composite", "single", "none"]);
+        expect(rotateVariants(VARIANTS, 2)).toEqual(["single", "none", "composite"]);
+    });
+
+    test("wraps around past the variant count", () => {
+        expect(rotateVariants(VARIANTS, 3)).toEqual(rotateVariants(VARIANTS, 0));
+        expect(rotateVariants(VARIANTS, 4)).toEqual(rotateVariants(VARIANTS, 1));
+    });
+
+    test("every rotation is a permutation containing all variants exactly once", () => {
+        for (let run = 0; run < 6; run++) {
+            const order = rotateVariants(VARIANTS, run);
+            expect([...order].sort()).toEqual([...VARIANTS].sort());
+        }
+    });
+});
+
+describe("index SQL", () => {
+    test("the none variant creates no index", () => {
+        expect(buildIndexSql("none")).toBeNull();
+    });
+
+    test("the composite variant indexes all three columns in order", () => {
+        expect(buildIndexSql("composite")).toBe(
+            "CREATE INDEX idx_composite ON relation(in_id, out_id, args);",
+        );
+    });
+
+    test("the single variant indexes only in_id", () => {
+        expect(buildIndexSql("single")).toBe("CREATE INDEX idx_single ON relation(in_id);");
+    });
+
+    test("neither index statement uses EXPLAIN", () => {
+        for (const variant of VARIANTS) {
+            const sql = buildIndexSql(variant);
+            if (sql) expect(() => assertNoExplain(sql)).not.toThrow();
+        }
+    });
+});
+
+describe("buildDatasetSql", () => {
+    test("derives in_id from a modulo of the configured distinct count, not a literal loop", () => {
+        const sql = buildDatasetSql(
+            parseIndexEfficacyConfig({
+                AX_BENCH_INDEX_ROWS: "40",
+                AX_BENCH_INDEX_DISTINCT: "10",
+                AX_BENCH_INDEX_LOOKUPS: "2",
+            }),
+        );
+        expect(sql).toContain("range(40)");
+        expect(sql).toContain("i % 10");
+        expect(sql).toContain("id VARCHAR PRIMARY KEY");
+    });
+
+    test("orders by a deterministic permutation, not natural insertion order", () => {
+        const sql = buildDatasetSql(parseIndexEfficacyConfig({}));
+        expect(sql).toContain("ORDER BY");
+        expect(sql).not.toMatch(/ORDER BY i\b/);
+    });
+
+    test("contains no EXPLAIN", () => {
+        expect(() => assertNoExplain(buildDatasetSql(parseIndexEfficacyConfig({})))).not.toThrow();
+    });
+});
+
+describe("buildLookupKeys", () => {
+    test("returns exactly lookupCount distinct keys spanning the distinct-id space", () => {
+        const keys = buildLookupKeys(
+            parseIndexEfficacyConfig({
+                AX_BENCH_INDEX_ROWS: "100",
+                AX_BENCH_INDEX_DISTINCT: "20",
+                AX_BENCH_INDEX_LOOKUPS: "5",
+            }),
+        );
+        expect(keys).toHaveLength(5);
+        expect(new Set(keys).size).toBe(5);
+        expect(keys[0]).toBe("id_0");
+    });
+});
+
+describe("buildLookupSql / result parsing / row validation (no-EXPLAIN invariant)", () => {
+    test("emits one SELECT per key, each with count(*) and a payload aggregate", () => {
+        const sql = buildLookupSql(["id_1", "id_2"]);
+        const statements = sql.trim().split("\n");
+        expect(statements).toHaveLength(2);
+        for (const stmt of statements) {
+            expect(stmt).toContain("count(*)");
+            expect(stmt).toContain("sum(payload)");
+        }
+        expect(sql).toContain("in_id = 'id_1'");
+        expect(sql).toContain("in_id = 'id_2'");
+    });
+
+    test("buildLookupSql refuses to build EXPLAIN'd SQL", () => {
+        // assertNoExplain is exercised directly here; buildLookupSql itself
+        // never emits EXPLAIN, so this pins the invariant at the guard.
+        expect(() => assertNoExplain("EXPLAIN SELECT 1")).toThrow(ExplainNotAllowedError);
+        expect(() => assertNoExplain("explain analyze select 1")).toThrow(ExplainNotAllowedError);
+        expect(() => assertNoExplain("SELECT 1 -- safe query")).not.toThrow();
+    });
+
+    test("parseLookupCsv parses count,sum lines in order", () => {
+        const rows = parseLookupCsv("4,1000\n4,2000\n\n");
+        expect(rows).toEqual([
+            { count: 4, payloadSum: 1000 },
+            { count: 4, payloadSum: 2000 },
+        ]);
+    });
+
+    test("validateLookupRows passes when every key returns the expected row count", () => {
+        const keys = ["id_1", "id_2"];
+        const rows = parseLookupCsv("4,64\n4,68\n");
+        const config = parseIndexEfficacyConfig({
+            AX_BENCH_INDEX_ROWS: "40",
+            AX_BENCH_INDEX_DISTINCT: "10",
+            AX_BENCH_INDEX_LOOKUPS: "2",
+        });
+        const result = validateLookupRows(keys, rows, config);
+        expect(result.ok).toBe(true);
+        expect(result.badKeys).toEqual([]);
+    });
+
+    test("validateLookupRows flags a key whose row count is wrong", () => {
+        const keys = ["id_1", "id_2", "id_3"];
+        const rows = parseLookupCsv("4,64\n3,20\n4,72\n");
+        const config = parseIndexEfficacyConfig({
+            AX_BENCH_INDEX_ROWS: "40",
+            AX_BENCH_INDEX_DISTINCT: "10",
+            AX_BENCH_INDEX_LOOKUPS: "3",
+        });
+        const result = validateLookupRows(keys, rows, config);
+        expect(result.ok).toBe(false);
+        expect(result.badKeys).toEqual(["id_2"]);
+    });
+
+    test("validateLookupRows flags a wrong payload sum when the row count is correct", () => {
+        const keys = ["id_1", "id_2"];
+        const rows = parseLookupCsv("4,64\n4,999\n");
+        const config = parseIndexEfficacyConfig({
+            AX_BENCH_INDEX_ROWS: "40",
+            AX_BENCH_INDEX_DISTINCT: "10",
+            AX_BENCH_INDEX_LOOKUPS: "2",
+        });
+        const result = validateLookupRows(keys, rows, config);
+        expect(result.ok).toBe(false);
+        expect(result.badKeys).toEqual(["id_2"]);
+    });
+
+    test("validateLookupRows flags a missing row as a mismatch, not a silent pass", () => {
+        const keys = ["id_1", "id_2"];
+        const rows = parseLookupCsv("4,64\n");
+        const config = parseIndexEfficacyConfig({
+            AX_BENCH_INDEX_ROWS: "40",
+            AX_BENCH_INDEX_DISTINCT: "10",
+            AX_BENCH_INDEX_LOOKUPS: "2",
+        });
+        const result = validateLookupRows(keys, rows, config);
+        expect(result.ok).toBe(false);
+        expect(result.badKeys).toEqual(["id_2"]);
+    });
+});
+
+describe("parseDuckdbVersion", () => {
+    test("extracts the version from `duckdb --version` output", () => {
+        expect(parseDuckdbVersion("v1.5.5 abc123def\n")).toBe("1.5.5");
+    });
+
+    test("returns null when the output has no v-prefixed version", () => {
+        expect(parseDuckdbVersion("not a version string")).toBeNull();
+    });
+});
+
+describe("index-efficacy integration (gated small-scale)", () => {
+    const duckdb = duckdbBinPath();
+    const duckdbVersion = duckdb
+        ? parseDuckdbVersion(Bun.spawnSync([duckdb, "--version"]).stdout.toString())
+        : null;
+    const duckdbTest = gatedTest({
+        reason:
+            duckdbVersion === null
+                ? "no duckdb binary resolvable (set AX_DUCKDB_BIN or put duckdb on PATH)"
+                : `DuckDB v1.5.5 required, found ${duckdbVersion}`,
+        when: !duckdb || duckdbVersion !== "1.5.5",
+    });
+
+    duckdbTest(
+        "runs all three variants end to end at a tiny scale, validating rows without asserting performance order",
+        async () => {
+            if (!duckdb) return;
+            const lines: string[] = [];
+            const exitCode = await main(
+                {
+                    ...process.env,
+                    AX_DUCKDB_BIN: duckdb,
+                    AX_BENCH_INDEX_ROWS: "400",
+                    AX_BENCH_INDEX_DISTINCT: "100",
+                    AX_BENCH_INDEX_LOOKUPS: "10",
+                    AX_BENCH_INDEX_WARM_RUNS: "1",
+                    AX_BENCH_INDEX_MEASURED_RUNS: "6",
+                },
+                (line) => lines.push(line),
+            );
+            const out = lines.join("\n");
+            expect(out).toContain("none:");
+            expect(out).toContain("composite:");
+            expect(out).toContain("single:");
+            expect(out).toContain("PASS");
+            expect(exitCode).toBe(0);
+        },
+        60_000,
+    );
+});

--- a/scripts/bench/index-efficacy.ts
+++ b/scripts/bench/index-efficacy.ts
@@ -1,0 +1,491 @@
+#!/usr/bin/env bun
+/**
+ * Wall-clock benchmark for issue #786: does a composite (in_id, out_id, args)
+ * index serve a `WHERE in_id = ?` point lookup as well as a single-column
+ * (in_id) index, on a relation table shaped like ax's edge tables?
+ *
+ * This is the reproducible source behind the measurement cited in
+ * `packages/schema/src/duckdb-schema.test.ts` ("every relation table is
+ * indexed on both sides"): a composite index does not serve a leftmost-prefix
+ * seek the way a B-tree would, so only a single-column index is actually
+ * served by DuckDB's ART index.
+ *
+ * Three isolated copies of the same 2M-row dataset are built, each with a
+ * different index (none / composite / single-column in_id), checkpointed,
+ * reopened, and measured with `AX_BENCH_INDEX_MEASURED_RUNS` repetitions of
+ * `AX_BENCH_INDEX_LOOKUPS` distinct point lookups run as separate statements
+ * inside one DuckDB CLI process. Variant order rotates across runs so a
+ * systematic drift (thermal throttling, page-cache warmup) cannot masquerade
+ * as an index effect.
+ *
+ * No EXPLAIN: this measures wall clock, not query plans. No threshold: this
+ * is a report, not a gate - `scripts/bench/targets.ts` (ingest/query budgets)
+ * is untouched.
+ */
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { duckdbBinPath } from "./duckdb-bin.ts";
+
+export const VARIANTS = ["none", "composite", "single"] as const;
+export type Variant = (typeof VARIANTS)[number];
+
+export type IndexEfficacyConfig = {
+    readonly rows: number;
+    readonly distinctInIds: number;
+    readonly rowsPerInId: number;
+    readonly lookupCount: number;
+    readonly warmRuns: number;
+    readonly measuredRuns: number;
+    readonly requiredDuckdbVersion: string;
+};
+
+export const DEFAULT_INDEX_EFFICACY_CONFIG: IndexEfficacyConfig = {
+    rows: 2_000_000,
+    distinctInIds: 500_000,
+    rowsPerInId: 4,
+    lookupCount: 200,
+    warmRuns: 1,
+    measuredRuns: 7,
+    requiredDuckdbVersion: "1.5.5",
+};
+
+export class InvalidIndexEfficacyConfigError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "InvalidIndexEfficacyConfigError";
+    }
+}
+
+const parseEnvInt = (
+    name: string,
+    raw: string | undefined,
+    fallback: number,
+): number => {
+    if (raw === undefined || raw === "") return fallback;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+        throw new InvalidIndexEfficacyConfigError(
+            `invalid ${name}=${JSON.stringify(raw)}: expected an integer`,
+        );
+    }
+    return n;
+};
+
+/** Parse the benchmark configuration from env, falling back to the #786
+ *  default (2M rows / 500k distinct in_id / 200 lookups / 1 warm + 7
+ *  measured runs). Every knob is overridable so the gated integration test
+ *  can run the same code path at a tiny scale. */
+export const parseIndexEfficacyConfig = (
+    env: Record<string, string | undefined> = process.env,
+): IndexEfficacyConfig => {
+    const rows = parseEnvInt(
+        "AX_BENCH_INDEX_ROWS",
+        env.AX_BENCH_INDEX_ROWS,
+        DEFAULT_INDEX_EFFICACY_CONFIG.rows,
+    );
+    const distinctInIds = parseEnvInt(
+        "AX_BENCH_INDEX_DISTINCT",
+        env.AX_BENCH_INDEX_DISTINCT,
+        DEFAULT_INDEX_EFFICACY_CONFIG.distinctInIds,
+    );
+    const lookupCount = parseEnvInt(
+        "AX_BENCH_INDEX_LOOKUPS",
+        env.AX_BENCH_INDEX_LOOKUPS,
+        DEFAULT_INDEX_EFFICACY_CONFIG.lookupCount,
+    );
+    const warmRuns = parseEnvInt(
+        "AX_BENCH_INDEX_WARM_RUNS",
+        env.AX_BENCH_INDEX_WARM_RUNS,
+        DEFAULT_INDEX_EFFICACY_CONFIG.warmRuns,
+    );
+    const measuredRuns = parseEnvInt(
+        "AX_BENCH_INDEX_MEASURED_RUNS",
+        env.AX_BENCH_INDEX_MEASURED_RUNS,
+        DEFAULT_INDEX_EFFICACY_CONFIG.measuredRuns,
+    );
+    if (rows <= 0 || distinctInIds <= 0) {
+        throw new InvalidIndexEfficacyConfigError(
+            "AX_BENCH_INDEX_ROWS and AX_BENCH_INDEX_DISTINCT must be positive",
+        );
+    }
+    if (rows % distinctInIds !== 0) {
+        throw new InvalidIndexEfficacyConfigError(
+            `AX_BENCH_INDEX_ROWS (${rows}) must be an exact multiple of AX_BENCH_INDEX_DISTINCT (${distinctInIds})`,
+        );
+    }
+    const rowsPerInId = rows / distinctInIds;
+    if (lookupCount <= 0 || lookupCount > distinctInIds) {
+        throw new InvalidIndexEfficacyConfigError(
+            `AX_BENCH_INDEX_LOOKUPS (${lookupCount}) must be between 1 and AX_BENCH_INDEX_DISTINCT (${distinctInIds})`,
+        );
+    }
+    if (warmRuns < 0) {
+        throw new InvalidIndexEfficacyConfigError(
+            "AX_BENCH_INDEX_WARM_RUNS must be >= 0",
+        );
+    }
+    if (measuredRuns < 1) {
+        throw new InvalidIndexEfficacyConfigError(
+            "AX_BENCH_INDEX_MEASURED_RUNS must be >= 1",
+        );
+    }
+
+    return {
+        rows,
+        distinctInIds,
+        rowsPerInId,
+        lookupCount,
+        warmRuns,
+        measuredRuns,
+        requiredDuckdbVersion: DEFAULT_INDEX_EFFICACY_CONFIG.requiredDuckdbVersion,
+    };
+};
+
+/** Middle value (average of the two middle values on an even count). */
+export const median = (values: readonly number[]): number => {
+    if (values.length === 0) {
+        throw new InvalidIndexEfficacyConfigError("median of an empty sample set");
+    }
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 1) return sorted[mid]!;
+    return (sorted[mid - 1]! + sorted[mid]!) / 2;
+};
+
+/** Linear-interpolated quantile (0..1) over a sample set, used for the IQR
+ *  check below. */
+export const quantile = (values: readonly number[], q: number): number => {
+    const sorted = [...values].sort((a, b) => a - b);
+    if (sorted.length === 1) return sorted[0]!;
+    const pos = (sorted.length - 1) * q;
+    const lo = Math.floor(pos);
+    const hi = Math.ceil(pos);
+    if (lo === hi) return sorted[lo]!;
+    const frac = pos - lo;
+    return sorted[lo]! * (1 - frac) + sorted[hi]! * frac;
+};
+
+/** (Q3 - Q1) / median - the noise check: a value over 0.15 means the 7
+ *  measured runs disagree with each other too much to trust the median. */
+export const iqrRatio = (values: readonly number[]): number => {
+    const m = median(values);
+    if (m === 0) return 0;
+    return (quantile(values, 0.75) - quantile(values, 0.25)) / m;
+};
+
+/** Round-robin rotation of the variant list by `runIndex`, so consecutive
+ *  measured runs don't all benchmark the same variant first (a systematic
+ *  drift across runs - thermal throttling, page-cache warmup - would
+ *  otherwise land entirely on whichever variant always goes first/last). */
+export const rotateVariants = (
+    variants: readonly Variant[],
+    runIndex: number,
+): Variant[] => {
+    const n = variants.length;
+    if (n === 0) return [];
+    const offset = ((runIndex % n) + n) % n;
+    return [...variants.slice(offset), ...variants.slice(0, offset)];
+};
+
+/** DDL for each variant. `null` for "none" - no index is created at all. */
+export const buildIndexSql = (variant: Variant): string | null => {
+    switch (variant) {
+        case "none":
+            return null;
+        case "composite":
+            return "CREATE INDEX idx_composite ON relation(in_id, out_id, args);";
+        case "single":
+            return "CREATE INDEX idx_single ON relation(in_id);";
+    }
+};
+
+/** The 2M-row (default) dataset: `rows` rows, `distinctInIds` distinct
+ *  `in_id` values with `rowsPerInId` rows each, physically stored in a
+ *  deterministic MIXED order (a multiplicative-hash permutation of the
+ *  insertion sequence) rather than grouped by `in_id` - a naturally sorted
+ *  insert order would flatter a sequential scan and understate what an
+ *  index buys on real, interleaved edge-table writes. */
+export const buildDatasetSql = (config: IndexEfficacyConfig): string => `
+CREATE TABLE relation (
+    id VARCHAR PRIMARY KEY,
+    in_id VARCHAR NOT NULL,
+    out_id VARCHAR NOT NULL,
+    args VARCHAR NOT NULL,
+    payload BIGINT NOT NULL
+);
+INSERT INTO relation
+SELECT
+    'edge:' || i AS id,
+    'id_' || (i % ${config.distinctInIds}) AS in_id,
+    'out_' || i AS out_id,
+    'args_' || (i % 97) AS args,
+    i AS payload
+FROM range(${config.rows}) AS r(i)
+ORDER BY (i * 2654435761) % ${config.rows};
+`.trim();
+
+/** `lookupCount` distinct in_id values, evenly spaced across the distinct-id
+ *  space so the sample isn't clustered in one physical region. */
+export const buildLookupKeys = (config: IndexEfficacyConfig): string[] =>
+    Array.from({ length: config.lookupCount }, (_, i) => {
+        const idx = Math.floor((i * config.distinctInIds) / config.lookupCount);
+        return `id_${idx}`;
+    });
+
+export class ExplainNotAllowedError extends Error {
+    constructor() {
+        super("index-efficacy SQL must not use EXPLAIN - this benchmark measures wall clock, not query plans");
+        this.name = "ExplainNotAllowedError";
+    }
+}
+
+/** Throws if the SQL mentions EXPLAIN in any form. Called on every SQL
+ *  string this module hands to a DuckDB process. */
+export const assertNoExplain = (sql: string): void => {
+    if (/\bEXPLAIN\b/i.test(sql)) throw new ExplainNotAllowedError();
+};
+
+/** One SELECT per lookup key (never combined into one query) - a payload
+ *  aggregate (so the optimizer can't short-circuit on an empty projection)
+ *  plus the exact row count (so a wrong index silently returning some other
+ *  in_id's rows is caught, not just timed). */
+export const buildLookupSql = (keys: readonly string[]): string => {
+    const sql = keys
+        .map(
+            (key) =>
+                `SELECT count(*), sum(payload) FROM relation WHERE in_id = '${key}';`,
+        )
+        .join("\n");
+    assertNoExplain(sql);
+    return sql;
+};
+
+export type LookupRow = { readonly count: number; readonly payloadSum: number };
+
+/** Parses `.mode csv .headers off` output from `buildLookupSql` - one
+ *  `count,sum` line per lookup, in order. */
+export const parseLookupCsv = (output: string): LookupRow[] =>
+    output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((line) => {
+            const idx = line.lastIndexOf(",");
+            const count = Number(line.slice(0, idx).trim());
+            const payloadSum = Number(line.slice(idx + 1).trim());
+            return { count, payloadSum };
+        });
+
+export type RowValidation = {
+    readonly ok: boolean;
+    readonly badKeys: string[];
+};
+
+/** Every lookup must return exactly `expectedCount` rows for its key (four,
+ *  by default) - a composite index silently returning a partial/degenerate
+ *  match would otherwise read as "fast" instead of "wrong". */
+export const validateLookupRows = (
+    keys: readonly string[],
+    rows: readonly LookupRow[],
+    config: IndexEfficacyConfig,
+): RowValidation => {
+    const badKeys = keys.filter((key, i) => {
+        const row = rows[i];
+        const keyIndex = Number(key.slice("id_".length));
+        const expectedPayloadSum =
+            config.rowsPerInId * keyIndex +
+            config.distinctInIds *
+                ((config.rowsPerInId * (config.rowsPerInId - 1)) / 2);
+        return (
+            row?.count !== config.rowsPerInId ||
+            row.payloadSum !== expectedPayloadSum
+        );
+    });
+    return { ok: badKeys.length === 0, badKeys };
+};
+
+/** Extracts `"1.5.5"` out of `duckdb --version` output (`v1.5.5 <hash>`). */
+export const parseDuckdbVersion = (versionOutput: string): string | null => {
+    const m = versionOutput.match(/v(\d+\.\d+\.\d+)/);
+    return m ? m[1]! : null;
+};
+
+/** True when the early-vs-late portion of a variant's rotated samples
+ *  differ by more than `thresholdRatio` - a sign that rotation position
+ *  (not the index) is driving the measurement. */
+export const detectOrderDrift = (
+    positionMedians: readonly number[],
+    thresholdRatio = 0.25,
+): boolean => {
+    if (positionMedians.length < 2) return false;
+    const fastest = Math.min(...positionMedians);
+    const slowest = Math.max(...positionMedians);
+    if (slowest === 0) return false;
+    return (slowest - fastest) / slowest > thresholdRatio;
+};
+
+// ---------------------------------------------------------------------------
+// IO orchestration - not unit tested directly; exercised end to end by the
+// gated integration test below at a tiny scale.
+// ---------------------------------------------------------------------------
+
+type DuckRun = { status: number; out: string; elapsedS: number };
+
+const runDuck = (bin: string, args: string[], sql: string, cwd: string): DuckRun => {
+    const start = performance.now();
+    const proc = spawnSync(bin, args, { cwd, input: sql, encoding: "utf8" });
+    return {
+        status: proc.status ?? 1,
+        out: `${proc.stdout ?? ""}${proc.stderr ?? ""}`,
+        elapsedS: (performance.now() - start) / 1000,
+    };
+};
+
+const variantFile = (variant: Variant): string => `${variant}.duckdb`;
+
+export const main = async (
+    env: Record<string, string | undefined> = process.env,
+    write: (line: string) => void = console.log,
+): Promise<number> => {
+    let config: IndexEfficacyConfig;
+    try {
+        config = parseIndexEfficacyConfig(env);
+    } catch (err) {
+        if (err instanceof InvalidIndexEfficacyConfigError) {
+            write(`ERROR: ${err.message}`);
+            return 1;
+        }
+        throw err;
+    }
+
+    const duckdb = duckdbBinPath(env);
+    if (!duckdb) {
+        write("SKIP: duckdb CLI not found (set AX_DUCKDB_BIN or install duckdb on PATH)");
+        return 0;
+    }
+
+    const versionRun = runDuck(duckdb, ["--version"], "", tmpdir());
+    const version = parseDuckdbVersion(versionRun.out);
+    if (version !== config.requiredDuckdbVersion) {
+        write(
+            `STOP: duckdb --version reported ${JSON.stringify(version)}, expected ${config.requiredDuckdbVersion} -- this benchmark's numbers do not transfer across DuckDB versions`,
+        );
+        return 1;
+    }
+
+    const workDir = join(tmpdir(), `ax-bench-index-${process.pid}-${Date.now()}`);
+    mkdirSync(workDir, { recursive: true });
+    const keepWork = env.AX_BENCH_INDEX_KEEP === "1";
+    const cleanup = () => {
+        if (!keepWork) rmSync(workDir, { recursive: true, force: true });
+    };
+
+    try {
+        const baseFile = variantFile("none");
+        const dataset = runDuck(duckdb, [baseFile], `${buildDatasetSql(config)}\nCHECKPOINT;`, workDir);
+        if (dataset.status !== 0) {
+            write(`ERROR: dataset build failed\n${dataset.out}`);
+            return 1;
+        }
+
+        for (const variant of VARIANTS) {
+            if (variant === "none") continue;
+            cpSync(join(workDir, baseFile), join(workDir, variantFile(variant)));
+            const indexSql = buildIndexSql(variant);
+            if (!indexSql) continue;
+            assertNoExplain(indexSql);
+            const built = runDuck(duckdb, [variantFile(variant)], `${indexSql}\nCHECKPOINT;`, workDir);
+            if (built.status !== 0) {
+                write(`ERROR: index build failed for ${variant}\n${built.out}`);
+                return 1;
+            }
+        }
+
+        const keys = buildLookupKeys(config);
+        const lookupSql = `.mode csv\n.headers off\n${buildLookupSql(keys)}`;
+
+        const samples = new Map<Variant, number[]>(VARIANTS.map((v) => [v, []]));
+        const positionSamples = new Map<Variant, number[][]>(
+            VARIANTS.map((variant) => [
+                variant,
+                VARIANTS.map(() => [] as number[]),
+            ]),
+        );
+        const totalRuns = config.warmRuns + config.measuredRuns;
+        for (let run = 0; run < totalRuns; run++) {
+            const order = rotateVariants(VARIANTS, run);
+            for (const [position, variant] of order.entries()) {
+                if (!existsSync(join(workDir, variantFile(variant)))) continue;
+                const result = runDuck(duckdb, [variantFile(variant)], lookupSql, workDir);
+                if (result.status !== 0) {
+                    write(`ERROR: lookup run failed for ${variant}\n${result.out}`);
+                    return 1;
+                }
+                const rows = parseLookupCsv(result.out);
+                const validation = validateLookupRows(keys, rows, config);
+                if (!validation.ok) {
+                    write(
+                        `STOP: ${variant} returned a wrong count or payload sum for ${validation.badKeys.length} lookup key(s) (expected ${config.rowsPerInId} rows each) -- e.g. ${validation.badKeys.slice(0, 5).join(", ")}`,
+                    );
+                    return 1;
+                }
+                if (run >= config.warmRuns) {
+                    samples.get(variant)!.push(result.elapsedS);
+                    positionSamples.get(variant)![position]!.push(result.elapsedS);
+                }
+            }
+        }
+
+        write(`duckdb version: ${version}`);
+        write(
+            `config: rows=${config.rows} distinctInIds=${config.distinctInIds} rowsPerInId=${config.rowsPerInId} lookups=${config.lookupCount} warmRuns=${config.warmRuns} measuredRuns=${config.measuredRuns}`,
+        );
+
+        const medians = new Map<Variant, number>();
+        for (const variant of VARIANTS) {
+            const values = samples.get(variant)!;
+            if (values.length === 0) continue;
+            const m = median(values);
+            medians.set(variant, m);
+            const ratio = iqrRatio(values);
+            write(`${variant}: samples=[${values.map((v) => v.toFixed(4)).join(", ")}] median=${m.toFixed(4)}s iqr/median=${(ratio * 100).toFixed(1)}%`);
+            if (ratio > 0.15) {
+                write(`STOP: ${variant} IQR/median (${(ratio * 100).toFixed(1)}%) exceeds 15% -- samples too noisy to compare`);
+                return 1;
+            }
+
+            const byPosition = positionSamples.get(variant)!;
+            if (byPosition.every((positionValues) => positionValues.length >= 2)) {
+                const positionMedians = byPosition.map((positionValues) =>
+                    median(positionValues),
+                );
+                if (detectOrderDrift(positionMedians)) {
+                    write(
+                        `STOP: ${variant} position medians [${positionMedians.map((value) => value.toFixed(4)).join(", ")}] diverge by more than 25% -- variant order may be driving the result`,
+                    );
+                    return 1;
+                }
+            }
+        }
+
+        const baseline = medians.get("none");
+        if (baseline !== undefined) {
+            for (const variant of VARIANTS) {
+                const m = medians.get(variant);
+                if (m === undefined || variant === "none") continue;
+                write(`ratio ${variant}/none: ${(m / baseline).toFixed(3)}x`);
+            }
+        }
+
+        write("PASS");
+        return 0;
+    } finally {
+        cleanup();
+    }
+};
+
+if (import.meta.main) {
+    process.exit(await main());
+}


### PR DESCRIPTION
## Summary

- add a repeatable DuckDB v1.5.5 wall-clock comparison for no index, composite index, and single-column index
- use 2,000,000 mixed-order rows and validate both row counts and payload sums
- rotate variant order, report raw samples and medians, and stop on unstable results
- run the comparison in the Bench workflow and document the local command

## Measured result

Latest local run:

- no index: `0.6374s` median
- composite index: `0.6627s` median, `1.040x` versus no index
- single-column index: `0.0832s` median, `0.131x` versus no index

All IQR ratios were below 7 percent. The run passed row and order checks.

## Verification

- `AX_DUCKDB_BIN=/Users/necmttn/Projects/ax/dist/duckdb/duckdb bun scripts/bench/index-efficacy.ts`
- `AX_DUCKDB_BIN=/Users/necmttn/Projects/ax/dist/duckdb/duckdb bun test scripts/bench` - 62 pass
- `bun run typecheck`
- `bun run check:no-node-fs`
- `bun run check:timestamp-cast`
- `bun run check:raw-numeric-cast`
- `git diff --check origin/main...HEAD`

Fixes #786

---

_Generated with [ax](https://github.com/Necmttn/ax)._
