### PR TITLE
fix(improve): measure reconciled artifacts and replace evidence atomically

### DIFF
--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -12,7 +12,7 @@
  * by hand.
  */
 import { describe, expect } from "bun:test";
-import { mkdir, utimes } from "node:fs/promises";
+import { mkdir, rm, utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { Effect, FileSystem, Layer, Path } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
@@ -20,10 +20,22 @@ import { AxConfigTest } from "@ax/lib/config";
 import { FixturePlatform, publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { Judgment, JudgmentLayer } from "@ax/lib/sqlite";
+import type { CacheWriteService } from "@ax/lib/duckdb/seam";
+import { WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import { acceptProposal } from "../improve/actions.ts";
 import { lintFiles } from "../improve/lint.ts";
-import { deriveOpportunities, type DeriveOpportunitiesStats } from "./derive-opportunities.ts";
+import {
+    deriveOpportunities,
+    opportunityKey,
+    replaceOpportunities,
+    type DeriveOpportunitiesStats,
+} from "./derive-opportunities.ts";
+import {
+    OPPORTUNITY_VERSION,
+    OPPORTUNITY_VERSION_PATH,
+    OPPORTUNITY_VERSION_SOURCE,
+} from "./opportunity-cache-version.ts";
 import { ingestTranscripts } from "./transcripts.ts";
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("opportunity artifact identity", {
@@ -212,13 +224,23 @@ const installHookExperiment = async (harness: Harness, opts: {
     expect(lint.reconciled).toHaveLength(1);
 };
 
-/** Ingest the transcripts, derive opportunities, and read back what landed. */
-const ingestAndDerive = async (
+/** One open cache fixture: the production DDL, a real ingest lock, and the real
+ *  sidecar behind `deriveOpportunities`. Handed to the body so a test can run
+ *  MORE THAN ONE pass and inspect what survived between them. */
+interface CacheSession {
+    readonly write: CacheWriteService;
+    /** Parse the fixture's transcripts through the real claude stage. */
+    readonly ingest: Effect.Effect<unknown, unknown, never>;
+    readonly derive: Effect.Effect<DeriveOpportunitiesStats, unknown, never>;
+    readonly rows: Effect.Effect<ReadonlyArray<OpportunityRow>, unknown, never>;
+    /** The stored derivation-version token, or null when no sentinel exists. */
+    readonly sentinel: Effect.Effect<string | null, unknown, never>;
+}
+
+const inCache = async <A>(
     harness: Harness,
-    seed?: (write: Parameters<Parameters<typeof publishCacheFixture>[2]>[0]) => Effect.Effect<unknown, unknown, never>,
-): Promise<{ readonly stats: DeriveOpportunitiesStats; readonly rows: ReadonlyArray<OpportunityRow> }> => {
-    let stats: DeriveOpportunitiesStats | null = null;
-    let rows: ReadonlyArray<OpportunityRow> = [];
+    body: (session: CacheSession) => Effect.Effect<A, unknown, never>,
+): Promise<A> => {
     // The claude stage walks this directory even when a scenario has no
     // transcripts (the guidance cases), so it always has to exist.
     await mkdir(harness.transcriptsDir, { recursive: true });
@@ -226,25 +248,49 @@ const ingestAndDerive = async (
         JudgmentLayer({ sidecarPath: harness.sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
         BunFileSystem.layer,
     );
+    let captured: { readonly value: A } | null = null;
     await runWithPlatform(publishCacheFixture(join(harness.root, "cache"), dylibPath, (write) =>
         Effect.gen(function* () {
-            if (seed) yield* seed(write);
-            yield* ingestTranscripts(write).pipe(
-                Effect.provide(AxConfigTest({ paths: { transcriptsDir: harness.transcriptsDir } })),
-                Effect.provide(FixturePlatform),
-            );
-            stats = yield* deriveOpportunities(write).pipe(
-                Effect.provide(judgmentLayer),
-                Effect.scoped,
-            );
-            const read = yield* write.raw(
-                "SELECT in_id, out_id, out_table, was_addressed FROM opportunity ORDER BY out_id",
-            );
-            rows = read.rows as unknown as OpportunityRow[];
+            const session: CacheSession = {
+                write,
+                ingest: ingestTranscripts(write).pipe(
+                    Effect.provide(AxConfigTest({ paths: { transcriptsDir: harness.transcriptsDir } })),
+                    Effect.provide(FixturePlatform),
+                ),
+                derive: deriveOpportunities(write).pipe(Effect.provide(judgmentLayer), Effect.scoped),
+                rows: Effect.gen(function* () {
+                    const read = yield* write.raw(
+                        "SELECT in_id, out_id, out_table, was_addressed FROM opportunity ORDER BY out_id",
+                    );
+                    return read.rows as unknown as OpportunityRow[];
+                }),
+                sentinel: Effect.gen(function* () {
+                    const read = yield* write.raw(
+                        `SELECT sha FROM ${WATERMARK_TABLE} WHERE source_kind = ? AND path = ?`,
+                        [OPPORTUNITY_VERSION_SOURCE, OPPORTUNITY_VERSION_PATH],
+                    );
+                    const row = (read.rows as unknown as Array<{ sha: string | null }>)[0];
+                    return row?.sha ?? null;
+                }),
+            };
+            captured = { value: yield* body(session) };
         })));
-    if (stats === null) throw new Error("deriveOpportunities did not run");
-    return { stats, rows };
+    if (captured === null) throw new Error("the cache body did not complete");
+    return (captured as { readonly value: A }).value;
 };
+
+/** Ingest the transcripts, derive opportunities once, and read back what landed. */
+const ingestAndDerive = async (
+    harness: Harness,
+    seed?: (write: CacheWriteService) => Effect.Effect<unknown, unknown, never>,
+): Promise<{ readonly stats: DeriveOpportunitiesStats; readonly rows: ReadonlyArray<OpportunityRow> }> =>
+    inCache(harness, (session) =>
+        Effect.gen(function* () {
+            if (seed) yield* seed(session.write);
+            yield* session.ingest;
+            const stats = yield* session.derive;
+            return { stats, rows: yield* session.rows };
+        }));
 
 /** Transcript timestamps must sit after the observed install, which happens at
  *  the real clock during `lint`. A minute of margin keeps it deterministic. */
@@ -458,6 +504,39 @@ describe("hook form: observed marker identity", () => {
         expect(rows.map((r) => r.was_addressed)).toEqual([false]);
     });
 
+    dtest("a failure from before the install was never this hook's opportunity", async () => {
+        const harness = makeHarness("ax-opp-identity-window-");
+        const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+        });
+        const beforeInstall = new Date(Date.now() - 3_600_000).toISOString();
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_old", ts: beforeInstall }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_old",
+                ts: beforeInstall,
+                text: "error: pathspec did not match",
+            }),
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_new", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_new",
+                ts: afterInstall(500),
+                text: `PreToolUse:Bash hook error: [${command}]: BLOCKED`,
+            }),
+        ]);
+
+        const { stats, rows } = await ingestAndDerive(harness);
+        // Both calls failed; only the one after the observed install counts.
+        expect(stats.byHookForm).toBe(1);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.out_id).toContain("toolu_new");
+    });
+
     dtest("an uninstalled hook has unavailable evidence, not zero addressed", async () => {
         const harness = makeHarness("ax-opp-identity-uninstalled-");
         const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
@@ -608,5 +687,172 @@ describe("stale opportunity rows", () => {
             out_table: "friction_event", was_addressed: true,
         });
         expect(rows.some((r) => r.in_id === experimentKey && r.out_id === "friction-1")).toBe(true);
+    });
+});
+
+describe("failure-safe replacement", () => {
+    dtest("a failed replacement preserves every previous row", async () => {
+        const harness = makeHarness("ax-opp-identity-atomic-");
+        const keep = {
+            id: "row-keep", out_id: "evidence-keep", out_table: "tool_call",
+            matched_at: "2026-09-01T00:00:00.000Z", was_addressed: true,
+        };
+        const drop = {
+            id: "row-drop", out_id: "evidence-drop", out_table: "tool_call",
+            matched_at: "2026-09-01T01:00:00.000Z", was_addressed: false,
+        };
+        const other = {
+            id: "row-other", out_id: "evidence-other", out_table: "tool_call",
+            matched_at: "2026-09-01T02:00:00.000Z", was_addressed: true,
+        };
+
+        const result = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                yield* replaceOpportunities(session.write, "experiment-a", [keep, drop]);
+                yield* replaceOpportunities(session.write, "experiment-b", [other]);
+                const before = yield* session.rows;
+
+                // One unusable timestamp in an otherwise ordinary replacement:
+                // it would have flipped `row-keep` and deleted `row-drop`.
+                const failed = yield* replaceOpportunities(session.write, "experiment-a", [
+                    { ...keep, was_addressed: false },
+                    { ...drop, id: "row-new", matched_at: "not-a-timestamp" },
+                ]).pipe(Effect.result);
+
+                return { failed, before, after: yield* session.rows };
+            }));
+
+        expect(result.failed._tag).toBe("Failure");
+        // Not "most rows survived" - the previous state is byte-for-byte intact.
+        expect(result.after).toEqual(result.before);
+        expect(result.after).toHaveLength(3);
+    });
+
+    dtest("an empty replacement clears only the selected experiment", async () => {
+        const harness = makeHarness("ax-opp-identity-empty-");
+        const mine = {
+            id: "row-mine", out_id: "evidence-mine", out_table: "tool_call",
+            matched_at: "2026-09-01T00:00:00.000Z", was_addressed: true,
+        };
+        const theirs = {
+            id: "row-theirs", out_id: "evidence-theirs", out_table: "tool_call",
+            matched_at: "2026-09-01T01:00:00.000Z", was_addressed: true,
+        };
+
+        const rows = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                yield* replaceOpportunities(session.write, "experiment-a", [mine]);
+                yield* replaceOpportunities(session.write, "experiment-b", [theirs]);
+                yield* replaceOpportunities(session.write, "experiment-a", []);
+                return yield* session.rows;
+            }));
+
+        expect(rows.map((r) => r.out_id)).toEqual(["evidence-theirs"]);
+    });
+});
+
+describe("guidance form: a failed stat is unavailable evidence", () => {
+    dtest("clears the experiment's rows instead of publishing them as unaddressed", async () => {
+        const harness = makeHarness("ax-opp-identity-stat-");
+        const guidancePath = join(harness.root, "CLAUDE.md");
+        const experimentKey = await installGuidanceExperiment(harness, { sig: "use-rg", guidancePath });
+        const correctionAt = new Date(Date.now() + 60_000);
+        await utimes(guidancePath, correctionAt, correctionAt);
+
+        const result = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                yield* session.write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);
+                const first = yield* session.derive;
+                const seeded = yield* session.rows;
+
+                // The recorded artifact goes away between runs. The detector now
+                // has no reading at all - which is not the same as a reading of
+                // "ignored", so the old rows must not simply stay.
+                yield* Effect.promise(() => rm(guidancePath));
+                const second = yield* session.derive;
+                return { first, seeded, second, after: yield* session.rows };
+            }));
+
+        expect(result.first.byGuidanceForm).toBe(1);
+        expect(result.seeded.map((r) => r.in_id)).toEqual([experimentKey]);
+        expect(result.second.artifactUnavailable).toBe(1);
+        expect(result.second.byGuidanceForm).toBe(0);
+        expect(result.after).toEqual([]);
+    });
+
+    dtest("a guidance path that became a directory clears its stale rows", async () => {
+        const harness = makeHarness("ax-opp-identity-dir-");
+        const guidancePath = join(harness.root, "CLAUDE.md");
+        const experimentKey = await installGuidanceExperiment(harness, { sig: "use-rg", guidancePath });
+        const correctionAt = new Date(Date.now() + 60_000);
+        await utimes(guidancePath, correctionAt, correctionAt);
+
+        const result = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                yield* session.write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);
+                yield* session.derive;
+                const seeded = yield* session.rows;
+
+                // The file is replaced by a directory of the same name. Its
+                // mtime is fresh, so the old detector would have called every
+                // opportunity addressed on the strength of a `mkdir`.
+                yield* Effect.promise(() => rm(guidancePath));
+                yield* Effect.promise(() => mkdir(guidancePath));
+                const second = yield* session.derive;
+                return { seeded, second, after: yield* session.rows };
+            }));
+
+        expect(result.seeded.map((r) => r.in_id)).toEqual([experimentKey]);
+        expect(result.second.artifactUnavailable).toBe(1);
+        expect(result.second.byGuidanceForm).toBe(0);
+        expect(result.after).toEqual([]);
+    });
+});
+
+describe("derivation-version sentinel", () => {
+    dtest("stamps a complete pass, and a later failed pass revokes it", async () => {
+        const harness = makeHarness("ax-opp-identity-sentinel-");
+        const guidancePath = join(harness.root, "CLAUDE.md");
+        const experimentKey = await installGuidanceExperiment(harness, { sig: "use-rg", guidancePath });
+        const correctionAt = new Date(Date.now() + 60_000);
+        await utimes(guidancePath, correctionAt, correctionAt);
+
+        const result = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                yield* session.write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);
+                yield* session.derive;
+                const afterSuccess = yield* session.sentinel;
+                const rowsAfterSuccess = yield* session.rows;
+
+                // A second correction gives the next pass a NEW row to insert,
+                // and another experiment already owns that row id - so the
+                // replacement statement fails.
+                yield* session.write.putMany("friction_event", [correctionRow("friction-2", correctionAt)]);
+                yield* replaceOpportunities(session.write, "experiment-elsewhere", [{
+                    id: opportunityKey(experimentKey, "friction-2"),
+                    out_id: "evidence-elsewhere",
+                    out_table: "friction_event",
+                    matched_at: correctionAt.toISOString(),
+                    was_addressed: true,
+                }]);
+
+                const failed = yield* session.derive.pipe(Effect.result);
+                return {
+                    afterSuccess,
+                    rowsAfterSuccess,
+                    failed,
+                    afterFailure: yield* session.sentinel,
+                    rows: yield* session.rows,
+                };
+            }));
+
+        expect(result.afterSuccess).toBe(OPPORTUNITY_VERSION);
+        expect(result.failed._tag).toBe("Failure");
+        // A cache published mid-failure carries no success certificate, even
+        // though the previous pass had earned one.
+        expect(result.afterFailure).toBeNull();
+        // ...and the failed pass changed none of the rows it had already written.
+        expect(result.rows.filter((r) => r.in_id === experimentKey))
+            .toEqual(result.rowsAfterSuccess.filter((r) => r.in_id === experimentKey));
     });
 });

