### PR TITLE
fix(improve): resume interrupted task publication and preserve decisions

### DIFF
--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -318,6 +318,8 @@ const improveAcceptCommand = Command.make(
             }
 
             // status === "ok"
+            // Set only when this run finished an interrupted publication.
+            if (result.message) console.log(result.message);
             if (result.task_path) {
                 console.log(`task emitted at ${result.task_path}`);
                 console.log(`apply with your agent: \`claude "do ${result.task_path}"\``);

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -307,6 +307,12 @@ const improveAcceptCommand = Command.make(
                 }
                 process.exit(2);
             }
+            if (result.status === "verdict_locked") {
+                // The brief may be on disk, but the experiment was judged and
+                // must not be moved - never print this as an emitted task.
+                console.error(result.message ?? "experiment verdict already locked");
+                process.exit(2);
+            }
             if (result.status === "unsupported_form") {
                 fail(result.message ?? "unsupported form");
             }

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -10,7 +10,7 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 import { Judgment, type JudgmentError, type JudgmentService } from "@ax/lib/sqlite";
 import { stableId } from "@ax/lib/stable-id";
-import { orAbsent } from "@ax/lib/shared/fs-error";
+import { isAlreadyExists, orAbsent } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import {
     type InterventionSafetyContract,
@@ -331,34 +331,70 @@ const finishPublication = (
     [EXPERIMENT_STATUS_TASK_EMITTED, experimentKey, EXPERIMENT_STATUS_PUBLISHING],
 );
 
-/** True only for a real file: a directory sitting on the task path is not a brief. */
-const publishedTaskExists = (
-    fs: FileSystem.FileSystem,
-    taskPath: string,
-): Effect.Effect<boolean, never> =>
-    fs.stat(taskPath).pipe(
-        Effect.map((info) => info.type === "File"),
-        orAbsent(false),
-    );
+/** What a publish attempt did with the task path. */
+type PublishOutcome = "published" | "kept_existing";
 
 /**
- * Drop the staged temp files an interrupted publication left behind. Their name
- * carries the pid of the process that died, so only the recovering run can tell
- * they are garbage. Best-effort: a sweep failure must not fail the recovery.
+ * Stage the rendered brief beside its target, then publish it in one step.
+ *
+ * The staging name carries BOTH the pid and a uuid, so it belongs to exactly one
+ * attempt: two concurrent accepts of the same proposal never share it, and the
+ * `ensuring` below removes only the file this attempt created. Nothing ever
+ * deletes a staging file by pattern - a name alone cannot prove ownership, and a
+ * pattern sweep would delete a live attempt's in-progress file.
+ *
+ * `replace` picks how the staged file lands, and the two modes are not
+ * interchangeable:
+ *   - `true` - the FIRST accept, which has already established that replacing is
+ *     authorized (the path was free, or the caller passed `force`). `rename`
+ *     swaps the target atomically.
+ *   - `false` - a RESUMED publication, which has no such authority. `link`
+ *     creates the target ONLY if nothing is there and fails with `AlreadyExists`
+ *     otherwise, which is reported as `kept_existing`. There is deliberately no
+ *     stat first: a file can appear between a probe and a rename, and the rename
+ *     would then destroy it. The exclusive create IS the check.
+ *
+ * `beforePublish` runs after the staged file is complete and before it lands, so
+ * a failure there aborts with the target untouched.
+ *
+ * Sibling of `@ax/lib/staged-rename`, which owns the replace-only form of this
+ * dance; it has no exclusive mode, and adding one would change the signature its
+ * snapshot/dylib callers depend on.
  */
-const sweepStagedTasks = (
-    fs: FileSystem.FileSystem,
-    taskDir: string,
-    taskFileName: string,
-): Effect.Effect<void, never> =>
-    fs.readDirectory(taskDir).pipe(
-        orAbsent([] as ReadonlyArray<string>),
-        Effect.flatMap((names) => Effect.forEach(
-            names.filter((name) => name.startsWith(`${taskFileName}.tmp.`)),
-            (name) => fs.remove(posixPath.join(taskDir, name), { force: true }).pipe(Effect.ignore),
-            { discard: true },
-        )),
-    );
+const publishTaskBrief = <E, R>(input: {
+    readonly taskPath: string;
+    readonly content: string;
+    readonly replace: boolean;
+    readonly beforePublish?: Effect.Effect<void, E, R>;
+}): Effect.Effect<PublishOutcome, E | PlatformError.PlatformError, R | FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const staging = `${input.taskPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+        const publish = Effect.gen(function* () {
+            yield* fs.makeDirectory(posixPath.dirname(input.taskPath), { recursive: true });
+            yield* fs.writeFileString(staging, input.content);
+            if (input.beforePublish !== undefined) yield* input.beforePublish;
+            if (input.replace) {
+                yield* fs.rename(staging, input.taskPath);
+                return "published" as PublishOutcome;
+            }
+            return yield* fs.link(staging, input.taskPath).pipe(
+                Effect.as("published" as PublishOutcome),
+                Effect.catchTag("PlatformError", (err) =>
+                    isAlreadyExists(err)
+                        ? Effect.succeed("kept_existing" as PublishOutcome)
+                        : Effect.fail(err),
+                ),
+            );
+        });
+        // Every exit path drops THIS attempt's staging file: after a successful
+        // rename it is already gone, after a successful link it is the spare
+        // name for the published inode, and after any failure it is the partial
+        // write nobody else can claim. It must not mask the primary error.
+        return yield* publish.pipe(
+            Effect.ensuring(fs.remove(staging, { force: true }).pipe(Effect.ignore)),
+        );
+    });
 
 export const acceptProposal = (
     opts: AcceptOptions,
@@ -507,7 +543,6 @@ export const acceptProposal = (
         // caller's taskDir has since changed.
         const taskPath = resumed?.task_path
             ?? posixPath.join(opts.taskDir ?? defaultTaskDir(), `${row.dedupe_sig}.md`);
-        const taskDir = posixPath.dirname(taskPath);
 
         if (resumed === null) {
             // existsSync probe: any fault → treat as absent (orAbsent(false)).
@@ -519,70 +554,53 @@ export const acceptProposal = (
                     task_path: taskPath,
                 };
             }
-        } else if (yield* publishedTaskExists(fs, taskPath)) {
-            // The brief is already there: either the rename landed and only the
-            // status update was lost, or the operator wrote the file themselves.
-            // Never overwrite it - just finish the acceptance in the sidecar.
-            yield* finishPublication(judgment, experimentKey);
-            yield* sweepStagedTasks(fs, taskDir, `${row.dedupe_sig}.md`);
-            return {
-                status: "ok",
-                proposal_id: `proposal:${proposalKey}`,
-                experiment_id: experimentId,
-                task_path: taskPath,
-                message: `finished the interrupted publication; kept the existing brief at ${taskPath}`,
-            };
         }
 
         const taskInput = buildTaskInput(row, experimentId);
         const taskContent = renderTaskFile(taskInput);
 
-        // mkdir + tmp write propagate (original used bare mkdirSync/writeFileSync).
-        yield* fs.makeDirectory(taskDir, { recursive: true });
-        // Atomic write: stage content in a temp file first, commit to final path only
-        // after the DB update succeeds. This avoids orphan task files when the DB
-        // query fails after the write.
-        const tmpPath = `${taskPath}.tmp.${process.pid}`;
-        yield* fs.writeFileString(tmpPath, taskContent);
+        // Phase 1 (first accept only): accept the proposal and record the path
+        // this run intends to publish, as `publishing`. That status is what a
+        // later retry reads to tell an interrupted publication from a completed
+        // acceptance. It runs between the staged write and the publish, so a DB
+        // failure leaves neither a brief nor a staging file behind.
+        // Phase 2: land the staged file. The first accept may replace (the guard
+        // above authorized it); a resume publishes exclusively and keeps whatever
+        // is already there. A failure propagates with the experiment still
+        // `publishing`, so the next accept resumes instead of refusing.
+        const outcome = yield* publishTaskBrief({
+            taskPath,
+            content: taskContent,
+            replace: resumed === null,
+            ...(resumed === null
+                ? {
+                    beforePublish: saveAcceptedExperiment(
+                        judgment,
+                        proposalKey,
+                        experimentKey,
+                        EXPERIMENT_STATUS_PUBLISHING,
+                        { taskPath },
+                    ),
+                }
+                : {}),
+        });
 
-        if (resumed === null) {
-            // Phase 1: accept the proposal and record the path this run intends to
-            // publish, as `publishing`. That status is what a later retry reads to
-            // tell an interrupted publication from a completed acceptance.
-            yield* saveAcceptedExperiment(
-                judgment,
-                proposalKey,
-                experimentKey,
-                EXPERIMENT_STATUS_PUBLISHING,
-                { taskPath },
-            ).pipe(
-                // Best-effort cleanup of the staged temp file on DB failure (matches
-                // main's `try { unlinkSync(tmpPath); } catch {}`): force tolerates an
-                // already-absent temp and `ignore` swallows any other fault so the
-                // original DbError still propagates.
-                Effect.tapError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)),
-            );
-        }
-
-        // Phase 2: commit the staged write to its final path. A failure here
-        // propagates and leaves the experiment `publishing`, so the next accept
-        // resumes instead of refusing.
-        yield* fs.rename(tmpPath, taskPath);
-
-        // Phase 3: the brief is on disk, so the publication is done. This path
-        // always emits a task, including when a resume arrives with
-        // --auto-scaffold, so the final status is task_emitted either way.
+        // Phase 3: a brief is on disk - this attempt's, or the one it refused to
+        // replace - so the publication is done. This path always emits a task,
+        // including when a resume arrives with --auto-scaffold, so the final
+        // status is task_emitted either way.
         yield* finishPublication(judgment, experimentKey);
-        if (resumed !== null) yield* sweepStagedTasks(fs, taskDir, `${row.dedupe_sig}.md`);
 
         return {
             status: "ok",
             proposal_id: `proposal:${proposalKey}`,
             experiment_id: experimentId,
             task_path: taskPath,
-            ...(resumed === null
-                ? {}
-                : { message: `finished the interrupted publication at ${taskPath}` }),
+            ...(resumed === null ? {} : {
+                message: outcome === "kept_existing"
+                    ? `finished the interrupted publication; kept the existing brief at ${taskPath}`
+                    : `finished the interrupted publication at ${taskPath}`,
+            }),
         };
     });
 

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -7,8 +7,8 @@
  * (CLI or HTTP) can render however it likes.
  */
 
-import { Effect, FileSystem, type PlatformError } from "effect";
-import { Judgment, type JudgmentError, type JudgmentService } from "@ax/lib/sqlite";
+import { Effect, FileSystem, Option, type PlatformError, Schema } from "effect";
+import { Judgment, TextColumn, type JudgmentError, type JudgmentService } from "@ax/lib/sqlite";
 import { stableId } from "@ax/lib/stable-id";
 import { isAlreadyExists, orAbsent } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
@@ -318,21 +318,82 @@ const saveAcceptedExperiment = (
     });
 }));
 
+/** Whether the experiment reached `task_emitted`, and why not when it did not. */
+type PublicationFinish =
+    | { readonly finished: true }
+    | { readonly finished: false; readonly locked: boolean; readonly reason: string };
+
+const ExperimentStateRow = Schema.Struct({
+    status: TextColumn,
+    locked_verdict: Schema.NullOr(TextColumn),
+});
+
 /**
- * Move an experiment off `publishing` once its brief is on disk. The status
- * predicate is the guard: a concurrent retire or a second retry finds no
- * `publishing` row, so this can never revive a closed experiment.
+ * Move an experiment off `publishing` once its brief is on disk.
+ *
+ * BOTH predicates are load-bearing. `status = 'publishing'` stops a second retry
+ * and a concurrent retire from being re-opened; `locked_verdict IS NULL` stops a
+ * row somebody judged BETWEEN the plan read and this update from being written
+ * at all - the status test alone cannot see that, because a locked row can still
+ * read `publishing`.
+ *
+ * A no-op update is ambiguous on its own, so the row is re-read to tell the two
+ * apart: another attempt that already finished the publication (complete), or a
+ * locked/retired row this attempt must not claim (incomplete). Callers must not
+ * report a completed publication for the second.
  */
 const finishPublication = (
     judgment: JudgmentService,
     experimentKey: string,
-) => judgment.exec(
-    "UPDATE experiment SET status = ? WHERE id = ? AND status = ?",
-    [EXPERIMENT_STATUS_TASK_EMITTED, experimentKey, EXPERIMENT_STATUS_PUBLISHING],
-);
+): Effect.Effect<PublicationFinish, JudgmentError> =>
+    Effect.gen(function* () {
+        const changed = yield* judgment.exec(
+            "UPDATE experiment SET status = ? WHERE id = ? AND status = ? AND locked_verdict IS NULL",
+            [EXPERIMENT_STATUS_TASK_EMITTED, experimentKey, EXPERIMENT_STATUS_PUBLISHING],
+        );
+        if (changed > 0) return { finished: true };
+        const current = yield* judgment.first(
+            ExperimentStateRow,
+            "SELECT status, locked_verdict FROM experiment WHERE id = ? LIMIT 1",
+            [experimentKey],
+        );
+        const row = Option.getOrUndefined(current);
+        if (row === undefined) {
+            return { finished: false, locked: false, reason: `experiment ${experimentKey} is gone` };
+        }
+        // Another attempt got there first: the publication IS complete.
+        if (row.status !== EXPERIMENT_STATUS_PUBLISHING) return { finished: true };
+        return row.locked_verdict === null
+            ? { finished: false, locked: false, reason: `experiment ${experimentKey} could not be finished` }
+            : { finished: false, locked: true, reason: `experiment verdict already locked: ${row.locked_verdict}` };
+    });
 
 /** What a publish attempt did with the task path. */
 type PublishOutcome = "published" | "kept_existing";
+
+/**
+ * Decide what an exclusive publish's `AlreadyExists` actually found.
+ *
+ * `stat` FOLLOWS symlinks, which is what makes it the right probe here: a
+ * symlink resolving to a regular file is a brief the operator chose to keep, and
+ * a DANGLING symlink reports NotFound and is rejected. A directory reports its
+ * own type and is rejected. Either way the path is left untouched - this only
+ * decides whether the caller may treat the publication as finished.
+ */
+const keepUsableDestination = (
+    fs: FileSystem.FileSystem,
+    taskPath: string,
+    alreadyExists: PlatformError.PlatformError,
+): Effect.Effect<PublishOutcome, PlatformError.PlatformError> =>
+    fs.stat(taskPath).pipe(
+        Effect.map((info) => info.type === "File"),
+        // Any fault (a dangling symlink's NotFound, a permission error) means
+        // "cannot confirm a readable brief", which is not a finished publication.
+        orAbsent(false),
+        Effect.flatMap((usable) =>
+            usable ? Effect.succeed("kept_existing" as PublishOutcome) : Effect.fail(alreadyExists),
+        ),
+    );
 
 /**
  * Stage the rendered brief beside its target, then publish it in one step.
@@ -345,14 +406,26 @@ type PublishOutcome = "published" | "kept_existing";
  *
  * `replace` picks how the staged file lands, and the two modes are not
  * interchangeable:
- *   - `true` - the FIRST accept, which has already established that replacing is
- *     authorized (the path was free, or the caller passed `force`). `rename`
- *     swaps the target atomically.
+ *   - `true` - ONLY a first accept carrying an explicit `force`. That flag is the
+ *     operator's authority to overwrite; `rename` then swaps the target
+ *     atomically. An earlier "the path was free" probe is NOT authority - the
+ *     path can fill between the probe and the publish - so ordinary acceptance
+ *     publishes exclusively too.
  *   - `false` - a RESUMED publication, which has no such authority. `link`
  *     creates the target ONLY if nothing is there and fails with `AlreadyExists`
- *     otherwise, which is reported as `kept_existing`. There is deliberately no
- *     stat first: a file can appear between a probe and a rename, and the rename
- *     would then destroy it. The exclusive create IS the check.
+ *     otherwise. There is deliberately no stat first: a file can appear between a
+ *     probe and a rename, and the rename would then destroy it. The exclusive
+ *     create IS the check.
+ *
+ * `AlreadyExists` alone does not mean "a brief is already published". It also
+ * describes a DIRECTORY on the path and a DANGLING SYMLINK - `link` refuses
+ * both, and neither is a task file anyone can read. So the destination is
+ * validated AFTER the refusal, which is safe precisely because the exclusive
+ * create already failed: whatever is there was not put there by this attempt and
+ * is left exactly as found. A regular file (or a symlink resolving to one) is
+ * reported as `kept_existing`; anything else re-raises the `AlreadyExists`
+ * failure, so the caller cannot mistake an unusable path for a finished
+ * publication.
  *
  * `beforePublish` runs after the staged file is complete and before it lands, so
  * a failure there aborts with the target untouched.
@@ -382,7 +455,7 @@ const publishTaskBrief = <E, R>(input: {
                 Effect.as("published" as PublishOutcome),
                 Effect.catchTag("PlatformError", (err) =>
                     isAlreadyExists(err)
-                        ? Effect.succeed("kept_existing" as PublishOutcome)
+                        ? keepUsableDestination(fs, input.taskPath, err)
                         : Effect.fail(err),
                 ),
             );
@@ -571,7 +644,10 @@ export const acceptProposal = (
         const outcome = yield* publishTaskBrief({
             taskPath,
             content: taskContent,
-            replace: resumed === null,
+            // Replacement needs the operator's explicit force on a first accept.
+            // Everything else - ordinary acceptance included - publishes
+            // exclusively and keeps whatever it finds.
+            replace: resumed === null && opts.force === true,
             ...(resumed === null
                 ? {
                     beforePublish: saveAcceptedExperiment(
@@ -585,22 +661,37 @@ export const acceptProposal = (
                 : {}),
         });
 
-        // Phase 3: a brief is on disk - this attempt's, or the one it refused to
-        // replace - so the publication is done. This path always emits a task,
-        // including when a resume arrives with --auto-scaffold, so the final
-        // status is task_emitted either way.
-        yield* finishPublication(judgment, experimentKey);
+        // Phase 3: a readable brief is on disk - this attempt's, or the one it
+        // refused to replace - so the publication can be finished. This path
+        // always emits a task, including when a resume arrives with
+        // --auto-scaffold, so the final status is task_emitted either way.
+        const finish = yield* finishPublication(judgment, experimentKey);
+        if (!finish.finished) {
+            // The brief is published, but this experiment must not be moved.
+            // Reporting "ok" here would claim a completed acceptance for a row
+            // somebody already judged.
+            return {
+                status: finish.locked ? "verdict_locked" : "wrong_status",
+                proposal_id: `proposal:${proposalKey}`,
+                experiment_id: experimentId,
+                task_path: taskPath,
+                message: `${finish.reason}; the brief at ${taskPath} was left in place and the acceptance was not finished`,
+            };
+        }
 
+        const keptMessage = resumed === null
+            ? `a task brief appeared at ${taskPath} first; kept it (pass force=true to overwrite)`
+            : `finished the interrupted publication; kept the existing brief at ${taskPath}`;
         return {
             status: "ok",
             proposal_id: `proposal:${proposalKey}`,
             experiment_id: experimentId,
             task_path: taskPath,
-            ...(resumed === null ? {} : {
-                message: outcome === "kept_existing"
-                    ? `finished the interrupted publication; kept the existing brief at ${taskPath}`
-                    : `finished the interrupted publication at ${taskPath}`,
-            }),
+            ...(outcome === "kept_existing"
+                ? { message: keptMessage }
+                : resumed === null
+                    ? {}
+                    : { message: `finished the interrupted publication at ${taskPath}` }),
         };
     });
 

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -15,8 +15,10 @@ import { posixPath } from "@ax/lib/shared/path";
 import {
     type InterventionSafetyContract,
     EXPERIMENT_STATUS_PUBLISHING,
+    EXPERIMENT_STATUS_SCAFFOLDED,
     EXPERIMENT_STATUS_TASK_EMITTED,
     PROPOSAL_STATUS_ACCEPTED,
+    PROPOSAL_STATUS_OPEN,
     PROPOSAL_STATUS_REJECTED,
     planAcceptCandidate,
     planLockVerdict,
@@ -293,30 +295,87 @@ const validateSig = (sig: string): void => {
     }
 };
 
-const saveAcceptedExperiment = (
+/**
+ * A first accept that reached the write and found the decision already made by
+ * someone else. It is a LOST RACE, not a fault: the caller turns it into a
+ * `wrong_status` result and publishes nothing.
+ */
+export class AcceptRaceLostError extends Schema.TaggedErrorClass<AcceptRaceLostError>(
+    "AcceptRaceLostError",
+)("AcceptRaceLostError", {
+    message: Schema.String,
+}) {}
+
+/**
+ * Phase one of a first accept: claim the proposal and create its experiment, in
+ * ONE transaction, and only if this attempt is the one making the decision.
+ *
+ * Both writes are GATED, and both gates protect a user decision the old
+ * unconditional pair could destroy:
+ *
+ *   - `WHERE status = 'open'` on the proposal. An unconditional UPDATE re-stamps
+ *     `accepted` over a REJECTED proposal, reversing the rejection, and over an
+ *     already-accepted one, re-opening a settled decision.
+ *   - `ON CONFLICT DO NOTHING` on the experiment. The previous `put` was an
+ *     UPSERT: a stale accept arriving after another accept finished and the user
+ *     locked a verdict would overwrite that row back to `publishing` with
+ *     `locked_verdict = NULL`, silently discarding the verdict.
+ *
+ * Losing either gate FAILS the transaction, so SQLite rolls the whole phase back
+ * - the proposal is never left claimed by an attempt that could not create its
+ * experiment - and the failure stops the publication before anything lands on
+ * disk.
+ */
+const claimAcceptedExperiment = (
     judgment: JudgmentService,
     proposalId: string,
     experimentId: string,
     status: string,
     values: { readonly artifactPath?: string; readonly taskPath?: string },
-) => judgment.transaction((transaction) => Effect.gen(function* () {
-    const now = new Date();
-    yield* transaction.exec(
-        "UPDATE proposal SET status = ?, updated_at = ? WHERE id = ?",
-        [PROPOSAL_STATUS_ACCEPTED, now, proposalId],
+): Effect.Effect<void, JudgmentError | AcceptRaceLostError> =>
+    judgment.transaction((transaction) => Effect.gen(function* () {
+        const now = new Date();
+        const claimed = yield* transaction.exec(
+            "UPDATE proposal SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+            [PROPOSAL_STATUS_ACCEPTED, now, proposalId, PROPOSAL_STATUS_OPEN],
+        );
+        if (claimed === 0) {
+            return yield* new AcceptRaceLostError({
+                message: `proposal ${proposalId} is no longer open`,
+            });
+        }
+        const created = yield* transaction.exec(
+            `INSERT INTO experiment
+                 (id, proposal, artifact, artifact_path, scaffolded_at, created_at, locked_verdict, status, task_path)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT (id) DO NOTHING`,
+            [
+                experimentId,
+                proposalId,
+                null,
+                values.artifactPath ?? null,
+                values.artifactPath === undefined ? null : now,
+                now,
+                null,
+                status,
+                values.taskPath ?? null,
+            ],
+        );
+        if (created === 0) {
+            return yield* new AcceptRaceLostError({
+                message: `experiment ${experimentId} already exists`,
+            });
+        }
+    }));
+
+/** `null` when the claim landed, else why it lost. */
+const claimOutcome = (
+    claim: Effect.Effect<void, JudgmentError | AcceptRaceLostError>,
+): Effect.Effect<string | null, JudgmentError> =>
+    claim.pipe(
+        Effect.as(null as string | null),
+        Effect.catchTag("AcceptRaceLostError", (err) => Effect.succeed(err.message)),
     );
-    yield* transaction.put("experiment", {
-        id: experimentId,
-        proposal: proposalId,
-        artifact: null,
-        artifact_path: values.artifactPath ?? null,
-        scaffolded_at: values.artifactPath === undefined ? null : now,
-        created_at: now,
-        locked_verdict: null,
-        status,
-        task_path: values.taskPath ?? null,
-    });
-}));
 
 /** Whether the experiment reached `task_emitted`, and why not when it did not. */
 type PublicationFinish =
@@ -329,6 +388,19 @@ const ExperimentStateRow = Schema.Struct({
 });
 
 /**
+ * The ONLY statuses that mean "a brief for this experiment is published". A
+ * concurrent `ax improve lint` reconcile moves a reconciled row from
+ * `task_emitted` to `scaffolded`, so both count; `scaffolded` is deliberate, not
+ * incidental. Every other value - `publishing`, `retired`, `regressed`, and
+ * anything a later release adds - is NOT a published state, and a no-op update
+ * that lands on one is a failure to finish, never a success.
+ */
+const PUBLISHED_EXPERIMENT_STATUSES: ReadonlySet<string> = new Set([
+    EXPERIMENT_STATUS_TASK_EMITTED,
+    EXPERIMENT_STATUS_SCAFFOLDED,
+]);
+
+/**
  * Move an experiment off `publishing` once its brief is on disk.
  *
  * BOTH predicates are load-bearing. `status = 'publishing'` stops a second retry
@@ -337,10 +409,16 @@ const ExperimentStateRow = Schema.Struct({
  * at all - the status test alone cannot see that, because a locked row can still
  * read `publishing`.
  *
- * A no-op update is ambiguous on its own, so the row is re-read to tell the two
- * apart: another attempt that already finished the publication (complete), or a
- * locked/retired row this attempt must not claim (incomplete). Callers must not
- * report a completed publication for the second.
+ * A no-op update is ambiguous on its own, so the row is re-read. The order of
+ * the two tests below is the contract:
+ *
+ *   1. `locked_verdict` FIRST. A judged row is never claimed as this attempt's
+ *      completed publication, whatever its status says - including a row that
+ *      was retired or regressed while carrying a verdict, which a status-first
+ *      test would wave through without ever reading the lock.
+ *   2. Then an ALLOWLIST of published statuses. "not publishing any more" is not
+ *      the same claim as "published": `retired` and `regressed` both satisfy the
+ *      first and neither satisfies the second.
  */
 const finishPublication = (
     judgment: JudgmentService,
@@ -361,11 +439,22 @@ const finishPublication = (
         if (row === undefined) {
             return { finished: false, locked: false, reason: `experiment ${experimentKey} is gone` };
         }
-        // Another attempt got there first: the publication IS complete.
-        if (row.status !== EXPERIMENT_STATUS_PUBLISHING) return { finished: true };
-        return row.locked_verdict === null
-            ? { finished: false, locked: false, reason: `experiment ${experimentKey} could not be finished` }
-            : { finished: false, locked: true, reason: `experiment verdict already locked: ${row.locked_verdict}` };
+        if (row.locked_verdict !== null) {
+            // The status rides along in the reason so a locked row that another
+            // attempt HAD published still reports what is actually on record.
+            return {
+                finished: false,
+                locked: true,
+                reason: `experiment verdict already locked: ${row.locked_verdict} (status=${row.status})`,
+            };
+        }
+        // Another attempt got there first and published: complete.
+        if (PUBLISHED_EXPERIMENT_STATUSES.has(row.status)) return { finished: true };
+        return {
+            finished: false,
+            locked: false,
+            reason: `experiment ${experimentKey} is ${row.status}, not published`,
+        };
     });
 
 /** What a publish attempt did with the task path. */
@@ -546,9 +635,14 @@ export const acceptProposal = (
                     artifact_path: scaffold.path,
                 };
             }
-            yield* saveAcceptedExperiment(judgment, proposalKey, experimentKey, experimentStatus, {
-                artifactPath: scaffold.path,
-            });
+            const skillClaim = yield* claimOutcome(claimAcceptedExperiment(
+                judgment, proposalKey, experimentKey, experimentStatus, { artifactPath: scaffold.path },
+            ));
+            if (skillClaim !== null) {
+                // Another accept settled this proposal while the stub was being
+                // written. The stub stays on disk; the decision is not reversed.
+                return { status: "wrong_status", message: skillClaim, artifact_path: scaffold.path };
+            }
             return {
                 status: "ok",
                 proposal_id: `proposal:${proposalKey}`,
@@ -592,9 +686,12 @@ export const acceptProposal = (
                     artifact_path: wfScaffold.path,
                 };
             }
-            yield* saveAcceptedExperiment(judgment, proposalKey, experimentKey, experimentStatus, {
-                artifactPath: wfScaffold.path,
-            });
+            const wfClaim = yield* claimOutcome(claimAcceptedExperiment(
+                judgment, proposalKey, experimentKey, experimentStatus, { artifactPath: wfScaffold.path },
+            ));
+            if (wfClaim !== null) {
+                return { status: "wrong_status", message: wfClaim, artifact_path: wfScaffold.path };
+            }
             return {
                 status: "ok",
                 proposal_id: `proposal:${proposalKey}`,
@@ -641,7 +738,7 @@ export const acceptProposal = (
         // above authorized it); a resume publishes exclusively and keeps whatever
         // is already there. A failure propagates with the experiment still
         // `publishing`, so the next accept resumes instead of refusing.
-        const outcome = yield* publishTaskBrief({
+        const published = yield* publishTaskBrief({
             taskPath,
             content: taskContent,
             // Replacement needs the operator's explicit force on a first accept.
@@ -650,7 +747,7 @@ export const acceptProposal = (
             replace: resumed === null && opts.force === true,
             ...(resumed === null
                 ? {
-                    beforePublish: saveAcceptedExperiment(
+                    beforePublish: claimAcceptedExperiment(
                         judgment,
                         proposalKey,
                         experimentKey,
@@ -659,7 +756,22 @@ export const acceptProposal = (
                     ),
                 }
                 : {}),
-        });
+        }).pipe(
+            Effect.map((outcome) => ({ lost: null, outcome }) as const),
+            // A lost phase-one claim aborts the publish while the brief is still
+            // only a staging file, so nothing reaches the task path and the
+            // staging file is removed on the way out.
+            Effect.catchTag("AcceptRaceLostError", (err) =>
+                Effect.succeed({ lost: err.message, outcome: null } as const)),
+        );
+        if (published.lost !== null) {
+            return {
+                status: "wrong_status",
+                proposal_id: `proposal:${proposalKey}`,
+                message: `${published.lost}; nothing was published to ${taskPath}`,
+            };
+        }
+        const outcome = published.outcome;
 
         // Phase 3: a readable brief is on disk - this attempt's, or the one it
         // refused to replace - so the publication can be finished. This path

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -14,6 +14,8 @@ import { orAbsent } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import {
     type InterventionSafetyContract,
+    EXPERIMENT_STATUS_PUBLISHING,
+    EXPERIMENT_STATUS_TASK_EMITTED,
     PROPOSAL_STATUS_ACCEPTED,
     PROPOSAL_STATUS_REJECTED,
     planAcceptCandidate,
@@ -316,6 +318,48 @@ const saveAcceptedExperiment = (
     });
 }));
 
+/**
+ * Move an experiment off `publishing` once its brief is on disk. The status
+ * predicate is the guard: a concurrent retire or a second retry finds no
+ * `publishing` row, so this can never revive a closed experiment.
+ */
+const finishPublication = (
+    judgment: JudgmentService,
+    experimentKey: string,
+) => judgment.exec(
+    "UPDATE experiment SET status = ? WHERE id = ? AND status = ?",
+    [EXPERIMENT_STATUS_TASK_EMITTED, experimentKey, EXPERIMENT_STATUS_PUBLISHING],
+);
+
+/** True only for a real file: a directory sitting on the task path is not a brief. */
+const publishedTaskExists = (
+    fs: FileSystem.FileSystem,
+    taskPath: string,
+): Effect.Effect<boolean, never> =>
+    fs.stat(taskPath).pipe(
+        Effect.map((info) => info.type === "File"),
+        orAbsent(false),
+    );
+
+/**
+ * Drop the staged temp files an interrupted publication left behind. Their name
+ * carries the pid of the process that died, so only the recovering run can tell
+ * they are garbage. Best-effort: a sweep failure must not fail the recovery.
+ */
+const sweepStagedTasks = (
+    fs: FileSystem.FileSystem,
+    taskDir: string,
+    taskFileName: string,
+): Effect.Effect<void, never> =>
+    fs.readDirectory(taskDir).pipe(
+        orAbsent([] as ReadonlyArray<string>),
+        Effect.flatMap((names) => Effect.forEach(
+            names.filter((name) => name.startsWith(`${taskFileName}.tmp.`)),
+            (name) => fs.remove(posixPath.join(taskDir, name), { force: true }).pipe(Effect.ignore),
+            { discard: true },
+        )),
+    );
+
 export const acceptProposal = (
     opts: AcceptOptions,
 ): Effect.Effect<AcceptResult, JudgmentError | PlatformError.PlatformError, Judgment | FileSystem.FileSystem> =>
@@ -329,6 +373,11 @@ export const acceptProposal = (
             proposalStatus: row.status,
             autoScaffold: Boolean(opts.autoScaffold),
             safetyContract: safetyContractForRow(row),
+            experiment: row.experiment === null ? null : {
+                status: row.experiment.status,
+                taskPath: row.experiment.task_path,
+                lockedVerdict: row.experiment.locked_verdict,
+            },
         });
         if (acceptPlan.status === "wrong_status") {
             const existing = row.experiment;
@@ -349,7 +398,7 @@ export const acceptProposal = (
             }
             return result;
         }
-        if (acceptPlan.status !== "ok") {
+        if (acceptPlan.status !== "ok" && acceptPlan.status !== "resume_publication") {
             return {
                 status: acceptPlan.status,
                 message: acceptPlan.message,
@@ -357,12 +406,17 @@ export const acceptProposal = (
         }
         const experimentStatus = acceptPlan.experimentStatus;
 
-        const experimentKey = stableId("experiment", [proposalKey]);
+        // A resumed accept finishes the publication the earlier run committed:
+        // same experiment row, same intended path, no second proposal update.
+        const resumed = acceptPlan.status === "resume_publication" ? row.experiment : null;
+        const experimentKey = resumed?.id ?? stableId("experiment", [proposalKey]);
         const experimentId = `experiment:${experimentKey}`;
         const judgment = yield* Judgment;
 
-        // autoScaffold=true && form=skill: legacy direct-write path
-        if (opts.autoScaffold && row.form === "skill") {
+        // autoScaffold=true && form=skill: legacy direct-write path.
+        // Both scaffold paths write the artifact BEFORE they commit, so they can
+        // never leave a `publishing` row - a resume always belongs to the task path.
+        if (opts.autoScaffold && row.form === "skill" && resumed === null) {
             validateSig(row.dedupe_sig);
             const payload = row.skill_payload ?? null;
             if (!payload) {
@@ -406,7 +460,7 @@ export const acceptProposal = (
         // autoScaffold=true && form=guidance && section=workflows: scaffold SKILL.md stub (#588)
         // Uses suggested_text (the arc "plan → tdd → review → commit") as the stub body.
         // Directives and all other guidance sections fall through to the brief path below.
-        if (opts.autoScaffold && shouldScaffoldWorkflowSkill(row)) {
+        if (opts.autoScaffold && shouldScaffoldWorkflowSkill(row) && resumed === null) {
             validateSig(row.dedupe_sig);
             const scaffoldOutcome = yield* runSafeScaffold({
                 title: row.title,
@@ -449,16 +503,34 @@ export const acceptProposal = (
 
         // Default path for all v0 forms: emit .ax/tasks/<dedupe_sig>.md
         validateSig(row.dedupe_sig);
-        const taskDir = opts.taskDir ?? defaultTaskDir();
-        const taskPath = posixPath.join(taskDir, `${row.dedupe_sig}.md`);
+        // A resume keeps the path the interrupted run recorded, even when the
+        // caller's taskDir has since changed.
+        const taskPath = resumed?.task_path
+            ?? posixPath.join(opts.taskDir ?? defaultTaskDir(), `${row.dedupe_sig}.md`);
+        const taskDir = posixPath.dirname(taskPath);
 
-        // existsSync probe: any fault → treat as absent (orAbsent(false)).
-        const taskExists = yield* fs.exists(taskPath).pipe(orAbsent(false));
-        if (taskExists && !opts.force) {
+        if (resumed === null) {
+            // existsSync probe: any fault → treat as absent (orAbsent(false)).
+            const taskExists = yield* fs.exists(taskPath).pipe(orAbsent(false));
+            if (taskExists && !opts.force) {
+                return {
+                    status: "scaffold_exists",
+                    message: `task brief already exists at ${taskPath} (pass force=true to overwrite)`,
+                    task_path: taskPath,
+                };
+            }
+        } else if (yield* publishedTaskExists(fs, taskPath)) {
+            // The brief is already there: either the rename landed and only the
+            // status update was lost, or the operator wrote the file themselves.
+            // Never overwrite it - just finish the acceptance in the sidecar.
+            yield* finishPublication(judgment, experimentKey);
+            yield* sweepStagedTasks(fs, taskDir, `${row.dedupe_sig}.md`);
             return {
-                status: "scaffold_exists",
-                message: `task brief already exists at ${taskPath} (pass force=true to overwrite)`,
+                status: "ok",
+                proposal_id: `proposal:${proposalKey}`,
+                experiment_id: experimentId,
                 task_path: taskPath,
+                message: `finished the interrupted publication; kept the existing brief at ${taskPath}`,
             };
         }
 
@@ -473,23 +545,44 @@ export const acceptProposal = (
         const tmpPath = `${taskPath}.tmp.${process.pid}`;
         yield* fs.writeFileString(tmpPath, taskContent);
 
-        yield* saveAcceptedExperiment(judgment, proposalKey, experimentKey, experimentStatus, { taskPath }).pipe(
-            // Best-effort cleanup of the staged temp file on DB failure (matches
-            // main's `try { unlinkSync(tmpPath); } catch {}`): force tolerates an
-            // already-absent temp and `ignore` swallows any other fault so the
-            // original DbError still propagates.
-            Effect.tapError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)),
-        );
+        if (resumed === null) {
+            // Phase 1: accept the proposal and record the path this run intends to
+            // publish, as `publishing`. That status is what a later retry reads to
+            // tell an interrupted publication from a completed acceptance.
+            yield* saveAcceptedExperiment(
+                judgment,
+                proposalKey,
+                experimentKey,
+                EXPERIMENT_STATUS_PUBLISHING,
+                { taskPath },
+            ).pipe(
+                // Best-effort cleanup of the staged temp file on DB failure (matches
+                // main's `try { unlinkSync(tmpPath); } catch {}`): force tolerates an
+                // already-absent temp and `ignore` swallows any other fault so the
+                // original DbError still propagates.
+                Effect.tapError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)),
+            );
+        }
 
-        // Commit the staged write to its final path. Propagates on failure
-        // (original used bare renameSync, no try/catch).
+        // Phase 2: commit the staged write to its final path. A failure here
+        // propagates and leaves the experiment `publishing`, so the next accept
+        // resumes instead of refusing.
         yield* fs.rename(tmpPath, taskPath);
+
+        // Phase 3: the brief is on disk, so the publication is done. This path
+        // always emits a task, including when a resume arrives with
+        // --auto-scaffold, so the final status is task_emitted either way.
+        yield* finishPublication(judgment, experimentKey);
+        if (resumed !== null) yield* sweepStagedTasks(fs, taskDir, `${row.dedupe_sig}.md`);
 
         return {
             status: "ok",
             proposal_id: `proposal:${proposalKey}`,
             experiment_id: experimentId,
             task_path: taskPath,
+            ...(resumed === null
+                ? {}
+                : { message: `finished the interrupted publication at ${taskPath}` }),
         };
     });
 

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -319,7 +319,14 @@ export class AcceptRaceLostError extends Schema.TaggedErrorClass<AcceptRaceLostE
  *   - `ON CONFLICT DO NOTHING` on the experiment. The previous `put` was an
  *     UPSERT: a stale accept arriving after another accept finished and the user
  *     locked a verdict would overwrite that row back to `publishing` with
- *     `locked_verdict = NULL`, silently discarding the verdict.
+ *     `locked_verdict = NULL`, silently discarding the verdict. The clause names
+ *     NO conflict target on purpose: `experiment` is unique on `id` AND on
+ *     `proposal` (`experiment_proposal_uq`), and the winner's row can carry a
+ *     DIFFERENT id - `ax retro emit`'s registration and an accept derive ids
+ *     their own way. Targeting `(id)` left that second conflict unhandled, so it
+ *     surfaced as a raw UNIQUE constraint failure instead of a lost race. Either
+ *     conflict now yields `created === 0`, which is the same answer: somebody
+ *     else owns this proposal's experiment.
  *
  * Losing either gate FAILS the transaction, so SQLite rolls the whole phase back
  * - the proposal is never left claimed by an attempt that could not create its
@@ -348,7 +355,7 @@ const claimAcceptedExperiment = (
             `INSERT INTO experiment
                  (id, proposal, artifact, artifact_path, scaffolded_at, created_at, locked_verdict, status, task_path)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT (id) DO NOTHING`,
+             ON CONFLICT DO NOTHING`,
             [
                 experimentId,
                 proposalId,
@@ -363,7 +370,9 @@ const claimAcceptedExperiment = (
         );
         if (created === 0) {
             return yield* new AcceptRaceLostError({
-                message: `experiment ${experimentId} already exists`,
+                // Names the proposal, not this attempt's id: the row that won
+                // may be stored under a different one.
+                message: `an experiment for proposal ${proposalId} already exists`,
             });
         }
     }));

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Effect, FileSystem, Layer } from "effect";
-import { existsSync, mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { buildAgentAcceptPrompt } from "./agent-accept.ts";
 import { acceptProposal, shouldScaffoldWorkflowSkill } from "./actions.ts";
+import { findStoredProposal } from "./judgment-proposals.ts";
 
 type ProposalFixture = {
     readonly id: string;
@@ -57,12 +58,17 @@ const seedProposal = (judgment: JudgmentService, row: ProposalFixture) =>
         }
     });
 
