### PR TITLE
fix: harden derive timeouts and project verification

### DIFF
--- a/apps/axctl/src/cli/commands/ingest-deadline-wiring.test.ts
+++ b/apps/axctl/src/cli/commands/ingest-deadline-wiring.test.ts
@@ -34,7 +34,7 @@ describe("ingest command deadline wiring", () => {
         });
         expect(firstRun.lockOptions.timeoutSeconds).toBe(FIRST_RUN_INGEST_TIMEOUT_SECONDS);
         expect(firstRun.runOptions.deadlineMs).toBe(
-            NOW_MS + firstRun.lockOptions.timeoutSeconds * 1000,
+            NOW_MS + firstRun.decision.seconds * 1000,
         );
 
         const explicit = resolveIngestCommandTiming({
@@ -45,6 +45,40 @@ describe("ingest command deadline wiring", () => {
         });
         expect(explicit.lockOptions.timeoutSeconds).toBe(37);
         expect(explicit.runOptions.deadlineMs).toBe(NOW_MS + 37_000);
+    });
+
+    test("derive-only with AX_STAGE_HUNG_SECONDS=180 does not inherit a divided shared deadline", () => {
+        const timing = resolveIngestCommandTiming({
+            configuredSeconds: 900,
+            knobExplicitlySet: false,
+            firstRun: false,
+            deriveOnly: true,
+            nowMs: NOW_MS,
+        });
+        expect(timing.runOptions).toEqual({});
+        expect(timing.lockOptions).toEqual({});
+    });
+
+    test("real lock seam leaves an unset derive-only timeout disabled", async () => {
+        const dataDir = mkdtempSync(join(tmpdir(), "ax-ingest-lock-seam-"));
+        const lockPath = join(dataDir, "ingest.lock");
+        const platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+        const run = (timeoutSeconds?: number) => withIngestLock(
+            {
+                lockPath,
+                command: "test",
+                staleMs: 10_000,
+                ...(timeoutSeconds === undefined ? {} : { timeoutSeconds }),
+                onBusy: () => Effect.succeed("busy" as const),
+            },
+            Effect.sleep(20).pipe(Effect.as("completed" as const)),
+        ).pipe(Effect.provide(platform));
+        try {
+            expect((await Effect.runPromise(run()))._tag).toBe("completed");
+            expect((await Effect.runPromise(run(0.001)))._tag).toBe("timeout");
+        } finally {
+            rmSync(dataDir, { recursive: true, force: true });
+        }
     });
 
     test("the real cmdIngest boundary forwards first-run and explicit deadlines", async () => {

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -196,13 +196,13 @@ interface IngestCommandOpts {
 export interface IngestCommandTiming {
     readonly decision: IngestDeadlineDecision;
     readonly runOptions: Pick<RunIngestOptions, "deadlineMs">;
-    readonly lockOptions: { readonly timeoutSeconds: number };
+    readonly lockOptions: { readonly timeoutSeconds?: number };
 }
 
 /** Resolve the CLI deadline once, then prepare the exact option fragments sent
  * to `runIngest` and `withIngestLock`. Exported for boundary tests. */
 export const resolveIngestCommandTiming = (
-    input: IngestDeadlineInput & { readonly nowMs: number },
+    input: IngestDeadlineInput & { readonly nowMs: number; readonly deriveOnly?: boolean },
 ): IngestCommandTiming => {
     const decision = resolveIngestDeadlineSeconds(input);
     return {
@@ -210,7 +210,7 @@ export const resolveIngestCommandTiming = (
         runOptions: decision.seconds > 0
             ? { deadlineMs: input.nowMs + decision.seconds * 1000 }
             : {},
-        lockOptions: { timeoutSeconds: decision.seconds },
+        lockOptions: decision.seconds > 0 ? { timeoutSeconds: decision.seconds } : {},
     };
 };
 
@@ -394,8 +394,9 @@ export const cmdIngest = (
                 .exists(snapshotPath())
                 .pipe(Effect.orElseSucceed(() => true))),
             nowMs: deps.nowMs(),
+            deriveOnly: args.includes("--derive-only"),
         });
-        const timeoutSeconds = timing.lockOptions.timeoutSeconds;
+        const timeoutSeconds = timing.decision.seconds;
         if (timing.decision.upgraded) yield* Effect.logInfo(`ingest: ${timing.decision.reason}`);
         // The runId is minted HERE (not inside runIngest) so the timeout and
         // failure paths below can address the `ingest_run` row.

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -504,10 +504,9 @@ export const cmdIngest = (
         // Single-flight + hard wall-clock cap, both owned by the lock. While one
         // ingest holds the lock another SKIPS (the watcher re-fires anyway, so a
         // redundant run is harmless and avoids the pile-up that wedges the DB).
-        // The timeout lives inside the lock so that a timed-out run LEAVES its
-        // lock to age into a cooldown - interrupting the fiber doesn't prove
-        // DuckDB stopped work, so the next ingest must hold off until
-        // the lock goes stale rather than charging a still-busy DB.
+        // A timed-out run leaves its lock in place. Interrupting the fiber does
+        // not prove DuckDB stopped work, so another process waits for the owner
+        // to exit. A live holder never loses its lock solely because of age.
         const outcome = yield* deps.withIngestLock(
             {
                 ...ingestLockOptions(path, cfg.paths.dataDir, commandName, timeoutSeconds),

--- a/apps/axctl/src/ingest/deadline.test.ts
+++ b/apps/axctl/src/ingest/deadline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import {
     FIRST_RUN_INGEST_TIMEOUT_SECONDS,
     resolveIngestDeadlineSeconds,
@@ -11,6 +11,10 @@ import {
  * first run failed with two stages reported failed (#830).
  */
 describe("resolveIngestDeadlineSeconds", () => {
+    test("derive-only has no shared deadline unless explicitly configured", () => {
+        expect(resolveIngestDeadlineSeconds({ ...base, firstRun: false, deriveOnly: true }).seconds).toBe(0);
+        expect(resolveIngestDeadlineSeconds({ ...base, firstRun: false, deriveOnly: true, knobExplicitlySet: true }).seconds).toBe(900);
+    });
     const base = { configuredSeconds: 900, knobExplicitlySet: false, firstRun: false } as const;
 
     it("raises a first run past the incremental default", () => {

--- a/apps/axctl/src/ingest/deadline.ts
+++ b/apps/axctl/src/ingest/deadline.ts
@@ -55,6 +55,8 @@ export interface IngestDeadlineInput {
      * transcript, commit and skill on disk is read for the first time.
      */
     readonly firstRun: boolean;
+    /** Derive-only runs have no shared deadline unless explicitly requested. */
+    readonly deriveOnly?: boolean;
 }
 
 export interface IngestDeadlineDecision {
@@ -81,6 +83,13 @@ export const resolveIngestDeadlineSeconds = (
             seconds: input.configuredSeconds,
             upgraded: false,
             reason: "AX_INGEST_TIMEOUT_SECONDS was set explicitly",
+        };
+    }
+    if (input.deriveOnly) {
+        return {
+            seconds: 0,
+            upgraded: false,
+            reason: "derive-only uses AX_STAGE_HUNG_SECONDS unless a shared timeout is explicit",
         };
     }
     if (!input.firstRun) {

--- a/apps/axctl/src/ingest/stage/derive-budget.ts
+++ b/apps/axctl/src/ingest/stage/derive-budget.ts
@@ -78,5 +78,6 @@ export const deriveStageBudget = (input: {
     const shareOfDeadline = untilDeadline / stageCount;
     const staticCap = input.staticCapMs > 0 ? input.staticCapMs : Number.POSITIVE_INFINITY;
     const capMs = Math.min(staticCap, shareOfDeadline);
-    return Number.isFinite(capMs) ? { _tag: "capped", capMs } : { _tag: "uncapped" };
+    if (!Number.isFinite(capMs)) return { _tag: "uncapped" };
+    return { _tag: "capped", capMs };
 };

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -734,6 +734,28 @@ describe("runPipeline derive budget (#697)", () => {
         expect(stats[0]?.summary).toMatch(/timed out|skipped/);
     });
 
+    it("names the shared deadline when it beats AX_STAGE_HUNG_SECONDS", async () => {
+        const previousHung = process.env.AX_STAGE_HUNG_SECONDS;
+        const previousHeartbeat = process.env.AX_INGEST_HEARTBEAT_SECONDS;
+        process.env.AX_STAGE_HUNG_SECONDS = "180";
+        process.env.AX_INGEST_HEARTBEAT_SECONDS = "0";
+        try {
+            const rec = outcomeRecorder();
+            await Effect.runPromise(runPipeline([hangs("deadline", ["derive"])], ctx, {
+                deadlineMs: Date.now() + 80,
+                reserveMs: 0,
+                recordStageOutcome: rec.recordStageOutcome,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>);
+            expect(rec.seen[0]!.errorText).toContain("AX_INGEST_TIMEOUT_SECONDS");
+            expect(rec.seen[0]!.errorText).not.toContain("AX_STAGE_HUNG_SECONDS");
+        } finally {
+            if (previousHung === undefined) delete process.env.AX_STAGE_HUNG_SECONDS;
+            else process.env.AX_STAGE_HUNG_SECONDS = previousHung;
+            if (previousHeartbeat === undefined) delete process.env.AX_INGEST_HEARTBEAT_SECONDS;
+            else process.env.AX_INGEST_HEARTBEAT_SECONDS = previousHeartbeat;
+        }
+    });
+
     it("an ingest-tagged stage is exempt - a real backfill legitimately runs long", async () => {
         const stats = await Effect.runPromise(
             runPipeline([instant("skills", ["ingest"])], ctx, {

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -190,7 +190,8 @@ export const topoLayers = <S extends BaseStageStats, R, E>(
  *  once. Each stage is wrapped in `LiveTrace.step` so progress flows through
  *  the configured `TraceTransport` (ADR-0007).
  *
- *  `opts.deadlineMs` is the run's wall-clock deadline (epoch ms). Derive stages
+ *  `opts.deadlineMs` is the run's wall-clock deadline (epoch ms). Derive-only
+ *  CLI runs omit it unless `AX_INGEST_TIMEOUT_SECONDS` is explicit. Derive stages
  *  are budgeted against it so the pass ends cleanly instead of being killed by
  *  the outer ingest timeout (#697); omit it and derives keep only their static
  *  `AX_STAGE_HUNG_SECONDS` cap. The time left before the deadline is divided
@@ -371,14 +372,21 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                             );
                         if (budget._tag === "uncapped") return selfGuarded;
                         const capSeconds = Math.round(budget.capMs / 1000);
+                        const deadlineCapped = hungCapMs <= 0 || budget.capMs < hungCapMs;
+                        const capName = deadlineCapped
+                            ? "shared ingest deadline"
+                            : "wall-clock hung detector";
                         return selfGuarded.pipe(
                             Effect.timeoutOrElse({
                                 duration: budget.capMs,
                                 orElse: () =>
                                     Effect.logWarning(
                                         `ingest: derive stage '${s.meta.key}' still running after ${capSeconds}s ` +
-                                            `of wall clock (hung detector) - skipping it (failed open) so the ` +
-                                            `run can finish. Raise/disable with AX_STAGE_HUNG_SECONDS.`,
+                                            `of wall clock (${capName}) - skipping it (failed open) so the ` +
+                                            `run can finish. ` +
+                                            (deadlineCapped
+                                                ? "Raise AX_INGEST_TIMEOUT_SECONDS."
+                                                : "Raise/disable with AX_STAGE_HUNG_SECONDS."),
                                     ).pipe(
                                         // Overwrite the `interrupted` row the
                                         // stage's own finalizer just wrote with
@@ -390,8 +398,9 @@ export const runPipeline = <S extends BaseStageStats, R, E>(
                                             opts.recordStageOutcome?.(s.meta.key, {
                                                 status: "timeout",
                                                 errorText:
-                                                    `hung - still running after the ${capSeconds}s wall-clock hung ` +
-                                                    `detector (raise or disable with AX_STAGE_HUNG_SECONDS); ` +
+                                                    `${deadlineCapped ? "deadline" : "hung"} - still running after ` +
+                                                    `the ${capSeconds}s ${capName} ` +
+                                                    `(raise ${deadlineCapped ? "AX_INGEST_TIMEOUT_SECONDS" : "or disable with AX_STAGE_HUNG_SECONDS"}); ` +
                                                     `the run continued without this stage`,
                                             }) ?? Effect.void,
                                         ),

--- a/apps/axctl/src/project/context.ts
+++ b/apps/axctl/src/project/context.ts
@@ -21,7 +21,7 @@ const buildProjectGrounding = (
 ): Effect.Effect<ProjectGrounding, never, ProcessService | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const git = yield* getGitState(cwd);
-        const stack = yield* loadProjectStack(git.root);
+        const stack = yield* loadProjectStack(git.root, git.changes.map((change) => change.path));
         const checks = deriveVerificationChecks({ git, stack });
         const diagnostics = yield* queryLiveDiagnostics(git.root);
         return {

--- a/apps/axctl/src/project/git.test.ts
+++ b/apps/axctl/src/project/git.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
-import { ProcessServiceTest } from "@ax/lib/process";
+import { ProcessServiceLive, ProcessServiceTest } from "@ax/lib/process";
 import { getGitState } from "./git.ts";
 
 const STATUS_OUTPUT = ["## main", "M  src/a.ts", " M src/b.ts", "?? new.md", ""].join("\0");
@@ -57,4 +57,18 @@ describe("getGitState", () => {
             await rm(root, { recursive: true, force: true });
         }
     });
+});
+
+
+test("expands untracked package directories into source files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ax-git-package-"));
+    try {
+        expect(Bun.spawnSync(["git", "init", "--quiet", root]).exitCode).toBe(0);
+        await mkdir(join(root, "frontend"));
+        await writeFile(join(root, "frontend", "package.json"), "{}");
+        await writeFile(join(root, "frontend", "main.ts"), "export {};");
+        const state = await Effect.runPromise(getGitState(root).pipe(Effect.provide(Layer.merge(ProcessServiceLive, BunFileSystem.layer))));
+        expect(state.changes.map(c => c.path)).toContain("frontend/main.ts");
+        expect(state.changes.map(c => c.path)).toContain("frontend/package.json");
+    } finally { await rm(root, { recursive: true, force: true }); }
 });

--- a/apps/axctl/src/project/git.ts
+++ b/apps/axctl/src/project/git.ts
@@ -104,7 +104,7 @@ export const getGitState = (
         }
 
         const [status, head] = yield* Effect.all([
-            runGit(root, ["status", "--porcelain=v1", "-z", "-b"]),
+            runGit(root, ["status", "--porcelain=v1", "-z", "-b", "--untracked-files=all"]),
             runGit(root, ["rev-parse", "--short", "HEAD"]),
         ]);
 

--- a/apps/axctl/src/project/package-path.ts
+++ b/apps/axctl/src/project/package-path.ts
@@ -1,0 +1,9 @@
+import { posixPath } from "@ax/lib/shared/path";
+
+/** Git paths must stay relative to the checkout, including Windows input. */
+export function projectRelativePath(value: string): string | null {
+    const path = value.replaceAll("\\", "/");
+    if (path.includes("\0") || path.startsWith("/") || /^[a-zA-Z]:/.test(path)) return null;
+    const normalized = posixPath.normalize(path);
+    return normalized === "." || normalized === ".." || normalized.startsWith("../") ? null : normalized;
+}

--- a/apps/axctl/src/project/stack.test.ts
+++ b/apps/axctl/src/project/stack.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
-import { extractInstructionMatches, loadPackageInfo, packageSignals } from "./stack.ts";
+import { extractInstructionMatches, loadPackageInfo, loadPackageInfos, packageSignals } from "./stack.ts";
 
 const fsLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
@@ -23,6 +23,24 @@ describe("loadPackageInfo", () => {
                 dependencies: [],
                 devDependencies: [],
             });
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    test("discovers the nearest manifest for POSIX and Windows changed paths", async () => {
+        const root = await mkdtemp(join(tmpdir(), "ax-stack-nested-"));
+        try {
+            await writeFile(join(root, "package.json"), JSON.stringify({ name: "root" }));
+            await mkdir(join(root, "apps", "axctl", "src", "project"), { recursive: true });
+            await writeFile(join(root, "apps", "axctl", "src", "project", "verify.ts"), "");
+            await Bun.write(join(root, "apps", "axctl", "package.json"), JSON.stringify({ name: "axctl" }));
+            for (const changedPath of ["apps/axctl/src/project/verify.ts", "apps\\axctl\\src\\project\\verify.ts"]) {
+                const infos = await Effect.runPromise(loadPackageInfos(root, [changedPath]).pipe(Effect.provide(fsLayer)));
+                expect(infos.map((info) => info.packageJsonPath)).toContain(join(root, "apps", "axctl", "package.json"));
+            }
+            const escaped = await Effect.runPromise(loadPackageInfos(root, ["../outside/file.ts"]).pipe(Effect.provide(fsLayer)));
+            expect(escaped).toHaveLength(1);
         } finally {
             await rm(root, { recursive: true, force: true });
         }

--- a/apps/axctl/src/project/stack.test.ts
+++ b/apps/axctl/src/project/stack.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -111,5 +111,24 @@ describe("extractInstructionMatches", () => {
         );
 
         expect(matches).toEqual([]);
+    });
+});
+
+
+describe("package discovery boundaries", () => {
+    test("rejects directory and manifest symlinks outside the checkout", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-stack-boundary-"));
+        try {
+            const root = join(base, "repo");
+            const outside = join(base, "outside");
+            await mkdir(root);
+            await mkdir(outside);
+            await writeFile(join(outside, "package.json"), JSON.stringify({ scripts: { test: "external" } }));
+            await symlink(outside, join(root, "frontend"));
+            await mkdir(join(root, "backend"));
+            await symlink(join(outside, "package.json"), join(root, "backend", "package.json"));
+            const infos = await Effect.runPromise(loadPackageInfos(root, ["frontend/a.ts", "backend/b.ts"]).pipe(Effect.provide(fsLayer)));
+            expect(infos).toEqual([]);
+        } finally { await rm(base, { recursive: true, force: true }); }
     });
 });

--- a/apps/axctl/src/project/stack.ts
+++ b/apps/axctl/src/project/stack.ts
@@ -46,13 +46,49 @@ export const loadPackageInfo = (root: string | null): Effect.Effect<PackageInfo,
 
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return emptyPackageInfo();
         const record = parsed as Record<string, unknown>;
+        let packageManager = typeof record.packageManager === "string" ? record.packageManager : null;
+        if (!packageManager) {
+            const locks = [
+                ["bun.lock", "bun"], ["bun.lockb", "bun"], ["pnpm-lock.yaml", "pnpm"],
+                ["yarn.lock", "yarn"], ["package-lock.json", "npm"],
+            ] as const;
+            const found = [] as string[];
+            for (const [lock, manager] of locks) {
+                if (yield* fs.exists(path.join(root, lock)).pipe(orAbsent(false))) found.push(manager);
+            }
+            const managers = [...new Set(found)];
+            packageManager = managers.length === 1 ? managers[0]! : managers.length > 1 ? "conflict" : null;
+        }
         return {
             packageJsonPath: pkgPath,
-            packageManager: typeof record.packageManager === "string" ? record.packageManager : null,
+            packageManager,
             scripts: asStringRecord(record.scripts),
             dependencies: packageNames(record.dependencies),
             devDependencies: packageNames(record.devDependencies),
         };
+    });
+
+export const loadPackageInfos = (
+    root: string | null,
+    changedPaths: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<PackageInfo>, never, FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        if (!root) return [];
+        const path = yield* Path.Path;
+        const dirs = new Set([root]);
+        for (const changedPath of changedPaths) {
+            const relativePath = changedPath.replaceAll("\\", "/");
+            const absolutePath = path.resolve(root, relativePath);
+            const relativeToRoot = path.relative(root, absolutePath);
+            if (relativeToRoot === ".." || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) continue;
+            let dir = path.dirname(absolutePath);
+            while (dir !== root) {
+                dirs.add(dir);
+                dir = path.dirname(dir);
+            }
+        }
+        const infos = yield* Effect.all([...dirs].map((dir) => loadPackageInfo(dir)), { concurrency: "unbounded" });
+        return infos.filter((info) => info.packageJsonPath !== null);
     });
 
 export function packageSignals(pkg: PackageInfo): ReadonlyArray<StackSignal> {
@@ -146,12 +182,15 @@ export const loadInstructionMatches = (
 
 export const loadProjectStack = (
     root: string | null,
+    changedPaths: ReadonlyArray<string> = [],
 ): Effect.Effect<ProjectStack, never, FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const pkg = yield* loadPackageInfo(root);
+        const packages = yield* loadPackageInfos(root, changedPaths);
         const instructions = yield* loadInstructionMatches(root);
         return {
             package: pkg,
+            packages,
             signals: packageSignals(pkg),
             instructions,
         };

--- a/apps/axctl/src/project/stack.ts
+++ b/apps/axctl/src/project/stack.ts
@@ -2,6 +2,8 @@ import { Effect, FileSystem, Path } from "effect";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import type { InstructionMatch, PackageInfo, ProjectStack, StackSignal } from "./types.ts";
 
+import { projectRelativePath } from "./package-path.ts";
+
 const INSTRUCTION_FILES = ["AGENTS.md", "CLAUDE.md"] as const;
 
 function emptyPackageInfo(): PackageInfo {
@@ -28,7 +30,7 @@ function packageNames(value: unknown): ReadonlyArray<string> {
     return Object.keys(value as Record<string, unknown>).sort();
 }
 
-export const loadPackageInfo = (root: string | null): Effect.Effect<PackageInfo, never, FileSystem.FileSystem | Path.Path> =>
+export const loadPackageInfo = (root: string | null, boundary: string | null = root): Effect.Effect<PackageInfo, never, FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         if (!root) return emptyPackageInfo();
 
@@ -36,11 +38,14 @@ export const loadPackageInfo = (root: string | null): Effect.Effect<PackageInfo,
         const path = yield* Path.Path;
 
         const pkgPath = path.join(root, "package.json");
-        // existsSync probe → orAbsent(false): a fault means "treat as absent".
-        if (!(yield* fs.exists(pkgPath).pipe(orAbsent(false)))) return emptyPackageInfo();
+        const realBoundary = yield* fs.realPath(boundary ?? root).pipe(Effect.orElseSucceed(() => null));
+        const realManifest = yield* fs.realPath(pkgPath).pipe(Effect.orElseSucceed(() => null));
+        if (!realBoundary || !realManifest) return emptyPackageInfo();
+        const relative = path.relative(realBoundary, realManifest);
+        if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return emptyPackageInfo();
 
         const parsed = yield* Effect.tryPromise({
-            try: () => Bun.file(pkgPath).json() as Promise<unknown>,
+            try: () => Bun.file(realManifest).json() as Promise<unknown>,
             catch: () => "PackageJsonReadError" as const,
         }).pipe(Effect.orElseSucceed(() => null));
 
@@ -75,19 +80,20 @@ export const loadPackageInfos = (
     Effect.gen(function* () {
         if (!root) return [];
         const path = yield* Path.Path;
-        const dirs = new Set([root]);
+        const checkout = path.resolve(root);
+        const dirs = new Set([checkout]);
         for (const changedPath of changedPaths) {
-            const relativePath = changedPath.replaceAll("\\", "/");
-            const absolutePath = path.resolve(root, relativePath);
-            const relativeToRoot = path.relative(root, absolutePath);
-            if (relativeToRoot === ".." || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) continue;
-            let dir = path.dirname(absolutePath);
-            while (dir !== root) {
+            const relativePath = projectRelativePath(changedPath);
+            if (relativePath === null) continue;
+            let dir = path.dirname(path.resolve(checkout, relativePath));
+            while (dir !== checkout) {
                 dirs.add(dir);
-                dir = path.dirname(dir);
+                const parent = path.dirname(dir);
+                if (parent === dir) break;
+                dir = parent;
             }
         }
-        const infos = yield* Effect.all([...dirs].map((dir) => loadPackageInfo(dir)), { concurrency: "unbounded" });
+        const infos = yield* Effect.all([...dirs].map((dir) => loadPackageInfo(dir, checkout)), { concurrency: 8 });
         return infos.filter((info) => info.packageJsonPath !== null);
     });
 

--- a/apps/axctl/src/project/types.ts
+++ b/apps/axctl/src/project/types.ts
@@ -51,6 +51,8 @@ export interface StackSignal {
 
 export interface ProjectStack {
     readonly package: PackageInfo;
+    /** Package manifests selected for changed paths, including the root. */
+    readonly packages?: ReadonlyArray<PackageInfo>;
     readonly signals: ReadonlyArray<StackSignal>;
     readonly instructions: ReadonlyArray<InstructionMatch>;
 }

--- a/apps/axctl/src/project/verify-security.test.ts
+++ b/apps/axctl/src/project/verify-security.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deriveVerificationChecks } from "./verify.ts";
+import type { PackageInfo, ProjectStack } from "./types.ts";
+
+const pkg = (dir: string | null, scripts: Record<string, string> = {}, manager: string | null = "npm"): PackageInfo => ({
+    packageJsonPath: dir ? `${dir}/package.json` : null, packageManager: manager,
+    scripts, dependencies: [], devDependencies: [],
+});
+const checks = (root: string, paths: string[], stack: ProjectStack) => deriveVerificationChecks({
+    git: { root, cwd: root, branch: "main", head: "abc", dirty: true,
+        changes: paths.map(path => ({ path, status: "M", staged: false, unstaged: true, untracked: false, lang: null })) },
+    stack,
+});
+const stack = (root: PackageInfo, packages: PackageInfo[]): ProjectStack => ({ package: root, packages, signals: [], instructions: [] });
+
+describe("verification command boundaries", () => {
+    test("selects a nested package without a root manifest", () => {
+        const result = checks("/repo", ["frontend/a.ts"], stack(pkg(null), [pkg("/repo/frontend", { typecheck: "tsc" })]));
+        expect(result[0]).toMatchObject({ id: "typescript-typecheck:frontend", command: "npm --prefix frontend run typecheck" });
+    });
+    test("recommends tests for each source package without a root test script", () => {
+        const result = checks("/repo", ["frontend/a.ts", "backend/b.ts"], stack(pkg("/repo"), [
+            pkg("/repo/frontend", { test: "vitest" }), pkg("/repo/backend", { test: "vitest" }),
+        ]));
+        expect(result.filter(c => c.id.startsWith("tests-consider")).map(c => [c.command, c.relatedFiles])).toEqual([
+            ["npm --prefix frontend run test", ["frontend/a.ts"]], ["npm --prefix backend run test", ["backend/b.ts"]],
+        ]);
+    });
+    test("a test edit in one package does not suppress source tests in another", () => {
+        const result = checks("/repo", ["frontend/a.test.ts", "backend/b.ts"], stack(pkg("/repo"), [
+            pkg("/repo/frontend", { test: "vitest" }), pkg("/repo/backend", { test: "vitest" }),
+        ]));
+        expect(result.find(c => c.id === "tests-consider:backend")?.command).toBe("npm --prefix backend run test");
+    });
+    test("unknown package managers and missing test runners produce no executable guess", () => {
+        for (const manager of ["unknown", "npm-malicious", null]) {
+            const result = checks("/repo", ["a.test.ts"], stack(pkg("/repo", { typecheck: "tsc" }, manager), []));
+            expect(result.every(c => c.command === null)).toBe(true);
+        }
+        const result = checks("/repo", ["a.test.ts"], stack(pkg("/repo"), []));
+        expect(result.find(c => c.id === "tests-run")?.command).toBeNull();
+    });
+    test("ignores paths outside the repository", () => {
+        const result = checks("/repo", ["../outside/a.ts", "/outside/b.ts", "C:\\outside\\c.ts"], stack(pkg("/repo", {typecheck:"tsc"}), []));
+        expect(result.some(c => c.id.startsWith("typescript-typecheck"))).toBe(false);
+    });
+    test("Bun binary lockfiles satisfy the lockfile check", () => {
+        const result = checks("/repo", ["package.json", "bun.lockb"], stack(pkg("/repo", {}, "bun"), []));
+        expect(result.some(c => c.id === "package-lockfile")).toBe(false);
+    });
+    test("shell commands preserve hostile directory names and use the package working directory", async () => {
+        const root = await realpath(await mkdtemp(join(tmpdir(), "ax-verify-security-")));
+        try {
+            for (const manager of ["npm", "pnpm", "yarn", "bun"]) {
+                const name = "-web ' $(touch INJECTED); app";
+                const dir = join(root, name);
+                await mkdir(dir, { recursive: true });
+                const bin = join(root, "bin");
+                await mkdir(bin, { recursive: true });
+                // Stub only the package manager; the real shell parses the generated command.
+                await writeFile(join(bin, manager), '#!/bin/sh\nif [ "$1" = "--prefix" ]; then cd "$2" || exit 2; fi\npwd\n', { mode: 0o755 });
+                const result = checks(root, [`${name}/a.ts`], stack(pkg(root), [pkg(dir, {typecheck:"tsc"}, manager)]));
+                const output = Bun.spawnSync(["/bin/sh", "-c", result[0]!.command!], { cwd: root, env: { ...process.env, PATH: `${bin}:${process.env.PATH}` } });
+                expect(output.exitCode).toBe(0);
+                expect(output.stdout.toString().trim()).toBe(dir);
+                expect(await Bun.file(join(root, "INJECTED")).exists()).toBe(false);
+            }
+        } finally { await rm(root, { recursive: true, force: true }); }
+    });
+    test("uses a hoisted compiler while keeping the nested working directory", async () => {
+        const root = await realpath(await mkdtemp(join(tmpdir(), "ax-verify-hoisted-")));
+        try {
+            const dir = join(root, "frontend");
+            await mkdir(dir);
+            await mkdir(join(root, "node_modules", ".bin"), { recursive: true });
+            await writeFile(join(root, "node_modules", ".bin", "tsc"), '#!/bin/sh\npwd\n', { mode: 0o755 });
+            const info = { ...pkg(dir), devDependencies: ["typescript"] };
+            const result = checks(root, ["frontend/a.ts"], stack(pkg(root), [info]));
+            const output = Bun.spawnSync(["/bin/sh", "-c", result[0]!.command!], { cwd: root });
+            expect(output.exitCode).toBe(0);
+            expect(output.stdout.toString().trim()).toBe(dir);
+        } finally { await rm(root, { recursive: true, force: true }); }
+    });
+    test("npm fallback runs the compiler from the nested package", async () => {
+        const root = await realpath(await mkdtemp(join(tmpdir(), "ax-verify-npm-")));
+        try {
+            const dir = join(root, "frontend");
+            await mkdir(join(dir, "node_modules", ".bin"), { recursive: true });
+            await writeFile(join(dir, "node_modules", ".bin", "tsc"), '#!/bin/sh\npwd\n', { mode: 0o755 });
+            const info = { ...pkg(dir), devDependencies: ["typescript"] };
+            const result = checks(root, ["frontend/a.ts"], stack(pkg(root), [info]));
+            const output = Bun.spawnSync(["/bin/sh", "-c", result[0]!.command!], { cwd: root });
+            expect(output.exitCode).toBe(0);
+            expect(output.stdout.toString().trim()).toBe(dir);
+        } finally { await rm(root, { recursive: true, force: true }); }
+    });
+});

--- a/apps/axctl/src/project/verify.test.ts
+++ b/apps/axctl/src/project/verify.test.ts
@@ -28,6 +28,73 @@ const baseStack: ProjectStack = {
 };
 
 describe("deriveVerificationChecks", () => {
+    test("emits independent checks for two nested packages", () => {
+        const checks = deriveVerificationChecks({
+            git: { ...baseGit, changes: [
+                { path: "frontend/a.ts", status: "M", staged: false, unstaged: true, untracked: false, lang: "typescript" },
+                { path: "backend/b.test.ts", status: "M", staged: false, unstaged: true, untracked: false, lang: "typescript" },
+            ] },
+            stack: { ...baseStack, package: { ...baseStack.package, packageManager: "npm" }, packages: [
+                { packageJsonPath: "/repo/frontend/package.json", packageManager: "npm", scripts: { typecheck: "tsc" }, dependencies: [], devDependencies: [] },
+                { packageJsonPath: "/repo/backend/package.json", packageManager: "npm", scripts: { test: "node --test" }, dependencies: [], devDependencies: [] },
+            ] },
+        });
+        expect(checks.map((check) => check.id)).toEqual(["typescript-typecheck:frontend", "typescript-typecheck:backend", "tests-run:backend"]);
+    });
+    test("handles Windows separators and package-local fallback commands", () => {
+        const checks = deriveVerificationChecks({
+            git: { ...baseGit, changes: [{ path: "frontend\\src\\main.ts", status: "M", staged: false, unstaged: true, untracked: false, lang: "typescript" }] },
+            stack: { ...baseStack, package: { ...baseStack.package, packageManager: "npm" }, packages: [{
+                packageJsonPath: "/repo/frontend/package.json", packageManager: null, scripts: {}, dependencies: [], devDependencies: [],
+            }] },
+        });
+        expect(checks[0]).toMatchObject({ id: "typescript-typecheck:frontend", command: "npm --prefix frontend exec -- tsc --noEmit" });
+    });
+    test("uses the nearest npm package for nested frontend changes", () => {
+        const checks = deriveVerificationChecks({
+            git: {
+                ...baseGit,
+                changes: [{
+                    path: "frontend/src/index.visual-regression.test.ts", status: "M",
+                    staged: false, unstaged: true, untracked: false, lang: "typescript",
+                }],
+            },
+            stack: {
+                ...baseStack,
+                package: { ...baseStack.package, packageManager: "npm", scripts: { test: "node --test" } },
+                packages: [{
+                    packageJsonPath: "/repo/frontend/package.json", packageManager: "npm",
+                    scripts: { typecheck: "tsc --noEmit", test: "vitest run" },
+                    dependencies: [], devDependencies: ["typescript"],
+                }],
+            },
+        });
+        expect(checks.find((check) => check.id === "typescript-typecheck:frontend")?.command)
+            .toBe("npm --prefix frontend run typecheck");
+        expect(checks.find((check) => check.id === "tests-run:frontend")?.command)
+            .toBe("npm --prefix frontend run test");
+    });
+    test("fails closed when root or nested package managers conflict", () => {
+        const changes = [
+            { path: "package.json", status: "M", staged: false, unstaged: true, untracked: false, lang: "json" },
+            { path: "frontend/package.json", status: "M", staged: false, unstaged: true, untracked: false, lang: "json" },
+            { path: "frontend/src/main.ts", status: "M", staged: false, unstaged: true, untracked: false, lang: "typescript" },
+        ];
+        const checks = deriveVerificationChecks({
+            git: { ...baseGit, changes },
+            stack: {
+                ...baseStack,
+                package: { ...baseStack.package, packageManager: "conflict", scripts: {} },
+                packages: [{
+                    packageJsonPath: "/repo/frontend/package.json", packageManager: "conflict",
+                    scripts: {}, dependencies: [], devDependencies: [],
+                }],
+            },
+        });
+        expect(checks.find((check) => check.id === "typescript-typecheck:frontend")?.command).toBeNull();
+        expect(checks.find((check) => check.id === "package-lockfile")?.command).toBeNull();
+        expect(checks.find((check) => check.id === "package-lockfile:frontend")?.command).toBeNull();
+    });
     test("requires typecheck for TypeScript edits", () => {
         const checks = deriveVerificationChecks({
             git: {
@@ -72,6 +139,22 @@ describe("deriveVerificationChecks", () => {
         });
 
         expect(checks.map((check) => check.id)).toContain("package-lockfile");
+    });
+
+    test("checks package-local lockfiles independently with mixed separators", () => {
+        const checks = deriveVerificationChecks({
+            git: { ...baseGit, changes: [
+                { path: "frontend\\package.json", status: "M", staged: false, unstaged: true, untracked: false, lang: "json" },
+                { path: "backend/package.json", status: "M", staged: false, unstaged: true, untracked: false, lang: "json" },
+                { path: "backend\\package-lock.json", status: "M", staged: false, unstaged: true, untracked: false, lang: "json" },
+            ] },
+            stack: { ...baseStack, packages: [
+                { packageJsonPath: "/repo/frontend/package.json", packageManager: "npm", scripts: {}, dependencies: [], devDependencies: [] },
+                { packageJsonPath: "/repo/backend/package.json", packageManager: "npm", scripts: {}, dependencies: [], devDependencies: [] },
+            ] },
+        });
+        expect(checks.map((check) => check.id)).toContain("package-lockfile:frontend");
+        expect(checks.map((check) => check.id)).not.toContain("package-lockfile:backend");
     });
 
     test("adds Effect guidance when Effect source changed", () => {

--- a/apps/axctl/src/project/verify.test.ts
+++ b/apps/axctl/src/project/verify.test.ts
@@ -48,7 +48,7 @@ describe("deriveVerificationChecks", () => {
                 packageJsonPath: "/repo/frontend/package.json", packageManager: null, scripts: {}, dependencies: [], devDependencies: [],
             }] },
         });
-        expect(checks[0]).toMatchObject({ id: "typescript-typecheck:frontend", command: "npm --prefix frontend exec -- tsc --noEmit" });
+        expect(checks[0]).toMatchObject({ id: "typescript-typecheck:frontend", command: "cd frontend && ../node_modules/.bin/tsc --noEmit" });
     });
     test("uses the nearest npm package for nested frontend changes", () => {
         const checks = deriveVerificationChecks({

--- a/apps/axctl/src/project/verify.ts
+++ b/apps/axctl/src/project/verify.ts
@@ -1,4 +1,5 @@
 import type { GitState, ProjectStack, VerificationCheck } from "./types.ts";
+import { posixPath } from "@ax/lib/shared/path";
 
 interface DeriveInput {
     readonly git: GitState;
@@ -6,19 +7,71 @@ interface DeriveInput {
 }
 
 function changed(git: GitState, predicate: (path: string) => boolean): ReadonlyArray<string> {
-    return git.changes.map((change) => change.path).filter(predicate);
+    return git.changes.map((change) => change.path.replaceAll("\\", "/")).filter(predicate);
 }
 
-function packageManagerRunCommand(packageManager: string | null, scriptName: string): string {
-    if (packageManager?.startsWith("npm")) return `npm run ${scriptName}`;
-    if (packageManager?.startsWith("pnpm")) return `pnpm run ${scriptName}`;
-    if (packageManager?.startsWith("yarn")) return `yarn ${scriptName}`;
-    return `bun run ${scriptName}`;
+function packageManagerRunCommand(packageManager: string | null, scriptName: string, prefix: string | null = null): string | null {
+    if (packageManager === "conflict") return null;
+    if (packageManager?.startsWith("npm")) return prefix ? `npm --prefix ${prefix} run ${scriptName}` : `npm run ${scriptName}`;
+    const at = (command: string) => prefix ? `cd ${prefix} && ${command}` : command;
+    if (packageManager?.startsWith("pnpm")) return at(`pnpm run ${scriptName}`);
+    if (packageManager?.startsWith("yarn")) return at(`yarn ${scriptName}`);
+    return at(`bun run ${scriptName}`);
 }
 
-function scriptCommand(stack: ProjectStack, scriptName: string, fallback: string): string {
-    return stack.package.scripts[scriptName] ? packageManagerRunCommand(stack.package.packageManager, scriptName) : fallback;
+function packageForPath(stack: ProjectStack, changedPath: string): { info: typeof stack.package; prefix: string | null } {
+    const root = stack.package.packageJsonPath ? posixPath.dirname(stack.package.packageJsonPath) : null;
+    const relative = changedPath.replaceAll("\\", "/");
+    const absolutePath = root ? posixPath.resolve(root, relative) : relative;
+    const candidates = (stack.packages ?? [stack.package])
+        .map((info) => ({ info, dir: info.packageJsonPath ? posixPath.dirname(info.packageJsonPath) : null }))
+        .filter((candidate) => {
+            const relative = posixPath.relative(candidate.dir!, absolutePath);
+            return candidate.dir && relative !== ".." && relative.split("/")[0] !== "..";
+        })
+        .sort((a, b) => posixPath.relative(a.dir!, absolutePath).length - posixPath.relative(b.dir!, absolutePath).length);
+    const info = candidates[0]?.info ?? stack.package;
+    if (!info.packageJsonPath || !stack.package.packageJsonPath) return { info, prefix: null };
+    const packageRoot = posixPath.dirname(stack.package.packageJsonPath);
+    const dir = posixPath.dirname(info.packageJsonPath);
+    const prefix = posixPath.relative(packageRoot, dir);
+    return { info, prefix: prefix || null };
 }
+
+function scriptCommand(stack: ProjectStack, scriptName: string, fallback: string, changedPath: string): string | null {
+    const selectedPackage = packageForPath(stack, changedPath);
+    const selected = selectedPackage.info;
+    const prefix = selectedPackage.prefix;
+    const manager = selected.packageManager ?? stack.package.packageManager;
+    if (selected.scripts[scriptName]) return packageManagerRunCommand(manager, scriptName, prefix);
+    const exec = manager?.startsWith("npm") ? `npm${prefix ? ` --prefix ${prefix}` : ""} exec -- ${fallback.replace(/^bunx\s+/, "")}`
+        : manager?.startsWith("pnpm") ? `${prefix ? `cd ${prefix} && ` : ""}pnpm exec ${fallback.replace(/^bunx\s+/, "")}`
+        : manager?.startsWith("yarn") ? `${prefix ? `cd ${prefix} && ` : ""}yarn exec ${fallback.replace(/^bunx\s+/, "")}`
+        : `${prefix ? `cd ${prefix} && ` : ""}${fallback}`;
+    return manager === "conflict" ? null : exec;
+}
+
+function groupedFiles(stack: ProjectStack, files: ReadonlyArray<string>): ReadonlyArray<{
+    readonly key: string;
+    readonly files: ReadonlyArray<string>;
+    readonly sample: string;
+}> {
+    const groups = new Map<string, { info: typeof stack.package; files: string[]; sample: string }>();
+    for (const file of files) {
+        const selected = packageForPath(stack, file);
+        const key = selected.info.packageJsonPath ?? "(root)";
+        const group = groups.get(key) ?? { info: selected.info, files: [], sample: file };
+        group.files.push(file);
+        groups.set(key, group);
+    }
+    return [...groups.entries()].map(([key, group]) => ({ key, files: group.files, sample: group.sample }));
+}
+
+const checkId = (base: string, key: string, stack: ProjectStack): string => {
+    const root = stack.package.packageJsonPath ? posixPath.dirname(stack.package.packageJsonPath) : "";
+    const suffix = key === (stack.package.packageJsonPath ?? "(root)") ? "" : posixPath.relative(root, posixPath.dirname(key));
+    return suffix ? `${base}:${suffix.replaceAll("\\", "/")}` : base;
+};
 
 function hasAnyDependency(stack: ProjectStack, names: ReadonlyArray<string>): boolean {
     const deps = new Set([...stack.package.dependencies, ...stack.package.devDependencies]);
@@ -36,26 +89,18 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
     const changedFiles = git.changes.map((change) => change.path);
 
     const tsFiles = changed(git, (path) => path.endsWith(".ts") || path.endsWith(".tsx"));
-    if (tsFiles.length > 0) {
-        pushUnique(checks, {
-            id: "typescript-typecheck",
-            severity: "required",
-            title: "Run the project typecheck",
-            reason: "TypeScript files changed.",
-            command: scriptCommand(stack, "typecheck", "bunx tsc --noEmit"),
-            relatedFiles: tsFiles,
-        });
-    }
+    for (const group of groupedFiles(stack, tsFiles)) pushUnique(checks, {
+        id: checkId("typescript-typecheck", group.key, stack), severity: "required",
+        title: "Run the project typecheck", reason: "TypeScript files changed.",
+        command: scriptCommand(stack, "typecheck", "bunx tsc --noEmit", group.sample), relatedFiles: group.files,
+    });
 
     const testFiles = changed(git, (path) => path.includes(".test.") || path.includes(".spec.") || path.includes("/__tests__/"));
     if (testFiles.length > 0) {
-        pushUnique(checks, {
-            id: "tests-run",
-            severity: "required",
-            title: "Run the relevant tests",
-            reason: "Test files changed.",
-            command: scriptCommand(stack, "test", "bun test"),
-            relatedFiles: testFiles,
+        for (const group of groupedFiles(stack, testFiles)) pushUnique(checks, {
+            id: checkId("tests-run", group.key, stack), severity: "required",
+            title: "Run the relevant tests", reason: "Test files changed.",
+            command: scriptCommand(stack, "test", "bun test", group.sample), relatedFiles: group.files,
         });
     } else if (tsFiles.length > 0 && stack.package.scripts.test) {
         pushUnique(checks, {
@@ -63,34 +108,50 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
             severity: "recommended",
             title: "Run tests that cover the edited TypeScript",
             reason: "Source files changed and this package declares a test script.",
-            command: scriptCommand(stack, "test", "bun test"),
+            command: scriptCommand(stack, "test", "bun test", tsFiles[0]!),
             relatedFiles: tsFiles,
         });
     }
 
     const lintable = changed(git, (path) => path.endsWith(".ts") || path.endsWith(".tsx") || path.endsWith(".js") || path.endsWith(".jsx"));
-    if (lintable.length > 0 && stack.package.scripts.lint) {
-        pushUnique(checks, {
-            id: "lint",
-            severity: "recommended",
-            title: "Run lint",
-            reason: "Lintable source files changed and a lint script exists.",
-            command: scriptCommand(stack, "lint", "bun run lint"),
-            relatedFiles: lintable,
-        });
+    if (lintable.length > 0) {
+        for (const group of groupedFiles(stack, lintable)) {
+            const packageInfo = packageForPath(stack, group.sample).info;
+            if (!packageInfo.scripts.lint) continue;
+            pushUnique(checks, {
+                id: checkId("lint", group.key, stack), severity: "recommended", title: "Run lint",
+                reason: "Lintable source files changed and a lint script exists.",
+                command: scriptCommand(stack, "lint", "bun run lint", group.sample), relatedFiles: group.files,
+            });
+        }
     }
 
-    const packageChanged = changedFiles.includes("package.json");
-    const lockChanged = changedFiles.some((path) => ["bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"].includes(path));
-    if (packageChanged && !lockChanged) {
-        pushUnique(checks, {
-            id: "package-lockfile",
-            severity: "recommended",
-            title: "Check whether the lockfile should change",
-            reason: "package.json changed but no known lockfile changed.",
-            command: null,
-            relatedFiles: ["package.json"],
-        });
+    const packageManifests = changed(git, (path) => path === "package.json" || path.endsWith("/package.json"));
+    const lockfiles = new Set(changedFiles.map((path) => path.replaceAll("\\", "/")));
+    for (const manifest of packageManifests) {
+        const selected = packageForPath(stack, manifest);
+        const packagePath = selected.info.packageJsonPath;
+        if (!packagePath) continue;
+        const root = posixPath.dirname(stack.package.packageJsonPath ?? packagePath);
+        const dir = posixPath.dirname(packagePath);
+        const prefix = posixPath.relative(root, dir);
+        const manager = selected.info.packageManager;
+        const lockName = manager?.startsWith("bun") ? "bun.lock"
+            : manager?.startsWith("pnpm") ? "pnpm-lock.yaml"
+            : manager?.startsWith("yarn") ? "yarn.lock"
+            : manager?.startsWith("npm") ? "package-lock.json"
+            : null;
+        const lockPath = prefix ? `${prefix}/${lockName ?? "lockfile"}` : lockName ?? "lockfile";
+        if (!lockfiles.has(lockPath) && !lockfiles.has(lockPath.replaceAll("/", "\\"))) {
+            pushUnique(checks, {
+                id: checkId("package-lockfile", packagePath, stack),
+                severity: "recommended",
+                title: manager === "conflict" ? "Resolve the package manager before checking the lockfile" : "Check whether the package-local lockfile should change",
+                reason: manager === "conflict" ? "Conflicting package-manager lockfiles were detected." : `${manifest} changed but ${lockPath} did not change.`,
+                command: null,
+                relatedFiles: [manifest, ...(lockName ? [lockPath] : [])],
+            });
+        }
     }
 
     const schemaFiles = changed(git, (path) => path.startsWith("schema/") || path.startsWith("migrations/") || path.endsWith(".surql") || path.endsWith(".sql"));
@@ -100,7 +161,7 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
             severity: "recommended",
             title: "Run a schema or database smoke check",
             reason: "Schema or migration files changed.",
-            command: stack.package.scripts["db:schema"] ? scriptCommand(stack, "db:schema", "bun run db:schema") : null,
+            command: stack.package.scripts["db:schema"] ? scriptCommand(stack, "db:schema", "bun run db:schema", schemaFiles[0]!) : null,
             relatedFiles: schemaFiles,
         });
     }

--- a/apps/axctl/src/project/verify.ts
+++ b/apps/axctl/src/project/verify.ts
@@ -1,5 +1,6 @@
 import type { GitState, ProjectStack, VerificationCheck } from "./types.ts";
 import { posixPath } from "@ax/lib/shared/path";
+import { projectRelativePath } from "./package-path.ts";
 
 interface DeriveInput {
     readonly git: GitState;
@@ -7,71 +8,83 @@ interface DeriveInput {
 }
 
 function changed(git: GitState, predicate: (path: string) => boolean): ReadonlyArray<string> {
-    return git.changes.map((change) => change.path.replaceAll("\\", "/")).filter(predicate);
+    return git.changes.map((change) => projectRelativePath(change.path))
+        .filter((path): path is string => path !== null && predicate(path));
 }
 
-function packageManagerRunCommand(packageManager: string | null, scriptName: string, prefix: string | null = null): string | null {
-    if (packageManager === "conflict") return null;
-    if (packageManager?.startsWith("npm")) return prefix ? `npm --prefix ${prefix} run ${scriptName}` : `npm run ${scriptName}`;
-    const at = (command: string) => prefix ? `cd ${prefix} && ${command}` : command;
-    if (packageManager?.startsWith("pnpm")) return at(`pnpm run ${scriptName}`);
-    if (packageManager?.startsWith("yarn")) return at(`yarn ${scriptName}`);
-    return at(`bun run ${scriptName}`);
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+function packageManager(value: string | null): PackageManager | null {
+    const name = value?.split("@")[0];
+    return name === "npm" || name === "pnpm" || name === "yarn" || name === "bun" ? name : null;
 }
 
-function packageForPath(stack: ProjectStack, changedPath: string): { info: typeof stack.package; prefix: string | null } {
-    const root = stack.package.packageJsonPath ? posixPath.dirname(stack.package.packageJsonPath) : null;
-    const relative = changedPath.replaceAll("\\", "/");
-    const absolutePath = root ? posixPath.resolve(root, relative) : relative;
-    const candidates = (stack.packages ?? [stack.package])
-        .map((info) => ({ info, dir: info.packageJsonPath ? posixPath.dirname(info.packageJsonPath) : null }))
-        .filter((candidate) => {
-            const relative = posixPath.relative(candidate.dir!, absolutePath);
-            return candidate.dir && relative !== ".." && relative.split("/")[0] !== "..";
+/** These commands target POSIX shells. Quote repository-controlled names as one argument. */
+function shellPath(value: string): string {
+    const argument = value.startsWith("-") ? `./${value}` : value;
+    return /^[a-zA-Z0-9_./-]+$/.test(argument) ? argument : `'${argument.replaceAll("'", "'\\''")}'`;
+}
+
+interface SelectedPackage {
+    readonly info: ProjectStack["package"];
+    readonly prefix: string | null;
+}
+
+function packageForPath(stack: ProjectStack, changedPath: string, root: string): SelectedPackage {
+    const absolutePath = posixPath.resolve(root, changedPath);
+    const candidates = [...(stack.packages ?? []), stack.package]
+        .flatMap((info) => {
+            if (!info.packageJsonPath) return [];
+            const dir = posixPath.resolve(info.packageJsonPath.replaceAll("\\", "/"), "..");
+            const prefix = posixPath.relative(root, dir);
+            if (prefix === ".." || prefix.startsWith("../")) return [];
+            const relative = posixPath.relative(dir, absolutePath);
+            return relative === ".." || relative.startsWith("../") ? [] : [{ info, dir, prefix: prefix || null }];
         })
-        .sort((a, b) => posixPath.relative(a.dir!, absolutePath).length - posixPath.relative(b.dir!, absolutePath).length);
-    const info = candidates[0]?.info ?? stack.package;
-    if (!info.packageJsonPath || !stack.package.packageJsonPath) return { info, prefix: null };
-    const packageRoot = posixPath.dirname(stack.package.packageJsonPath);
-    const dir = posixPath.dirname(info.packageJsonPath);
-    const prefix = posixPath.relative(packageRoot, dir);
-    return { info, prefix: prefix || null };
+        .sort((a, b) => b.dir.length - a.dir.length);
+    return candidates[0] ?? { info: stack.package, prefix: null };
 }
 
-function scriptCommand(stack: ProjectStack, scriptName: string, fallback: string, changedPath: string): string | null {
-    const selectedPackage = packageForPath(stack, changedPath);
-    const selected = selectedPackage.info;
-    const prefix = selectedPackage.prefix;
-    const manager = selected.packageManager ?? stack.package.packageManager;
-    if (selected.scripts[scriptName]) return packageManagerRunCommand(manager, scriptName, prefix);
-    const exec = manager?.startsWith("npm") ? `npm${prefix ? ` --prefix ${prefix}` : ""} exec -- ${fallback.replace(/^bunx\s+/, "")}`
-        : manager?.startsWith("pnpm") ? `${prefix ? `cd ${prefix} && ` : ""}pnpm exec ${fallback.replace(/^bunx\s+/, "")}`
-        : manager?.startsWith("yarn") ? `${prefix ? `cd ${prefix} && ` : ""}yarn exec ${fallback.replace(/^bunx\s+/, "")}`
-        : `${prefix ? `cd ${prefix} && ` : ""}${fallback}`;
-    return manager === "conflict" ? null : exec;
+function scriptCommand(stack: ProjectStack, scriptName: string, selected: SelectedPackage): string | null {
+    const { info, prefix } = selected;
+    const manager = packageManager(info.packageManager ?? stack.package.packageManager);
+    if (!manager) return null;
+    const at = (command: string) => prefix ? `cd ${shellPath(prefix)} && ${command}` : command;
+    if (info.scripts[scriptName]) {
+        if (manager === "npm") return `npm${prefix ? ` --prefix ${shellPath(prefix)}` : ""} run ${scriptName}`;
+        return at(`${manager}${manager === "yarn" ? "" : " run"} ${scriptName}`);
+    }
+    // Execute only a declared local compiler. Package-manager exec commands can
+    // fetch a different package from the registry when the tool is not installed.
+    if (scriptName === "typecheck") {
+        const ownsCompiler = (pkg: ProjectStack["package"]) => [...pkg.dependencies, ...pkg.devDependencies].includes("typescript");
+        const local = "./node_modules/.bin/tsc --noEmit";
+        const compiler = posixPath.join(posixPath.relative(prefix ?? ".", "."), "node_modules/.bin/tsc");
+        const hoisted = `${shellPath(compiler.startsWith(".") ? compiler : `./${compiler}`)} --noEmit`;
+        if (ownsCompiler(info)) {
+            return at(prefix ? `if [ -x ./node_modules/.bin/tsc ]; then ${local}; else ${hoisted}; fi` : local);
+        }
+        if (ownsCompiler(stack.package)) return at(hoisted);
+    }
+    return scriptName === "test" && manager === "bun" ? at("bun test") : null;
 }
 
-function groupedFiles(stack: ProjectStack, files: ReadonlyArray<string>): ReadonlyArray<{
-    readonly key: string;
+function groupedFiles(stack: ProjectStack, files: ReadonlyArray<string>, root: string): ReadonlyArray<{
+    readonly selected: SelectedPackage;
     readonly files: ReadonlyArray<string>;
-    readonly sample: string;
 }> {
-    const groups = new Map<string, { info: typeof stack.package; files: string[]; sample: string }>();
+    const groups = new Map<string, { selected: SelectedPackage; files: string[] }>();
     for (const file of files) {
-        const selected = packageForPath(stack, file);
+        const selected = packageForPath(stack, file, root);
         const key = selected.info.packageJsonPath ?? "(root)";
-        const group = groups.get(key) ?? { info: selected.info, files: [], sample: file };
+        const group = groups.get(key) ?? { selected, files: [] };
         group.files.push(file);
         groups.set(key, group);
     }
-    return [...groups.entries()].map(([key, group]) => ({ key, files: group.files, sample: group.sample }));
+    return [...groups.values()];
 }
 
-const checkId = (base: string, key: string, stack: ProjectStack): string => {
-    const root = stack.package.packageJsonPath ? posixPath.dirname(stack.package.packageJsonPath) : "";
-    const suffix = key === (stack.package.packageJsonPath ?? "(root)") ? "" : posixPath.relative(root, posixPath.dirname(key));
-    return suffix ? `${base}:${suffix.replaceAll("\\", "/")}` : base;
-};
+const checkId = (base: string, selected: SelectedPackage): string =>
+    selected.prefix ? `${base}:${selected.prefix}` : base;
 
 function hasAnyDependency(stack: ProjectStack, names: ReadonlyArray<string>): boolean {
     const deps = new Set([...stack.package.dependencies, ...stack.package.devDependencies]);
@@ -86,42 +99,42 @@ function pushUnique(checks: VerificationCheck[], check: VerificationCheck): void
 export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<VerificationCheck> {
     const { git, stack } = input;
     const checks: VerificationCheck[] = [];
-    const changedFiles = git.changes.map((change) => change.path);
+    const root = posixPath.resolve((git.root ?? git.cwd).replaceAll("\\", "/"));
+    const changedFiles = changed(git, () => true);
 
     const tsFiles = changed(git, (path) => path.endsWith(".ts") || path.endsWith(".tsx"));
-    for (const group of groupedFiles(stack, tsFiles)) pushUnique(checks, {
-        id: checkId("typescript-typecheck", group.key, stack), severity: "required",
+    for (const group of groupedFiles(stack, tsFiles, root)) pushUnique(checks, {
+        id: checkId("typescript-typecheck", group.selected), severity: "required",
         title: "Run the project typecheck", reason: "TypeScript files changed.",
-        command: scriptCommand(stack, "typecheck", "bunx tsc --noEmit", group.sample), relatedFiles: group.files,
+        command: scriptCommand(stack, "typecheck", group.selected), relatedFiles: group.files,
     });
 
     const testFiles = changed(git, (path) => path.includes(".test.") || path.includes(".spec.") || path.includes("/__tests__/"));
-    if (testFiles.length > 0) {
-        for (const group of groupedFiles(stack, testFiles)) pushUnique(checks, {
-            id: checkId("tests-run", group.key, stack), severity: "required",
-            title: "Run the relevant tests", reason: "Test files changed.",
-            command: scriptCommand(stack, "test", "bun test", group.sample), relatedFiles: group.files,
-        });
-    } else if (tsFiles.length > 0 && stack.package.scripts.test) {
+    const testGroups = groupedFiles(stack, testFiles, root);
+    for (const group of testGroups) pushUnique(checks, {
+        id: checkId("tests-run", group.selected), severity: "required",
+        title: "Run the relevant tests", reason: "Test files changed.",
+        command: scriptCommand(stack, "test", group.selected), relatedFiles: group.files,
+    });
+    for (const group of groupedFiles(stack, tsFiles, root)) {
+        if (!group.selected.info.scripts.test || testGroups.some(test => test.selected.info === group.selected.info)) continue;
         pushUnique(checks, {
-            id: "tests-consider",
-            severity: "recommended",
+            id: checkId("tests-consider", group.selected), severity: "recommended",
             title: "Run tests that cover the edited TypeScript",
             reason: "Source files changed and this package declares a test script.",
-            command: scriptCommand(stack, "test", "bun test", tsFiles[0]!),
-            relatedFiles: tsFiles,
+            command: scriptCommand(stack, "test", group.selected), relatedFiles: group.files,
         });
     }
 
     const lintable = changed(git, (path) => path.endsWith(".ts") || path.endsWith(".tsx") || path.endsWith(".js") || path.endsWith(".jsx"));
     if (lintable.length > 0) {
-        for (const group of groupedFiles(stack, lintable)) {
-            const packageInfo = packageForPath(stack, group.sample).info;
+        for (const group of groupedFiles(stack, lintable, root)) {
+            const packageInfo = group.selected.info;
             if (!packageInfo.scripts.lint) continue;
             pushUnique(checks, {
-                id: checkId("lint", group.key, stack), severity: "recommended", title: "Run lint",
+                id: checkId("lint", group.selected), severity: "recommended", title: "Run lint",
                 reason: "Lintable source files changed and a lint script exists.",
-                command: scriptCommand(stack, "lint", "bun run lint", group.sample), relatedFiles: group.files,
+                command: scriptCommand(stack, "lint", group.selected), relatedFiles: group.files,
             });
         }
     }
@@ -129,12 +142,10 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
     const packageManifests = changed(git, (path) => path === "package.json" || path.endsWith("/package.json"));
     const lockfiles = new Set(changedFiles.map((path) => path.replaceAll("\\", "/")));
     for (const manifest of packageManifests) {
-        const selected = packageForPath(stack, manifest);
+        const selected = packageForPath(stack, manifest, root);
         const packagePath = selected.info.packageJsonPath;
         if (!packagePath) continue;
-        const root = posixPath.dirname(stack.package.packageJsonPath ?? packagePath);
-        const dir = posixPath.dirname(packagePath);
-        const prefix = posixPath.relative(root, dir);
+        const prefix = selected.prefix;
         const manager = selected.info.packageManager;
         const lockName = manager?.startsWith("bun") ? "bun.lock"
             : manager?.startsWith("pnpm") ? "pnpm-lock.yaml"
@@ -142,9 +153,9 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
             : manager?.startsWith("npm") ? "package-lock.json"
             : null;
         const lockPath = prefix ? `${prefix}/${lockName ?? "lockfile"}` : lockName ?? "lockfile";
-        if (!lockfiles.has(lockPath) && !lockfiles.has(lockPath.replaceAll("/", "\\"))) {
+        if (!lockfiles.has(lockPath) && !(manager?.startsWith("bun") && lockfiles.has(`${prefix ? `${prefix}/` : ""}bun.lockb`))) {
             pushUnique(checks, {
-                id: checkId("package-lockfile", packagePath, stack),
+                id: checkId("package-lockfile", selected),
                 severity: "recommended",
                 title: manager === "conflict" ? "Resolve the package manager before checking the lockfile" : "Check whether the package-local lockfile should change",
                 reason: manager === "conflict" ? "Conflicting package-manager lockfiles were detected." : `${manifest} changed but ${lockPath} did not change.`,
@@ -161,7 +172,7 @@ export function deriveVerificationChecks(input: DeriveInput): ReadonlyArray<Veri
             severity: "recommended",
             title: "Run a schema or database smoke check",
             reason: "Schema or migration files changed.",
-            command: stack.package.scripts["db:schema"] ? scriptCommand(stack, "db:schema", "bun run db:schema", schemaFiles[0]!) : null,
+            command: stack.package.scripts["db:schema"] ? scriptCommand(stack, "db:schema", packageForPath(stack, schemaFiles[0]!, root)) : null,
             relatedFiles: schemaFiles,
         });
     }

--- a/apps/axctl/src/skills-frontmatter.test.ts
+++ b/apps/axctl/src/skills-frontmatter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+
+const skillsDir = join(import.meta.dir, "../../../skills");
+
+describe("shipped skill safety", () => {
+    test("every skill frontmatter parses as YAML", () => {
+        for (const name of readdirSync(skillsDir, { withFileTypes: true })) {
+            if (!name.isDirectory()) continue;
+            const file = join(skillsDir, name.name, "SKILL.md");
+            const text = readFileSync(file, "utf8");
+            const match = text.match(/^---\n([\s\S]*?)\n---/);
+            expect(match, name.name).not.toBeNull();
+            const frontmatter = YAML.parse(match![1]!);
+            expect(frontmatter, name.name).toBeObject();
+            expect(frontmatter.name, name.name).toBeString();
+            expect(frontmatter.description, name.name).toBeString();
+        }
+    });
+
+    test("setup does not pipe a remote script to a shell or auto-delete", () => {
+        const text = readFileSync(join(skillsDir, "setup", "SKILL.md"), "utf8");
+        expect(text).not.toMatch(/curl[^\n|]*\|\s*(ba)?sh/);
+        expect(text).not.toMatch(/wget[^\n|]*\|\s*(ba)?sh/);
+        expect(text).toContain("does not publish a checksum for install.sh");
+        expect(text).toMatch(/Execute this installer\?/);
+        expect(text).not.toMatch(/\brm\s+-rf\b/);
+    });
+
+    test("dojo does not require a SurrealDB daemon", () => {
+        const text = readFileSync(join(skillsDir, "dojo", "SKILL.md"), "utf8");
+        expect(text).not.toMatch(/local SurrealDB running/i);
+        expect(text).toContain("embedded DuckDB");
+        expect(text).toContain("no database daemon is required");
+    });
+});

--- a/apps/axctl/src/skills-frontmatter.test.ts
+++ b/apps/axctl/src/skills-frontmatter.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";
+import { tmpdir } from "node:os";
 
 const skillsDir = join(import.meta.dir, "../../../skills");
 
@@ -35,4 +36,38 @@ describe("shipped skill safety", () => {
         expect(text).toContain("embedded DuckDB");
         expect(text).toContain("no database daemon is required");
     });
+});
+
+
+test("setup executes only a successfully downloaded and approved installer", () => {
+    const text = readFileSync(join(skillsDir, "setup", "SKILL.md"), "utf8");
+    const script = text.match(/```bash\n([\s\S]*?)```/)![1]!;
+    const root = mkdtempSync(join(tmpdir(), "ax-setup-security-"));
+    try {
+        const bin = join(root, "bin");
+        const temporary = join(root, "temporary");
+        mkdirSync(bin);
+        mkdirSync(temporary);
+        writeFileSync(join(bin, "curl"), `#!/bin/sh
+[ "$DOWNLOAD" = ok ] || exit 22
+while [ "$1" != -o ]; do shift; done
+shift
+printf '%s\n' '#!/bin/sh' 'printf installed > "$RESULT_FILE"' > "$1"
+`, { mode: 0o755 });
+        writeFileSync(join(bin, "less"), '#!/bin/sh\n[ "$REVIEW" = ok ]\n', { mode: 0o755 });
+        for (const [download, review, answer, success] of [
+            ["fail", "ok", "yes\n", false], ["ok", "fail", "yes\n", false],
+            ["ok", "ok", "no\n", false], ["ok", "ok", "", false], ["ok", "ok", "yes\n", true],
+        ] as const) {
+            const resultFile = join(root, "installed");
+            const result = Bun.spawnSync(["/bin/bash", "-c", script], {
+                stdin: Buffer.from(answer),
+                env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, TMPDIR: temporary,
+                    DOWNLOAD: download, REVIEW: review, RESULT_FILE: resultFile },
+            });
+            expect(result.exitCode === 0).toBe(success);
+            expect(existsSync(resultFile)).toBe(success);
+            expect(readdirSync(temporary)).toEqual([]);
+        }
+    } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -356,6 +356,8 @@ a workflow worth codifying as a skill?). `--json` emits the arc array.
 - `axctl improve recommend [--limit=N] [--form=skill] [--apply]` - print N
   ranked proposals as paste-ready blocks (already wrapped in `<!--ax:id-->`
   provenance markers). `--apply` enters an interactive accept loop.
+  Harness filtering is not supported until proposal provenance can be stored
+  structurally; `--include-tools` on tool-oriented queries exposes provider tools.
 - `axctl improve accept <id> [--with-agent] [--auto-scaffold] [--force]` -
   Default emits `.ax/tasks/<id>.md`, a brief your agent (Claude Code,
   Codex) executes. `--auto-scaffold` writes `SKILL.md` directly.

--- a/docs/insights-cli-reference.md
+++ b/docs/insights-cli-reference.md
@@ -900,7 +900,7 @@ axctl skills lint --task-dir=.ax/tasks --json
 Sweeps all prior `source="brief"` edges for a skill before writing the current
 set, so role shrinkage is handled atomically.
 
-### `ax skills weighted [--window=Nd --limit=N --doctor-threshold=N --json]`
+### `ax skills weighted [--window=Nd --limit=N --doctor-threshold=N --include-tools --json]`
 
 Rank skills by a composite weighted score over a rolling time window. The score
 blends invocations (positive), errors near invocation (negative), user
@@ -914,12 +914,14 @@ Flags:
 - `--limit=N` (default 25) - rows to show
 - `--doctor-threshold=N` (default 5) - correction count above which a skill is
   flagged for review
+- `--include-tools` - include provider built-in tools; they are excluded by default
 - `--json`
 
 ```bash
 axctl skills weighted
 axctl skills weighted --window=7 --limit=10
 axctl skills weighted --doctor-threshold=3 --json
+axctl skills weighted --include-tools --limit=10
 ```
 
 ### `ax skills by-role <role> [--json --limit=N]`

--- a/packages/lib/src/ingest-lock.test.ts
+++ b/packages/lib/src/ingest-lock.test.ts
@@ -295,18 +295,18 @@ describe("withIngestLock", () => {
         });
     });
 
-    test("steals a lock older than staleMs even when its owner is alive", async () => {
+    test("preserves a live holder even after staleMs", async () => {
         await withTempDir(async (dir) => {
             const lockPath = join(dir, "ingest.lock");
             writeFileSync(
                 lockPath,
-                encodeLockPayload({ pid: 1, startedAt: Date.now() - 120_000, command: "wedged" }),
+                encodeLockPayload({ pid: 1, startedAt: Date.now() - 120_000, command: "long-running" }),
             );
 
             const outcome = await run(
                 withIngestLock(opts(lockPath, { staleMs: 60_000 }), Effect.succeed("stolen")),
             );
-            expect(outcome).toEqual({ _tag: "completed", value: "stolen" });
+            expect(outcome).toEqual({ _tag: "busy", value: "busy:1:long-running" });
         });
     });
 

--- a/packages/lib/src/ingest-lock.ts
+++ b/packages/lib/src/ingest-lock.ts
@@ -73,24 +73,15 @@
  * work: a second in-process ingest must skip as busy, not queue.
  *
  * TIMEOUT / INTERRUPT. On normal completion (or a normal error) the lock is
- * released. On TIMEOUT or INTERRUPT it is deliberately LEFT in place: interrupting
- * the fiber does not prove the in-flight work stopped, so the stale lock becomes a
- * cooldown window - the next ingest skips until it ages past `staleMs`, giving
- * things time to settle. A hard process crash (no finalizer) is recovered by the
- * dead-pid / staleness takeover.
+ * released. On timeout or interruption it remains on disk. Another process must
+ * wait for the holder to exit: elapsed time cannot prove native work stopped.
+ * Dead processes and reused process ids remain recoverable through the liveness
+ * and fingerprint checks. An active same-process holder also blocks a new run.
  *
- * TWO RESIDUALS - what a plain lockfile cannot arbitrate (issue #789):
- *  1. The takeover removes BY PATH. Invariant 5 closes the common interleave, but
- *     not the window between the confirm re-read and the remove itself: a racer
- *     descheduled inside it can still delete a lock installed after its read. No
- *     additional re-check closes this - every step here is check-then-act on a
- *     path, so another check only moves the window.
- *  2. `staleMs` is a TIMEOUT-based liveness heuristic, not a proof. A process
- *     merely SUSPENDED past the window - `SIGSTOP`, suspend-to-RAM, a VM snapshot
- *     restore, a forward NTP step - can have its live lock taken over.
- * Only an OS advisory lock (`flock`/`fcntl`) held ACROSS the takeover, or a design
- * that never removes a foreign file, actually closes either. Both are out of scope
- * here and tracked on #789.
+ * RESIDUAL - what a plain lockfile cannot arbitrate (issue #789): takeover removes
+ * by path. A racer descheduled between confirmation and removal can delete a
+ * successor's lock. Only an OS advisory lock held across takeover, or a design
+ * that never removes a foreign file, closes this remaining check/remove race.
  *
  * RULING R6: this is a runtime module under `packages/lib/src/`, so `node:fs` /
  * `node:path` are banned. Filesystem access goes through `FileSystem.FileSystem`.
@@ -138,12 +129,9 @@ export type IngestLockOutcome<A, A2> =
  * `dataDir` is `AxConfig.paths.dataDir`, and `<dataDir>/ingest.lock` is THE one
  * lock path in v2 - there is no environment override and no second default.
  *
- * `timeoutSeconds` here only SIZES the staleness grace window - it is
- * deliberately not itself part of the returned object. A caller that wants
- * `work` bounded spreads this alongside its own `timeoutSeconds`; a caller that
- * wants `work` unbounded (the dashboard's live-ingest path) spreads this and
- * stops there, still sizing `staleMs` off the same number so a would-be timeout
- * leaves a lock that ages out on the same schedule a bounded run's would have.
+ * `staleMs` remains in the option shape for existing callers. It no longer
+ * authorizes takeover of a live process. `timeoutSeconds` bounds work only when
+ * a caller separately passes it to `withIngestLock`.
  */
 export const ingestLockOptions = (
     path: Path.Path,
@@ -282,7 +270,7 @@ const acquireMutexFor = (key: string): Semaphore.Semaphore => {
  * BOTH HALVES ARE CHECKED, and the file half is not optional. The registry
  * alone answers "did this process take a lock at this path and not release it" -
  * which is NOT the same question. Between the acquire and the write, invariant
- * 5's takeover (or a `staleMs` misjudgement, or a stray `rm`) can hand the lock
+ * 5's takeover (or a stray `rm`) can hand the lock
  * to someone else, and the registry cannot see that happen: it holds the token
  * WE minted, so a replaced lock file still read as "held here" and the seam
  * opened the live database while another process owned it - two writers, the
@@ -323,14 +311,14 @@ const UNKNOWN_HOLDER = (now: number): IngestLockInfo => ({ pid: -1, startedAt: n
  *
  * Returns `{ _tag: "completed", value }` with the work's value on success,
  * `{ _tag: "busy", value }` with the `onBusy` value when skipped, or
- * `{ _tag: "timeout" }` when `work` timed out (the lock is then left to age out
- * as a cooldown).
+ * `{ _tag: "timeout" }` when `work` timed out (the lock remains until the
+ * owner exits or this process explicitly starts another run).
  */
 export const withIngestLock = <A, E, R, A2, E2, R2, R3 = never>(
     opts: {
         readonly lockPath: string;
         readonly command: string;
-        /** a lock older than this (ms) is considered stale and taken over */
+        /** Legacy age setting; a live holder never expires based on elapsed time. */
         readonly staleMs: number;
         /** hard wall-clock cap on `work`; omitted = no timeout */
         readonly timeoutSeconds?: number;
@@ -341,7 +329,7 @@ export const withIngestLock = <A, E, R, A2, E2, R2, R3 = never>(
          *  under test is not decided by whether the runner allows `ps`. */
         readonly procStartedAt?: ProcStartedAtProbe;
         readonly onBusy: (holder: IngestLockInfo) => Effect.Effect<A2, E2, R2>;
-        /** run when `work` exceeds `timeoutSeconds` (lock left to age) - e.g.
+        /** run when `work` exceeds `timeoutSeconds` (lock retained) - e.g.
          *  finalize the run row + tell the user; runs AFTER the interrupted
          *  work's own finalizers have completed */
         readonly onTimeout?: () => Effect.Effect<void, never, never>;
@@ -396,7 +384,6 @@ export const withIngestLock = <A, E, R, A2, E2, R2, R3 = never>(
             if (text === null) return null;
             const holder = decodeLockPayload(text);
             if (holder === null) return null; // corrupt => take it over
-            if (now() - holder.startedAt >= opts.staleMs) return null; // aged out
             if (holder.pid === process.pid && !inProcessHolders.has(key)) {
                 // Our own pid, but this process is not holding it: a leftover
                 // from a crashed earlier run, or a pid the OS reused. Liveness

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dojo
-description: Surplus-quota training loop over the ax graph - the agent burns the remaining 5h/7d plan-quota window on self-improvement: locking pending verdicts, filling briefs, backtesting routing classes, minting proposals, running worktree experiments, and drafting upstream issue reports. Triggers when the user says "/dojo", "enter the dojo", "dojo time", "train overnight", "burn my surplus quota", "dream mode" (legacy name), or invokes /loop /dojo. Requires ax (axctl) on PATH and the local SurrealDB running. Do NOT auto-trigger on unrelated work or when the user merely mentions quotas.
+description: "Surplus-quota training loop over the ax graph - the agent burns the remaining 5h/7d plan-quota window on self-improvement: locking pending verdicts, filling briefs, backtesting routing classes, minting proposals, running worktree experiments, and drafting upstream issue reports. Triggers when the user says \"/dojo\", \"enter the dojo\", \"dojo time\", \"train overnight\", \"burn my surplus quota\", \"dream mode\" (legacy name), or invokes /loop /dojo. Requires ax (axctl) on PATH. ax uses embedded DuckDB; no database daemon is required. Do NOT auto-trigger on unrelated work or when the user merely mentions quotas."
 ---
 
 # ax:dojo - overnight training loop

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -27,13 +27,16 @@ an ax workflow (`ax improve list`, `ax recall …`).
 ## Install
 
 ```bash
-# 1. CLI binary (downloads the latest GitHub release; macOS-first,
-#    Linux works for ingest + CLI without launchd reactivity).
-curl -fsSL https://raw.githubusercontent.com/Necmttn/ax/main/install.sh | bash
+# 1. Download the installer and inspect it before executing. Review the target
+#    paths first; this repository does not publish a checksum for install.sh.
+curl -fsSL https://raw.githubusercontent.com/Necmttn/ax/main/install.sh -o /tmp/ax-install.sh
+less /tmp/ax-install.sh
+read -r -p "Execute this installer? [y/N] " answer
+case "$answer" in [yY][eE][sS]|[yY]) bash /tmp/ax-install.sh ;; *) echo "Installer not run." ;; esac
 
-# 2. Skills - installs this skill + ax:retro + ax:extract-workflow
-#    into ~/.claude/skills/ (and ~/.agents/skills/ for codex).
-npx skills add Necmttn/ax
+# 2. Review the skill changes and confirm before installing into the selected
+#    agent skill directory. Omit -g unless a global install is intentional.
+npx skills add Necmttn/ax -a codex
 
 # 3. First ingest - seeds the graph from the user's last 7 days of
 #    Claude Code + Codex transcripts.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -29,11 +29,26 @@ an ax workflow (`ax improve list`, `ax recall …`).
 ```bash
 # 1. Download the installer and inspect it before executing. Review the target
 #    paths first; this repository does not publish a checksum for install.sh.
-curl -fsSL https://raw.githubusercontent.com/Necmttn/ax/main/install.sh -o /tmp/ax-install.sh
-less /tmp/ax-install.sh
-read -r -p "Execute this installer? [y/N] " answer
-case "$answer" in [yY][eE][sS]|[yY]) bash /tmp/ax-install.sh ;; *) echo "Installer not run." ;; esac
+(
+    set -eu
+    ax_install_dir="$(mktemp -d "${TMPDIR:-/tmp}/ax-install.XXXXXXXX")"
+    trap 'rm -f "$ax_install_dir/install.sh"; rmdir "$ax_install_dir"' EXIT
+    curl -fsSL https://raw.githubusercontent.com/Necmttn/ax/main/install.sh -o "$ax_install_dir/install.sh"
+    less "$ax_install_dir/install.sh"
+    read -r -p "Execute this installer? [y/N] " answer
+    case "$answer" in
+        [yY][eE][sS]|[yY]) bash "$ax_install_dir/install.sh" ;;
+        *) echo "Installer not run."; exit 1 ;;
+    esac
+)
+```
 
+Continue only after the installer completes successfully. A failed download,
+failed review command, declined approval, or end of input stops installation.
+Agents inspect the downloaded file and obtain approval before executing that
+same file. The private directory prevents another local user replacing it.
+
+```bash
 # 2. Review the skill changes and confirm before installing into the selected
 #    agent skill directory. Omit -g unless a global install is intentional.
 npx skills add Necmttn/ax -a codex


### PR DESCRIPTION
Derive-only ingestion no longer receives an implicit shared deadline. Explicit timeout settings retain precedence. Project verification selects the package for each changed file and runs checks from that package directory.

The change also repairs Dojo YAML frontmatter and removes its retired database-daemon prerequisite. The CLI documentation includes skills weighted --include-tools and states the current limitation on proposal harness filtering.

Corrections from review:

- Quote package paths before placing them in shell commands.
- Use the Git root when the checkout has no root package manifest.
- Generate test recommendations for each changed package, including newly created packages.
- Run a declared local TypeScript compiler from the package directory. Support nested and hoisted compiler installations. Do not use registry downloads as a fallback.
- Return no executable guess for unknown package managers or unidentified test runners.
- Reject changed paths outside the checkout and manifests reached through external symbolic links.
- Recognize Bun binary lockfiles.
- Preserve live ingest locks regardless of age. A timed-out holder in another process blocks ingestion until that process exits.
- Download the installer into a private temporary directory. Stop on download failure, review failure, declined approval, or end of input.

Validation:

- Independent standards/security and specification reviews report no remaining blocking defect within this PR scope.
- Focused suite: 124 passed. The later compiler correction passes 22 command tests, including the added hoisted-compiler test.
- TypeScript typecheck, CLI reference check, banned filesystem-import check, and git diff --check pass.
- Full local suite: 6,710 passed, 13 skipped, 5 failed, and 4 errors. The failures comprise one five-second timeout and four missing Electron imports. After installing Electron and allowing 30 seconds for the repeated check, all 23 tests in the five affected files pass.
- GitHub CI and benchmark workflows pass for c3a70dcd. CI includes the full test suite, end-to-end tests, TypeScript checks, documentation gates, the build, and compiled CLI smoke tests.

Verification commands remain suggestions. Package discovery does not execute package scripts. This security review covers the PR changes; the lock module retains the documented check/remove race from issue #789.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
