### PR TITLE
feat(duckdb): decode additional scalar types

### DIFF
--- a/packages/lib/src/duckdb/client.test.ts
+++ b/packages/lib/src/duckdb/client.test.ts
@@ -134,61 +134,58 @@ describe("DuckDb", () => {
         ),
     );
 
-    // Fix round 1 (ruling R10), Part A: duckdb_value_varchar returns a NULL
-    // pointer for TIMESTAMP WITH TIME ZONE (verified against libduckdb
-    // v1.5.5 directly, on both a literal and a real table column), so it is
-    // now excluded from row-decode.ts's VARCHAR_TYPES - querying it raises
-    // DuckDbUnsupportedTypeError naming the column instead of silently
-    // decoding to "". The documented workaround (CAST ... AS VARCHAR) works.
     dtest(
-        "refuses to decode TIMESTAMP WITH TIME ZONE instead of returning an empty string",
+        "decodes napi scalar wrappers, timestamp variants, and nulls",
         withDuckDb((db) =>
             Effect.gen(function* () {
                 const conn = yield* db.open(tempDb());
-                const result = yield* Effect.result(
-                    conn.query("SELECT TIMESTAMP WITH TIME ZONE '2026-08-14 10:11:12+02' AS ts_tz"),
+                yield* conn.exec("CREATE TYPE mood AS ENUM ('ready', 'waiting')");
+                yield* conn.exec(
+                    `CREATE TABLE scalar_values (
+                        ts_s TIMESTAMP_S,
+                        ts_ms TIMESTAMP_MS,
+                        ts_ns TIMESTAMP_NS,
+                        ts_tz TIMESTAMPTZ,
+                        time_tz TIMETZ,
+                        id UUID,
+                        state mood,
+                        bits BIT
+                    )`,
                 );
-                expect(result._tag).toBe("Failure");
-                if (result._tag === "Failure") {
-                    expect(result.failure._tag).toBe("DuckDbUnsupportedTypeError");
-                    expect((result.failure as { message: string }).message).toContain(
-                        "CAST(ts_tz AS VARCHAR)",
-                    );
-                }
-                // the documented workaround works
-                const ok = yield* conn.query(
-                    "SELECT CAST(TIMESTAMP WITH TIME ZONE '2026-08-14 10:11:12+02' AS VARCHAR) AS ts_tz",
+                yield* conn.exec(
+                    `INSERT INTO scalar_values VALUES (
+                        '2026-08-14 10:11:12',
+                        '2026-08-14 10:11:12.123',
+                        '2026-08-14 10:11:12.123456789',
+                        '2026-08-14 10:11:12+02:00',
+                        '10:11:12+02:00',
+                        '11111111-1111-1111-1111-111111111111',
+                        'ready',
+                        '1010'
+                    )`,
                 );
-                expect(typeof ok.rows[0]!.ts_tz).toBe("string");
-                yield* conn.close;
-            }),
-        ),
-    );
+                yield* conn.exec("INSERT INTO scalar_values VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)");
 
-    // Fix round 1 (ruling R10): UUID showed the exact same accessor failure
-    // as TIMESTAMP_TZ during the investigation (duckdb_value_varchar -> NULL
-    // for a real, non-SQL-NULL value) and is excluded from VARCHAR_TYPES the
-    // same way - confirmed structurally here, mirroring the TZ test above.
-    dtest(
-        "refuses to decode UUID instead of returning an empty string",
-        withDuckDb((db) =>
-            Effect.gen(function* () {
-                const conn = yield* db.open(tempDb());
-                yield* conn.exec("CREATE TABLE u (id UUID)");
-                yield* conn.exec("INSERT INTO u VALUES ('11111111-1111-1111-1111-111111111111')");
-                const result = yield* Effect.result(conn.query("SELECT id FROM u"));
-                expect(result._tag).toBe("Failure");
-                if (result._tag === "Failure") {
-                    expect(result.failure._tag).toBe("DuckDbUnsupportedTypeError");
-                    expect((result.failure as { message: string }).message).toContain("CAST(id AS VARCHAR)");
-                }
-                // the documented workaround works, including for a NULL row
-                yield* conn.exec("INSERT INTO u VALUES (NULL)");
-                const ok = yield* conn.query("SELECT CAST(id AS VARCHAR) AS id FROM u ORDER BY id");
-                expect(ok.rows).toEqual([
-                    { id: "11111111-1111-1111-1111-111111111111" },
-                    { id: null },
-                ]);
+                const result = yield* conn.query("SELECT * FROM scalar_values ORDER BY id NULLS LAST");
+                const row = result.rows[0]!;
+                expect((row.ts_s as Date).toISOString()).toBe("2026-08-14T10:11:12.000Z");
+                expect((row.ts_ms as Date).toISOString()).toBe("2026-08-14T10:11:12.123Z");
+                expect((row.ts_ns as Date).toISOString()).toBe("2026-08-14T10:11:12.123Z");
+                expect((row.ts_tz as Date).toISOString()).toBe("2026-08-14T08:11:12.000Z");
+                expect(row.time_tz).toBe("10:11:12+02");
+                expect(row.id).toBe("11111111-1111-1111-1111-111111111111");
+                expect(row.state).toBe("ready");
+                expect(row.bits).toBe("1010");
+                expect(result.rows[1]).toEqual({
+                    ts_s: null,
+                    ts_ms: null,
+                    ts_ns: null,
+                    ts_tz: null,
+                    time_tz: null,
+                    id: null,
+                    state: null,
+                    bits: null,
+                });
                 yield* conn.close;
             }),
         ),

--- a/packages/lib/src/duckdb/client.ts
+++ b/packages/lib/src/duckdb/client.ts
@@ -292,13 +292,14 @@ export const encodeParams = (
  *     row's TS type never depends on a value's magnitude; int128 is
  *     arbitrary-precision in a JS bigint)
  *   - VARCHAR -> string
- *   - TIMESTAMP -> `Date`, MILLISECOND-truncated (P2-2 contract): the napi
+ *   - TIMESTAMP variants -> `Date`, MILLISECOND-truncated (P2-2 contract): the napi
  *     value renders to DuckDB's own text form and goes through the SAME
  *     `coerceValue` text path the FFI client used, so `.999999` still reads
  *     back `.999` and an unparseable rendering (e.g. `infinity`) still falls
  *     back to its text
  *   - DATE/TIME/INTERVAL/DECIMAL -> their DuckDB text rendering (string),
  *     exactly as `duckdb_value_varchar` produced
+ *   - TIME_TZ/UUID/ENUM/BIT -> canonical text from the napi value wrapper
  *
  * Exported for direct unit-testing without a database.
  */
@@ -335,7 +336,7 @@ export const decodeCell = (typeId: number, value: NapiValue): DuckDbValue => {
  *   - duplicate column names (cross-review P2-1, half one: rows are keyed by
  *     name, so two columns sharing one would silently overwrite each other),
  *   - any column outside the supported closed set (`DuckDbUnsupportedTypeError`
- *     via `unsupportedColumns` - a BLOB/TIMESTAMP_TZ/UUID/... column must
+ *     via `unsupportedColumns` - a BLOB/LIST/STRUCT/... column must
  *     never let a differently-shaped value through just because the napi
  *     driver CAN render it; every caller was written against the closed set).
  */

--- a/packages/lib/src/duckdb/errors.test.ts
+++ b/packages/lib/src/duckdb/errors.test.ts
@@ -35,19 +35,8 @@ describe("duckdb errors", () => {
         expect(err.message).toContain("to_json(tags)");
     });
 
-    // Fix round 1 (ruling R10): every accessor-failure type (the eight swept
-    // against libduckdb v1.5.5, plus whatever the general Part B guard
-    // catches next) wants a CAST suggestion, not hex()/to_json() - neither
-    // of those apply to a scalar type.
-    test("every accessor-failure type suggests CAST(col AS VARCHAR)", () => {
-        for (const [column, typeId] of [
-            ["t", 30 /* TIME_TZ */],
-            ["ts", 31 /* TIMESTAMP_TZ */],
-            ["id", 27 /* UUID */],
-            ["created", 20 /* TIMESTAMP_S */],
-        ] as const) {
-            const err = new DuckDbUnsupportedTypeError({ column, typeId });
-            expect(err.message).toContain(`CAST(${column} AS VARCHAR)`);
-        }
+    test("an unknown future scalar type suggests CAST(col AS VARCHAR)", () => {
+        const err = new DuckDbUnsupportedTypeError({ column: "future", typeId: 999 });
+        expect(err.message).toContain("CAST(future AS VARCHAR)");
     });
 });

--- a/packages/lib/src/duckdb/errors.ts
+++ b/packages/lib/src/duckdb/errors.ts
@@ -11,12 +11,8 @@ const NESTED_TYPES: ReadonlySet<number> = new Set([
 
 /**
  * The SQL to suggest projecting the column through instead, tailored to WHY
- * this client can't decode `typeId`: BLOB and the nested types have no
- * row-major accessor at all, while `TIME_TZ`/`TIMESTAMP_TZ` (and, as of fix
- * round 1, several other types - see the comment on `VARCHAR_TYPES` in
- * row-decode.ts) DO have an accessor kind assigned but the underlying
- * `duckdb_value_varchar` call fails for them regardless - `CAST(col AS
- * VARCHAR)` is the one workaround proven to render every case tried so far.
+ * this client cannot decode `typeId`. BLOB needs a hexadecimal projection.
+ * Nested types need JSON. Unknown future types use a text cast.
  */
 const workaroundFor = (typeId: number, column: string): string => {
     if (typeId === DuckDbTypeId.BLOB) return `hex(${column})`;
@@ -50,13 +46,8 @@ export class DuckDbDecodeError extends Schema.TaggedErrorClass<DuckDbDecodeError
 }) {}
 
 /**
- * A result column has a type this client cannot read through the row-major
- * `duckdb_value_*` API. Two distinct reasons land here: BLOB and the nested
- * types have no pointer-based accessor at all; TIME_TZ/TIMESTAMP_TZ and
- * several other types (fix round 1 - see `VARCHAR_TYPES` in row-decode.ts)
- * DO have an accessor assigned but `duckdb_value_varchar` fails for them
- * regardless. Project the column in SQL instead - `hex(col)` / `to_json(col)`
- * / `CAST(col AS VARCHAR)`, depending on which.
+ * A result column has a type outside the client's closed decode contract.
+ * Project it with `hex`, `to_json`, or `CAST`, depending on its type.
  */
 export class DuckDbUnsupportedTypeError extends Schema.TaggedErrorClass<DuckDbUnsupportedTypeError>(
     "DuckDbUnsupportedTypeError",

--- a/packages/lib/src/duckdb/row-decode.test.ts
+++ b/packages/lib/src/duckdb/row-decode.test.ts
@@ -3,7 +3,7 @@ import { accessorFor, coerceValue, unsupportedColumns } from "./row-decode.ts";
 import { DuckDbTypeId } from "./types.ts";
 
 describe("accessorFor", () => {
-    test("maps each integer width to the widest safe row-major accessor", () => {
+    test("maps each integer width to the widest safe decoder family", () => {
         for (const id of [
             DuckDbTypeId.TINYINT,
             DuckDbTypeId.SMALLINT,
@@ -48,7 +48,7 @@ describe("accessorFor", () => {
         }
     });
 
-    test("refuses BLOB and the nested types (no row-major accessor exists at all)", () => {
+    test("refuses BLOB and the nested types", () => {
         for (const id of [
             DuckDbTypeId.BLOB,
             DuckDbTypeId.LIST,
@@ -61,20 +61,7 @@ describe("accessorFor", () => {
         }
     });
 
-    // Fix round 1 (ruling R10): empirically swept against libduckdb v1.5.5 -
-    // for every one of these eight, duckdb_value_is_null correctly reports
-    // false for a real (non-SQL-NULL) value, for both a bare literal and a
-    // real table column, but duckdb_value_varchar STILL returns a NULL
-    // char* - a different failure mode than BLOB/nested above (which have
-    // no accessor at all; these DO have one, it just doesn't work). The
-    // value is displayable via CAST(col AS VARCHAR) in SQL; the fixed-width
-    // accessors don't rescue it either (duckdb_value_int64 returns a
-    // plausible-looking 0 for all eight, with no failure signal). Before
-    // this fix these all mapped to "varchar" and silently decoded to "".
-    // Some of these assertions used to live in the "reads ... as text" test
-    // above (TIMESTAMP_S/_MS/_NS, UUID, ENUM all asserted "varchar"); they
-    // move here now that that mapping is wrong, rather than being deleted.
-    test("refuses TIME_TZ, TIMESTAMP_TZ, TIMESTAMP_S/MS/NS, UUID, ENUM, BIT - duckdb_value_varchar cannot render them", () => {
+    test("accepts the additional scalar types rendered by the napi reader", () => {
         for (const id of [
             DuckDbTypeId.TIME_TZ,
             DuckDbTypeId.TIMESTAMP_TZ,
@@ -85,7 +72,7 @@ describe("accessorFor", () => {
             DuckDbTypeId.ENUM,
             DuckDbTypeId.BIT,
         ]) {
-            expect(accessorFor(id)).toBeNull();
+            expect(accessorFor(id)).toBe("varchar");
         }
     });
 });
@@ -116,15 +103,30 @@ describe("coerceValue", () => {
         expect(coerceValue(DuckDbTypeId.TIME, "10:11:12")).toBe("10:11:12");
     });
 
-    // Fix round 1 (ruling R10): TIMESTAMP_TZ is no longer in the reachable
-    // set (accessorFor now excludes it entirely, see row-decode.ts's
-    // VARCHAR_TYPES comment - duckdb_value_varchar can't render it, so it
-    // never reaches coerceValue from the real read path). It falls through
-    // to plain text, same as DATE/TIME.
-    test("TIMESTAMP_TZ is no longer special-cased - accessorFor excludes it upstream, so coerceValue now treats it as opaque text like DATE/TIME", () => {
-        expect(coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "2026-08-14 10:11:12+02")).toBe(
-            "2026-08-14 10:11:12+02",
+    test("turns timestamp variants into Dates and applies TIMESTAMP_TZ offsets", () => {
+        for (const id of [
+            DuckDbTypeId.TIMESTAMP_S,
+            DuckDbTypeId.TIMESTAMP_MS,
+            DuckDbTypeId.TIMESTAMP_NS,
+        ]) {
+            const value = coerceValue(id, "2026-08-14 10:11:12.999999999");
+            expect(value).toBeInstanceOf(Date);
+            expect((value as Date).toISOString()).toBe("2026-08-14T10:11:12.999Z");
+        }
+        const zoned = coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "2026-08-14 10:11:12+02:00");
+        expect(zoned).toBeInstanceOf(Date);
+        expect((zoned as Date).toISOString()).toBe("2026-08-14T08:11:12.000Z");
+        const utc = coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "2026-08-14 08:11:12+00");
+        expect((utc as Date).toISOString()).toBe("2026-08-14T08:11:12.000Z");
+    });
+
+    test("keeps TIME_TZ, UUID, ENUM, and BIT in canonical text form", () => {
+        expect(coerceValue(DuckDbTypeId.TIME_TZ, "10:11:12+02:00")).toBe("10:11:12+02:00");
+        expect(coerceValue(DuckDbTypeId.UUID, "11111111-1111-1111-1111-111111111111")).toBe(
+            "11111111-1111-1111-1111-111111111111",
         );
+        expect(coerceValue(DuckDbTypeId.ENUM, "ready")).toBe("ready");
+        expect(coerceValue(DuckDbTypeId.BIT, "1010")).toBe("1010");
     });
 
     // Cross-review P2-2: DuckDB keeps TIMESTAMP at MICROSECOND grain and a JS
@@ -143,6 +145,7 @@ describe("coerceValue", () => {
 
     test("leaves an unparseable timestamp as its original text rather than an Invalid Date", () => {
         expect(coerceValue(DuckDbTypeId.TIMESTAMP, "infinity")).toBe("infinity");
+        expect(coerceValue(DuckDbTypeId.TIMESTAMP_TZ, "infinity")).toBe("infinity");
     });
 
     /**
@@ -183,7 +186,7 @@ describe("coerceValue", () => {
 });
 
 describe("unsupportedColumns", () => {
-    test("returns only the columns with no row-major accessor", () => {
+    test("returns only the columns with no decoder", () => {
         const columns = [
             { name: "id", typeId: DuckDbTypeId.BIGINT },
             { name: "payload", typeId: DuckDbTypeId.BLOB },

--- a/packages/lib/src/duckdb/row-decode.ts
+++ b/packages/lib/src/duckdb/row-decode.ts
@@ -4,8 +4,8 @@
  *
  * The set was originally forced by the `bun:ffi` client's row-major
  * `duckdb_value_*` accessors (`bun:ffi` could not pass structs by value, so
- * BLOB/LIST/STRUCT/... had no accessor at all). The napi driver (#880) COULD
- * render more types - the set stays closed anyway, as a compatibility
+ * BLOB/LIST/STRUCT/... had no accessor at all). The napi driver (#880) CAN
+ * render more scalar types - the set stays closed anyway, as a compatibility
  * contract: every caller, and the DDL itself (JSON-in-VARCHAR for arrays and
  * nested objects), was written against exactly these types, and widening the
  * set silently would change what existing queries decode to. This module
@@ -34,41 +34,10 @@ const UINT64_TYPES: ReadonlySet<number> = new Set([
 const DOUBLE_TYPES: ReadonlySet<number> = new Set([DuckDbTypeId.FLOAT, DuckDbTypeId.DOUBLE]);
 
 /**
- * Types with no fixed-width row-major accessor that DuckDB WILL render
- * faithfully as text via `duckdb_value_varchar`: strings, date/time/plain
- * timestamp, intervals, 128-bit ints, decimal. `SQLNULL` is here too, but
- * never actually reaches the accessor - a literal SQL `NULL`'s cell always
- * reports `duckdb_value_is_null() == true`, so `readResult` takes the
- * null-cell branch before any accessor is called for it.
- *
- * EIGHT other types were empirically swept against libduckdb v1.5.5 (fix
- * round 1, ruling R10) and are DELIBERATELY EXCLUDED, for a DIFFERENT reason
- * than BLOB/nested types below (which have no row-major accessor at all):
- * for these eight, `duckdb_value_is_null` correctly reports `false` for a
- * real value, but `duckdb_value_varchar` still returns a NULL `char *` - on
- * both a bare literal and a real table column, and even though a SQL
- * `CAST(col AS VARCHAR)` on the same value renders it fine. (One caveat:
- * UUID's `duckdb_value_is_null` was also observed reporting `false` for a
- * GENUINELY NULL value under a `WHERE u IS NULL` filter - the other seven
- * were not re-swept for the same anomaly. This does not change shipped
- * behavior: UUID is rejected earlier, structurally, at `unsupportedColumns`
- * below, so `readResult`'s per-cell `is_null` check is never reached for it
- * at all.) The fixed-width
- * accessors don't rescue them either: `duckdb_value_int64` was checked and
- * returns a plausible-looking `0` for every one of them, with no failure
- * signal at all - so none of these should ever be routed to
- * `int64`/`uint64`/`double` as a workaround. Before this fix, the NULL
- * varchar pointer silently decoded to `""` for all eight. A future reader:
- * do not try to "fix" this by giving these an accessor again without first
- * re-verifying against whatever libduckdb build is in use.
- *
- *   TIME_TZ (30), TIMESTAMP_TZ (31), TIMESTAMP_S (20), TIMESTAMP_MS (21),
- *   TIMESTAMP_NS (22), UUID (27), ENUM (23), BIT (29)
- *
- * `client.ts`'s `readResult` also carries a general guard for this exact
- * failure shape (not-null cell, NULL varchar pointer) on any type still
- * listed here as "varchar" - it is what would have caught these eight
- * before they shipped, and is what will catch whatever DuckDB adds next.
+ * Scalar types that the current napi reader can normalize through text.
+ * The name stays `VARCHAR_TYPES` for compatibility with `accessorFor`.
+ * Some entries arrive as napi value objects. `client.ts` passes their
+ * canonical `String(value)` representation to `coerceValue`.
  */
 const VARCHAR_TYPES: ReadonlySet<number> = new Set([
     DuckDbTypeId.VARCHAR,
@@ -80,9 +49,17 @@ const VARCHAR_TYPES: ReadonlySet<number> = new Set([
     DuckDbTypeId.UHUGEINT,
     DuckDbTypeId.DECIMAL,
     DuckDbTypeId.SQLNULL,
+    DuckDbTypeId.TIMESTAMP_S,
+    DuckDbTypeId.TIMESTAMP_MS,
+    DuckDbTypeId.TIMESTAMP_NS,
+    DuckDbTypeId.ENUM,
+    DuckDbTypeId.UUID,
+    DuckDbTypeId.BIT,
+    DuckDbTypeId.TIME_TZ,
+    DuckDbTypeId.TIMESTAMP_TZ,
 ]);
 
-/** Which `duckdb_value_*` accessor reads this column, or null when none can. */
+/** Decoder family for this column. `varchar` also covers napi wrapper text. */
 export const accessorFor = (typeId: number): AccessorKind | null => {
     if (typeId === DuckDbTypeId.BOOLEAN) return "boolean";
     if (INT64_TYPES.has(typeId)) return "int64";
@@ -103,6 +80,10 @@ export const accessorFor = (typeId: number): AccessorKind | null => {
  */
 const parseTimestamp = (text: string): Date | string =>
     finishTimestamp(`${text.replace(" ", "T")}Z`, text);
+
+/** TIMESTAMP_TZ includes an offset. The napi renderer shortens whole-hour offsets. */
+const parseTimestampTz = (text: string): Date | string =>
+    finishTimestamp(text.replace(" ", "T").replace(/([+-]\d{2})$/, "$1:00"), text);
 
 /**
  * Parse `iso`; fall back to `original` text rather than an Invalid Date.
@@ -168,7 +149,15 @@ export const coerceValue = (
     raw: boolean | bigint | number | string,
 ): DuckDbValue => {
     if (typeof raw === "string") {
-        if (typeId === DuckDbTypeId.TIMESTAMP) return parseTimestamp(raw);
+        if (
+            typeId === DuckDbTypeId.TIMESTAMP ||
+            typeId === DuckDbTypeId.TIMESTAMP_S ||
+            typeId === DuckDbTypeId.TIMESTAMP_MS ||
+            typeId === DuckDbTypeId.TIMESTAMP_NS
+        ) {
+            return parseTimestamp(raw);
+        }
+        if (typeId === DuckDbTypeId.TIMESTAMP_TZ) return parseTimestampTz(raw);
         if (typeId === DuckDbTypeId.HUGEINT || typeId === DuckDbTypeId.UHUGEINT) {
             return parseHugeint(raw);
         }

--- a/packages/lib/src/duckdb/types.ts
+++ b/packages/lib/src/duckdb/types.ts
@@ -50,8 +50,8 @@ export const duckDbTypeName = (id: number): string =>
 /**
  * Every JS value a decoded cell can take.
  *
- * `Date` (a `TIMESTAMP` column) is MILLISECOND-grain while DuckDB stores
- * microseconds, so the last three digits of a sub-second value are TRUNCATED
+ * `Date` values from timestamp columns are MILLISECOND-grain. Finer DuckDB
+ * timestamp variants therefore lose their sub-millisecond digits
  * on the way out - `10:11:12.999999` reads back as `10:11:12.999`
  * (cross-review P2-2; see `finishTimestamp` in row-decode.ts for why this is
  * the accepted trade for ax data, and what to do when it is not acceptable:

--- a/packages/schema/src/duckdb-load.test.ts
+++ b/packages/schema/src/duckdb-load.test.ts
@@ -77,11 +77,9 @@ describe("schema.duckdb.sql loads into a fresh DuckDB", () => {
     // semantics, JSON-encoded scalar arrays) and asserts the values survive a
     // round trip through the real DuckDB engine.
     //
-    // TIMESTAMPTZ + native list columns (P2-1/P2-3 as originally reviewed) are
-    // REVERTED: the bun:ffi DuckDB client's row-major `duckdb_value_*`
-    // accessors cannot decode TIMESTAMP_TZ or LIST (probe-confirmed
-    // DuckDbUnsupportedTypeError). This test now exercises the UTC-contract
-    // TIMESTAMP path and JSON-encoded VARCHAR arrays in their place.
+    // The schema keeps plain UTC TIMESTAMP columns. TIMESTAMPTZ decoder support
+    // does not change stored columns without a separate migration. Native LIST
+    // stays unsupported, so arrays remain JSON-encoded VARCHAR values.
     test("representative inserts round-trip through UTC timestamps, JSON-encoded arrays, defaults, and a polymorphic edge", () => {
         withTempDuckdbDir((dbPath) => {
             const script = [

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -80,17 +80,13 @@ function surrealTypesByTable(): Map<string, Map<string, SurrealFieldType>> {
 
 /** Maps a Surreal DEFINE FIELD TYPE to the DuckDB type it must translate to.
  *
- *  P2-3 (native list columns for scalar `array<T>` fields) and P2-1
- *  (`datetime` -> TIMESTAMPTZ) are both REVERTED (see the UTC CONTRACT / FFI
- *  CLIENT COMPATIBILITY notes in schema.duckdb.sql's header): the bun:ffi
- *  DuckDB client's row-major `duckdb_value_*` accessors cannot decode
- *  TIMESTAMP_TZ or LIST, so every scalar array stays JSON-encoded VARCHAR
- *  (same as record/object arrays - no distinction by element type anymore)
- *  and every datetime is plain TIMESTAMP. */
+ *  Native list columns remain outside the read contract. Every array stays
+ *  JSON-encoded VARCHAR. Datetimes remain plain TIMESTAMP to preserve the
+ *  current UTC storage contract. TIMESTAMPTZ needs a separate migration. */
 function expectedDuckType(t: string): string {
     if (t.startsWith("record<")) return "VARCHAR";
     // Every array<T> - scalar or not - is JSON-encoded VARCHAR now; DuckDB
-    // native list columns (`T[]`) are banned (FFI client can't decode LIST).
+    // Native list columns (`T[]`) remain outside the read contract.
     if (t.startsWith("array<")) return "VARCHAR";
     if (t === "object") return "VARCHAR";
     switch (t) {
@@ -105,9 +101,8 @@ function expectedDuckType(t: string): string {
         case "bool":
             return "BOOLEAN";
         case "datetime":
-            // Plain TIMESTAMP, never TIMESTAMPTZ - the FFI client cannot decode
-            // TIMESTAMP_TZ (DuckDbUnsupportedTypeError, probe-confirmed). Writers
-            // must normalize to UTC before insert; readers append `Z`.
+            // Keep the current UTC storage contract. Writers normalize to UTC
+            // before insert, and readers append `Z`.
             return "TIMESTAMP";
         default:
             return `?${t}`;
@@ -328,28 +323,17 @@ describe("type + nullability parity (Surreal DEFINE FIELD TYPE == owning engine'
     });
 });
 
-// Regression guard for the whole "DDL drifted ahead of the FFI client" conflict
-// class (TIMESTAMPTZ + native LIST columns were both added in a review round
-// that didn't know the reader can't decode either - see the BANNED TYPES note
-// in schema.duckdb.sql's header). The bun:ffi DuckDB client decodes results
-// with the deprecated row-major `duckdb_value_*` accessors (it cannot pass
-// structs by value, so it can't use the columnar/vector API); a probe against
-// the real client + dylib confirmed TIMESTAMP_TZ and LIST both raise
-// DuckDbUnsupportedTypeError. None of these may appear as a column type
-// anywhere in the DDL, and this test scans every column's actual type token -
-// not a fixed set of "known offender" columns - so a future column reintroducing
-// any of them fails here regardless of which table it lands on.
-describe("banned-type guard (FFI client compatibility)", () => {
-    // Derived, not hand-maintained (v2 W1 "derived schema truth"): a type
-    // token is banned exactly when the FFI client has no row-major accessor
+// A type can enter the DDL only after the read decoder supports it.
+describe("banned-type guard (read decoder compatibility)", () => {
+    // A token is banned exactly when the client has no decoder
     // for it - `accessorFor` (packages/lib/src/duckdb/row-decode.ts) returns
     // null for the `DuckDbTypeId` (packages/lib/src/duckdb/types.ts) it maps
     // to. Two SQL spelling aliases are added on top because they are real
     // spellings a DDL author could type for the same (unsupported) type but
     // are not `DuckDbTypeId` enum key names themselves.
     const SQL_SPELLING_ALIASES = [
-        "TIMESTAMPTZ", // alias for TIMESTAMP_TZ / TIMESTAMP WITH TIME ZONE
-        "TIMETZ", // alias for TIME_TZ
+        ...(accessorFor(DuckDbTypeId.TIMESTAMP_TZ) === null ? ["TIMESTAMPTZ"] : []),
+        ...(accessorFor(DuckDbTypeId.TIME_TZ) === null ? ["TIMETZ"] : []),
     ];
     const BANNED_TYPE_TOKENS = [
         ...Object.entries(DuckDbTypeId)
@@ -358,27 +342,20 @@ describe("banned-type guard (FFI client compatibility)", () => {
         ...SQL_SPELLING_ALIASES,
     ];
 
-    test("the derived set still covers every previously known FFI-unreadable spelling", () => {
-        // Regression floor: the derivation must never shrink below the set
-        // that was hand-maintained before this chunk (it may grow - see the
-        // parser-sanity test below for the exact superset this derives to).
+    test("the derived set still covers every unsupported stored shape", () => {
         for (const must of [
-            "UUID",
-            "ENUM",
-            "BIT",
-            "TIMESTAMP_S",
-            "TIMESTAMP_MS",
-            "TIMESTAMP_NS",
-            "TIMESTAMP_TZ",
-            "TIMESTAMPTZ",
-            "TIME_TZ",
-            "TIMETZ",
+            "BLOB",
+            "LIST",
+            "STRUCT",
+            "MAP",
+            "UNION",
+            "ARRAY",
         ]) {
             expect(BANNED_TYPE_TOKENS).toContain(must);
         }
     });
 
-    test("no column in the DDL uses a banned (FFI-unreadable) type", () => {
+    test("no column in the DDL uses a type outside the read contract", () => {
         const problems: string[] = [];
         let checked = 0;
 
@@ -386,7 +363,7 @@ describe("banned-type guard (FFI client compatibility)", () => {
             for (const def of parseDuckdbColumnDefs(table)) {
                 checked += 1;
                 if (def.type.endsWith("[]")) {
-                    // Native DuckDB list column - the FFI client cannot decode LIST.
+                    // Native DuckDB list columns remain outside the read contract.
                     problems.push(`${table}.${def.name}: native LIST column (${def.type}) is banned`);
                     continue;
                 }
@@ -403,33 +380,17 @@ describe("banned-type guard (FFI client compatibility)", () => {
 
     // Pins the exact derived set so a future accessorFor/DuckDbTypeId change
     // is a visible diff here, not a silent widening or narrowing. The
-    // derivation is WIDER than the hand-written list it replaced (which had
-    // exactly the 10 entries in the regression-floor test above): BLOB,
-    // STRUCT, MAP, UNION, ARRAY and INVALID also have no row-major accessor
-    // and are real DuckDB type spellings, so they are correctly banned too -
-    // none of them appear as a column type in the current DDL (verified by
-    // the "no column ... banned" test above still passing), so this is a
-    // strictly more complete guard, not a behavior change.
+    // The exact set makes every decoder change visible in this policy test.
     test("pins the exact derived token set", () => {
         expect([...BANNED_TYPE_TOKENS].sort()).toEqual(
             [
                 "ARRAY",
-                "BIT",
                 "BLOB",
-                "ENUM",
                 "INVALID",
                 "LIST",
                 "MAP",
                 "STRUCT",
-                "TIME_TZ",
-                "TIMESTAMP_MS",
-                "TIMESTAMP_NS",
-                "TIMESTAMP_S",
-                "TIMESTAMP_TZ",
-                "TIMESTAMPTZ",
-                "TIMETZ",
                 "UNION",
-                "UUID",
             ].sort(),
         );
     });

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -158,18 +158,12 @@ describe("types and Surreal leftovers", () => {
         }
     });
 
-    // P2-1 (TIMESTAMPTZ for every datetime) is REVERTED: the bun:ffi DuckDB
-    // client cannot decode TIMESTAMP_TZ (probe-confirmed DuckDbUnsupportedTypeError
-    // against the real client + dylib). Every datetime column is plain TIMESTAMP
-    // now, under a UTC contract (writers normalize to UTC before insert; readers
-    // append `Z`). TIMESTAMPTZ is a banned type - see the banned-type guard in
-    // duckdb-parity.test.ts for the exhaustive per-column scan; this test just
-    // pins the header-level contract.
-    test("datetimes are plain TIMESTAMP (UTC contract); TIMESTAMPTZ is banned", () => {
+    // Every stored datetime remains plain TIMESTAMP under the UTC contract.
+    // TIMESTAMPTZ decoder support does not change the DDL without a migration.
+    test("datetimes remain plain TIMESTAMP under the UTC contract", () => {
         expect(DUCKDB_SCHEMA_SQL).toMatch(/\bTIMESTAMP\b/);
         expect(DUCKDB_SCHEMA_SQL).not.toMatch(/\bDATETIME\b/);
-        // No column declaration line (comments stripped via `statements`) may use
-        // TIMESTAMPTZ - the FFI client can't decode it.
+        // No stored column changes type in this decoder-only change.
         expect(statements).not.toMatch(/\bTIMESTAMPTZ\b/);
     });
 
@@ -185,11 +179,9 @@ describe("types and Surreal leftovers", () => {
 });
 
 describe("arrays (P2-3, reverted)", () => {
-    // P2-3 (native DuckDB list columns for scalar array<T> fields) is REVERTED:
-    // the bun:ffi DuckDB client cannot decode LIST columns (probe-confirmed
-    // DuckDbUnsupportedTypeError against the real client + dylib). Every
+    // Native LIST columns remain outside the read contract. Every
     // array<T> field - scalar or record/object - now stays JSON-encoded
-    // VARCHAR, same treatment. See the ARRAYS / BANNED TYPES notes in the
+    // VARCHAR, same treatment. See the ARRAYS / READ CLIENT notes in the
     // schema.duckdb.sql header; the exhaustive per-column scan lives in the
     // banned-type guard in duckdb-parity.test.ts.
     test("formerly-native-list scalar array fields are JSON VARCHAR, not list columns", () => {

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -58,12 +58,11 @@
 -- TYPES. Surreal `datetime` -> plain `TIMESTAMP` (NOT `TIMESTAMPTZ`). `int` ->
 -- BIGINT, `float`/`number` -> DOUBLE, `bool` -> BOOLEAN.
 --
--- UTC CONTRACT (supersedes P2-1; reverted from TIMESTAMPTZ, see FFI CLIENT
--- COMPATIBILITY below). All TIMESTAMP columns store UTC instants. Writers MUST
+-- UTC CONTRACT (supersedes P2-1). All TIMESTAMP columns store UTC instants. Writers MUST
 -- normalize to UTC before insert - DuckDB silently drops offsets on naive
 -- TIMESTAMP inserts, so an offset string reaching the DB is a writer bug.
--- Readers append `Z` when they need an ISO string back out. TIMESTAMPTZ is
--- banned in this file: the FFI client cannot decode it (see below).
+-- Readers append `Z` when they need an ISO string back out. The reader now
+-- supports TIMESTAMPTZ, but changing stored columns needs a separate migration.
 --
 -- ARRAYS (P2-3, reverted). Surreal `array<T>` where T is a scalar (string/int/
 -- float/number/bool/datetime) stays JSON-encoded VARCHAR, marked `-- JSON` at
@@ -71,24 +70,19 @@
 -- of records/objects, `flexible`/nested-object shapes - v3 has no
 -- `flexible<object>`). An earlier revision of this file made scalar arrays
 -- native DuckDB list columns (`VARCHAR[]` etc.) since DuckDB lists are a real
--- first-class type; that native-list form is banned here until the FFI client
--- gains LIST decoding (see below) - all scalar arrays are JSON text in VARCHAR
+-- first-class type; that native-list form is banned until the client gains
+-- LIST decoding (see below) - all scalar arrays are JSON text in VARCHAR
 -- for now, readable with DuckDB's json functions.
 --
--- FFI CLIENT COMPATIBILITY. Every reader of this cache goes through the
+-- READ CLIENT COMPATIBILITY. Every reader of this cache goes through the
 -- `@ax/lib/duckdb` client, which answers for a CLOSED SET of column types
 -- (row-decode.ts). The set was forced by the original bun:ffi client's
 -- row-major `duckdb_value_*` accessors; the napi driver that replaced it
 -- (#880) keeps the set closed as a compatibility contract - every query and
--- this DDL were written against exactly these types, and widening the set
--- silently would change what existing readers decode to. BANNED TYPES - none
--- of these may appear as a column type in this file:
---   UUID, ENUM, BIT, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIMESTAMP_TZ,
---   TIME_TZ, LIST
--- The client raises `DuckDbUnsupportedTypeError` for all of them - not a
--- column type any writer should be allowed to introduce silently, so
--- duckdb-parity.test.ts scans every column type token in this file against
--- this exact list.
+-- this DDL were written against exactly these types. New scalar types enter
+-- only after explicit decode rules and boundary tests. Nested native types,
+-- including LIST, remain outside the contract. `duckdb-parity.test.ts` derives
+-- the banned type tokens from the decoder.
 --
 -- NUL-BYTE CONTRACT. Text columns must never contain NUL bytes - the FFI
 -- client's CString decode truncates at the first NUL, silently dropping


### PR DESCRIPTION
## Summary

- decode eight additional non-nested DuckDB scalar types through the napi reader
- convert timestamp variants to Date values with explicit offset handling
- keep UUID, ENUM, BIT, and TIME_TZ values as canonical text
- retain typed errors for BLOB and nested types
- update the DDL compatibility guard without changing stored columns

## Verification

- 367 pass, 1 platform skip, 0 fail across DuckDB and schema suites
- typecheck passes
- no-node-fs, timestamp-cast, and raw-numeric-cast checks pass

Fixes #788

---

_Generated with [ax](https://github.com/Necmttn/ax)._