-const runWithProposal = <A>(
-    row: ProposalFixture,
-    body: (judgment: JudgmentService, root: string) => Effect.Effect<A, unknown, Judgment | FileSystem.FileSystem>,
-    schemaSuffix = "",
-): Promise<A> => {
-    const root = mkdtempSync(join(tmpdir(), "ax-accept-sidecar-"));
+type SidecarBody<A> = (
+    judgment: JudgmentService,
+    root: string,
+) => Effect.Effect<A, unknown, Judgment | FileSystem.FileSystem>;
+
+/**
+ * One run against the sidecar file in `root`. Each call opens its own layer, so
+ * two calls over the same root are two independent processes as far as the
+ * SQLite file is concerned - which is what a retry after a crash looks like.
+ */
+const runInRoot = <A>(root: string, body: SidecarBody<A>, schemaSuffix = ""): Promise<A> => {
     const layer = Layer.mergeAll(
         JudgmentLayer({ sidecarPath: join(root, "judgment.sqlite"), schemaSql: `${SIDECAR_SCHEMA_SQL}\n${schemaSuffix}` }),
         BunFileSystem.layer,
@@ -70,9 +76,20 @@ const runWithProposal = <A>(
     );
     return Effect.runPromise(Effect.gen(function* () {
         const judgment = yield* Judgment;
-        yield* seedProposal(judgment, row);
         return yield* body(judgment, root);
     }).pipe(Effect.provide(layer), Effect.scoped));
+};
+
+const runWithProposal = <A>(
+    row: ProposalFixture,
+    body: SidecarBody<A>,
+    schemaSuffix = "",
+): Promise<A> => {
+    const root = mkdtempSync(join(tmpdir(), "ax-accept-sidecar-"));
+    return runInRoot(root, (judgment, dir) => Effect.gen(function* () {
+        yield* seedProposal(judgment, row);
+        return yield* body(judgment, dir);
+    }), schemaSuffix);
 };
 
 describe("buildAgentAcceptPrompt", () => {
@@ -323,6 +340,147 @@ describe("acceptProposal with real SQLite", () => {
         }));
         expect(result.exit._tag).toBe("Failure");
         expect(readdirSync(result.root).filter((name) => name.endsWith(".md"))).toHaveLength(0);
+    });
+});
+
+describe("acceptProposal publication recovery", () => {
+    const sig = "resume_publication";
+    const fixture: ProposalFixture = {
+        id: "resume-one",
+        form: "guidance",
+        title: "Use rg",
+        hypothesis: "Search is slow.",
+        dedupe_sig: sig,
+        guidance_payload: { file_target: "CLAUDE.md", section: "tools", suggested_text: "Use rg." },
+    };
+
+    /**
+     * Interrupt a publication for real: a directory sits on the task path, so the
+     * write and the accept transaction both succeed and only the rename fails.
+     * Nothing here is mocked - the fault is in the filesystem the code really uses.
+     */
+    const interruptPublication = async (): Promise<string> => {
+        const root = mkdtempSync(join(tmpdir(), "ax-accept-resume-"));
+        await runInRoot(root, (judgment) => seedProposal(judgment, fixture));
+        mkdirSync(join(root, `${sig}.md`));
+        const exit = await runInRoot(root, () =>
+            acceptProposal({ sigOrId: sig, taskDir: root, force: true }).pipe(Effect.exit));
+        expect(exit._tag).toBe("Failure");
+        return root;
+    };
+
+    const storedState = (root: string) =>
+        runInRoot(root, () => Effect.gen(function* () {
+            const stored = yield* findStoredProposal(sig);
+            return {
+                proposalStatus: stored?.status ?? null,
+                experimentId: stored?.experiment?.id ?? null,
+                experimentStatus: stored?.experiment?.status ?? null,
+                taskPath: stored?.experiment?.task_path ?? null,
+            };
+        }));
+
+    test("keeps the experiment publishing when the rename fails after the commit", async () => {
+        const root = await interruptPublication();
+        const state = await storedState(root);
+        expect(state.proposalStatus).toBe("accepted");
+        expect(state.experimentStatus).toBe("publishing");
+        expect(state.taskPath).toBe(join(root, `${sig}.md`));
+        expect(existsSync(join(root, `${sig}.md`, "anything"))).toBe(false);
+    });
+
+    test("finishes the interrupted publication on a process-style retry", async () => {
+        const root = await interruptPublication();
+        const before = await storedState(root);
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+
+        const retry = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(retry.status).toBe("ok");
+        expect(retry.task_path).toBe(join(root, `${sig}.md`));
+        const body = readFileSync(retry.task_path!, "utf8");
+        expect(body).toContain(`<!--ax:${sig}-->`);
+        expect(body).toContain("Use rg.");
+        const after = await storedState(root);
+        expect(after.experimentId).toBe(before.experimentId);
+        expect(retry.experiment_id).toBe(`experiment:${before.experimentId}`);
+        expect(after.experimentStatus).toBe("task_emitted");
+        expect(after.taskPath).toBe(before.taskPath);
+        expect(readdirSync(root).filter((name) => name.includes(`${sig}.md.tmp.`))).toHaveLength(0);
+    });
+
+    test("refuses a repeated retry once the publication is complete", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+        await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+        const body = readFileSync(join(root, `${sig}.md`), "utf8");
+
+        const again = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(again.status).toBe("wrong_status");
+        expect(again.message).toBe("proposal already accepted");
+        expect(again.existing_experiment?.id).toBeDefined();
+        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toBe(body);
+    });
+
+    test("never overwrites a brief that is already on disk", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+        writeFileSync(join(root, `${sig}.md`), "operator edit\n");
+
+        const retry = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(retry.status).toBe("ok");
+        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toBe("operator edit\n");
+        expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+    });
+
+    test("finishes the brief even when the retry asks for a direct scaffold", async () => {
+        const root = mkdtempSync(join(tmpdir(), "ax-accept-resume-skill-"));
+        const skillSig = "resume_skill";
+        await runInRoot(root, (judgment) => seedProposal(judgment, {
+            id: "resume-skill",
+            form: "skill",
+            title: "Guard Bash",
+            hypothesis: "Bash fails.",
+            dedupe_sig: skillSig,
+            skill_payload: {
+                trigger_pattern: "tool=Bash",
+                suspected_gap: "no validation",
+                proposed_behavior: "validate first",
+                expected_impact: "fewer failures",
+            },
+        }));
+        mkdirSync(join(root, `${skillSig}.md`));
+        await runInRoot(root, () =>
+            acceptProposal({ sigOrId: skillSig, taskDir: root, force: true }).pipe(Effect.exit));
+        rmSync(join(root, `${skillSig}.md`), { recursive: true });
+
+        const retry = await runInRoot(root, () => acceptProposal({
+            sigOrId: skillSig,
+            taskDir: root,
+            autoScaffold: true,
+            scaffoldBaseDir: join(root, "skills"),
+        }));
+
+        expect(retry.status).toBe("ok");
+        expect(retry.task_path).toBe(join(root, `${skillSig}.md`));
+        expect(existsSync(join(root, "skills"))).toBe(false);
+        const stored = await runInRoot(root, () => findStoredProposal(skillSig));
+        expect(stored?.experiment?.status).toBe("task_emitted");
+    });
+
+    test("does not revive an experiment a verdict already judged", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+        await runInRoot(root, (judgment) =>
+            judgment.exec("UPDATE experiment SET locked_verdict = ? WHERE status = ?", ["adopted", "publishing"]));
+
+        const retry = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(retry.status).toBe("wrong_status");
+        expect(existsSync(join(root, `${sig}.md`))).toBe(false);
+        expect((await storedState(root)).experimentStatus).toBe("publishing");
     });
 });
 

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -5,6 +5,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
+import { stableId } from "@ax/lib/stable-id";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { buildAgentAcceptPrompt } from "./agent-accept.ts";
 import { acceptProposal, shouldScaffoldWorkflowSkill } from "./actions.ts";