--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -1,0 +1,612 @@
+/**
+ * F02 (#1133): the opportunity detector must measure the artifact ax OBSERVED
+ * being installed, and must credit a hook fire only when the fire carries that
+ * hook's complete marker identity.
+ *
+ * Nothing here is mocked around the code path under test: the sidecar is a real
+ * temporary SQLite judgment store, the cache is a real DuckDB built from the
+ * production `schema.duckdb.sql`, the experiment is installed through the real
+ * `improve accept` + `improve lint` pair, and every hook fire reaches the graph
+ * through the real claude transcript parser (a blocked tool_result line, a
+ * `hook_success` attachment, a `hook_progress` line) rather than being inserted
+ * by hand.
+ */
+import { describe, expect } from "bun:test";
+import { mkdir, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { FixturePlatform, publishCacheFixture, runWithPlatform } from "@ax/lib/testing/cache-fixture";
+import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
+import { Judgment, JudgmentLayer } from "@ax/lib/sqlite";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { acceptProposal } from "../improve/actions.ts";
+import { lintFiles } from "../improve/lint.ts";
+import { deriveOpportunities, type DeriveOpportunitiesStats } from "./derive-opportunities.ts";
+import { ingestTranscripts } from "./transcripts.ts";
+
+const { dylibPath, dtest, tempDir } = await duckdbTestSetup("opportunity artifact identity", {
+    requireFts: true,
+});
+
+const SESSION = "identity-session";
+const OTHER_SESSION = "other-session";
+
+interface OpportunityRow {
+    readonly in_id: string;
+    readonly out_id: string;
+    readonly out_table: string;
+    readonly was_addressed: boolean;
+}
+
+interface Harness {
+    readonly root: string;
+    readonly sidecarPath: string;
+    readonly transcriptsDir: string;
+    /** Run judgment-side work (accept / lint / seed) against the real sidecar. */
+    readonly judgment: <A>(
+        effect: Effect.Effect<A, unknown, Judgment | FileSystem.FileSystem | Path.Path>,
+    ) => Promise<A>;
+}
+
+const makeHarness = (label: string): Harness => {
+    const root = tempDir(label);
+    const sidecarPath = join(root, "judgment.sqlite");
+    const transcriptsDir = join(root, "transcripts");
+    const layer = Layer.mergeAll(
+        JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
+        BunFileSystem.layer,
+        BunPath.layer,
+    );
+    return {
+        root,
+        sidecarPath,
+        transcriptsDir,
+        judgment: <A>(effect: Effect.Effect<A, unknown, Judgment | FileSystem.FileSystem | Path.Path>) =>
+            Effect.runPromise(
+                effect.pipe(Effect.provide(layer), Effect.scoped) as Effect.Effect<A, unknown, never>,
+            ),
+    };
+};
+
+/** Write one claude transcript file (one session) under the fixture root. */
+const writeTranscript = async (
+    harness: Harness,
+    sessionId: string,
+    entries: ReadonlyArray<Record<string, unknown>>,
+): Promise<void> => {
+    const projectDir = join(harness.transcriptsDir, "-repo");
+    await mkdir(projectDir, { recursive: true });
+    await Bun.write(
+        join(projectDir, `${sessionId}.jsonl`),
+        entries.map((entry) => JSON.stringify(entry)).join("\n"),
+    );
+};
+
+const assistantToolUse = (opts: {
+    readonly sessionId: string;
+    readonly toolUseId: string;
+    readonly ts: string;
+}): Record<string, unknown> => ({
+    type: "assistant",
+    uuid: `${opts.toolUseId}-call`,
+    sessionId: opts.sessionId,
+    timestamp: opts.ts,
+    cwd: "/repo",
+    message: {
+        role: "assistant",
+        model: "claude-sonnet-4-5",
+        content: [{ type: "tool_use", id: opts.toolUseId, name: "Bash", input: { command: "git reset --hard" } }],
+    },
+});
+
+const failingToolResult = (opts: {
+    readonly sessionId: string;
+    readonly toolUseId: string;
+    readonly ts: string;
+    readonly text: string;
+}): Record<string, unknown> => ({
+    type: "user",
+    uuid: `${opts.toolUseId}-result`,
+    sessionId: opts.sessionId,
+    timestamp: opts.ts,
+    cwd: "/repo",
+    message: {
+        role: "user",
+        content: [{
+            type: "tool_result",
+            tool_use_id: opts.toolUseId,
+            is_error: true,
+            content: opts.text,
+        }],
+    },
+    toolUseResult: `Error: ${opts.text}`,
+});
+
+const hookSuccessAttachment = (opts: {
+    readonly sessionId: string;
+    readonly toolUseId: string;
+    readonly ts: string;
+    readonly command: string;
+    readonly hookEvent: string;
+    readonly stdout: string;
+}): Record<string, unknown> => ({
+    type: "attachment",
+    uuid: `${opts.toolUseId}-${opts.hookEvent}-success`,
+    sessionId: opts.sessionId,
+    timestamp: opts.ts,
+    cwd: "/repo",
+    attachment: {
+        type: "hook_success",
+        hookName: `${opts.hookEvent}:Bash`,
+        hookEvent: opts.hookEvent,
+        toolUseID: opts.toolUseId,
+        command: opts.command,
+        stdout: opts.stdout,
+        stderr: "",
+        exitCode: 0,
+        durationMs: 12,
+    },
+});
+
+const hookProgressLine = (opts: {
+    readonly sessionId: string;
+    readonly toolUseId: string;
+    readonly ts: string;
+    readonly command: string;
+}): Record<string, unknown> => ({
+    type: "progress",
+    uuid: `${opts.toolUseId}-progress`,
+    sessionId: opts.sessionId,
+    timestamp: opts.ts,
+    cwd: "/repo",
+    toolUseID: opts.toolUseId,
+    data: {
+        type: "hook_progress",
+        hookEvent: "PreToolUse",
+        hookName: "PreToolUse:Bash",
+        command: opts.command,
+    },
+});
+
+/** Seed an open hook proposal with complete safety gates, then install it the
+ *  way a user does: `improve accept` emits the task, the settings file gets the
+ *  marked command, `improve lint` records the artifact it FOUND. */
+const installHookExperiment = async (harness: Harness, opts: {
+    readonly sig: string;
+    readonly eventName: string;
+    readonly settingsCommand: string;
+    readonly install?: boolean;
+}): Promise<void> => {
+    await harness.judgment(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        const now = new Date();
+        yield* judgment.put("proposal", {
+            id: `proposal-${opts.sig}`, form: "hook", title: "Guard resets",
+            hypothesis: "hard resets keep failing", dedupe_sig: opts.sig, frequency: 3,
+            confidence: "high", status: "open", origin: "agent", hypothesis_template: null,
+            evidence_query: null, reject_reason: null, baseline: null, created_at: now, updated_at: now,
+        });
+        yield* judgment.put("hook_proposal", {
+            id: `hook-${opts.sig}`, proposal: `proposal-${opts.sig}`, event_name: opts.eventName,
+            target_tool: "Bash", hook_command: opts.settingsCommand,
+            recovery_path: "delete the settings entry", smoke_test_command: "echo ok",
+            disable_command: "ax hooks remove", failure_mode: "fail_open",
+        });
+        yield* acceptProposal({ sigOrId: opts.sig, taskDir: join(harness.root, "tasks") });
+    }));
+
+    if (opts.install === false) return;
+    await Bun.write(
+        join(harness.root, "settings.json"),
+        JSON.stringify({
+            hooks: {
+                [opts.eventName]: [
+                    { matcher: "Bash", hooks: [{ type: "command", command: opts.settingsCommand }] },
+                ],
+            },
+        }),
+    );
+    const lint = await harness.judgment(lintFiles({ roots: [harness.root] }));
+    expect(lint.reconciled).toHaveLength(1);
+};
+
+/** Ingest the transcripts, derive opportunities, and read back what landed. */
+const ingestAndDerive = async (
+    harness: Harness,
+    seed?: (write: Parameters<Parameters<typeof publishCacheFixture>[2]>[0]) => Effect.Effect<unknown, unknown, never>,
+): Promise<{ readonly stats: DeriveOpportunitiesStats; readonly rows: ReadonlyArray<OpportunityRow> }> => {
+    let stats: DeriveOpportunitiesStats | null = null;
+    let rows: ReadonlyArray<OpportunityRow> = [];
+    // The claude stage walks this directory even when a scenario has no
+    // transcripts (the guidance cases), so it always has to exist.
+    await mkdir(harness.transcriptsDir, { recursive: true });
+    const judgmentLayer = Layer.mergeAll(
+        JudgmentLayer({ sidecarPath: harness.sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
+        BunFileSystem.layer,
+    );
+    await runWithPlatform(publishCacheFixture(join(harness.root, "cache"), dylibPath, (write) =>
+        Effect.gen(function* () {
+            if (seed) yield* seed(write);
+            yield* ingestTranscripts(write).pipe(
+                Effect.provide(AxConfigTest({ paths: { transcriptsDir: harness.transcriptsDir } })),
+                Effect.provide(FixturePlatform),
+            );
+            stats = yield* deriveOpportunities(write).pipe(
+                Effect.provide(judgmentLayer),
+                Effect.scoped,
+            );
+            const read = yield* write.raw(
+                "SELECT in_id, out_id, out_table, was_addressed FROM opportunity ORDER BY out_id",
+            );
+            rows = read.rows as unknown as OpportunityRow[];
+        })));
+    if (stats === null) throw new Error("deriveOpportunities did not run");
+    return { stats, rows };
+};
+
+/** Transcript timestamps must sit after the observed install, which happens at
+ *  the real clock during `lint`. A minute of margin keeps it deterministic. */
+const afterInstall = (offsetMs: number): string => new Date(Date.now() + 60_000 + offsetMs).toISOString();
+
+describe("hook form: observed marker identity", () => {
+    dtest("credits a blocked fire recovered from tool-result text, end to end", async () => {
+        const harness = makeHarness("ax-opp-identity-hook-");
+        const command = "bun ~/.ax/hooks/enforce-worktree.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: `PreToolUse:Bash hook error: [${command}]: BLOCKED: dirty primary tree`,
+            }),
+        ]);
+
+        const { stats, rows } = await ingestAndDerive(harness);
+        expect(stats.byHookForm).toBe(1);
+        expect(stats.artifactUnavailable).toBe(0);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.was_addressed).toBe(true);
+        expect(rows[0]!.out_table).toBe("tool_call");
+    });
+
+    dtest("credits python, node and wrapper hooks, and never a prefix collision", async () => {
+        for (const [index, command] of [
+            "python3 ~/.ax/hooks/guard.py # ax:74da7418",
+            "node ./guard.js --marker ax:74da7418",
+            "bash -c \"echo 'ax:74da7418' && exec ~/.ax/hooks/guard\"",
+        ].entries()) {
+            const harness = makeHarness(`ax-opp-identity-shape-${index}-`);
+            await installHookExperiment(harness, {
+                sig: "74da7418",
+                eventName: "PreToolUse",
+                settingsCommand: command,
+            });
+            await writeTranscript(harness, SESSION, [
+                assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+                failingToolResult({
+                    sessionId: SESSION,
+                    toolUseId: "toolu_1",
+                    ts: afterInstall(500),
+                    text: `PreToolUse:Bash hook error: [${command}]: BLOCKED`,
+                }),
+            ]);
+            const { rows } = await ingestAndDerive(harness);
+            expect(rows.map((r) => r.was_addressed)).toEqual([true]);
+        }
+    });
+
+    dtest("a longer marker sharing this one's prefix is a different experiment", async () => {
+        const harness = makeHarness("ax-opp-identity-prefix-");
+        const installed = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        const neighbour = "bun ~/.ax/hooks/other-guard.ts # ax:74da7418ff";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: installed,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: `PreToolUse:Bash hook error: [${neighbour}]: BLOCKED`,
+            }),
+        ]);
+
+        const { rows } = await ingestAndDerive(harness);
+        expect(rows.map((r) => r.was_addressed)).toEqual([false]);
+    });
+
+    dtest("credits only the call the fire names, not its neighbour in the same session", async () => {
+        const harness = makeHarness("ax-opp-identity-call-");
+        const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_a", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_a",
+                ts: afterInstall(500),
+                text: "error: pathspec did not match",
+            }),
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_b", ts: afterInstall(1_000) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_b",
+                ts: afterInstall(1_500),
+                text: `PreToolUse:Bash hook error: [${command}]: BLOCKED`,
+            }),
+        ]);
+
+        const { stats, rows } = await ingestAndDerive(harness);
+        expect(stats.byHookForm).toBe(2);
+        expect(stats.addressed).toBe(1);
+        expect(rows.filter((r) => r.was_addressed)).toHaveLength(1);
+    });
+
+    dtest("a fire in another session never credits this session's failure", async () => {
+        const harness = makeHarness("ax-opp-identity-session-");
+        const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: "error: pathspec did not match",
+            }),
+        ]);
+        await writeTranscript(harness, OTHER_SESSION, [
+            assistantToolUse({ sessionId: OTHER_SESSION, toolUseId: "toolu_2", ts: afterInstall(600) }),
+            failingToolResult({
+                sessionId: OTHER_SESSION,
+                toolUseId: "toolu_2",
+                ts: afterInstall(700),
+                text: `PreToolUse:Bash hook error: [${command}]: BLOCKED`,
+            }),
+        ]);
+
+        const { rows } = await ingestAndDerive(harness);
+        // Two failing Bash calls; only the OTHER session's call was blocked.
+        expect(rows.filter((r) => r.was_addressed)).toHaveLength(1);
+        const blocked = rows.find((r) => r.was_addressed);
+        // The blocked call is the other session's `toolu_2`, never this one's.
+        expect(blocked?.out_id).toContain("toolu_2");
+    });
+
+    dtest("a fire on a different event name is not this hook's evidence", async () => {
+        const harness = makeHarness("ax-opp-identity-event-");
+        const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            hookSuccessAttachment({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(200),
+                command,
+                hookEvent: "PostToolUse",
+                stdout: '{"hookSpecificOutput":{"additionalContext":"noted"}}',
+            }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: "error: pathspec did not match",
+            }),
+        ]);
+
+        const { rows } = await ingestAndDerive(harness);
+        expect(rows.map((r) => r.was_addressed)).toEqual([false]);
+    });
+
+    dtest("progress-only and no-op records are not interventions", async () => {
+        const harness = makeHarness("ax-opp-identity-effect-");
+        const progressCommand = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: progressCommand,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            hookProgressLine({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(100),
+                command: progressCommand,
+            }),
+            hookSuccessAttachment({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(200),
+                command: `${progressCommand} --quiet`,
+                hookEvent: "PreToolUse",
+                stdout: "",
+            }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: "error: pathspec did not match",
+            }),
+        ]);
+
+        const { rows } = await ingestAndDerive(harness);
+        expect(rows.map((r) => r.was_addressed)).toEqual([false]);
+    });
+
+    dtest("an uninstalled hook has unavailable evidence, not zero addressed", async () => {
+        const harness = makeHarness("ax-opp-identity-uninstalled-");
+        const command = "bun ~/.ax/hooks/guard.ts # ax:74da7418";
+        await installHookExperiment(harness, {
+            sig: "74da7418",
+            eventName: "PreToolUse",
+            settingsCommand: command,
+            install: false,
+        });
+        await writeTranscript(harness, SESSION, [
+            assistantToolUse({ sessionId: SESSION, toolUseId: "toolu_1", ts: afterInstall(0) }),
+            failingToolResult({
+                sessionId: SESSION,
+                toolUseId: "toolu_1",
+                ts: afterInstall(500),
+                text: `PreToolUse:Bash hook error: [${command}]: BLOCKED`,
+            }),
+        ]);
+
+        const { stats, rows } = await ingestAndDerive(harness);
+        expect(stats.artifactUnavailable).toBe(1);
+        expect(stats.byHookForm).toBe(0);
+        expect(rows).toEqual([]);
+    });
+});
+
+/** Seed an open guidance proposal, accept it, install the marker in the given
+ *  file, and let `improve lint` record the file it actually found. Returns the
+ *  experiment key the derived rows are keyed by. */
+const installGuidanceExperiment = async (harness: Harness, opts: {
+    readonly sig: string;
+    readonly guidancePath: string;
+    readonly install?: boolean;
+}): Promise<string> => {
+    const accepted = await harness.judgment(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        const now = new Date();
+        yield* judgment.put("proposal", {
+            id: `proposal-${opts.sig}`, form: "guidance", title: "Use rg",
+            hypothesis: "grep is slow", dedupe_sig: opts.sig, frequency: 2, confidence: "high",
+            status: "open", origin: "agent", hypothesis_template: null, evidence_query: null,
+            reject_reason: null, baseline: null, created_at: now, updated_at: now,
+        });
+        yield* judgment.put("guidance_proposal", {
+            id: `guidance-${opts.sig}`, proposal: `proposal-${opts.sig}`,
+            // A BARE basename on purpose: the old detector expanded this to
+            // `~/.claude/CLAUDE.md` and measured a file it never installed.
+            file_target: "CLAUDE.md", section: "tools", suggested_text: "Use rg.",
+        });
+        return yield* acceptProposal({ sigOrId: opts.sig, taskDir: join(harness.root, "tasks") });
+    }));
+    const experimentKey = (accepted.experiment_id ?? "").replace(/^experiment:/, "");
+    expect(experimentKey).not.toBe("");
+    if (opts.install === false) return experimentKey;
+    await Bun.write(opts.guidancePath, `<!--ax:${opts.sig}-->Use rg.<!--/ax:${opts.sig}-->\n`);
+    const lint = await harness.judgment(lintFiles({ roots: [join(opts.guidancePath, "..")] }));
+    expect(lint.reconciled).toHaveLength(1);
+    return experimentKey;
+};
+
+const correctionRow = (id: string, ts: Date) => ({
+    id,
+    session: SESSION,
+    turn: null,
+    kind: "correction",
+    text: "no, use rg",
+    labels: null,
+    metrics: null,
+    raw: null,
+    ts,
+});
+
+describe("guidance form: observed artifact path", () => {
+    dtest("only the recorded file supplies evidence, even when two experiments name CLAUDE.md", async () => {
+        const harness = makeHarness("ax-opp-identity-guidance-");
+        const touchedDir = join(harness.root, "touched");
+        const untouchedDir = join(harness.root, "untouched");
+        await mkdir(touchedDir, { recursive: true });
+        await mkdir(untouchedDir, { recursive: true });
+        const touched = join(touchedDir, "CLAUDE.md");
+        const untouched = join(untouchedDir, "CLAUDE.md");
+        const touchedKey = await installGuidanceExperiment(harness, { sig: "use-rg-touched", guidancePath: touched });
+        await installGuidanceExperiment(harness, { sig: "use-rg-untouched", guidancePath: untouched });
+
+        // One correction after both installs; the two recorded files differ only
+        // in mtime, so the addressed flag can come from nothing but the path.
+        const correctionAt = new Date(Date.now() + 60_000);
+        await utimes(touched, new Date(correctionAt.getTime() + 60_000), new Date(correctionAt.getTime() + 60_000));
+        await utimes(untouched, new Date(correctionAt.getTime() - 3_600_000), new Date(correctionAt.getTime() - 3_600_000));
+
+        const { stats, rows } = await ingestAndDerive(harness, (write) =>
+            write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]));
+
+        expect(stats.byGuidanceForm).toBe(2);
+        expect(stats.artifactUnavailable).toBe(0);
+        expect(rows).toHaveLength(2);
+        expect(rows.filter((r) => r.was_addressed).map((r) => r.in_id)).toEqual([touchedKey]);
+        expect(rows.every((r) => r.out_table === "friction_event")).toBe(true);
+    });
+
+    dtest("an unreconciled guidance experiment reports unavailable evidence", async () => {
+        const harness = makeHarness("ax-opp-identity-guidance-absent-");
+        await installGuidanceExperiment(harness, {
+            sig: "use-rg",
+            guidancePath: join(harness.root, "CLAUDE.md"),
+            install: false,
+        });
+
+        const { stats, rows } = await ingestAndDerive(harness, (write) =>
+            write.putMany("friction_event", [correctionRow("friction-1", new Date(Date.now() + 60_000))]));
+
+        // No recorded artifact - and emphatically NOT a fall back to a global
+        // CLAUDE.md that happens to share the proposal's basename.
+        expect(stats.artifactUnavailable).toBe(1);
+        expect(stats.byGuidanceForm).toBe(0);
+        expect(rows).toEqual([]);
+    });
+});
+
+describe("stale opportunity rows", () => {
+    dtest("re-derive rebuilds this experiment's rows and leaves others alone", async () => {
+        const harness = makeHarness("ax-opp-identity-stale-");
+        const guidancePath = join(harness.root, "CLAUDE.md");
+        const experimentKey = await installGuidanceExperiment(harness, { sig: "use-rg", guidancePath });
+        const correctionAt = new Date(Date.now() + 60_000);
+        await utimes(guidancePath, correctionAt, correctionAt);
+
+        const { rows } = await ingestAndDerive(harness, (write) =>
+            Effect.gen(function* () {
+                yield* write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);
+                // A row the OLD matching rules produced, for evidence that no
+                // longer matches, plus one belonging to a different experiment.
+                yield* write.putMany("opportunity", [
+                    {
+                        id: "stale-row", in_id: experimentKey, out_id: "friction-gone",
+                        out_table: "friction_event", matched_at: correctionAt, was_addressed: true,
+                    },
+                    {
+                        id: "unrelated-row", in_id: "experiment-elsewhere", out_id: "friction-other",
+                        out_table: "friction_event", matched_at: correctionAt, was_addressed: true,
+                    },
+                ]);
+            }));
+
+        expect(rows.some((r) => r.out_id === "friction-gone")).toBe(false);
+        expect(rows).toContainEqual({
+            in_id: "experiment-elsewhere", out_id: "friction-other",
+            out_table: "friction_event", was_addressed: true,
+        });
+        expect(rows.some((r) => r.in_id === experimentKey && r.out_id === "friction-1")).toBe(true);
+    });
+});

