### PR TITLE
fix(ingest): remove watermarks for pruned OTLP spool files

### DIFF
--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -6,6 +6,7 @@ import { Effect, Schema } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { pruneOtlpSpool } from "../otel/spool-server.ts";
 import { cacheRow } from "@ax/lib/duckdb/row";
 import { WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
 import { metricPointRowId } from "../otel/rows.ts";
@@ -203,4 +204,37 @@ describe("stampReceivedAt (timeless-event epoch collision guard)", () => {
         expect(stampReceivedAt(rows, null)[0]!.observed_at.getTime()).toBe(0);
         expect(stampReceivedAt(rows, new Date("nope"))[0]!.observed_at.getTime()).toBe(0);
     });
+});
+
+describe("OTLP spool retention watermarks", () => {
+    dtest("removes watermarks for pruned files while preserving other spool directories", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-prune-"));
+        const otherDir = await mkdtemp(join(tmpdir(), "ax-otel-other-"));
+        roots.push(spoolDir, otherDir);
+        const oldPath = join(spoolDir, "2026-01-01.jsonl");
+        const keptPath = join(spoolDir, "2026-08-14.jsonl");
+        const otherPath = join(otherDir, "2026-01-01.jsonl");
+        const line = JSON.stringify({ path: "/v1/metrics", body: JSON.stringify(metricPayload) }) + "\n";
+        await Promise.all([oldPath, keptPath, otherPath].map((path) => writeFile(path, line)));
+        await runWithPlatform(publishCacheFixture(tempDir("ax-otel-prune-db-"), dylibPath, (write) =>
+            Effect.gen(function* () {
+                yield* ingestOtelSpool(write, { spoolDir });
+                yield* ingestOtelSpool(write, { spoolDir: otherDir });
+                expect(yield* pruneOtlpSpool({ spoolDir, now: new Date("2026-08-14T12:00:00Z") })).toBe(1);
+                // A missing file in a different configured directory remains
+                // that directory's responsibility, even when it shares a name.
+                yield* Effect.promise(() => rm(otherPath));
+                yield* ingestOtelSpool(write, { spoolDir });
+                const marks = yield* write.rows(Schema.Struct({ path: Schema.String }),
+                    "SELECT path FROM ingest_file_state WHERE source_kind = 'otel_spool' ORDER BY path");
+                expect(marks.map((row) => row.path).sort()).toEqual([
+                    keptPath, otherPath, METRIC_KEY_CUTOVER_SENTINEL_PATH,
+                ].sort());
+                const sentinels = yield* write.rows(Schema.Struct({ path: Schema.String }),
+                    "SELECT path FROM ingest_file_state WHERE path = ?", [METRIC_KEY_CUTOVER_SENTINEL_PATH]);
+                expect(sentinels).toHaveLength(1);
+            }).pipe(Effect.provide(BunFileSystem.layer), Effect.provide(BunPath.layer)),
+        ));
+    });
+
 });

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -2,6 +2,7 @@ import { Effect, FileSystem, Option, Path, PlatformError, Schema } from "effect"
 import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { DbError } from "@ax/lib/errors";
 import { WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
+import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { defaultOtlpSpoolDir } from "../otel/spool-server.ts";
 import { SIGNALS } from "../otel/signals.ts";
 import { OTLP_SIGNAL_PATHS } from "../otel/signal.ts";
@@ -176,6 +177,21 @@ export const ingestOtelSpool = (
         const fs = yield* FileSystem.FileSystem;
         const spoolDir = opts.spoolDir ?? defaultOtlpSpoolDir();
         const candidates = yield* walkJsonlFilesStrict(spoolDir, 0);
+        // The receiver is database-free. Reconcile retention here under the
+        // ingest write capability, after a successful directory walk. Only
+        // remove marks in this spool directory whose files are truly absent.
+        const path = yield* Path.Path;
+        const discovered = new Set(candidates.map((candidate) => candidate.path));
+        const marks = yield* write.rows(Schema.Struct({ path: Schema.String }),
+            `SELECT path FROM ${WATERMARK_TABLE} WHERE source_kind = ?`, ["otel_spool"]);
+        for (const mark of marks) {
+            if (discovered.has(mark.path) || !mark.path.endsWith(".jsonl")) continue;
+            const relative = path.relative(path.resolve(spoolDir), path.resolve(mark.path));
+            if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) continue;
+            const exists = yield* fs.stat(mark.path).pipe(Effect.as(true), skipNotFound(false));
+            if (!exists) yield* write.exec(
+                `DELETE FROM ${WATERMARK_TABLE} WHERE source_kind = ? AND path = ?`, ["otel_spool", mark.path]);
+        }
         let payloads = 0;
         let rows = 0;
         let malformed = 0;


### PR DESCRIPTION
## Summary

Closes #770.

Retention deletes old OTLP spool files, but their ingest watermarks previously remained indefinitely. The next ingest now removes watermark rows for missing spool files.

## Behavior change

Cleanup runs against the live cache through the existing ingest write capability. A successful directory walk precedes cleanup. Each deletion requires a missing file inside the selected spool directory and the `otel_spool` source kind. Filesystem permission and I/O errors cannot authorize deletion. Marks for other spool directories and migration sentinels remain intact.

The receiver remains database-free. Cleanup occurs on the next ingest, rather than in the receiver acknowledgement path. The optional warning for never-ingested files is not added; retention still uses file age.

## Test plan

- [x] Regression reproduces a retained watermark after `pruneOtlpSpool` removes its file.
- [x] 20 spool ingest and receiver tests pass, including preservation of other directories and migration sentinels.
- [x] `bun run typecheck`
- [x] SQL numeric and timestamp checks; `git diff --check`

- [x] Full suite: 6,687 tests pass and 13 skip. Four test files initially fail because Electron is not installed. After installation, all 16 tests in those files pass.

## Release notes

- [x] Conventional commit uses `fix(ingest)`.
- Website release notes wait for the release PR.

## Notes for reviewer

This branch merges cleanly with #1125. Each correction has separate regression tests.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