@@ -609,12 +610,11 @@ describe("acceptProposal task publication", () => {
             runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
         ]);
 
-        // Whichever attempt loses the exclusive publish finds a regular file that
-        // appeared after its own probe, and keeps it rather than overwriting.
-        expect([first.status, second.status]).toContain("ok");
-        for (const result of [first, second]) {
-            expect(["ok", "wrong_status", "scaffold_exists"]).toContain(result.status);
-        }
+        // Exactly one attempt claims the proposal. The loser's phase-one gate
+        // fails inside the transaction, so it never publishes and never
+        // re-stamps the decision.
+        expect([first.status, second.status].filter((s) => s === "ok")).toHaveLength(1);
+        expect([first.status, second.status].filter((s) => s === "wrong_status")).toHaveLength(1);
         expect(readdirSync(root).filter((name) => name === `${sig}.md`)).toHaveLength(1);
         expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
         expect(stagingFiles(root, sig)).toHaveLength(0);
@@ -631,6 +631,104 @@ describe("acceptProposal task publication", () => {
         expect(forced.status).toBe("ok");
         expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
         expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+    });
+
+    /**
+     * Drive a REAL concurrent state change: the trigger fires inside the accept
+     * transaction, so by the time the publication tries to finish, the row
+     * already carries the status (and verdict) another actor set. No mocks - the
+     * database moves the row exactly as `ax improve housekeep` or a verdict lock
+     * would.
+     */
+    const acceptWithExperimentTrigger = (sigSuffix: string, setClause: string) =>
+        runWithProposal(
+            { ...fixture, id: `state-${sigSuffix}`, dedupe_sig: `state_${sigSuffix}` },
+            (_judgment, root) => Effect.gen(function* () {
+                const accepted = yield* acceptProposal({ sigOrId: `state_${sigSuffix}`, taskDir: root });
+                const stored = yield* findStoredProposal(`state_${sigSuffix}`);
+                return { accepted, root, stored, sig: `state_${sigSuffix}` };
+            }),
+            `CREATE TRIGGER move_experiment AFTER INSERT ON experiment
+             BEGIN UPDATE experiment SET ${setClause} WHERE id = NEW.id; END;`,
+        );
+
+    test.each([
+        ["retired", "status = 'retired'", null],
+        ["regressed", "status = 'regressed'", null],
+        ["retired_locked", "status = 'retired', locked_verdict = 'no_longer_needed'", "no_longer_needed"],
+        ["regressed_locked", "status = 'regressed', locked_verdict = 'regressed'", "regressed"],
+    ] as const)(
+        "does not report a completed publication when the experiment goes %s",
+        async (label, setClause, lockedVerdict) => {
+            const result = await acceptWithExperimentTrigger(label, setClause);
+
+            // "not publishing any more" is not "published": neither state may
+            // report success, and a locked row reports the lock, not the status.
+            expect(result.accepted.status).toBe(lockedVerdict === null ? "wrong_status" : "verdict_locked");
+            expect(result.accepted.message).toContain("was left in place and the acceptance was not finished");
+            if (lockedVerdict === null) {
+                expect(result.accepted.message).toContain("not published");
+            } else {
+                expect(result.accepted.message).toContain(`verdict already locked: ${lockedVerdict}`);
+            }
+            // The row keeps the state the other actor set - nothing was moved to
+            // task_emitted behind their back.
+            expect(result.stored?.experiment?.status).toBe(setClause.includes("retired") ? "retired" : "regressed");
+            expect(result.stored?.experiment?.locked_verdict).toBe(lockedVerdict);
+            // The brief itself was published and is left in place.
+            expect(readFileSync(join(result.root, `${result.sig}.md`), "utf8")).toContain(`<!--ax:${result.sig}-->`);
+            expect(stagingFiles(result.root, result.sig)).toHaveLength(0);
+        },
+    );
+
+    test("treats a concurrent lint reconcile to scaffolded as published", async () => {
+        // `ax improve lint` moves a reconciled row task_emitted -> scaffolded.
+        // That IS a published state, so the publication counts as finished.
+        const result = await acceptWithExperimentTrigger("scaffolded", "status = 'scaffolded'");
+
+        expect(result.accepted.status).toBe("ok");
+        expect(result.stored?.experiment?.status).toBe("scaffolded");
+        expect(readFileSync(join(result.root, `${result.sig}.md`), "utf8")).toContain(`<!--ax:${result.sig}-->`);
+    });
+
+    test("a stale first accept never overwrites a finished, verdict-locked experiment", async () => {
+        // The state a stale accept walks into: another accept already published
+        // and the user locked a verdict, but this attempt still reads the
+        // proposal as open (its plan snapshot is out of date).
+        const root = mkdtempSync(join(tmpdir(), "ax-accept-stale-"));
+        const experimentKey = stableId("experiment", [fixture.id]);
+        const settled = new Date("2026-01-02T00:00:00Z");
+        await runInRoot(root, (judgment) => Effect.gen(function* () {
+            yield* seedProposal(judgment, fixture);
+            yield* judgment.put("experiment", {
+                id: experimentKey,
+                proposal: fixture.id,
+                artifact: null,
+                artifact_path: null,
+                scaffolded_at: null,
+                created_at: settled,
+                locked_verdict: "adopted",
+                status: "task_emitted",
+                task_path: join(root, `${sig}.md`),
+            });
+        }));
+
+        const stale = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(stale.status).toBe("wrong_status");
+        expect(stale.message).toContain("nothing was published");
+        // The verdict and the finished status survive: no upsert reset them.
+        const state = await storedState(root);
+        expect(state.experimentStatus).toBe("task_emitted");
+        expect(state.experimentId).toBe(experimentKey);
+        const stored = await runInRoot(root, () => findStoredProposal(sig));
+        expect(stored?.experiment?.locked_verdict).toBe("adopted");
+        expect(stored?.experiment?.created_at.toISOString()).toBe(settled.toISOString());
+        // The whole phase rolled back, so the proposal was not claimed either.
+        expect(state.proposalStatus).toBe("open");
+        // And nothing reached the task path.
+        expect(existsSync(join(root, `${sig}.md`))).toBe(false);
+        expect(stagingFiles(root, sig)).toHaveLength(0);
     });
 
     test("does not report a completed publication for a verdict-locked experiment", async () => {

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Effect, FileSystem, Layer } from "effect";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Judgment, JudgmentLayer, type JudgmentService } from "@ax/lib/sqlite";
@@ -350,7 +350,7 @@ describe("acceptProposal with real SQLite", () => {
     });
 });
 
