### PR TITLE
fix(ingest): resume OTLP spool reads at the completed byte offset

### DIFF
--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -92,6 +92,8 @@ export const shouldHeartbeatIngestRun = (completedFiles: number): boolean =>
 export interface JsonlWorkUnitLoop {
     /** Files currently in flight (the current file IS counted here). */
     readonly activeFiles: number;
+    /** Provider-owned cursor when contentHash is off; null during forced runs. */
+    readonly storedSha: (path: string) => string | null;
 }
 
 export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate> {
@@ -133,12 +135,14 @@ export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate
      * live `loop` accessor for any progress emits. Return `true` on success
      * (the work-unit then commits the watermark), or `false` if the file
      * vanished / had nothing to write and must NOT advance the watermark.
+     * Append-only providers can return { sha } to commit a provider cursor
+     * after writes succeed. This requires contentHash to remain off.
      */
     readonly processFile: (
         candidate: C,
         index: number,
         loop: JsonlWorkUnitLoop,
-    ) => Effect.Effect<boolean, E, R>;
+    ) => Effect.Effect<boolean | { readonly sha: string }, E, R>;
 }
 
 export interface JsonlWorkUnitResult {
@@ -173,6 +177,7 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
         let skippedUnchanged = 0;
         let refreshedUnchanged = 0;
         const loop: JsonlWorkUnitLoop = {
+            storedSha: wm.storedSha,
             get activeFiles() {
                 return activeFiles;
             },
@@ -255,15 +260,20 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                             // false ⇒ vanished/empty: never count, never commit
                             // (so it isn't marked done and retries next run).
                             if (!committed) return;
+                            // Append-only providers persist a cursor in sha.
+                            // The content-hash tier retains its own hash contract.
+                            const markSha = typeof committed === "object" && opts.contentHash !== true
+                                ? committed.sha
+                                : contentSha;
                             files += 1;
                             const completedFiles = files;
                             // Commit ONLY after writes succeed. With a spool,
                             // "succeed" includes the flush, so the mark is
                             // deferred to the flush cycle instead.
                             if (opts.spool !== undefined) {
-                                pendingMarks.push(wm.row(candidate.path, candidate.mtimeMs, candidate.sizeBytes, contentSha));
+                                pendingMarks.push(wm.row(candidate.path, candidate.mtimeMs, candidate.sizeBytes, markSha));
                             } else {
-                                yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes, contentSha);
+                                yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes, markSha);
                             }
                             if (opts.runId !== undefined && shouldHeartbeatIngestRun(completedFiles)) {
                                 // Courtesy signal only: a transient heartbeat

--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
 import { Effect, Schema } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
@@ -45,6 +46,21 @@ const metricPayload = {
 };
 
 describe("otel-spool ingest stage", () => {
+    dtest("only decodes appended payloads on the next ingest", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-tail-"));
+        roots.push(spoolDir);
+        const path = join(spoolDir, "2026-08-14.jsonl");
+        const line = JSON.stringify({ path: "/v1/metrics", body: JSON.stringify(metricPayload) }) + "\n";
+        await writeFile(path, line);
+        await runWithPlatform(publishCacheFixture(tempDir("ax-otel-tail-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(1);
+                yield* Effect.promise(() => appendFile(path, line));
+                expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(1);
+            }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+        ));
+    });
+
     dtest("decodes a spool file and writes OTLP rows once", async () => {
         const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-spool-stage-"));
         roots.push(spoolDir);
@@ -73,6 +89,81 @@ describe("otel-spool ingest stage", () => {
         expect(first).toMatchObject({ files: 1, payloads: 1, rows: 1, malformed: 0 });
         expect(second).toMatchObject({ files: 0, skippedUnchanged: 1 });
         expect(rows).toEqual([{ metric: "claude_code.cost.usage", session_id: "session-1" }]);
+    });
+
+    dtest("retains partial UTF-8 records until the terminating newline arrives", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-partial-"));
+        roots.push(spoolDir);
+        const path = join(spoolDir, "2026-08-14.jsonl");
+        const payload = JSON.stringify(metricPayload).replace("session-1", "session-日本語");
+        const bytes = Buffer.from(JSON.stringify({ path: "/v1/metrics", body: payload }) + "\n");
+        const split = bytes.indexOf(Buffer.from("日")) + 1;
+        await writeFile(path, bytes.subarray(0, split));
+        await runWithPlatform(publishCacheFixture(tempDir("ax-otel-partial-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                expect(yield* ingestOtelSpool(write, { spoolDir })).toMatchObject({ payloads: 0, malformed: 0 });
+                yield* Effect.promise(() => appendFile(path, bytes.subarray(split)));
+                expect(yield* ingestOtelSpool(write, { spoolDir })).toMatchObject({ payloads: 1, malformed: 0 });
+                const rows = yield* write.rows(Schema.Struct({ session_id: Schema.String }),
+                    "SELECT session_id FROM otel_metric_point");
+                expect(rows).toEqual([{ session_id: "session-日本語" }]);
+            }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+        ));
+    });
+
+    dtest("replays truncated, rewritten and replaced files and honors forced replay", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-rewrite-"));
+        roots.push(spoolDir);
+        const path = join(spoolDir, "2026-08-14.jsonl");
+        const line = JSON.stringify({ path: "/v1/metrics", body: JSON.stringify(metricPayload) }) + "\n";
+        await writeFile(path, line.repeat(2));
+        const previousForce = process.env.AX_REDERIVE_OTEL_SPOOL;
+        try {
+            await runWithPlatform(publishCacheFixture(tempDir("ax-otel-rewrite-db-"), dylibPath, (write) =>
+                Effect.gen(function* () {
+                    expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(2);
+                    yield* Effect.promise(() => writeFile(path, line));
+                    expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(1);
+                    // Same inode, larger rewrite, changed old boundary.
+                    yield* Effect.promise(() => writeFile(path, line.replace("session-1", "session-2").repeat(2)));
+                    expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(2);
+                    // Rename replacement guarantees a different inode.
+                    yield* Effect.promise(async () => {
+                        await writeFile(path + ".new", line.repeat(3));
+                        await rename(path + ".new", path);
+                    });
+                    expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(3);
+                    process.env.AX_REDERIVE_OTEL_SPOOL = "1";
+                    expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(3);
+                }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+            ));
+        } finally {
+            if (previousForce === undefined) delete process.env.AX_REDERIVE_OTEL_SPOOL;
+            else process.env.AX_REDERIVE_OTEL_SPOOL = previousForce;
+        }
+    });
+
+    dtest("does not advance the cursor after a failed payload write", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-retry-"));
+        roots.push(spoolDir);
+        const path = join(spoolDir, "2026-08-14.jsonl");
+        const line = JSON.stringify({ path: "/v1/metrics", body: JSON.stringify(metricPayload) }) + "\n";
+        await writeFile(path, line);
+        await runWithPlatform(publishCacheFixture(tempDir("ax-otel-retry-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* ingestOtelSpool(write, { spoolDir });
+                yield* Effect.promise(() => appendFile(path, line.repeat(2)));
+                let calls = 0;
+                const failing: CacheWriteService = { ...write, putMany: (table, rows) => {
+                    if (table === "otel_metric_point" && ++calls === 2) {
+                        return write.exec("INSERT INTO missing_spool_test_table VALUES (1)").pipe(Effect.asVoid);
+                    }
+                    return write.putMany(table, rows);
+                } };
+                expect((yield* ingestOtelSpool(failing, { spoolDir })).failedFiles).toBe(1);
+                expect((yield* ingestOtelSpool(write, { spoolDir })).payloads).toBe(2);
+            }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+        ));
     });
 
     it("declares the ingest stage contract", () => {

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -149,6 +149,55 @@ const parseBody = (body: string): unknown | undefined => {
     }
 };
 
+/** Cursor lives in the existing watermark sha column, not in the judgment store.
+ * The suffix verifies the old boundary after same-inode truncation/rewrite.
+ * Reads stop at discovery size, so appends during parsing remain for next run.
+ */
+const readSpoolTail = (fs: FileSystem.FileSystem, candidate: JsonlFileCandidate, previous: string | null) =>
+    Effect.gen(function* () {
+        const file = yield* fs.open(candidate.path);
+        const stat = yield* file.stat;
+        const identity = `${stat.dev}:${stat.ino._tag === "Some" ? stat.ino.value : "unknown"}`;
+        const end = Math.min(candidate.sizeBytes, Number(stat.size));
+        const readRange = (start: number, length: number) => Effect.gen(function* () {
+            yield* file.seek(start, "start");
+            const chunks: Uint8Array[] = [];
+            let remaining = length;
+            while (remaining > 0) {
+                const chunk = yield* file.readAlloc(Math.min(remaining, 64 * 1024));
+                if (chunk._tag === "None" || chunk.value.length === 0) break;
+                chunks.push(chunk.value);
+                remaining -= chunk.value.length;
+            }
+            return Buffer.concat(chunks);
+        });
+        let start = 0;
+        if (previous !== null) {
+            let cursor: unknown;
+            try { cursor = JSON.parse(previous); } catch { cursor = null; }
+            if (cursor !== null && typeof cursor === "object") {
+                const c = cursor as Record<string, unknown>;
+                if (c.version === 1 && c.identity === identity && typeof c.offset === "number"
+                    && Number.isSafeInteger(c.offset) && c.offset > 0 && c.offset <= end
+                    && typeof c.anchor === "string") {
+                    const boundary = yield* readRange(Math.max(0, c.offset - 256), Math.min(c.offset, 256));
+                    if (new Bun.CryptoHasher("sha256").update(boundary).digest("hex") === c.anchor) start = c.offset;
+                }
+            }
+        }
+        const bytes = yield* readRange(start, end - start);
+        // A receiver can be in the middle of an append. Never consume an
+        // unterminated record, including a partial UTF-8 code point.
+        const complete = bytes.lastIndexOf(10) + 1;
+        const offset = start + complete;
+        const anchorBytes = yield* readRange(Math.max(0, offset - 256), Math.min(offset, 256));
+        return {
+            text: bytes.subarray(0, complete).toString("utf8"),
+            sha: JSON.stringify({ version: 1, identity, offset,
+                anchor: new Bun.CryptoHasher("sha256").update(anchorBytes).digest("hex") }),
+        };
+    }).pipe(Effect.scoped);
+
 export interface IngestOtelSpoolOptions {
     readonly spoolDir?: string;
     readonly runId?: string;
@@ -198,17 +247,11 @@ export const ingestOtelSpool = (
             forceEnv: "AX_REDERIVE_OTEL_SPOOL",
             source: "otel-spool",
             ...(opts.runId === undefined ? {} : { runId: opts.runId }),
-            processFile: (candidate) =>
+            processFile: (candidate, _index, loop) =>
                 Effect.gen(function* () {
-                    // Whole-file read (not a true tail): the daily spool file is
-                    // re-read in full whenever it changes. The work-unit
-                    // watermark (jsonl-work-unit.ts) skips UNCHANGED files, so a
-                    // quiescent day is not re-read; only a file that grew is read
-                    // whole. A real offset tail is a larger change, deferred
-                    // past the wave-1 seam.
-                    const text = yield* fs.readFileString(candidate.path);
+                    const tail = yield* readSpoolTail(fs, candidate, loop.storedSha(candidate.path));
                     const writer = yield* OtelWriter;
-                    for (const line of text.split("\n")) {
+                    for (const line of tail.text.split("\n")) {
                         if (line.trim().length === 0) continue;
                         const envelope = decodeEnvelope(line);
                         const signal = envelope ? OTLP_SIGNAL_PATHS[envelope.path] : undefined;
@@ -237,7 +280,7 @@ export const ingestOtelSpool = (
                         payloads += 1;
                         rows += normalized.length;
                     }
-                    return true;
+                    return { sha: tail.sha };
                 }),
         }).pipe(Effect.provide(OtelWriterLive(write)));
 


### PR DESCRIPTION
## Summary

Closes #769.

Appending one OTLP payload previously caused ingest to decode and write every payload in the daily spool file again. Ingest now resumes at the last completed byte position.

## Behavior change

The existing watermark stores a versioned cursor after payload writes succeed. Reads stop at the file size observed during discovery. Incomplete records remain for the next append. File identity and a bounded boundary hash detect replacement and truncation. Forced replay starts from zero. Legacy marks replay once when the file changes.

The shared JSONL work unit accepts a provider cursor while preserving content-hash behavior and deferred watermark writes.

## Test plan

- [x] Regression reproduces two decoded payloads after one append before the correction.
- [x] 23 focused tests pass, including partial UTF-8 records, replacement, truncation, forced replay, write failure recovery, and existing work-unit behavior.
- [x] `bun run typecheck`
- [x] SQL numeric and timestamp checks; `git diff --check`
- [x] Full suite: 6,690 tests pass and 13 skip. Four test files initially fail because Electron is not installed. After installation, all 16 tests in those files pass.

## Release notes

- [x] Conventional commit uses `fix(ingest)`.
- Website release notes wait for the release PR.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