--- a/apps/axctl/src/ingest/derive-opportunities.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -79,14 +79,26 @@ describe("overlapFilesMatch", () => {
 });
 
 describe("buildOpportunityRows", () => {
-    test("emits one bound row per match with a stable edge id", () => {
+    test("emits one row per match with a stable edge id and an ISO matched_at", () => {
         const rows = buildOpportunityRows("exp_1", [
             { evidenceTable: "later_fixed_by", evidenceKey: "edge_a", ts: "2026-05-25T00:00:00.000Z" },
             { evidenceTable: "later_fixed_by", evidenceKey: "edge_b", ts: "2026-05-25T01:00:00.000Z" },
         ]);
         expect(rows).toHaveLength(2);
-        expect(rows[0]).toMatchObject({ in_id: "exp_1", out_id: "edge_a", out_table: "later_fixed_by", was_addressed: false });
-        expect(rows[0]!.id).toBe(opportunityKey("exp_1", "edge_a"));
+        expect(rows[0]).toEqual({
+            id: opportunityKey("exp_1", "edge_a"),
+            out_id: "edge_a",
+            out_table: "later_fixed_by",
+            matched_at: "2026-05-25T00:00:00.000Z",
+            was_addressed: false,
+        });
+    });
+
+    test("carries no in_id - the replacement statement binds the experiment", () => {
+        const rows = buildOpportunityRows("exp_1", [
+            { evidenceTable: "later_fixed_by", evidenceKey: "edge_a", ts: "2026-05-25T00:00:00.000Z" },
+        ]);
+        expect(rows[0]).not.toHaveProperty("in_id");
     });
 
     test("no matches -> no statements", () => {
@@ -138,6 +150,20 @@ describe("safeFileMtimeMs", () => {
             const when = new Date("2026-01-02T03:04:05.000Z");
             await utimes(file, when, when);
             expect(await runMtime(file)).toBe(when.getTime());
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("returns null for a directory - a directory mtime is not artifact activity", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "ax-mtime-"));
+        try {
+            // The guidance path became a directory (a stray `mkdir -p`, a
+            // reshaped checkout). Its mtime moves whenever anything lands
+            // inside it, which says nothing about the guidance file.
+            const asDir = join(dir, "CLAUDE.md");
+            await mkdir(asDir);
+            expect(await runMtime(asDir)).toBeNull();
         } finally {
             await rm(dir, { recursive: true, force: true });
         }
@@ -262,6 +288,22 @@ describe("hookOpportunityAddressed", () => {
     test("does not fall back to the window when the fire carries tool-call identity", () => {
         const fires = [invocation({ tool_call: "tool-call-9" })];
         expect(hookOpportunityAddressed(opportunity({ id: "tool-call-1" }), fires)).toBe(false);
+    });
+
+    test("a named fire never credits a call whose own identity is unknown", () => {
+        // The fire names `toolu_1`; this call carries no `call_id` at all, so it
+        // is not the named call. Falling through to the window here would credit
+        // a call the fire demonstrably did not act on.
+        const fires = [invocation({ tool_call_id: "toolu_1" })];
+        expect(hookOpportunityAddressed(opportunity({ call_id: null }), fires)).toBe(false);
+    });
+
+    test("the row reference still wins over the provider id", () => {
+        // Both identities present and disagreeing: `tool_call` is the row this
+        // fire was recorded against, so it decides.
+        const fires = [invocation({ tool_call: "tool-call-1", tool_call_id: "toolu_other" })];
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-1", call_id: "toolu_1" }), fires)).toBe(true);
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-2", call_id: "toolu_other" }), fires)).toBe(false);
     });
 
     test("falls back to the time window inside the same session when neither record has identity", () => {

--- a/apps/axctl/src/ingest/derive-opportunities.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.test.ts
@@ -6,15 +6,19 @@ import { Effect } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
 import {
     buildOpportunityRows,
-    hookBasenameFromArtifactPath,
+    commandCarriesMarker,
+    hookOpportunityAddressed,
+    installedArtifactPath,
+    isCreditableHookInvocation,
     kebabNameFromArtifactPath,
     opportunityKey,
     overlapFilesMatch,
     parseOverlapFiles,
     parseSkillTriggerTool,
-    resolveGuidanceTargetPath,
     safeFileMtimeMs,
     triggerTokensFromCandidate,
+    type HookInvocationFact,
+    type HookOpportunityFact,
 } from "./derive-opportunities.ts";
 
 const runMtime = (absPath: string): Promise<number | null> =>
@@ -111,21 +115,6 @@ describe("kebabNameFromArtifactPath (C5a addressed-detector helper)", () => {
     });
 });
 
-describe("hookBasenameFromArtifactPath (hook-form addressed-detector helper)", () => {
-    test("returns the .sh basename", () => {
-        expect(hookBasenameFromArtifactPath("/Users/x/.claude/hooks/pre-bash-guard.sh"))
-            .toBe("pre-bash-guard.sh");
-        expect(hookBasenameFromArtifactPath("./hooks/my-hook.sh")).toBe("my-hook.sh");
-    });
-
-    test("returns null for null/empty/non-.sh paths", () => {
-        expect(hookBasenameFromArtifactPath(null)).toBeNull();
-        expect(hookBasenameFromArtifactPath("")).toBeNull();
-        expect(hookBasenameFromArtifactPath("/Users/x/.claude/hooks/script.py")).toBeNull();
-        expect(hookBasenameFromArtifactPath("/Users/x/.claude/hooks/")).toBeNull();
-    });
-});
-
 describe("parseSkillTriggerTool", () => {
     test("extracts the tool name from a tool=<Name> pattern", () => {
         expect(parseSkillTriggerTool("tool=Bash")).toBe("Bash");
@@ -137,27 +126,6 @@ describe("parseSkillTriggerTool", () => {
         expect(parseSkillTriggerTool("garbage")).toBeNull();
         expect(parseSkillTriggerTool("")).toBeNull();
         expect(parseSkillTriggerTool("cmd=foo")).toBeNull();
-    });
-});
-
-describe("resolveGuidanceTargetPath", () => {
-    const home = "/Users/test";
-
-    test("expands bare CLAUDE.md / AGENTS.md to <home>/.claude/<file>", () => {
-        expect(resolveGuidanceTargetPath("CLAUDE.md", home)).toBe("/Users/test/.claude/CLAUDE.md");
-        expect(resolveGuidanceTargetPath("AGENTS.md", home)).toBe("/Users/test/.claude/AGENTS.md");
-    });
-
-    test("expands ~/ prefix to home", () => {
-        expect(resolveGuidanceTargetPath("~/.claude/CLAUDE.md", home)).toBe("/Users/test/.claude/CLAUDE.md");
-    });
-
-    test("leaves absolute paths unchanged", () => {
-        expect(resolveGuidanceTargetPath("/etc/foo", home)).toBe("/etc/foo");
-    });
-
-    test("leaves other relative paths unchanged", () => {
-        expect(resolveGuidanceTargetPath("docs/notes.md", home)).toBe("docs/notes.md");
     });
 });
 
@@ -182,5 +150,134 @@ describe("safeFileMtimeMs", () => {
         } finally {
             await rm(dir, { recursive: true, force: true });
         }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// F02 (#1133): observed artifact identity
+// ---------------------------------------------------------------------------
+
+const invocation = (over: Partial<HookInvocationFact> = {}): HookInvocationFact => ({
+    session: "session-1",
+    ts: "2026-05-25T00:00:00.000Z",
+    command: "echo 'ax:74da7418' && bun ~/.ax/hooks/enforce-worktree.ts",
+    event_name: "PreToolUse",
+    tool_call: null,
+    tool_call_id: null,
+    effect: "blocked",
+    provider_status: "blocking_error",
+    ...over,
+});
+
+const opportunity = (over: Partial<HookOpportunityFact> = {}): HookOpportunityFact => ({
+    id: "tool-call-1",
+    session: "session-1",
+    call_id: null,
+    ts: "2026-05-25T00:00:00.000Z",
+    ...over,
+});
+
+describe("installedArtifactPath", () => {
+    test("returns the recorded path", () => {
+        expect(installedArtifactPath("/repo/.claude/settings.json")).toBe("/repo/.claude/settings.json");
+    });
+
+    test("null for a missing or blank path - never a guessed global file", () => {
+        expect(installedArtifactPath(null)).toBeNull();
+        expect(installedArtifactPath("")).toBeNull();
+        expect(installedArtifactPath("   ")).toBeNull();
+        expect(installedArtifactPath("CLAUDE.md")).toBe("CLAUDE.md");
+    });
+});
+
+describe("commandCarriesMarker", () => {
+    test("matches the complete installed marker id in any command shape", () => {
+        expect(commandCarriesMarker("echo 'ax:74da7418' && bash guard.sh", "74da7418")).toBe(true);
+        expect(commandCarriesMarker("python3 ~/.ax/hooks/guard.py # ax:74da7418", "74da7418")).toBe(true);
+        expect(commandCarriesMarker("node ./guard.js --sig ax:74da7418", "74da7418")).toBe(true);
+        expect(commandCarriesMarker("bun ~/.ax/hooks/dispatch.ts # ax:74da7418", "74da7418")).toBe(true);
+        expect(commandCarriesMarker("ax:74da7418", "74da7418")).toBe(true);
+    });
+
+    test("a shared prefix is not the same identity", () => {
+        expect(commandCarriesMarker("echo 'ax:74da7418ff' && bash guard.sh", "74da7418")).toBe(false);
+        expect(commandCarriesMarker("echo 'ax:74da7418' && bash guard.sh", "74da7418ff")).toBe(false);
+        expect(commandCarriesMarker("echo 'ax:74da' && bash guard.sh", "74da7418")).toBe(false);
+    });
+
+    test("no marker at all is not a match", () => {
+        expect(commandCarriesMarker("bash /Users/x/.claude/hooks/74da7418.sh", "74da7418")).toBe(false);
+        expect(commandCarriesMarker("", "74da7418")).toBe(false);
+        expect(commandCarriesMarker("echo 'ax:74da7418'", "")).toBe(false);
+    });
+
+    test("picks the right one when two markers share a prefix", () => {
+        const command = "echo 'ax:74da7418' && echo 'ax:74da7418ff' && bash guard.sh";
+        expect(commandCarriesMarker(command, "74da7418")).toBe(true);
+        expect(commandCarriesMarker(command, "74da7418ff")).toBe(true);
+        expect(commandCarriesMarker(command, "74da74")).toBe(false);
+    });
+});
+
+describe("isCreditableHookInvocation", () => {
+    const identity = { dedupeSig: "74da7418", eventName: "PreToolUse" };
+
+    test("credits a real-effect fire carrying the installed marker", () => {
+        expect(isCreditableHookInvocation(invocation(), identity)).toBe(true);
+        expect(isCreditableHookInvocation(invocation({ effect: "injected_context", provider_status: "success" }), identity)).toBe(true);
+        expect(isCreditableHookInvocation(invocation({ effect: "modified_input", provider_status: "success" }), identity)).toBe(true);
+        expect(isCreditableHookInvocation(invocation({ effect: "notified", provider_status: "success" }), identity)).toBe(true);
+    });
+
+    test("rejects a different configured event name", () => {
+        expect(isCreditableHookInvocation(invocation({ event_name: "PostToolUse" }), identity)).toBe(false);
+    });
+
+    test("rejects progress_only, no_op, unknown and allowed records", () => {
+        expect(isCreditableHookInvocation(invocation({ provider_status: "progress_only" }), identity)).toBe(false);
+        expect(isCreditableHookInvocation(invocation({ effect: "no_op", provider_status: "success" }), identity)).toBe(false);
+        expect(isCreditableHookInvocation(invocation({ effect: "unknown", provider_status: "success" }), identity)).toBe(false);
+        expect(isCreditableHookInvocation(invocation({ effect: "allowed", provider_status: "success" }), identity)).toBe(false);
+    });
+
+    test("rejects a command without the installed marker identity", () => {
+        expect(isCreditableHookInvocation(invocation({ command: "bash /Users/x/.claude/hooks/guard.sh" }), identity)).toBe(false);
+        expect(isCreditableHookInvocation(invocation({ command: "echo 'ax:74da7418ff' && bash guard.sh" }), identity)).toBe(false);
+    });
+});
+
+describe("hookOpportunityAddressed", () => {
+    test("exact tool_call identity credits only its own call", () => {
+        const fires = [invocation({ tool_call: "tool-call-1" })];
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-1" }), fires)).toBe(true);
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-2" }), fires)).toBe(false);
+    });
+
+    test("exact tool_call_id identity credits only its own call", () => {
+        const fires = [invocation({ tool_call_id: "toolu_1" })];
+        expect(hookOpportunityAddressed(opportunity({ call_id: "toolu_1" }), fires)).toBe(true);
+        expect(hookOpportunityAddressed(opportunity({ call_id: "toolu_2" }), fires)).toBe(false);
+    });
+
+    test("does not fall back to the window when the fire carries tool-call identity", () => {
+        const fires = [invocation({ tool_call: "tool-call-9" })];
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-1" }), fires)).toBe(false);
+    });
+
+    test("falls back to the time window inside the same session when neither record has identity", () => {
+        const fires = [invocation({ ts: "2026-05-25T00:30:00.000Z" })];
+        expect(hookOpportunityAddressed(opportunity(), fires)).toBe(true);
+        expect(hookOpportunityAddressed(opportunity({ ts: "2026-05-25T04:00:00.000Z" }), fires)).toBe(false);
+    });
+
+    test("never credits across sessions", () => {
+        const fires = [invocation({ session: "session-2", tool_call: "tool-call-1" })];
+        expect(hookOpportunityAddressed(opportunity({ id: "tool-call-1" }), fires)).toBe(false);
+        expect(hookOpportunityAddressed(opportunity(), [invocation({ session: "session-2" })])).toBe(false);
+        expect(hookOpportunityAddressed(opportunity({ session: null }), [invocation({ session: null })])).toBe(false);
+    });
+
+    test("no fires at all is not addressed", () => {
+        expect(hookOpportunityAddressed(opportunity(), [])).toBe(false);
     });
 });

--- a/apps/axctl/src/ingest/derive-opportunities.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.ts
@@ -12,25 +12,38 @@
  *  - skill (retro-derived, no skill_candidate): trigger_pattern fallback,
  *    matches failing tool_call rows for the named tool.
  *  - hook: failing tool_call rows for hook_proposal.target_tool;
- *    was_addressed if a hook_command_invocation referencing the scaffold's
- *    basename fired within ±ADDRESSED_WINDOW_MS.
- *  - guidance: friction_event rows of kind='correction'; was_addressed if
- *    the target file's mtime is later than the opportunity's matched_at.
+ *    was_addressed if a hook_command_invocation carrying the experiment's
+ *    COMPLETE `ax:<dedupe_sig>` marker, on the configured event, with a real
+ *    effect, correlates to the failing call (exact tool-call identity first,
+ *    ±ADDRESSED_WINDOW_MS inside the same session only as a fallback).
+ *  - guidance: friction_event rows of kind='correction'; was_addressed if the
+ *    OBSERVED artifact's (experiment.artifact_path) mtime is later than the
+ *    opportunity's matched_at - file activity, not proof of better behaviour.
  *  - automation/subagent: explicitly skipped pending detectors.
+ *
+ * Artifact identity comes from what `improve lint` RECORDED (#1133), never from
+ * a path guessed off the proposal. An experiment with no recorded artifact /
+ * install time has UNAVAILABLE evidence: it contributes no rows, and its stale
+ * ones are cleared rather than left to read as "not addressed".
+ *
+ * Measurement starts at `experiment.scaffolded_at` (the observed install),
+ * because acceptance can precede installation by days.
  *
  * The opportunity row is a RELATION (in=experiment, out=evidence record).
  * Edge id = sha-style key over (experimentKey, evidenceKey) so re-derive
- * passes are idempotent.
+ * passes are idempotent; every selected experiment's rows are REBUILT each run
+ * so a match the corrected rules drop cannot survive as a stale row.
  */
 
 import { Effect, FileSystem, Option, Schema } from "effect";
 import { jsonArrayField } from "@ax/lib/decode";
-import { homedir } from "node:os";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { cacheRow, tsParam } from "@ax/lib/duckdb/row";
 import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { Judgment, JudgmentError } from "@ax/lib/sqlite";
 import { listStoredProposals } from "../improve/judgment-proposals.ts";
+import { parseHookCommandMarkers } from "../improve/markers.ts";
+import { REAL_HOOK_EFFECTS } from "./transcripts.ts";
 import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
 
 export interface DeriveOpportunitiesStats {
@@ -40,6 +53,10 @@ export interface DeriveOpportunitiesStats {
     readonly bySkillForm: number;
     readonly byHookForm: number;
     readonly byGuidanceForm: number;
+    /** Experiments whose installed artifact could not be resolved - no recorded
+     *  `artifact_path` / `scaffolded_at`, so their evidence is UNAVAILABLE
+     *  rather than negative. Their stale rows are cleared, not kept. */
+    readonly artifactUnavailable: number;
 }
 
 /**
@@ -53,6 +70,9 @@ export interface DeriveOpportunitiesStats {
  */
 export const ADDRESSED_WINDOW_MS = 60 * 60 * 1000;
 
+/** Bound the `IN (...)` list of the per-experiment rebuild delete. */
+const DELETE_CHUNK = 200;
+
 export const kebabNameFromArtifactPath = (path: string | null): string | null => {
     if (!path) return null;
     const parts = path.split("/").filter(Boolean);
@@ -63,14 +83,102 @@ export const kebabNameFromArtifactPath = (path: string | null): string | null =>
 };
 
 /**
- * Extract the hook script basename from an experiment's artifact_path,
- * e.g. `/Users/x/.claude/hooks/pre-bash-guard.sh` → `pre-bash-guard.sh`.
- * Returns null for empty/non-.sh paths.
+ * The artifact ax OBSERVED being installed - `experiment.artifact_path`, written
+ * by `improve lint` (lint.ts) when it reconciles the marker it actually found on
+ * disk. A blank/absent value means nothing was reconciled yet: the caller reports
+ * unavailable artifact evidence rather than guessing a path from the proposal
+ * (a guessed `<basename>.sh` misses python/node/bun/inline hooks, and a bare
+ * `CLAUDE.md` expanded to `~/.claude/CLAUDE.md` measures a DIFFERENT file that
+ * merely shares a basename).
  */
-export const hookBasenameFromArtifactPath = (path: string | null): string | null => {
-    if (!path) return null;
-    const last = path.split("/").pop();
-    return last && last.endsWith(".sh") ? last : null;
+export const installedArtifactPath = (path: string | null): string | null => {
+    const trimmed = path?.trim() ?? "";
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+/**
+ * Does this hook command carry the experiment's installed marker identity?
+ *
+ * The task template installs `ax:<dedupe_sig>` INSIDE the configured command,
+ * and every producer path preserves the command verbatim (progress line,
+ * `hook_success` attachment, and the command recovered from a blocked
+ * tool_result), so the marker survives into `hook_command_invocation.command`.
+ *
+ * Identity is COMPLETE-id equality through the shared marker parser, never a
+ * SQL substring: `ax:74da7418` and `ax:74da7418ff` are different experiments,
+ * and a shell filename that happens to contain the signature is not a marker.
+ */
+export const commandCarriesMarker = (command: string, dedupeSig: string): boolean => {
+    if (dedupeSig.length === 0) return false;
+    return parseHookCommandMarkers(command).some((marker) => marker.id === dedupeSig);
+};
+
+/** The `hook_command_invocation` columns the hook detector reads. */
+export interface HookInvocationFact {
+    readonly session: string | null;
+    readonly ts: string;
+    readonly command: string;
+    readonly event_name: string;
+    /** ref -> tool_call.id (the row key), when the harness named the call. */
+    readonly tool_call: string | null;
+    /** The provider's own tool-use id, comparable to `tool_call.call_id`. */
+    readonly tool_call_id: string | null;
+    readonly effect: string;
+    readonly provider_status: string;
+}
+
+/** The `tool_call` columns the hook detector correlates against. */
+export interface HookOpportunityFact {
+    readonly id: string;
+    readonly session: string | null;
+    readonly call_id: string | null;
+    readonly ts: string;
+}
+
+/**
+ * Is this fire evidence that THIS experiment's hook ran with a real effect?
+ *
+ * Three independent gates, all required: the installed marker identity, the
+ * configured event name, and a real effect. `progress_only` records are a
+ * mid-flight status line rather than an outcome, and `no_op`/`unknown`/`allowed`
+ * are fires with no observed consequence - none of them is an intervention.
+ * A hook that passes SILENTLY is written nowhere by the harness, so it stays
+ * unmeasured; presence of the configuration is not evidence that it ran.
+ */
+export const isCreditableHookInvocation = (
+    invocation: HookInvocationFact,
+    identity: { readonly dedupeSig: string; readonly eventName: string },
+): boolean =>
+    invocation.provider_status !== "progress_only"
+    && REAL_HOOK_EFFECTS.includes(invocation.effect as (typeof REAL_HOOK_EFFECTS)[number])
+    && invocation.event_name === identity.eventName
+    && commandCarriesMarker(invocation.command, identity.dedupeSig);
+
+/**
+ * Did a creditable fire address this failing tool call?
+ *
+ * Same session always (a fire in another run says nothing about this one). Then
+ * exact tool-call correlation is PREFERRED: when the fire names a call - either
+ * the `tool_call` row ref or the provider's `tool_call_id` - it credits that one
+ * call and no other. The ±{@link ADDRESSED_WINDOW_MS} window survives only as
+ * the fallback for fires the harness recorded without any call identity.
+ */
+export const hookOpportunityAddressed = (
+    call: HookOpportunityFact,
+    invocations: readonly HookInvocationFact[],
+    windowMs: number = ADDRESSED_WINDOW_MS,
+): boolean => {
+    const callMs = new Date(call.ts).getTime();
+    return invocations.some((invocation) => {
+        if (!call.session || !invocation.session || call.session !== invocation.session) return false;
+        if (invocation.tool_call !== null) return invocation.tool_call === call.id;
+        if (invocation.tool_call_id !== null && call.call_id !== null) {
+            return invocation.tool_call_id === call.call_id;
+        }
+        const fireMs = new Date(invocation.ts).getTime();
+        if (!Number.isFinite(callMs) || !Number.isFinite(fireMs)) return false;
+        return Math.abs(fireMs - callMs) <= windowMs;
+    });
 };
 
 /**
@@ -82,25 +190,17 @@ export const parseSkillTriggerTool = (pattern: string): string | null => {
     return m && m[1] ? m[1].trim() : null;
 };
 
-/**
- * Resolve a guidance_proposal.file_target to an absolute filesystem path.
- * - "CLAUDE.md" / "AGENTS.md" → `<home>/.claude/<file>`
- * - "~/foo" → `<home>/foo`
- * - absolute paths returned unchanged
- * - anything else returned unchanged (caller defends against stat failure)
- */
-export const resolveGuidanceTargetPath = (target: string, home: string): string => {
-    const t = target.trim();
-    if (t.startsWith("/")) return t;
-    if (t.startsWith("~/")) return `${home}/${t.slice(2)}`;
-    if (t === "CLAUDE.md" || t === "AGENTS.md") return `${home}/.claude/${t}`;
-    return t;
-};
-
 interface ActiveExperimentRow {
     readonly id: string | { tb: string; id: string };
     readonly created_at: string;
+    /** When `improve lint` OBSERVED the artifact installed - the earliest time a
+     *  measurement can mean anything. Null until lint has reconciled the marker
+     *  (acceptance can precede installation by days). */
+    readonly scaffolded_at: string | null;
     readonly form: string;
+    /** The proposal's `ax:<dedupe_sig>` marker identity, installed inside the
+     *  hook command by the task template. */
+    readonly dedupe_sig: string;
     readonly candidate_id: string | { tb: string; id: string } | null;
     readonly artifact_path: string | null;
     readonly skill_trigger: string | null;
@@ -125,12 +225,13 @@ interface ToolCallRow {
     readonly ts: string;
 }
 
-interface FrictionEventRow {
-    readonly id: string | { tb: string; id: string };
-    readonly ts: string;
+interface HookToolCallRow extends ToolCallRow {
+    readonly session: string | null;
+    readonly call_id: string | null;
 }
 
-interface HookInvocationTsRow {
+interface FrictionEventRow {
+    readonly id: string | { tb: string; id: string };
     readonly ts: string;
 }
 
@@ -264,7 +365,9 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             return {
                 id: experiment.id,
                 created_at: experiment.created_at.toISOString(),
+                scaffolded_at: experiment.scaffolded_at?.toISOString() ?? null,
                 form: proposal.form,
+                dedupe_sig: proposal.dedupe_sig,
                 artifact_path: experiment.artifact_path,
                 candidate_id: candidateByProposal.get(proposal.id) ?? null,
                 skill_trigger: proposal.skill_payload?.trigger_pattern ?? null,
@@ -284,13 +387,16 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
         let bySkillForm = 0;
         let byHookForm = 0;
         let byGuidanceForm = 0;
+        let artifactUnavailable = 0;
+        // Every experiment this run SELECTED gets its derived rows rebuilt, so a
+        // `was_addressed` computed by the old matching rules cannot outlive them.
+        const rebuiltExperimentKeys: string[] = [];
         const allRows: Array<Record<string, import("@ax/lib/duckdb/types").DuckDbParam>> = [];
-
-        const home = homedir();
 
         for (const exp of experiments) {
             const experimentKey = recordKeyPart(exp.id, "experiment");
             if (!experimentKey) continue;
+            rebuiltExperimentKeys.push(experimentKey);
             const form = exp.form;
 
             // -------- skill form (legacy: closure-derived via skill_candidate) --------
@@ -400,41 +506,68 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             // -------- hook form --------
             if (form === "hook") {
                 const tool = exp.hook_payload?.target_tool ?? null;
+                const eventName = exp.hook_payload?.event_name ?? null;
                 if (!tool) continue;
 
+                // The identity a fire has to carry to be THIS hook. Without an
+                // installed marker + a configured event + an observed install
+                // time there is nothing to match on: the hook is UNMEASURED, not
+                // unaddressed, so its stale rows go and no new ones land. The
+                // executable is never guessed from the proposal - a wrapper, a
+                // python/node/bun script and an inline command all look the same
+                // from here, and only the marker distinguishes them.
+                const installedAt = exp.scaffolded_at;
+                if (!eventName || exp.dedupe_sig.length === 0 || installedAt === null) {
+                    artifactUnavailable += 1;
+                    continue;
+                }
+
                 const callsResult = yield* write.raw(`
-                    SELECT id, CAST(ts AS VARCHAR) AS ts
+                    SELECT id, session, call_id, CAST(ts AS VARCHAR) AS ts
                     FROM tool_call
                     WHERE name = ? AND has_error = true AND ts > ?`, [tool, new Date(exp.created_at)]);
-                const calls = callsResult.rows as unknown as ToolCallRow[];
-                const matches: Array<{ evidenceTable: string; evidenceKey: string; ts: string }> = [];
+                const calls = callsResult.rows as unknown as HookToolCallRow[];
+                const matches: Array<{
+                    evidenceTable: string;
+                    evidenceKey: string;
+                    ts: string;
+                    call: HookOpportunityFact;
+                }> = [];
                 for (const c of calls) {
                     const evidenceKey = recordKeyPart(c.id, "tool_call");
                     if (!evidenceKey) continue;
-                    matches.push({ evidenceTable: "tool_call", evidenceKey, ts: c.ts });
+                    matches.push({
+                        evidenceTable: "tool_call",
+                        evidenceKey,
+                        ts: c.ts,
+                        call: { id: evidenceKey, session: c.session, call_id: c.call_id, ts: c.ts },
+                    });
                 }
                 if (matches.length === 0) continue;
 
-                // was_addressed: any hook_command_invocation whose command
-                // references the scaffold basename, near the failing call.
-                const basename = hookBasenameFromArtifactPath(exp.artifact_path);
-                let invocationTimestamps: number[] = [];
-                if (basename) {
-                    const invResult = yield* write.raw(`
-                        SELECT CAST(ts AS VARCHAR) AS ts
-                        FROM hook_command_invocation
-                        WHERE command LIKE ? AND ts > ?`, [`%${basename}%`, new Date(exp.created_at)]);
-                    invocationTimestamps = (invResult.rows as unknown as HookInvocationTsRow[])
-                        .map((r) => new Date(r.ts).getTime())
-                        .filter((t) => Number.isFinite(t));
-                }
+                // was_addressed: a hook_command_invocation recorded AFTER the
+                // install, carrying this experiment's complete marker id, on the
+                // configured event, with a real effect. Marker identity is
+                // matched in JS through the shared parser - a SQL substring would
+                // credit a prefix collision or a filename that merely contains
+                // the signature.
+                const invResult = yield* write.raw(`
+                    SELECT session, CAST(ts AS VARCHAR) AS ts, command, event_name,
+                           tool_call, tool_call_id, effect, provider_status
+                    FROM hook_command_invocation
+                    WHERE ts > ? AND event_name = ? AND provider_status <> 'progress_only'
+                      AND effect IN (${REAL_HOOK_EFFECTS.map(() => "?").join(", ")})`,
+                    [new Date(installedAt), eventName, ...REAL_HOOK_EFFECTS]);
+                const fires = (invResult.rows as unknown as HookInvocationFact[]).filter(
+                    (invocation) => isCreditableHookInvocation(invocation, {
+                        dedupeSig: exp.dedupe_sig,
+                        eventName,
+                    }),
+                );
                 const enriched = matches.map((m) => {
-                    const matchedMs = new Date(m.ts).getTime();
-                    const addressed = invocationTimestamps.some(
-                        (t) => Math.abs(t - matchedMs) <= ADDRESSED_WINDOW_MS,
-                    );
+                    const addressed = hookOpportunityAddressed(m.call, fires);
                     if (addressed) totalAddressed += 1;
-                    return { ...m, addressed };
+                    return { evidenceTable: m.evidenceTable, evidenceKey: m.evidenceKey, ts: m.ts, addressed };
                 });
 
                 totalOpportunities += matches.length;
@@ -445,15 +578,26 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
             // -------- guidance form --------
             if (form === "guidance") {
-                const target = exp.guidance_payload?.file_target ?? null;
-                if (!target) continue;
+                // The file lint OBSERVED the marker in, not the proposal's
+                // `file_target`. A bare `CLAUDE.md` in a proposal must never be
+                // read as `~/.claude/CLAUDE.md`: that is a DIFFERENT file that
+                // merely shares a basename, and its mtime says nothing about
+                // this experiment. No recorded path (or no observed install
+                // time) = unavailable artifact evidence; the user has to run
+                // `ax improve lint` in the target repository first.
+                const artifactPath = installedArtifactPath(exp.artifact_path);
+                const installedAt = exp.scaffolded_at;
+                if (artifactPath === null || installedAt === null) {
+                    artifactUnavailable += 1;
+                    continue;
+                }
 
-                // Cheap initial wedge: every recent correction friction_event
-                // is one opportunity for the guidance to have prevented.
+                // Cheap initial wedge: every correction friction_event AFTER the
+                // install is one opportunity for the guidance to have prevented.
                 const frictionResult = yield* write.raw(`
                     SELECT id, CAST(ts AS VARCHAR) AS ts
                     FROM friction_event
-                    WHERE kind = 'correction' AND ts > ?`, [new Date(exp.created_at)]);
+                    WHERE kind = 'correction' AND ts > ?`, [new Date(installedAt)]);
                 const events = frictionResult.rows as unknown as FrictionEventRow[];
                 const matches: Array<{ evidenceTable: string; evidenceKey: string; ts: string }> = [];
                 for (const ev of events) {
@@ -463,11 +607,12 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 }
                 if (matches.length === 0) continue;
 
-                // was_addressed: target file mtime > matched_at. The file
-                // either has been touched post-accept (every later
-                // opportunity addressed) or not. Defensive: stat may fail.
-                const absPath = resolveGuidanceTargetPath(target, home);
-                const mtimeMs = yield* safeFileMtimeMs(absPath);
+                // was_addressed: the recorded artifact's mtime > matched_at.
+                // This is FILE ACTIVITY on the installed guidance file, not
+                // proof that behaviour improved - the indicator is kept as-is
+                // for this bounded patch, only pointed at the right file.
+                // Defensive: stat may fail.
+                const mtimeMs = yield* safeFileMtimeMs(artifactPath);
                 const enriched = matches.map((m) => {
                     const matchedMs = new Date(m.ts).getTime();
                     const addressed = mtimeMs !== null && mtimeMs > matchedMs;
@@ -484,6 +629,19 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             // automation + subagent forms: detectors deferred to follow-up.
         }
 
+        // Rebuild, don't accumulate: an opportunity the corrected identity rules
+        // no longer match must DISAPPEAR, and a `was_addressed` computed by the
+        // old rules must not stay authoritative. Only the experiments this run
+        // selected are cleared - unrelated experiments (and every sidecar
+        // judgment) are untouched. Same write service, same held lock, so the
+        // delete and the insert land together.
+        for (let i = 0; i < rebuiltExperimentKeys.length; i += DELETE_CHUNK) {
+            const chunk = rebuiltExperimentKeys.slice(i, i + DELETE_CHUNK);
+            yield* write.exec(
+                `DELETE FROM opportunity WHERE in_id IN (${chunk.map(() => "?").join(", ")})`,
+                chunk,
+            );
+        }
         yield* write.putMany("opportunity", allRows);
         return {
             experimentsScanned: experiments.length,
@@ -492,6 +650,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             bySkillForm,
             byHookForm,
             byGuidanceForm,
+            artifactUnavailable,
         };
     });
 
@@ -524,9 +683,12 @@ export const opportunitiesStage: StageDef<
         Effect.gen(function* () {
             const t0 = Date.now();
             const result = yield* deriveOpportunities(write);
+            const unavailable = result.artifactUnavailable > 0
+                ? `, ${result.artifactUnavailable} without installed-artifact evidence (run \`ax improve lint\` in the target repo)`
+                : "";
             return OpportunitiesStats.make({
                 durationMs: Date.now() - t0,
-                summary: `scanned ${result.experimentsScanned} experiments, derived ${result.opportunities} opportunities`,
+                summary: `scanned ${result.experimentsScanned} experiments, derived ${result.opportunities} opportunities${unavailable}`,
                 experimentsScanned: result.experimentsScanned,
                 opportunities: result.opportunities,
             });

--- a/apps/axctl/src/ingest/derive-opportunities.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.ts
@@ -32,18 +32,28 @@
  * The opportunity row is a RELATION (in=experiment, out=evidence record).
  * Edge id = sha-style key over (experimentKey, evidenceKey) so re-derive
  * passes are idempotent; every selected experiment's rows are REBUILT each run
- * so a match the corrected rules drop cannot survive as a stale row.
+ * so a match the corrected rules drop cannot survive as a stale row. The
+ * rebuild is one atomic MERGE per experiment (ingest holds no transaction), and
+ * a completed pass stamps the derivation-version sentinel that tells a
+ * checkpoint reader these rows came from the corrected rules
+ * (`opportunity-cache-version.ts`).
  */
 
 import { Effect, FileSystem, Option, Schema } from "effect";
 import { jsonArrayField } from "@ax/lib/decode";
 import { orAbsent } from "@ax/lib/shared/fs-error";
-import { cacheRow, tsParam } from "@ax/lib/duckdb/row";
+import { tsParam } from "@ax/lib/duckdb/row";
 import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { Judgment, JudgmentError } from "@ax/lib/sqlite";
 import { listStoredProposals } from "../improve/judgment-proposals.ts";
 import { parseHookCommandMarkers } from "../improve/markers.ts";
-import { REAL_HOOK_EFFECTS } from "./transcripts.ts";
+import { REAL_HOOK_EFFECTS, isRealHookEffect } from "@ax/lib/shared/hook-effects";
+import { WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
+import {
+    OPPORTUNITY_VERSION,
+    OPPORTUNITY_VERSION_PATH,
+    OPPORTUNITY_VERSION_SOURCE,
+} from "./opportunity-cache-version.ts";
 import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
 
 export interface DeriveOpportunitiesStats {
@@ -69,9 +79,6 @@ export interface DeriveOpportunitiesStats {
  * land asynchronously.
  */
 export const ADDRESSED_WINDOW_MS = 60 * 60 * 1000;
-
-/** Bound the `IN (...)` list of the per-experiment rebuild delete. */
-const DELETE_CHUNK = 200;
 
 export const kebabNameFromArtifactPath = (path: string | null): string | null => {
     if (!path) return null;
@@ -150,7 +157,7 @@ export const isCreditableHookInvocation = (
     identity: { readonly dedupeSig: string; readonly eventName: string },
 ): boolean =>
     invocation.provider_status !== "progress_only"
-    && REAL_HOOK_EFFECTS.includes(invocation.effect as (typeof REAL_HOOK_EFFECTS)[number])
+    && isRealHookEffect(invocation.effect)
     && invocation.event_name === identity.eventName
     && commandCarriesMarker(invocation.command, identity.dedupeSig);
 
@@ -172,8 +179,12 @@ export const hookOpportunityAddressed = (
     return invocations.some((invocation) => {
         if (!call.session || !invocation.session || call.session !== invocation.session) return false;
         if (invocation.tool_call !== null) return invocation.tool_call === call.id;
-        if (invocation.tool_call_id !== null && call.call_id !== null) {
-            return invocation.tool_call_id === call.call_id;
+        // A NAMED fire credits the call it names and nothing else. When the call
+        // it points at carries no comparable id, the answer is "not this one" -
+        // falling through to the window here would let a fire that named some
+        // other call credit a call of unknown identity.
+        if (invocation.tool_call_id !== null) {
+            return call.call_id !== null && invocation.tool_call_id === call.call_id;
         }
         const fireMs = new Date(invocation.ts).getTime();
         if (!Number.isFinite(callMs) || !Number.isFinite(fireMs)) return false;
@@ -266,6 +277,22 @@ export const overlapFilesMatch = (
     return false;
 };
 
+/**
+ * One `opportunity` row as the atomic replacement sees it.
+ *
+ * `in_id` is deliberately ABSENT: the replacement statement derives it from the
+ * bound experiment id, so a row can never claim to belong to another experiment
+ * and reach past this experiment's scope.
+ */
+export interface OpportunityReplacementRow {
+    readonly id: string;
+    readonly out_id: string;
+    readonly out_table: string;
+    /** ISO-8601; the statement casts it to TIMESTAMP. */
+    readonly matched_at: string;
+    readonly was_addressed: boolean;
+}
+
 export const buildOpportunityRows = (
     experimentKey: string,
     matches: ReadonlyArray<{
@@ -274,16 +301,89 @@ export const buildOpportunityRows = (
         readonly ts: string;
         readonly addressed?: boolean;
     }>,
-): Array<Record<string, import("@ax/lib/duckdb/types").DuckDbParam>> => {
-    const rows: Array<Record<string, import("@ax/lib/duckdb/types").DuckDbParam>> = [];
+): OpportunityReplacementRow[] => {
+    const rows: OpportunityReplacementRow[] = [];
     for (const m of matches) {
-        const edgeKey = opportunityKey(experimentKey, m.evidenceKey);
-        rows.push(cacheRow({ id: edgeKey, in_id: experimentKey, out_id: m.evidenceKey,
-            out_table: m.evidenceTable, matched_at: tsParam(m.ts) ?? new Date(),
-            was_addressed: m.addressed ?? false }));
+        rows.push({
+            id: opportunityKey(experimentKey, m.evidenceKey),
+            out_id: m.evidenceKey,
+            out_table: m.evidenceTable,
+            matched_at: (tsParam(m.ts) ?? new Date()).toISOString(),
+            was_addressed: m.addressed ?? false,
+        });
     }
     return rows;
 };
+
+/**
+ * Replace exactly one experiment's derived rows, in ONE statement.
+ *
+ * The seam runs ingest WITHOUT a transaction (see `seam.ts`), so a
+ * `DELETE`-then-`INSERT` pair has a real window in which the experiment has lost
+ * its old rows and not yet gained its new ones - and if the insert fails, that
+ * window becomes the published state. DuckDB applies a `MERGE` as one statement:
+ * inserts, updates and the scoped delete either all land or none do, and a
+ * failure leaves every previous row exactly as it was.
+ *
+ * The delete arm is bounded by `target.in_id = ?`, so it can only ever remove
+ * rows of the experiment being replaced; every other experiment is untouched.
+ * An empty `rows` array is a meaningful call - it clears this experiment.
+ */
+export const REPLACE_OPPORTUNITIES_SQL = `
+MERGE INTO opportunity AS target
+USING (
+    SELECT
+        CAST(? AS VARCHAR) AS in_id,
+        value ->> 'id' AS id,
+        value ->> 'out_id' AS out_id,
+        value ->> 'out_table' AS out_table,
+        CAST(value ->> 'matched_at' AS TIMESTAMP) AS matched_at,
+        CAST(value ->> 'was_addressed' AS BOOLEAN) AS was_addressed
+    FROM json_each(CAST(? AS JSON))
+) AS source
+ON target.id = source.id AND target.in_id = source.in_id
+WHEN MATCHED THEN UPDATE SET
+    out_id = source.out_id,
+    out_table = source.out_table,
+    matched_at = source.matched_at,
+    was_addressed = source.was_addressed
+WHEN NOT MATCHED THEN INSERT
+    (id, in_id, out_id, out_table, matched_at, was_addressed)
+    VALUES (source.id, source.in_id, source.out_id, source.out_table, source.matched_at, source.was_addressed)
+WHEN NOT MATCHED BY SOURCE AND target.in_id = CAST(? AS VARCHAR) THEN DELETE
+`;
+
+/** Duplicate ids inside one replacement have ambiguous MERGE semantics, so they
+ *  are rejected BEFORE the statement rather than left to a cryptic engine error.
+ *  Ids come from {@link opportunityKey}, so a duplicate means two evidence rows
+ *  collided on a key - a bug worth failing loudly on, never one to dedupe away. */
+const duplicateRowId = (rows: readonly OpportunityReplacementRow[]): string | null => {
+    const seen = new Set<string>();
+    for (const row of rows) {
+        if (seen.has(row.id)) return row.id;
+        seen.add(row.id);
+    }
+    return null;
+};
+
+export const replaceOpportunities = (
+    write: CacheWriteService,
+    experimentKey: string,
+    rows: readonly OpportunityReplacementRow[],
+): Effect.Effect<void, CacheWriteError | CacheReadError> =>
+    Effect.gen(function* () {
+        const duplicate = duplicateRowId(rows);
+        if (duplicate !== null) {
+            return yield* Effect.die(
+                new Error(`opportunity replacement for ${experimentKey} repeats row id ${duplicate}`),
+            );
+        }
+        yield* write.raw(REPLACE_OPPORTUNITIES_SQL, [
+            experimentKey,
+            JSON.stringify(rows),
+            experimentKey,
+        ]);
+    });
 
 interface SkillIdRow {
     readonly id: string | { tb: string; id: string };
@@ -294,11 +394,20 @@ interface InvokedTsRow {
 }
 
 /**
- * Best-effort file mtime in epoch-ms, or `null` when the file is absent /
- * unreadable. OLD: `statSync` in try/catch returning `null` on ANY fault →
- * `orAbsent` (a missing or unreadable guidance target is "not addressed").
- * `fs.stat` follows symlinks (matching node's `statSync`); `.mtime` is an
- * `Option<Date>`, so a stat that lands but lacks mtime also maps to `null`.
+ * The artifact's mtime in epoch-ms, or `null` when there is NO READING to be
+ * had: the path is absent, unreadable, carries no mtime, or is not a regular
+ * file. Every one of those means the evidence is UNAVAILABLE - not that the
+ * guidance went unaddressed - and the caller treats it that way.
+ *
+ * The file-type check is load-bearing. A guidance path can become a DIRECTORY
+ * (a `CLAUDE.md/` created by a stray `mkdir -p`, a checkout that reshaped the
+ * tree), and a directory's mtime moves whenever anything inside it is created
+ * or removed. Counting that as activity on the guidance file would manufacture
+ * `was_addressed = true` out of unrelated filesystem noise.
+ *
+ * `fs.stat` follows symlinks (matching node's `statSync`), so a symlink to a
+ * real file still reads as a file. `.mtime` is an `Option<Date>`, so a stat that
+ * lands but lacks one maps to `null` too.
  */
 export const safeFileMtimeMs = (
     absPath: string,
@@ -307,6 +416,7 @@ export const safeFileMtimeMs = (
         const fs = yield* FileSystem.FileSystem;
         const info = yield* fs.stat(absPath).pipe(Effect.asSome, orAbsent(Option.none()));
         if (Option.isNone(info)) return null;
+        if (info.value.type !== "File") return null;
         return Option.match(info.value.mtime, {
             onNone: () => null,
             onSome: (d) => d.getTime(),
@@ -333,6 +443,15 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
     Judgment | FileSystem.FileSystem
 > =>
     Effect.gen(function* () {
+        // FIRST, before any read or write: drop the version certificate. Ingest
+        // can continue past a failed stage and publish a partially changed
+        // cache, and such a snapshot must not keep an older pass's success
+        // marker. Nothing re-stamps it except a complete pass below.
+        yield* write.exec(
+            `DELETE FROM ${WATERMARK_TABLE} WHERE source_kind = ? AND path = ?`,
+            [OPPORTUNITY_VERSION_SOURCE, OPPORTUNITY_VERSION_PATH],
+        );
+
         // Active = accepted proposal + experiment without a locked verdict.
         // Both live in the sidecar, so this is the sidecar's own reader rather
         // than a join in SQL.
@@ -390,8 +509,10 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
         let artifactUnavailable = 0;
         // Every experiment this run SELECTED gets its derived rows rebuilt, so a
         // `was_addressed` computed by the old matching rules cannot outlive them.
+        // An experiment that computes NO rows still gets a replacement call: that
+        // is what clears rows the corrected rules no longer match.
         const rebuiltExperimentKeys: string[] = [];
-        const allRows: Array<Record<string, import("@ax/lib/duckdb/types").DuckDbParam>> = [];
+        const rowsByExperiment = new Map<string, OpportunityReplacementRow[]>();
 
         for (const exp of experiments) {
             const experimentKey = recordKeyPart(exp.id, "experiment");
@@ -447,7 +568,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
                 totalOpportunities += matches.length;
                 bySkillForm += matches.length;
-                allRows.push(...buildOpportunityRows(experimentKey, enriched));
+                rowsByExperiment.set(experimentKey, buildOpportunityRows(experimentKey, enriched));
                 continue;
             }
 
@@ -499,7 +620,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
                 totalOpportunities += matches.length;
                 bySkillForm += matches.length;
-                allRows.push(...buildOpportunityRows(experimentKey, enriched));
+                rowsByExperiment.set(experimentKey, buildOpportunityRows(experimentKey, enriched));
                 continue;
             }
 
@@ -522,10 +643,14 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     continue;
                 }
 
+                // Both sides of the match are windowed on the OBSERVED install:
+                // a call that failed before the hook existed was never an
+                // opportunity for it, and counting it would dilute the ratio
+                // with failures the hook could not have been present for.
                 const callsResult = yield* write.raw(`
                     SELECT id, session, call_id, CAST(ts AS VARCHAR) AS ts
                     FROM tool_call
-                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, new Date(exp.created_at)]);
+                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, new Date(installedAt)]);
                 const calls = callsResult.rows as unknown as HookToolCallRow[];
                 const matches: Array<{
                     evidenceTable: string;
@@ -572,7 +697,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
                 totalOpportunities += matches.length;
                 byHookForm += matches.length;
-                allRows.push(...buildOpportunityRows(experimentKey, enriched));
+                rowsByExperiment.set(experimentKey, buildOpportunityRows(experimentKey, enriched));
                 continue;
             }
 
@@ -611,18 +736,29 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 // This is FILE ACTIVITY on the installed guidance file, not
                 // proof that behaviour improved - the indicator is kept as-is
                 // for this bounded patch, only pointed at the right file.
-                // Defensive: stat may fail.
+                //
+                // No reading at all - the path is missing, unreadable, or is not
+                // a regular file any more - is UNAVAILABLE evidence, not a
+                // negative reading. Emitting `was_addressed = false` rows here
+                // would publish "the guidance was ignored" on the strength of a
+                // failed syscall or a directory's mtime. Clear this experiment's
+                // rows instead (`rowsByExperiment` stays unset, so the
+                // replacement below removes them) and report the gap.
                 const mtimeMs = yield* safeFileMtimeMs(artifactPath);
+                if (mtimeMs === null) {
+                    artifactUnavailable += 1;
+                    continue;
+                }
                 const enriched = matches.map((m) => {
                     const matchedMs = new Date(m.ts).getTime();
-                    const addressed = mtimeMs !== null && mtimeMs > matchedMs;
+                    const addressed = mtimeMs > matchedMs;
                     if (addressed) totalAddressed += 1;
                     return { ...m, addressed };
                 });
 
                 totalOpportunities += matches.length;
                 byGuidanceForm += matches.length;
-                allRows.push(...buildOpportunityRows(experimentKey, enriched));
+                rowsByExperiment.set(experimentKey, buildOpportunityRows(experimentKey, enriched));
                 continue;
             }
 
@@ -631,18 +767,24 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
         // Rebuild, don't accumulate: an opportunity the corrected identity rules
         // no longer match must DISAPPEAR, and a `was_addressed` computed by the
-        // old rules must not stay authoritative. Only the experiments this run
-        // selected are cleared - unrelated experiments (and every sidecar
-        // judgment) are untouched. Same write service, same held lock, so the
-        // delete and the insert land together.
-        for (let i = 0; i < rebuiltExperimentKeys.length; i += DELETE_CHUNK) {
-            const chunk = rebuiltExperimentKeys.slice(i, i + DELETE_CHUNK);
-            yield* write.exec(
-                `DELETE FROM opportunity WHERE in_id IN (${chunk.map(() => "?").join(", ")})`,
-                chunk,
-            );
+        // old rules must not stay authoritative. Each experiment is replaced by
+        // ONE atomic statement scoped to its own `in_id`, so a failure mid-way
+        // leaves that experiment's previous rows intact and every other
+        // experiment (and every sidecar judgment) untouched.
+        for (const key of rebuiltExperimentKeys) {
+            yield* replaceOpportunities(write, key, rowsByExperiment.get(key) ?? []);
         }
-        yield* write.putMany("opportunity", allRows);
+
+        // Only now - after every selected replacement landed - does the snapshot
+        // deserve the certificate that its opportunity rows came from the
+        // corrected derivation. A failure above skips this, leaving the sentinel
+        // deleted, so a cache published mid-failure reads as "needs derivation".
+        yield* write.put(
+            WATERMARK_TABLE,
+            watermarkRow(OPPORTUNITY_VERSION_SOURCE, OPPORTUNITY_VERSION_PATH, {
+                sha: OPPORTUNITY_VERSION,
+            }),
+        );
         return {
             experimentsScanned: experiments.length,
             opportunities: totalOpportunities,
@@ -678,7 +820,16 @@ export const opportunitiesStage: StageDef<
     Judgment | FileSystem.FileSystem,
     CacheWriteError | CacheReadError | JudgmentError
 > = {
-    meta: StageMeta.make({ key: "opportunities", deps: ["proposals"], tags: ["derive"], writes: [{ table: "opportunity", mode: "derive" }] }),
+    meta: StageMeta.make({
+        key: "opportunities",
+        deps: ["proposals"],
+        tags: ["derive"],
+        writes: [
+            { table: "opportunity", mode: "derive" },
+            // The derivation-version sentinel (see opportunity-cache-version.ts).
+            { table: "ingest_file_state", mode: "bookkeep" },
+        ],
+    }),
     run: (_ctx: IngestContext, write: CacheWriteService) =>
         Effect.gen(function* () {
             const t0 = Date.now();

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -31,7 +31,7 @@ import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { stableDigest } from "@ax/lib/ids";
 import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
 import { checkFamilyFromCommand, isCheckFamily } from "./check-family.ts";
-import { REAL_HOOK_EFFECTS } from "./transcripts.ts";
+import { REAL_HOOK_EFFECTS } from "@ax/lib/shared/hook-effects";
 import {
     runEvidenceEventRecordKey,
     runEvidenceRefRecordKey,

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -31,6 +31,7 @@ import type { CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import { stableDigest } from "@ax/lib/ids";
 import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
 import { checkFamilyFromCommand, isCheckFamily } from "./check-family.ts";
+import { REAL_HOOK_EFFECTS } from "./transcripts.ts";
 import {
     runEvidenceEventRecordKey,
     runEvidenceRefRecordKey,
@@ -582,7 +583,7 @@ export const policyDecisionSql = (since: number | undefined): string =>
     `SELECT id, session, tool_call AS toolCall,
             CAST(ts AS VARCHAR) AS ts, hook_name AS hookName, effect, provider_status AS providerStatus
      FROM hook_command_invocation
-     WHERE session IS NOT NULL AND effect IN ('blocked', 'injected_context', 'modified_input', 'notified') ${sinceAnd(since)}`;
+     WHERE session IS NOT NULL AND effect IN (${REAL_HOOK_EFFECTS.map((e) => `'${e}'`).join(", ")}) ${sinceAnd(since)}`;
 
 // Repo state: each session's checkout (single-hop derefs for repo identity).
 // NOTE: dirty is intentionally not read - the git ingest writes it always-false.

--- a/apps/axctl/src/ingest/opportunity-cache-version.ts
+++ b/apps/axctl/src/ingest/opportunity-cache-version.ts
@@ -1,0 +1,28 @@
+/**
+ * The opportunity-derivation version sentinel (#1133 / #1134).
+ *
+ * One row in the existing `ingest_file_state` bookkeeping table certifies that
+ * the PUBLISHED snapshot's `opportunity` rows were produced by the corrected
+ * artifact-identity derivation. The opportunities stage invalidates it before it
+ * starts replacing rows and stamps it again only after the complete pass
+ * succeeds, so a partially-changed cache that gets published carries no success
+ * certificate.
+ *
+ * What it proves is narrow, and worth stating: ALGORITHM COMPATIBILITY, not
+ * freshness, not that an artifact worked, not a causal improvement. A checkpoint
+ * reader that finds a missing, null, old or unknown token must treat the
+ * opportunity rows as needing derivation rather than measuring them.
+ *
+ * These constants live in their own module so a reader (the checkpoint side owns
+ * the read) can have them without importing the whole derive stage.
+ */
+
+/** `ingest_file_state.source_kind` for the sentinel. */
+export const OPPORTUNITY_VERSION_SOURCE = "opportunity_derivation";
+
+/** `ingest_file_state.path` for the sentinel - globally unique, never a real
+ *  file, and deliberately not shared with a transcript or content-hash mark. */
+export const OPPORTUNITY_VERSION_PATH = "__opportunity_derivation__";
+
+/** The token stored in `sha`. Bump it when matching semantics change again. */
+export const OPPORTUNITY_VERSION = "artifact-identity-v2";

--- a/apps/axctl/src/ingest/table-writes.behavior.test.ts
+++ b/apps/axctl/src/ingest/table-writes.behavior.test.ts
@@ -9,7 +9,7 @@
  * undeclared-write failure modes are UPDATEs, which change no count [R#4]
  * (pinned below by the invoked-positions case: count constant, hash moves).
  *
- * Coverage is a deliberate SUBSET: six stages whose fixtures are cheap,
+ * Coverage is a deliberate SUBSET: seven stages whose fixtures are cheap,
  * chosen to exercise each write mode (parse via the shared normalized batch,
  * enrich via UPDATE stamping, derive, bookkeep) plus the
  * session-health-writes-session_token_usage exception. The static test in
@@ -34,6 +34,16 @@ import { outcomesStage } from "./outcomes.ts";
 import { contentTypesStage } from "./derive-content-types.ts";
 import { sessionHealthStage } from "./session-health.ts";
 import { deriveMetricsStage } from "./derive-metrics.ts";
+import { opportunitiesStage } from "./derive-opportunities.ts";
+import {
+    OPPORTUNITY_VERSION,
+    OPPORTUNITY_VERSION_PATH,
+    OPPORTUNITY_VERSION_SOURCE,
+} from "./opportunity-cache-version.ts";
+import { Layer } from "effect";
+import { JudgmentLayer } from "@ax/lib/sqlite";
+import { WATERMARK_TABLE } from "@ax/lib/duckdb/watermark";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("table-writes behavior", { requireFts: true });
 
@@ -64,6 +74,8 @@ const assertStageWrites = (
     label: string,
     seed: (write: CacheWriteService) => Effect.Effect<void, unknown, unknown>,
     provide: <A, E>(effect: Effect.Effect<A, E, unknown>) => Effect.Effect<A, E, never>,
+    /** Assert on the store the stage left behind, while the fixture is open. */
+    inspect?: (write: CacheWriteService) => Effect.Effect<void, unknown, unknown>,
 ): Promise<{ changed: readonly string[]; before: Digest; after: Digest }> => {
     // Identity, not key equality: the descriptor exercised IS the registered one.
     expect((ALL_STAGES as readonly unknown[]).includes(stage)).toBe(true);
@@ -79,6 +91,7 @@ const assertStageWrites = (
                 const declared = new Set(stage.meta.writes.map((w) => w.table));
                 const undeclared = changed.filter((table) => !declared.has(table));
                 expect(undeclared, `${label}: undeclared writes`).toEqual([]);
+                if (inspect) yield* provide(inspect(write));
                 outcome = { changed, before, after };
             }),
         ),
@@ -181,5 +194,37 @@ describe("event-layer write contract (behavioral)", () => {
         expect(changed).toContain("session_metrics");
         // The enrich write: cost backfill UPDATEs the seeded usage row.
         expect(changed).toContain("session_token_usage");
+    }, 60_000);
+
+    dtest("opportunities (derive + the derivation-version bookkeep)", async () => {
+        // No proposals: an empty eligible set is still a COMPLETE corrected
+        // pass, so the sentinel is earned and the row is the only thing that
+        // moves. That also pins the new bookkeeping declaration behaviorally.
+        const sidecarPath = join(tempDir("ax-tw-opportunities-sidecar-"), "judgment.sqlite");
+        const provideJudgment = <A, E>(effect: Effect.Effect<A, E, unknown>): Effect.Effect<A, E, never> =>
+            effect.pipe(
+                Effect.provide(Layer.mergeAll(
+                    JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL }),
+                    FixturePlatform,
+                )),
+                Effect.scoped,
+            ) as Effect.Effect<A, E, never>;
+
+        const { changed } = await assertStageWrites(
+            opportunitiesStage,
+            "opportunities",
+            noSeed,
+            provideJudgment,
+            (write) => Effect.gen(function* () {
+                const result = yield* write.raw(
+                    `SELECT sha FROM ${WATERMARK_TABLE} WHERE source_kind = ? AND path = ?`,
+                    [OPPORTUNITY_VERSION_SOURCE, OPPORTUNITY_VERSION_PATH],
+                );
+                const rows = result.rows as unknown as Array<{ sha: string | null }>;
+                expect(rows).toHaveLength(1);
+                expect(rows[0]!.sha).toBe(OPPORTUNITY_VERSION);
+            }),
+        );
+        expect(changed).toEqual(["ingest_file_state"]);
     }, 60_000);
 });

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -137,6 +137,23 @@ interface Edit {
 export type HookProviderStatus = "progress_only" | "success" | "blocking_error";
 export type HookEffect = "allowed" | "blocked" | "injected_context" | "modified_input" | "notified" | "no_op" | "unknown";
 
+/**
+ * The effects that mean a hook actually DID something to the run - the single
+ * real-effect vocabulary, owned here beside {@link HookEffect} so no reader
+ * invents a second one. `allowed`/`no_op`/`unknown` are fires with no observed
+ * consequence and never count as an intervention.
+ *
+ * Consumers: `derive-run-evidence`'s policy-decision read (a `policy_decision`
+ * event is by definition a real intervention) and `derive-opportunities`'
+ * hook-form addressed detector.
+ */
+export const REAL_HOOK_EFFECTS: ReadonlyArray<HookEffect> = [
+    "blocked",
+    "injected_context",
+    "modified_input",
+    "notified",
+];
+
 export interface HarnessHookEventWrite {
     readonly key: string;
     readonly session: string;

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -136,16 +136,14 @@ interface Edit {
 }
 
 export type HookProviderStatus = "progress_only" | "success" | "blocking_error";
-export type HookEffect = "allowed" | "blocked" | "injected_context" | "modified_input" | "notified" | "no_op" | "unknown";
-
 /**
- * The four real-intervention effects live in `@ax/lib/shared/hook-effects` so a
- * derivation needing them does not import this parser for four strings. The
- * coupling back to the union this parser writes is TYPE-only, and it is checked:
- * this alias stops compiling if the shared list ever names an effect that is not
- * a {@link HookEffect}.
+ * Every effect this parser can write. The four real-intervention members are
+ * BUILT FROM `@ax/lib/shared/hook-effects`, so a derivation that needs only
+ * those four does not import this parser to get them, and the two cannot drift
+ * apart: they are literally the same type here. The rest are fires with no
+ * observed consequence.
  */
-export type _RealHookEffectsAreHookEffects = RealHookEffect extends HookEffect ? true : never;
+export type HookEffect = RealHookEffect | "allowed" | "no_op" | "unknown";
 
 export interface HarnessHookEventWrite {
     readonly key: string;

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -7,6 +7,7 @@ import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { resolveSkillName } from "@ax/lib/skill-id";
 import { skillRowId } from "@ax/lib/stable-id";
+import type { RealHookEffect } from "@ax/lib/shared/hook-effects";
 import { blobName, putBlobFromFile } from "@ax/lib/blob-store";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import { JSONL_WORK_UNIT_WRITES, NORMALIZED_BATCH_WRITES } from "./stage/table-writes.ts";
@@ -138,21 +139,13 @@ export type HookProviderStatus = "progress_only" | "success" | "blocking_error";
 export type HookEffect = "allowed" | "blocked" | "injected_context" | "modified_input" | "notified" | "no_op" | "unknown";
 
 /**
- * The effects that mean a hook actually DID something to the run - the single
- * real-effect vocabulary, owned here beside {@link HookEffect} so no reader
- * invents a second one. `allowed`/`no_op`/`unknown` are fires with no observed
- * consequence and never count as an intervention.
- *
- * Consumers: `derive-run-evidence`'s policy-decision read (a `policy_decision`
- * event is by definition a real intervention) and `derive-opportunities`'
- * hook-form addressed detector.
+ * The four real-intervention effects live in `@ax/lib/shared/hook-effects` so a
+ * derivation needing them does not import this parser for four strings. The
+ * coupling back to the union this parser writes is TYPE-only, and it is checked:
+ * this alias stops compiling if the shared list ever names an effect that is not
+ * a {@link HookEffect}.
  */
-export const REAL_HOOK_EFFECTS: ReadonlyArray<HookEffect> = [
-    "blocked",
-    "injected_context",
-    "modified_input",
-    "notified",
-];
+export type _RealHookEffectsAreHookEffects = RealHookEffect extends HookEffect ? true : never;
 
 export interface HarnessHookEventWrite {
     readonly key: string;

--- a/packages/lib/src/shared/hook-effects.ts
+++ b/packages/lib/src/shared/hook-effects.ts
@@ -1,0 +1,29 @@
+/**
+ * The hook-effect vocabulary, in one dependency-free place.
+ *
+ * `hook_command_invocation.effect` is written by the claude transcript parser
+ * (`apps/axctl/src/ingest/transcripts.ts` owns the full `HookEffect` union) and
+ * read by several derivations. Only FOUR of its values mean the hook actually
+ * did something to the run; `allowed`, `no_op` and `unknown` are fires with no
+ * observed consequence, and a hook that passes silently is written nowhere at
+ * all, so its absence is not evidence either way.
+ *
+ * This module exists so a reader needing those four strings does not import the
+ * whole parser to get them - and so nobody writes a second, drifting list. It
+ * has no imports on purpose: `packages/lib` cannot depend on `apps/*`, and the
+ * parser side asserts compatibility with a TYPE-only import back to here.
+ */
+
+export const REAL_HOOK_EFFECTS = [
+    "blocked",
+    "injected_context",
+    "modified_input",
+    "notified",
+] as const;
+
+/** One of the four effects that count as a real intervention. */
+export type RealHookEffect = (typeof REAL_HOOK_EFFECTS)[number];
+
+/** Does this stored `effect` value name a real intervention? */
+export const isRealHookEffect = (effect: string): effect is RealHookEffect =>
+    (REAL_HOOK_EFFECTS as ReadonlyArray<string>).includes(effect);


### PR DESCRIPTION
Guidance measurement now uses the reconciled artifact path and installation time. Hook measurement requires the complete installed marker, matching event and session, a real effect, and the available tool-call identity. Missing files and directories produce unavailable evidence.

Each experiment's derived rows are replaced with one atomic MERGE. A failed replacement preserves its previous rows. A version marker is cleared before derivation and restored only after every replacement succeeds; #1134 uses it to reject evidence from older matching rules. The marker identifies compatible derivation logic, not freshness or improved task quality.

Validation: independent review passes. There are 52 passing opportunity tests, 14 passing write-contract tests, and 110 passing related tests. Typecheck passes. Production-DDL fixtures cover artifact identity, hook correlation, unavailable files, atomic write failures, scoped deletion, and version publication. Combined full-suite validation follows integration.

Fixes #1133

---

_Generated with [ax](https://github.com/Necmttn/ax)._