-describe("acceptProposal publication recovery", () => {
+describe("acceptProposal task publication", () => {
     const sig = "resume_publication";
     const fixture: ProposalFixture = {
         id: "resume-one",
@@ -373,6 +373,13 @@ describe("acceptProposal publication recovery", () => {
         const exit = await runInRoot(root, () =>
             acceptProposal({ sigOrId: sig, taskDir: root, force: true }).pipe(Effect.exit));
         expect(exit._tag).toBe("Failure");
+        return root;
+    };
+
+    /** A root holding one OPEN proposal - the state a first accept starts from. */
+    const seedFresh = async (): Promise<string> => {
+        const root = mkdtempSync(join(tmpdir(), "ax-accept-initial-"));
+        await runInRoot(root, (judgment) => seedProposal(judgment, fixture));
         return root;
     };
 
@@ -526,6 +533,44 @@ describe("acceptProposal publication recovery", () => {
         expect(stored?.experiment?.status).toBe("task_emitted");
     });
 
+    test("keeps a directory on the task path and leaves the publication unfinished", async () => {
+        const root = await interruptPublication();
+        // interruptPublication left the blocking directory in place: it is what
+        // made the first rename fail. The recovery must not adopt it as a brief.
+        mkdirSync(join(root, `${sig}.md`, "child"), { recursive: true });
+
+        const exit = await runInRoot(root, () =>
+            acceptProposal({ sigOrId: sig, taskDir: root }).pipe(Effect.exit));
+
+        expect(exit._tag).toBe("Failure");
+        // The directory is untouched, and the experiment is still publishing -
+        // a later retry can still finish it once the path is cleared.
+        expect(lstatSync(join(root, `${sig}.md`)).isDirectory()).toBe(true);
+        expect(existsSync(join(root, `${sig}.md`, "child"))).toBe(true);
+        const state = await storedState(root);
+        expect(state.experimentStatus).toBe("publishing");
+        expect(state.proposalStatus).toBe("accepted");
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
+    test("keeps a dangling symlink on the task path and leaves the publication unfinished", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+        symlinkSync(join(root, "no-such-target.md"), join(root, `${sig}.md`));
+
+        const exit = await runInRoot(root, () =>
+            acceptProposal({ sigOrId: sig, taskDir: root }).pipe(Effect.exit));
+
+        expect(exit._tag).toBe("Failure");
+        // The link itself survives, still pointing where the operator aimed it,
+        // and nothing was written through it.
+        expect(lstatSync(join(root, `${sig}.md`)).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(join(root, `${sig}.md`))).toBe(join(root, "no-such-target.md"));
+        expect(existsSync(join(root, "no-such-target.md"))).toBe(false);
+        expect((await storedState(root)).experimentStatus).toBe("publishing");
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
     test("does not revive an experiment a verdict already judged", async () => {
         const root = await interruptPublication();
         rmSync(join(root, `${sig}.md`), { recursive: true });
@@ -537,6 +582,80 @@ describe("acceptProposal publication recovery", () => {
         expect(retry.status).toBe("wrong_status");
         expect(existsSync(join(root, `${sig}.md`))).toBe(false);
         expect((await storedState(root)).experimentStatus).toBe("publishing");
+    });
+
+    test("an ordinary first accept never replaces a path its probe could not see", async () => {
+        const root = await seedFresh();
+        // `exists` follows the link, so the probe reports the path free; `link`
+        // does not, so the exclusive publish is the only thing that sees it.
+        // Under a replacing rename this symlink would be destroyed.
+        symlinkSync(join(root, "no-such-target.md"), join(root, `${sig}.md`));
+
+        const exit = await runInRoot(root, () =>
+            acceptProposal({ sigOrId: sig, taskDir: root }).pipe(Effect.exit));
+
+        expect(exit._tag).toBe("Failure");
+        expect(lstatSync(join(root, `${sig}.md`)).isSymbolicLink()).toBe(true);
+        expect(existsSync(join(root, "no-such-target.md"))).toBe(false);
+        expect((await storedState(root)).experimentStatus).toBe("publishing");
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
+    test("two concurrent first accepts publish one brief and keep the other", async () => {
+        const root = await seedFresh();
+
+        const [first, second] = await Promise.all([
+            runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
+            runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
+        ]);
+
+        // Whichever attempt loses the exclusive publish finds a regular file that
+        // appeared after its own probe, and keeps it rather than overwriting.
+        expect([first.status, second.status]).toContain("ok");
+        for (const result of [first, second]) {
+            expect(["ok", "wrong_status", "scaffold_exists"]).toContain(result.status);
+        }
+        expect(readdirSync(root).filter((name) => name === `${sig}.md`)).toHaveLength(1);
+        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+        expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+    });
+
+    test("an explicit force still replaces an existing brief", async () => {
+        const root = await seedFresh();
+        writeFileSync(join(root, `${sig}.md`), "stale brief\n");
+
+        const forced = await runInRoot(root, () =>
+            acceptProposal({ sigOrId: sig, taskDir: root, force: true }));
+
+        expect(forced.status).toBe("ok");
+        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
+        expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+    });
+
+    test("does not report a completed publication for a verdict-locked experiment", async () => {
+        // The verdict lands between the plan read and the final update: the
+        // trigger locks the row inside the accept transaction itself, so the
+        // status test alone would still have moved it to task_emitted.
+        const result = await runWithProposal(
+            { ...fixture, id: "locked-race", dedupe_sig: "locked_race" },
+            (_judgment, root) => Effect.gen(function* () {
+                const accepted = yield* acceptProposal({ sigOrId: "locked_race", taskDir: root });
+                const stored = yield* findStoredProposal("locked_race");
+                return { accepted, root, stored };
+            }),
+            `CREATE TRIGGER lock_experiment AFTER INSERT ON experiment
+             BEGIN UPDATE experiment SET locked_verdict = 'adopted' WHERE id = NEW.id; END;`,
+        );
+
+        expect(result.accepted.status).toBe("verdict_locked");
+        expect(result.accepted.message).toContain("verdict already locked: adopted");
+        expect(result.accepted.message).toContain("was left in place");
+        // The brief did land - it is the experiment row that must not move.
+        expect(readFileSync(join(result.root, "locked_race.md"), "utf8")).toContain("<!--ax:locked_race-->");
+        expect(result.stored?.experiment?.status).toBe("publishing");
+        expect(result.stored?.experiment?.locked_verdict).toBe("adopted");
+        expect(stagingFiles(result.root, "locked_race")).toHaveLength(0);
     });
 });
 

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -610,15 +610,37 @@ describe("acceptProposal task publication", () => {
             runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
         ]);
 
-        // Exactly one attempt claims the proposal. The loser's phase-one gate
-        // fails inside the transaction, so it never publishes and never
-        // re-stamps the decision.
-        expect([first.status, second.status].filter((s) => s === "ok")).toHaveLength(1);
-        expect([first.status, second.status].filter((s) => s === "wrong_status")).toHaveLength(1);
+        // NOTHING synchronises the two plan reads, so the second caller's answer
+        // depends on WHEN it looked, and several answers are correct:
+        //   - it read `open` too       -> its phase-one gate loses -> wrong_status
+        //   - it read the claim mid-flight (accepted + publishing + a task path,
+        //     no verdict)              -> a legitimate resume       -> ok
+        //   - it read the finished row -> wrong_status
+        //   - its exists probe saw the published file -> scaffold_exists
+        // Demanding one ok and one wrong_status would pin an interleaving this
+        // test cannot force. The losing-claim assertion belongs to the
+        // deterministic transaction-boundary tests ("a stale first accept ..."
+        // and "... a winner experiment stored under a different id"), which
+        // construct the state instead of racing for it.
+        //
+        // What holds under EVERY interleaving is asserted here.
+        expect([first.status, second.status]).toContain("ok");
+        for (const result of [first, second]) {
+            expect(["ok", "wrong_status", "scaffold_exists"]).toContain(result.status);
+        }
+        // One brief, whole, written once. The heading opens the document exactly
+        // once, so a second copy concatenated onto the first would show up here
+        // (the marker itself appears three times in one rendered brief).
         expect(readdirSync(root).filter((name) => name === `${sig}.md`)).toHaveLength(1);
-        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
+        const body = readFileSync(join(root, `${sig}.md`), "utf8");
+        expect(body).toContain(`<!--ax:${sig}-->`);
+        expect(body.split(`# ax task: ${sig} (form=guidance)`)).toHaveLength(2);
+        expect(lstatSync(join(root, `${sig}.md`)).isFile()).toBe(true);
+        // No attempt left staging litter, and the durable state is published.
         expect(stagingFiles(root, sig)).toHaveLength(0);
-        expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+        const state = await storedState(root);
+        expect(state.experimentStatus).toBe("task_emitted");
+        expect(state.proposalStatus).toBe("accepted");
     });
 
     test("an explicit force still replaces an existing brief", async () => {

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -731,6 +731,60 @@ describe("acceptProposal task publication", () => {
         expect(stagingFiles(root, sig)).toHaveLength(0);
     });
 
+    test("a first accept loses to a winner experiment stored under a different id", async () => {
+        // `experiment(proposal)` is UNIQUE, so the winner row survives whatever id
+        // it was written under - a retro registration and an accept derive
+        // different ids for the same proposal. The claim must classify THAT
+        // conflict as a lost race too, not just an id collision.
+        const root = mkdtempSync(join(tmpdir(), "ax-accept-otherid-"));
+        const winnerId = "winner-experiment-row";
+        const settled = new Date("2026-01-03T00:00:00Z");
+        expect(winnerId).not.toBe(stableId("experiment", [fixture.id]));
+        await runInRoot(root, (judgment) => Effect.gen(function* () {
+            yield* seedProposal(judgment, fixture);           // proposal stays OPEN
+            yield* judgment.put("experiment", {
+                id: winnerId,
+                proposal: fixture.id,
+                artifact: null,
+                artifact_path: null,
+                scaffolded_at: null,
+                created_at: settled,
+                locked_verdict: "adopted",
+                status: "task_emitted",
+                task_path: join(root, "winner-brief.md"),
+            });
+            yield* judgment.put("checkpoint", {
+                id: "winner-checkpoint",
+                experiment: winnerId,
+                kind: "+3s",
+                measured: "{}",
+                suggested: "adopted",
+                user_verdict: "adopted",
+                observed_at: settled,
+            });
+        }));
+
+        const lost = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
+
+        expect(lost.status).toBe("wrong_status");
+        expect(lost.message).toContain("nothing was published");
+        // The winner row is untouched, down to its id, verdict and timestamp.
+        const stored = await runInRoot(root, () => findStoredProposal(sig));
+        expect(stored?.experiment?.id).toBe(winnerId);
+        expect(stored?.experiment?.status).toBe("task_emitted");
+        expect(stored?.experiment?.locked_verdict).toBe("adopted");
+        expect(stored?.experiment?.created_at.toISOString()).toBe(settled.toISOString());
+        expect(stored?.experiment?.task_path).toBe(join(root, "winner-brief.md"));
+        // Its checkpoints survive with the user's verdict intact.
+        expect(stored?.experiment?.checkpoints).toHaveLength(1);
+        expect(stored?.experiment?.checkpoints[0]?.user_verdict).toBe("adopted");
+        // The phase rolled back whole: the proposal was never claimed.
+        expect(stored?.status).toBe("open");
+        // Nothing published, and this attempt's staging file is gone.
+        expect(existsSync(join(root, `${sig}.md`))).toBe(false);
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
     test("does not report a completed publication for a verdict-locked experiment", async () => {
         // The verdict lands between the plan read and the final update: the
         // trigger locks the row inside the accept transaction itself, so the

--- a/apps/axctl/src/improve/agent-accept.test.ts
+++ b/apps/axctl/src/improve/agent-accept.test.ts
@@ -92,6 +92,13 @@ const runWithProposal = <A>(
     }), schemaSuffix);
 };
 
+/**
+ * The staging files an attempt owns: `<sig>.md.<pid>.<uuid>.tmp`, siblings of the
+ * brief. Tests assert an attempt leaves none of its own behind.
+ */
+const stagingFiles = (root: string, sig: string): ReadonlyArray<string> =>
+    readdirSync(root).filter((name) => name.startsWith(`${sig}.md.`) && name.endsWith(".tmp"));
+
 describe("buildAgentAcceptPrompt", () => {
     test("includes the proposal and evidence", () => {
         const text = buildAgentAcceptPrompt({
@@ -303,7 +310,7 @@ describe("acceptProposal with real SQLite", () => {
 
         expect(result.exit._tag).toBe("Failure");
         expect(existsSync(join(result.root, `${sig}.md`))).toBe(false);
-        expect(readdirSync(result.root).filter((name) => name.includes(`${sig}.md.tmp.`))).toHaveLength(0);
+        expect(stagingFiles(result.root, sig)).toHaveLength(0);
     });
 
     test("uses different stable experiment IDs for different proposals", async () => {
@@ -406,7 +413,7 @@ describe("acceptProposal publication recovery", () => {
         expect(retry.experiment_id).toBe(`experiment:${before.experimentId}`);
         expect(after.experimentStatus).toBe("task_emitted");
         expect(after.taskPath).toBe(before.taskPath);
-        expect(readdirSync(root).filter((name) => name.includes(`${sig}.md.tmp.`))).toHaveLength(0);
+        expect(stagingFiles(root, sig)).toHaveLength(0);
     });
 
     test("refuses a repeated retry once the publication is complete", async () => {
@@ -423,16 +430,65 @@ describe("acceptProposal publication recovery", () => {
         expect(readFileSync(join(root, `${sig}.md`), "utf8")).toBe(body);
     });
 
-    test("never overwrites a brief that is already on disk", async () => {
+    test("never replaces a user file sitting on the task path", async () => {
         const root = await interruptPublication();
         rmSync(join(root, `${sig}.md`), { recursive: true });
+        // The recovery never probes the path before it publishes, so a file that
+        // is there when the exclusive publish runs is a file that appeared during
+        // publication as far as the code is concerned.
         writeFileSync(join(root, `${sig}.md`), "operator edit\n");
 
         const retry = await runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root }));
 
         expect(retry.status).toBe("ok");
+        expect(retry.message).toContain("kept the existing brief");
         expect(readFileSync(join(root, `${sig}.md`), "utf8")).toBe("operator edit\n");
         expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
+    test("keeps a user file that appears while the recovery is staging its brief", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+
+        // Race the operator's editor against the recovery: whoever the exclusive
+        // publish finds first wins, and the recovery must never destroy the file.
+        const [retry] = await Promise.all([
+            runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
+            Effect.runPromise(Effect.sync(() => writeFileSync(join(root, `${sig}.md`), "operator edit\n"))),
+        ]);
+
+        expect(retry.status).toBe("ok");
+        const landed = readFileSync(join(root, `${sig}.md`), "utf8");
+        // Either order is legal; what is not legal is a truncated or mixed file.
+        expect(landed === "operator edit\n" || landed.includes(`<!--ax:${sig}-->`)).toBe(true);
+        expect((await storedState(root)).experimentStatus).toBe("task_emitted");
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+    });
+
+    test("two concurrent recoveries publish one brief and lose no files", async () => {
+        const root = await interruptPublication();
+        rmSync(join(root, `${sig}.md`), { recursive: true });
+
+        const [first, second] = await Promise.all([
+            runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
+            runInRoot(root, () => acceptProposal({ sigOrId: sig, taskDir: root })),
+        ]);
+
+        // One attempt publishes. The other either loses the exclusive publish and
+        // keeps the brief it found (`ok`), or arrives after the winner already
+        // finished the experiment and correctly refuses (`wrong_status`). Neither
+        // may fail, and neither may delete the other's staging file.
+        expect([first.status, second.status]).toContain("ok");
+        for (const result of [first, second]) {
+            expect(["ok", "wrong_status"]).toContain(result.status);
+            if (result.status === "ok") expect(result.task_path).toBe(join(root, `${sig}.md`));
+        }
+        expect(readdirSync(root).filter((name) => name === `${sig}.md`)).toHaveLength(1);
+        expect(readFileSync(join(root, `${sig}.md`), "utf8")).toContain(`<!--ax:${sig}-->`);
+        expect(stagingFiles(root, sig)).toHaveLength(0);
+        const state = await storedState(root);
+        expect(state.experimentStatus).toBe("task_emitted");
     });
 
     test("finishes the brief even when the retry asks for a direct scaffold", async () => {

--- a/apps/axctl/src/improve/lifecycle.test.ts
+++ b/apps/axctl/src/improve/lifecycle.test.ts
@@ -79,6 +79,57 @@ describe("intervention lifecycle vocabulary", () => {
         });
     });
 
+    test("plans a resume only for an interrupted publication", () => {
+        const publishing = { status: "publishing", taskPath: "/tmp/ax/tasks/sig.md", lockedVerdict: null };
+        expect(planAcceptCandidate({
+            form: "guidance",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            experiment: publishing,
+        })).toEqual({
+            status: "resume_publication",
+            experimentStatus: "task_emitted",
+        });
+        // A completed acceptance keeps the old answer.
+        expect(planAcceptCandidate({
+            form: "guidance",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            experiment: { status: "task_emitted", taskPath: "/tmp/ax/tasks/sig.md", lockedVerdict: null },
+        })).toEqual({
+            status: "wrong_status",
+            message: "proposal already accepted",
+        });
+        // A retired or judged experiment is never revived.
+        expect(planAcceptCandidate({
+            form: "guidance",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            experiment: { ...publishing, lockedVerdict: "adopted" },
+        }).status).toBe("wrong_status");
+        expect(planAcceptCandidate({
+            form: "guidance",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            experiment: { status: "retired", taskPath: "/tmp/ax/tasks/sig.md", lockedVerdict: null },
+        }).status).toBe("wrong_status");
+        // No intended path means there is nothing to finish.
+        expect(planAcceptCandidate({
+            form: "guidance",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            experiment: { ...publishing, taskPath: null },
+        }).status).toBe("wrong_status");
+        // Safety gates still apply to a resumed acceptance.
+        expect(planAcceptCandidate({
+            form: "hook",
+            proposalStatus: "accepted",
+            autoScaffold: false,
+            safetyContract: null,
+            experiment: publishing,
+        }).status).toBe("unsupported_form");
+    });
+
     test("plans reject transitions with the default reject reason", () => {
         expect(planRejectCandidate({ proposalStatus: "open" })).toEqual({
             status: "ok",

--- a/apps/axctl/src/improve/lifecycle.ts
+++ b/apps/axctl/src/improve/lifecycle.ts
@@ -17,6 +17,14 @@ export const MANUAL_TASK_PROPOSAL_FORMS = INTERVENTION_FORMS;
 
 export const EXPERIMENT_STATUS_TASK_EMITTED = "task_emitted";
 export const EXPERIMENT_STATUS_SCAFFOLDED = "scaffolded";
+/**
+ * Transient: the accept transaction has committed, but the task brief is not on
+ * disk yet. It is the durable difference between an INTERRUPTED publication (a
+ * retry must finish it) and a COMPLETED acceptance (a retry is wrong_status).
+ * No accept ever leaves it as a final status - `acceptedExperimentStatus` never
+ * returns it, and the publication finalizes it in the same call.
+ */
+export const EXPERIMENT_STATUS_PUBLISHING = "publishing";
 export const LIFECYCLE_VERDICT_REGRESSED = "regressed";
 export type ExperimentStatus =
     | typeof EXPERIMENT_STATUS_TASK_EMITTED
@@ -109,17 +117,47 @@ export type AcceptCandidatePlan =
         readonly experimentStatus: ExperimentStatus;
     }
     | {
+        /** Finish an interrupted publication in place, on the same experiment. */
+        readonly status: "resume_publication";
+        readonly experimentStatus: ExperimentStatus;
+    }
+    | {
         readonly status: "wrong_status" | "unsupported_form";
         readonly message: string;
     };
+
+/** The stored experiment an accept retry would land on, if there is one. */
+export interface AcceptExperimentState {
+    readonly status: string;
+    readonly taskPath: string | null;
+    readonly lockedVerdict: string | null;
+}
+
+/**
+ * True iff an accept retry should FINISH a publication rather than refuse it:
+ * the experiment still says `publishing`, it names the path it meant to write,
+ * and nobody has judged it. A retired or verdict-locked experiment is never
+ * revived, and a completed acceptance stays `wrong_status`.
+ */
+export function isInterruptedPublication(
+    proposalStatus: string,
+    experiment: AcceptExperimentState | null | undefined,
+): boolean {
+    return proposalStatus === PROPOSAL_STATUS_ACCEPTED
+        && experiment?.status === EXPERIMENT_STATUS_PUBLISHING
+        && experiment.taskPath !== null
+        && experiment.lockedVerdict === null;
+}
 
 export function planAcceptCandidate(input: {
     readonly form: string;
     readonly proposalStatus: string;
     readonly autoScaffold: boolean;
     readonly safetyContract?: InterventionSafetyContract | null;
+    readonly experiment?: AcceptExperimentState | null;
 }): AcceptCandidatePlan {
-    if (input.proposalStatus !== PROPOSAL_STATUS_OPEN) {
+    const resume = isInterruptedPublication(input.proposalStatus, input.experiment);
+    if (input.proposalStatus !== PROPOSAL_STATUS_OPEN && !resume) {
         return {
             status: "wrong_status",
             message: `proposal already ${input.proposalStatus}`,
@@ -141,10 +179,10 @@ export function planAcceptCandidate(input: {
             };
         }
     }
-    return {
-        status: "ok",
-        experimentStatus: acceptedExperimentStatus(input),
-    };
+    const experimentStatus = acceptedExperimentStatus(input);
+    return resume
+        ? { status: "resume_publication", experimentStatus }
+        : { status: "ok", experimentStatus };
 }
 
 export type RejectCandidatePlan =

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -856,6 +856,8 @@ export interface CheckpointSnapshotDto {
 }
 
 export type ExperimentStatus =
+    /** transient: accepted and committed, brief not yet on disk */
+    | "publishing"
     | "task_emitted"
     | "scaffolded"
     | "regressed"

--- a/packages/lib/src/shared/fs-error.ts
+++ b/packages/lib/src/shared/fs-error.ts
@@ -9,6 +9,16 @@ export const isNotFound = (e: PlatformError.PlatformError): boolean =>
     e.reason._tag === "NotFound";
 
 /**
+ * True iff a `PlatformError` is "the path is already there" (EEXIST). It is the
+ * answer an EXCLUSIVE create (`FileSystem.link`, an `open` with a `wx` flag)
+ * gives when the target appeared before it got there - the race an
+ * exists-then-write pair cannot see, so a caller that must never replace a file
+ * tests this rather than probing the path first.
+ */
+export const isAlreadyExists = (e: PlatformError.PlatformError): boolean =>
+    e.reason._tag === "AlreadyExists";
+
+/**
  * Recover a NotFound (vanished file) read to `fallback`; RE-RAISE every other
  * `PlatformError` (never swallow IO/permission errors). Composes data-last:
  *

--- a/packages/schema/src/schema.sidecar.sql
+++ b/packages/schema/src/schema.sidecar.sql
@@ -164,7 +164,10 @@ CREATE TABLE IF NOT EXISTS experiment (
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     locked_verdict TEXT,
     status TEXT NOT NULL DEFAULT 'task_emitted',
-    -- task_emitted | scaffolded | regressed | retired
+    -- publishing | task_emitted | scaffolded | regressed | retired
+    -- `publishing` is transient: the accept transaction has committed but the
+    -- task brief is not on disk yet, so a retry finishes the publication instead
+    -- of refusing it (see apps/axctl/src/improve/actions.ts).
     task_path TEXT
     -- absolute path to .ax/tasks/<id>.md while pending
 );


### PR DESCRIPTION
An accepted proposal can lose its task brief when file publication fails after the database commit. A later accept now resumes the recorded publication. It keeps the original experiment and task path, publishes exclusively unless the first request explicitly uses force, and preserves existing files and user decisions.

The SQLite claim and final state checks protect concurrent acceptance, rejection, retirement, and verdict changes. Each attempt removes only its own temporary file. Recovery rejects directories and dangling links at the task path.

Validation: independent review passes. The root review run passes 50 acceptance, lifecycle, and HTTP contract tests with 250 assertions. Real SQLite and filesystem regressions cover interrupted publication, repeated recovery, concurrent requests, existing files, and saved verdicts. Root typecheck passes. Studio typecheck reports three unchanged baseline errors. Combined full-suite validation follows integration.

Fixes #1129

---

_Generated with [ax](https://github.com/Necmttn/ax)._
