### PR TITLE
fix(improve): serialize generated skill metadata safely

### DIFF
--- a/apps/axctl/src/improve/skill-scaffold.test.ts
+++ b/apps/axctl/src/improve/skill-scaffold.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { parse as parseYaml } from "yaml";
+import { parseSkillFile } from "../ingest/skills.ts";
 import { kebabCase, scaffoldContent, scaffoldSkill, skillScaffoldFile, type ScaffoldOptions } from "./skill-scaffold.ts";
 
 // scaffoldSkill now returns an Effect requiring FileSystem + Path (migrated to
@@ -62,6 +64,63 @@ describe("scaffoldContent", () => {
 });
 
 describe("scaffoldSkill", () => {
+    test.each(["", "   ", "!!!", "日本語", "🚀"])("rejects an empty normalized name: %j", async (title) => {
+        const root = mkdtempSync(join(tmpdir(), "ax-scaffold-"));
+        const input = {
+            title,
+            hypothesis: "Problem: repeated root checks",
+            proposedBehavior: "Check the files.",
+            dedupeSig: "skill__empty",
+            nowIso: "2026-05-25T00:00:00.000Z",
+        };
+        try {
+            const baseDir = join(root, "not-created");
+            await expect(runScaffold({ baseDir, input })).rejects.toThrow("Skill title must contain at least one ASCII letter or digit");
+            expect(existsSync(baseDir)).toBe(false);
+            const existing = join(root, "SKILL.md");
+            writeFileSync(existing, "Keep this file.");
+            for (const force of [false, true]) {
+                await expect(runScaffold({ baseDir: root, input, force })).rejects.toThrow("Skill title must contain at least one ASCII letter or digit");
+                expect(readFileSync(existing, "utf-8")).toBe("Keep this file.");
+            }
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test.each([
+        ["colon", "Problem: repeated root checks", "Problem: repeated root checks"],
+        ["quotes", '"Check" the user\'s files # carefully', '"Check" the user\'s files # carefully'],
+        ["newline", "First line\nSecond line", "First line Second line"],
+        ["Unicode", "Vérifier 日本語 🚀", "Vérifier 日本語 🚀"],
+        ["YAML scalar", "null", "null"],
+    ])("creates parseable metadata for %s", async (_label, hypothesis, description) => {
+        const baseDir = mkdtempSync(join(tmpdir(), "ax-scaffold-"));
+        try {
+            const result = await runScaffold({
+                baseDir,
+                input: {
+                    title: "Café Checks",
+                    hypothesis: hypothesis!,
+                    proposedBehavior: "Check the files.",
+                    dedupeSig: "skill__metadata",
+                    nowIso: "2026-05-25T00:00:00.000Z",
+                },
+            });
+            expect(result.created).toBe(true);
+            expect(result.path).toBe(join(baseDir, "cafe-checks", "SKILL.md"));
+            const content = readFileSync(result.path, "utf-8");
+            // The real parser tolerates invalid YAML, so also require strict YAML.
+            expect(parseYaml(content.split("---\n")[1]!)).toEqual({ name: "cafe-checks", description });
+            const parsed = parseSkillFile(content, "fallback-must-not-be-used");
+            expect(parsed.name).toBe("cafe-checks");
+            expect(parsed.description).toBe(description);
+            expect(parsed.body).toContain("Check the files.");
+        } finally {
+            rmSync(baseDir, { recursive: true, force: true });
+        }
+    });
+
     test("creates SKILL.md under baseDir/<kebab-name>/", async () => {
         const baseDir = mkdtempSync(join(tmpdir(), "ax-scaffold-"));
         try {

--- a/apps/axctl/src/improve/skill-scaffold.ts
+++ b/apps/axctl/src/improve/skill-scaffold.ts
@@ -13,8 +13,9 @@
  * the existing path or error.
  */
 
-import { Effect, FileSystem, type PlatformError } from "effect";
+import { Effect, FileSystem, PlatformError } from "effect";
 import { homedir } from "node:os";
+import { stringify as stringifyYaml } from "yaml";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 
@@ -59,9 +60,7 @@ export const scaffoldContent = (input: ScaffoldInput): string => {
     const trigger = input.triggerPattern?.trim();
     const impact = input.expectedImpact?.trim();
     return `---
-name: ${nameKebab}
-description: ${description}
----
+${stringifyYaml({ name: nameKebab, description })}---
 
 # ${input.title}
 
@@ -85,6 +84,13 @@ export const scaffoldSkill = (
     opts: ScaffoldOptions,
 ): Effect.Effect<ScaffoldResult, PlatformError.PlatformError, FileSystem.FileSystem> =>
     Effect.gen(function* () {
+        if (!kebabCase(opts.input.title)) {
+            return yield* Effect.fail(PlatformError.badArgument({
+                module: "skill-scaffold",
+                method: "scaffoldSkill",
+                description: "Skill title must contain at least one ASCII letter or digit after normalization",
+            }));
+        }
         const fs = yield* FileSystem.FileSystem;
         const dir = skillScaffoldDir(opts.input.title, opts.baseDir);
         const path = posixPath.join(dir, "SKILL.md");

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -93,7 +93,7 @@ export function extractRoles(fm: Record<string, unknown>, skillName?: string): s
     return result;
 }
 
-function parseSkillFile(content: string, fallbackName: string): ParsedSkill {
+export function parseSkillFile(content: string, fallbackName: string): ParsedSkill {
     const m = content.match(FRONTMATTER_RE);
     if (!m) {
         return { name: fallbackName, description: undefined, frontmatter: {}, body: content, roles: [] };


### PR DESCRIPTION
Proposal descriptions containing a colon can produce invalid skill frontmatter. Serialize YAML and reject titles with no usable normalized name before filesystem changes. Tests parse real generated skills and preserve existing-file protection.

Validation: 31 focused tests pass; bun run typecheck passes. Full root verification and independent review are tracked in #1132.

Closes #1130.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
