### PR TITLE
fix(improve): require usable evidence before suggesting verdicts

### DIFF
--- a/apps/axctl/src/cli/commands/improve-measurement-text.test.ts
+++ b/apps/axctl/src/cli/commands/improve-measurement-text.test.ts
@@ -1,0 +1,185 @@
+/**
+ * `ax improve verdict` / `ax improve checkpoint` text (#1134): the CLI has to
+ * say WHY there is no suggestion. Pure formatters, tested here; the command
+ * wiring that prints them is one console.log per line.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+    formatCheckpointHistoryLine,
+    formatCheckpointSummary,
+    formatCurrentVerdictLine,
+    formatVerdictListLine,
+    isCurrentCheckpointRow,
+    measurementReasonText,
+} from "./improve.ts";
+
+describe("measurementReasonText", () => {
+    test("names the gap without inventing a waiting-for-sessions story", () => {
+        expect(measurementReasonText("detector_unavailable")).toBe("no detector for this form");
+        expect(measurementReasonText("no_opportunities")).toBe("no opportunities in the window");
+        expect(measurementReasonText("artifact_unavailable")).toBe("no installed artifact recorded");
+        expect(measurementReasonText("refresh_required")).toBe("opportunity evidence needs derivation");
+        expect(measurementReasonText("retired")).toBe("experiment retired");
+        expect(measurementReasonText("not_started")).toBe("artifact not installed yet");
+        expect(measurementReasonText(null)).toBeNull();
+    });
+
+    test("a missing detector is never described as waiting for more sessions", () => {
+        expect(measurementReasonText("detector_unavailable")).not.toContain("session");
+    });
+});
+
+describe("formatVerdictListLine", () => {
+    const row = (overrides: Record<string, unknown> = {}) => ({
+        dedupe_sig: "abc123",
+        title: "Guard resets",
+        locked_verdict: null,
+        latest_checkpoint: { kind: "+10s", suggested: "adopted" },
+        current_reason: null,
+        ...overrides,
+    });
+
+    test("a current suggestion reads as a suggestion", () => {
+        expect(formatVerdictListLine(row())).toBe("  abc123  [+10s suggested: adopted]  Guard resets");
+    });
+
+    test("a locked verdict outranks the checkpoint", () => {
+        expect(formatVerdictListLine(row({ locked_verdict: "partial" })))
+            .toBe("  abc123  [locked: partial]  Guard resets");
+    });
+
+    test("no suggestion reads as insufficient data with its reason, never `suggested: ?`", () => {
+        const line = formatVerdictListLine(row({
+            latest_checkpoint: { kind: "+10s", suggested: null },
+            current_reason: "no_opportunities",
+        }));
+        expect(line).toBe("  abc123  [+10s insufficient data: no opportunities in the window]  Guard resets");
+        expect(line).not.toContain("suggested: ?");
+    });
+
+    test("a lifecycle state is reported as the state, not as a measurement", () => {
+        expect(formatVerdictListLine(row({
+            latest_checkpoint: { kind: "+10s", suggested: null },
+            current_reason: "retired",
+        }))).toBe("  abc123  [experiment retired]  Guard resets");
+    });
+
+    test("no checkpoint at all still says so", () => {
+        expect(formatVerdictListLine(row({ latest_checkpoint: null, current_reason: "no_checkpoint" })))
+            .toBe("  abc123  [no checkpoint yet]  Guard resets");
+    });
+});
+
+describe("formatCurrentVerdictLine", () => {
+    test("reports the current recommendation before any history", () => {
+        expect(formatCurrentVerdictLine({
+            latest_checkpoint: { kind: "+3s", suggested: "partial" },
+            current_reason: null,
+        })).toBe("  current       +3s suggested: partial (observed use, not proven improvement)");
+    });
+
+    test("reports the reason when there is nothing to recommend", () => {
+        expect(formatCurrentVerdictLine({
+            latest_checkpoint: { kind: "+3s", suggested: null },
+            current_reason: "refresh_required",
+        })).toBe("  current       insufficient data - opportunity evidence needs derivation");
+    });
+});
+
+describe("formatCheckpointHistoryLine", () => {
+    test("labels a historical row that is not the current recommendation", () => {
+        const line = formatCheckpointHistoryLine({
+            kind: "+3s", observed_at: "2026-01-20T00:00:00Z", suggested: "adopted",
+            user_verdict: null,
+            measured: { opportunities: 12, addressed: 8 },
+        }, false);
+        expect(line).toContain("historical");
+        expect(line).toContain("opportunities=12 addressed=8");
+    });
+
+    test("an insufficient-data row shows its reason instead of a suggestion", () => {
+        const line = formatCheckpointHistoryLine({
+            kind: "+10s", observed_at: "2026-01-25T00:00:00Z", suggested: null,
+            user_verdict: null,
+            measured: {
+                opportunities: 0, addressed: 0,
+                measurement_status: "insufficient_data", reason: "detector_unavailable",
+            },
+        }, true);
+        expect(line).toContain("insufficient data: no detector for this form");
+        expect(line).not.toContain("suggested: ?");
+    });
+});
+
+describe("isCurrentCheckpointRow", () => {
+    const live = {
+        latest_checkpoint: { kind: "+10s", suggested: "adopted" },
+        current_reason: null,
+    };
+
+    test("the row a live recommendation came from is current", () => {
+        expect(isCurrentCheckpointRow(live, { kind: "+10s" })).toBe(true);
+        expect(isCurrentCheckpointRow(live, { kind: "+3s" })).toBe(false);
+    });
+
+    test("a suppressed suggestion leaves EVERY stored row historical", () => {
+        // Same kind as the newest row, but the projection withheld it - so the
+        // old positive answer must not be presented as the current one.
+        for (const row of [
+            { latest_checkpoint: { kind: "+10s", suggested: null }, current_reason: "no_opportunities" },
+            { latest_checkpoint: { kind: "+10s", suggested: "adopted" }, current_reason: "retired" },
+            { latest_checkpoint: null, current_reason: "no_checkpoint" },
+        ]) {
+            expect(isCurrentCheckpointRow(row, { kind: "+10s" })).toBe(false);
+        }
+    });
+});
+
+describe("formatCheckpointSummary", () => {
+    const stats = (overrides: Record<string, number> = {}) => ({
+        experimentsScanned: 2,
+        experimentsExcluded: 1,
+        checkpointsInserted: 1,
+        checkpointsRefreshed: 1,
+        checkpointsSkipped: 4,
+        insufficientData: 1,
+        cacheRefreshRequired: 0,
+        ...overrides,
+    });
+
+    test("reports excluded and insufficient-data counts separately", () => {
+        expect(formatCheckpointSummary(stats())).toEqual([
+            "checkpoints scanned: 2 eligible experiment(s)",
+            "checkpoints excluded: 1 (not installed, retired, regressed or locked)",
+            "checkpoints inserted: 1",
+            "checkpoints refreshed: 1",
+            "checkpoints skipped: 4",
+            "insufficient data: 1 window(s) - stored with no suggested verdict",
+        ]);
+    });
+
+    test("a zero-write run says why, instead of always blaming due windows", () => {
+        expect(formatCheckpointSummary(stats({
+            checkpointsInserted: 0, checkpointsRefreshed: 0, cacheRefreshRequired: 2,
+        }))).toContain(
+            "2 experiment(s) need opportunity derivation - run `ax ingest`, then re-run this command",
+        );
+    });
+
+    test("a zero-write run with nothing eligible names the exclusion", () => {
+        expect(formatCheckpointSummary(stats({
+            experimentsScanned: 0, experimentsExcluded: 3, checkpointsInserted: 0,
+            checkpointsRefreshed: 0, checkpointsSkipped: 0, insufficientData: 0,
+        }))).toContain(
+            "No eligible experiments: 3 excluded (run `ax improve lint` to record an installed artifact)",
+        );
+    });
+
+    test("a zero-write run with eligible experiments falls back to due windows", () => {
+        expect(formatCheckpointSummary(stats({
+            checkpointsInserted: 0, checkpointsRefreshed: 0, insufficientData: 0,
+        }))).toContain(
+            "No new windows due. Re-run with --force to refresh unreviewed checkpoints",
+        );
+    });
+});

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -5,7 +5,7 @@ import { Judgment } from "@ax/lib/sqlite";
 import { prettyPrint } from "@ax/lib/json";
 import { decodeJsonOrNull } from "@ax/lib/decode";
 import { homedir } from "node:os";
-import { deriveCheckpoints } from "../../ingest/derive-checkpoints.ts";
+import { deriveCheckpoints, type DeriveCheckpointsStats } from "../../ingest/derive-checkpoints.ts";
 import { runAgentAccept } from "../../improve/agent-accept.ts";
 import { acceptProposal, rejectProposal, setVerdict } from "../../improve/actions.ts";
 import { lintFiles } from "../../improve/lint.ts";
@@ -402,6 +402,153 @@ const ALLOWED_VERDICTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Short, honest text for a missing recommendation (#1134).
+ *
+ * Two different absences share this table: a MEASUREMENT gap (nothing to
+ * measure, no detector, evidence that needs re-deriving) and a LIFECYCLE state
+ * (never installed, retired). Neither is "waiting for more sessions", and
+ * saying so would send the user off to generate exposure that no detector will
+ * ever read.
+ */
+const MEASUREMENT_REASON_TEXT: Readonly<Record<string, string>> = {
+    no_opportunities: "no opportunities in the window",
+    detector_unavailable: "no detector for this form",
+    artifact_unavailable: "no installed artifact recorded",
+    refresh_required: "opportunity evidence needs derivation",
+    no_checkpoint: "no checkpoint yet",
+    not_started: "artifact not installed yet",
+    retired: "experiment retired",
+    regressed: "experiment marked regressed",
+    not_accepted: "proposal not accepted",
+    locked: "verdict locked",
+};
+
+export const measurementReasonText = (reason: string | null | undefined): string | null =>
+    typeof reason === "string" ? MEASUREMENT_REASON_TEXT[reason] ?? reason : null;
+
+/** Reasons that describe the EXPERIMENT rather than a measured window - they
+ *  read as a state, not as "insufficient data". */
+const LIFECYCLE_REASONS: ReadonlySet<string> = new Set([
+    "no_checkpoint", "not_started", "retired", "regressed", "not_accepted", "locked",
+]);
+
+const currentBadge = (row: Record<string, unknown>): string => {
+    const checkpoint = row.latest_checkpoint as Record<string, unknown> | null | undefined;
+    const kind = checkpoint ? String(checkpoint.kind ?? "?") : null;
+    const suggested = checkpoint?.suggested ?? null;
+    if (suggested !== null && suggested !== undefined) return `${kind} suggested: ${String(suggested)}`;
+    const reason = typeof row.current_reason === "string" ? row.current_reason : null;
+    const text = measurementReasonText(reason) ?? "insufficient data";
+    if (reason !== null && LIFECYCLE_REASONS.has(reason)) return text;
+    return kind === null ? `insufficient data: ${text}` : `${kind} insufficient data: ${text}`;
+};
+
+/** One row of `ax improve verdict` (no positional argument). */
+export const formatVerdictListLine = (row: Record<string, unknown>): string => {
+    const badge = row.locked_verdict
+        ? `locked: ${String(row.locked_verdict)}`
+        : currentBadge(row);
+    return `  ${String(row.dedupe_sig ?? "?")}  [${badge}]  ${String(row.title ?? "?")}`;
+};
+
+/** The CURRENT recommendation line in `ax improve verdict <id>`, printed above
+ *  the stored history so the two are never confused. */
+export const formatCurrentVerdictLine = (row: Record<string, unknown>): string => {
+    const checkpoint = row.latest_checkpoint as Record<string, unknown> | null | undefined;
+    const suggested = checkpoint?.suggested ?? null;
+    if (suggested !== null && suggested !== undefined) {
+        return `  current       ${String(checkpoint?.kind ?? "?")} suggested: ${String(suggested)}` +
+            " (observed use, not proven improvement)";
+    }
+    const reason = typeof row.current_reason === "string" ? row.current_reason : null;
+    const text = measurementReasonText(reason);
+    if (reason !== null && LIFECYCLE_REASONS.has(reason)) return `  current       ${text}`;
+    return `  current       insufficient data${text === null ? "" : ` - ${text}`}`;
+};
+
+/**
+ * Is this stored row the one the CURRENT recommendation came from?
+ *
+ * Kind equality alone is not enough. When the projection suppresses the newest
+ * row's suggestion, that row is evidence like any other - matching it by kind
+ * would leave an old positive answer standing unlabelled at the bottom of the
+ * output, which is the exact confusion the current/history split exists to end.
+ * So: only a live recommendation (a suggestion, and no reason withholding it)
+ * marks its row current.
+ */
+export const isCurrentCheckpointRow = (
+    row: Record<string, unknown>,
+    checkpoint: Record<string, unknown>,
+): boolean => {
+    const latest = row.latest_checkpoint as Record<string, unknown> | null | undefined;
+    if (latest == null) return false;
+    if (latest.suggested === null || latest.suggested === undefined) return false;
+    if (row.current_reason !== null && row.current_reason !== undefined) return false;
+    return checkpoint.kind === latest.kind;
+};
+
+/** One stored checkpoint in the history block. `isCurrent` marks the row the
+ *  current recommendation came from; every other row is labelled historical so
+ *  an old positive answer cannot be mistaken for today's advice. */
+export const formatCheckpointHistoryLine = (
+    checkpoint: Record<string, unknown>,
+    isCurrent: boolean,
+): string => {
+    const measured = checkpoint.measured as Record<string, unknown> | string | undefined;
+    const fields = typeof measured === "object" && measured !== null ? measured : {};
+    const opportunities = Number(fields.opportunities ?? 0);
+    const addressed = Number(fields.addressed ?? 0);
+    const reasonText = measurementReasonText(
+        typeof fields.reason === "string" ? fields.reason : null,
+    );
+    const verdict = checkpoint.suggested
+        ? `suggested: ${String(checkpoint.suggested)}`
+        : `insufficient data${reasonText === null ? "" : `: ${reasonText}`}`;
+    return `    ${String(checkpoint.kind ?? "?")}  observed=${String(checkpoint.observed_at ?? "?")}  ` +
+        `opportunities=${opportunities} addressed=${addressed}  ${verdict}  ` +
+        `user_verdict=${checkpoint.user_verdict ? String(checkpoint.user_verdict) : "(none)"}` +
+        `${isCurrent ? "" : "  (historical)"}`;
+};
+
+/**
+ * The `ax improve checkpoint` summary.
+ *
+ * A run that writes nothing has to say WHICH nothing it hit. "No new windows
+ * due" used to be printed even when every experiment was excluded, or when the
+ * opportunity evidence itself needed re-deriving - two states the user can act
+ * on, reported as one they cannot.
+ */
+export const formatCheckpointSummary = (stats: DeriveCheckpointsStats): string[] => {
+    const lines = [
+        `checkpoints scanned: ${stats.experimentsScanned} eligible experiment(s)`,
+        `checkpoints excluded: ${stats.experimentsExcluded} (not installed, retired, regressed or locked)`,
+        `checkpoints inserted: ${stats.checkpointsInserted}`,
+        `checkpoints refreshed: ${stats.checkpointsRefreshed}`,
+        `checkpoints skipped: ${stats.checkpointsSkipped}`,
+    ];
+    if (stats.insufficientData > 0) {
+        lines.push(`insufficient data: ${stats.insufficientData} window(s) - stored with no suggested verdict`);
+    }
+    if (stats.checkpointsInserted + stats.checkpointsRefreshed > 0) return lines;
+    lines.push("");
+    if (stats.cacheRefreshRequired > 0) {
+        lines.push(
+            `${stats.cacheRefreshRequired} experiment(s) need opportunity derivation - ` +
+            "run `ax ingest`, then re-run this command",
+        );
+    } else if (stats.experimentsScanned === 0) {
+        lines.push(
+            `No eligible experiments: ${stats.experimentsExcluded} excluded ` +
+            "(run `ax improve lint` to record an installed artifact)",
+        );
+    } else {
+        lines.push("No new windows due. Re-run with --force to refresh unreviewed checkpoints");
+        lines.push("(use `axctl improve verdict <id>` to see suggested verdicts).");
+    }
+    return lines;
+};
+
+/**
  * `axctl improve verdict` - surface checkpoint-derived suggested verdicts
  * for each active experiment, let the human lock the final one. Three modes:
  *
@@ -432,15 +579,7 @@ const cmdImproveVerdict = (input: {
                 return;
             }
             console.log("Current experiments (newest first):");
-            for (const row of list) {
-                const cp = row.latest_checkpoint as Record<string, unknown> | null;
-                const verdict = row.locked_verdict
-                    ? `[locked: ${String(row.locked_verdict)}]`
-                    : cp
-                        ? `[${String(cp.kind ?? "?")} suggested: ${String(cp.suggested ?? "?")}]`
-                        : "[no checkpoint yet]";
-                console.log(`  ${String(row.dedupe_sig ?? "?")}  ${verdict}  ${String(row.title ?? "?")}`);
-            }
+            for (const row of list) console.log(formatVerdictListLine(row));
             console.log("");
             console.log("Run `axctl improve checkpoint` to refresh due windows.");
             console.log("Run `axctl improve verdict <sig> --set <verdict>` to lock.");
@@ -472,19 +611,15 @@ const cmdImproveVerdict = (input: {
         console.log(`  artifact      ${String(row.artifact_path ?? "(none)")}`);
         console.log(`  scaffolded_at ${String(row.scaffolded_at ?? "(none)")}`);
         console.log(`  verdict       ${row.locked_verdict ? String(row.locked_verdict) + " (locked)" : "pending"}`);
+        console.log(formatCurrentVerdictLine(row));
         if (checkpoints.length === 0) {
             console.log(`  checkpoints   none (run \`axctl improve checkpoint\` once due windows pass)`);
         } else {
+            // History below the current state, and marked as history: only a
+            // LIVE recommendation claims a row as current.
             console.log(`  checkpoints:`);
             for (const cp of checkpoints) {
-                const measured = cp.measured as Record<string, unknown> | string | undefined;
-                const opp = (typeof measured === "object" && measured) ? Number(measured.opportunities ?? 0) : 0;
-                const add = (typeof measured === "object" && measured) ? Number(measured.addressed ?? 0) : 0;
-                console.log(
-                    `    ${String(cp.kind ?? "?")}  observed=${String(cp.observed_at ?? "?")}  ` +
-                    `opportunities=${opp} addressed=${add}  suggested=${String(cp.suggested ?? "?")}  ` +
-                    `user_verdict=${cp.user_verdict ? String(cp.user_verdict) : "(none)"}`,
-                );
+                console.log(formatCheckpointHistoryLine(cp, isCurrentCheckpointRow(row, cp)));
             }
         }
         console.log("");
@@ -559,14 +694,7 @@ const cmdImproveCheckpoint = (input: {
             console.log(prettyPrint(stats));
             return;
         }
-        console.log(`checkpoints scanned: ${stats.experimentsScanned} experiments`);
-        console.log(`checkpoints inserted: ${stats.checkpointsInserted}`);
-        console.log(`checkpoints skipped: ${stats.checkpointsSkipped}`);
-        if (stats.checkpointsInserted === 0) {
-            console.log("");
-            console.log("No new windows due. Re-run with --force to refresh existing checkpoints");
-            console.log("(use `axctl improve verdict <id>` to see suggested verdicts).");
-        }
+        for (const line of formatCheckpointSummary(stats)) console.log(line);
     });
 
 const improveCheckpointCommand = Command.make(

--- a/apps/axctl/src/dashboard/improve-proposals.test.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.test.ts
@@ -54,3 +54,83 @@ describe("fetchImproveProposals", () => {
         expect(await Effect.runPromise(fetchImproveProposals(deps()).pipe(Effect.provide(env([]))))).toEqual([]);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Checkpoint DTOs - history versus current recommendation (#1134)
+// ---------------------------------------------------------------------------
+
+const measured = (overrides: Record<string, unknown> = {}) => ({
+    opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+    measurement_status: "measured", measurement_version: 2,
+    ...overrides,
+});
+
+const experimentRow = (overrides: Record<string, unknown> = {}) => ({
+    id: "experiment-one", proposal: "abc", artifact: null,
+    artifact_path: "/repo/CLAUDE.md", scaffolded_at: new Date("2026-01-10T00:00:00Z"),
+    created_at: new Date("2026-01-01T00:00:00Z"), locked_verdict: null,
+    status: "scaffolded", task_path: null,
+    ...overrides,
+});
+
+const checkpointRow = (overrides: Record<string, unknown> = {}) => ({
+    id: "cp-1", experiment: "experiment-one", kind: "+3s", measured: measured(),
+    suggested: "adopted", user_verdict: null, observed_at: new Date("2026-01-20T00:00:00Z"),
+    ...overrides,
+});
+
+const withExperiment = (
+    experiment: Record<string, unknown>,
+    checkpoints: ReadonlyArray<Record<string, unknown>>,
+) => Layer.mergeAll(
+    judgmentTestLayer((sql) =>
+        sql.includes("FROM proposal") ? [proposal({ status: "accepted" })]
+        : sql.includes("FROM experiment") ? [experiment]
+        : sql.includes("FROM checkpoint") ? checkpoints
+        : []),
+    cacheReadTestLayer(() => []),
+);
+
+const experimentDto = async (
+    experiment: Record<string, unknown>,
+    checkpoints: ReadonlyArray<Record<string, unknown>>,
+) => {
+    const rows = await Effect.runPromise(
+        fetchImproveProposals(deps()).pipe(Effect.provide(withExperiment(experiment, checkpoints))),
+    );
+    return rows[0]?.experiment;
+};
+
+describe("checkpoint DTOs", () => {
+    it("preserves the optional measurement status, reason and version", async () => {
+        const exp = await experimentDto(experimentRow(), [checkpointRow({
+            suggested: null,
+            measured: measured({
+                opportunities: 0, addressed: 0, ratio: 0,
+                measurement_status: "insufficient_data", reason: "no_opportunities",
+            }),
+        })]);
+        expect(exp?.checkpoints?.[0]?.measured).toEqual({
+            opportunities: 0, addressed: 0, ratio: 0, built: true,
+            measurement_status: "insufficient_data", reason: "no_opportunities",
+            measurement_version: 2,
+        });
+        // JSON null, not an absent field and not a substitute verdict string.
+        expect(exp?.checkpoints?.[0]?.suggested).toBeNull();
+        expect(exp?.latest_checkpoint?.suggested).toBeNull();
+        expect(exp?.current_reason).toBe("no_opportunities");
+    });
+
+    it("keeps history while the current projection withholds an unsafe suggestion", async () => {
+        const exp = await experimentDto(experimentRow({ status: "retired" }), [checkpointRow()]);
+        expect(exp?.checkpoints?.[0]?.suggested).toBe("adopted");
+        expect(exp?.latest_checkpoint?.suggested).toBeNull();
+        expect(exp?.current_reason).toBe("retired");
+    });
+
+    it("passes a current measured suggestion through untouched", async () => {
+        const exp = await experimentDto(experimentRow(), [checkpointRow()]);
+        expect(exp?.latest_checkpoint?.suggested).toBe("adopted");
+        expect(exp?.current_reason).toBeNull();
+    });
+});

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { CacheRead } from "@ax/lib/duckdb/seam";
-import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
+import type { CheckpointSnapshotDto, ProposalDto } from "@ax/lib/shared/dashboard-types";
 import {
     estimateImpactCached,
     type ImpactEstimateCache,
@@ -8,6 +8,7 @@ import {
 } from "../improve/impact.ts";
 import { renderAgentBrief } from "./agent-brief.ts";
 import { listStoredProposals, type StoredCheckpoint, type StoredProposal } from "../improve/judgment-proposals.ts";
+import { currentCheckpointProjection } from "../improve/measurement.ts";
 
 /** Brief shown for an open proposal - shared by /api/improve rows and next-action cards. */
 export const proposalReviewBrief = (p: ProposalDto): string =>
@@ -134,8 +135,19 @@ const hydrateHypothesis = Effect.fn("dashboard.hydrateHypothesis")(function* (
     return { ...p, hypothesis: hydrated };
 });
 
-const checkpointDto = (checkpoint: StoredCheckpoint) => {
+/**
+ * One stored checkpoint as the studio sees it.
+ *
+ * The numeric fields are validated (a malformed blob yields `measured: null`
+ * rather than a half-typed object), and the #1134 status fields ride along when
+ * present: without them the studio cannot tell "measured a zero" from "had
+ * nothing to measure", and it rendered both as a quiet `measuring…`.
+ */
+const checkpointDto = (checkpoint: StoredCheckpoint): CheckpointSnapshotDto => {
     const measured = checkpoint.measured;
+    const status = measured.measurement_status;
+    const reason = measured.reason;
+    const version = measured.measurement_version;
     const typedMeasured =
         typeof measured.opportunities === "number" &&
         typeof measured.addressed === "number" &&
@@ -146,6 +158,9 @@ const checkpointDto = (checkpoint: StoredCheckpoint) => {
                 addressed: measured.addressed,
                 ratio: measured.ratio,
                 built: measured.built,
+                ...(status === "measured" || status === "insufficient_data" ? { measurement_status: status } : {}),
+                ...(typeof reason === "string" ? { reason } : {}),
+                ...(typeof version === "number" ? { measurement_version: version } : {}),
             }
             : null;
     return {
@@ -159,6 +174,24 @@ const checkpointDto = (checkpoint: StoredCheckpoint) => {
 
 const proposalDto = (proposal: StoredProposal): ProposalDto => {
     const checkpoints = proposal.experiment?.checkpoints.map(checkpointDto) ?? [];
+    // `checkpoints` is history; `latest_checkpoint` is the CURRENT
+    // recommendation, and it withholds a suggestion the experiment's present
+    // state no longer supports (#1134).
+    const newest = proposal.experiment?.checkpoints.at(-1);
+    const projection = proposal.experiment === null || proposal.experiment === undefined
+        ? null
+        : currentCheckpointProjection({
+            proposalStatus: proposal.status,
+            experimentStatus: proposal.experiment.status,
+            lockedVerdict: proposal.experiment.locked_verdict,
+            artifactPath: proposal.experiment.artifact_path,
+            scaffoldedAt: proposal.experiment.scaffolded_at,
+        }, newest === undefined ? null : {
+            suggested: newest.suggested,
+            user_verdict: newest.user_verdict,
+            measured: newest.measured,
+        });
+    const latest = checkpoints.at(-1);
     return {
         id: proposal.id,
         form: proposal.form,
@@ -187,7 +220,10 @@ const proposalDto = (proposal: StoredProposal): ProposalDto => {
             locked_verdict: proposal.experiment.locked_verdict,
             created_at: proposal.experiment.created_at.toISOString(),
             scaffolded_at: proposal.experiment.scaffolded_at?.toISOString() ?? null,
-            latest_checkpoint: checkpoints.at(-1) ?? null,
+            latest_checkpoint: latest === undefined
+                ? null
+                : { ...latest, suggested: projection?.suggested ?? null },
+            current_reason: projection?.reason ?? null,
             checkpoints,
         },
     };

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -41,7 +41,22 @@ const openProposal = (overrides: Partial<ProposalDto> = {}): ProposalDto => ({
     ...overrides,
 });
 
-const acceptedWithExperiment = (withCheckpoint: boolean): ProposalDto => ({
+const measuredCheckpoint = (overrides: Record<string, unknown> = {}) => ({
+    kind: "+3s",
+    suggested: "adopted" as string | null,
+    user_verdict: null,
+    measured: {
+        opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+        measurement_status: "measured", measurement_version: 2,
+    },
+    observed_at: "2026-06-03T00:00:00Z",
+    ...overrides,
+});
+
+const acceptedWithExperiment = (
+    withCheckpoint: boolean,
+    experimentOverrides: Record<string, unknown> = {},
+): ProposalDto => ({
     id: "proposal:def",
     form: "guidance",
     title: "Always read CLAUDE.md before editing",
@@ -54,21 +69,15 @@ const acceptedWithExperiment = (withCheckpoint: boolean): ProposalDto => ({
     created_at: "2026-06-01T00:00:00Z",
     experiment: {
         id: "exp:1",
-        artifact_path: null,
+        artifact_path: "/repo/CLAUDE.md",
         status: "scaffolded",
         task_path: null,
         locked_verdict: null,
         created_at: "2026-06-02T00:00:00Z",
         scaffolded_at: "2026-06-02T00:00:00Z",
-        latest_checkpoint: withCheckpoint
-            ? {
-                  kind: "+3s",
-                  suggested: "adopted",
-                  user_verdict: null,
-                  measured: null,
-                  observed_at: "2026-06-03T00:00:00Z",
-              }
-            : null,
+        latest_checkpoint: withCheckpoint ? measuredCheckpoint() : null,
+        current_reason: withCheckpoint ? null : "no_checkpoint",
+        ...experimentOverrides,
     },
 });
 
@@ -297,21 +306,20 @@ describe("fixKind", () => {
 });
 
 describe("verdictCards", () => {
-    test("only accepted proposals with experiment and no locked_verdict", () => {
+    test("only accepted, eligible experiments carrying a current measured suggestion", () => {
         const proposals = [
             openProposal({ status: "open" }),
-            acceptedWithExperiment(false),
+            acceptedWithExperiment(true),
             lockedExperimentProposal(),
             // accepted but no experiment
             openProposal({ status: "accepted", dedupe_sig: "no-exp" }),
         ];
         const cards = verdictCards(proposals);
-        // Only acceptedWithExperiment (no checkpoint, no locked verdict)
         expect(cards).toHaveLength(1);
         expect(cards[0]!.id).toBe("verdict:def456");
     });
 
-    test("suggested_verdict passthrough when checkpoint exists", () => {
+    test("suggested_verdict passthrough for a measured checkpoint", () => {
         const cards = verdictCards([acceptedWithExperiment(true)]);
         expect(cards[0]!.inline_action).toEqual({
             type: "verdict",
@@ -321,23 +329,81 @@ describe("verdictCards", () => {
         });
     });
 
-    test("suggested_verdict is null when no checkpoint", () => {
-        const cards = verdictCards([acceptedWithExperiment(false)]);
-        expect(cards[0]!.inline_action!.suggested_verdict).toBeNull();
+    test("no card at all when there is nothing to lock", () => {
+        // A one-click verdict on an absent measurement is exactly the invitation
+        // #1134 removes: the experiment stays in the normal lists instead.
+        expect(verdictCards([acceptedWithExperiment(false)])).toEqual([]);
     });
 
-    test("brief mentions the suggested verdict when present", () => {
+    test("no card for an insufficient-data or unrefreshed window", () => {
+        for (const checkpoint of [
+            measuredCheckpoint({
+                suggested: null,
+                measured: {
+                    opportunities: 0, addressed: 0, ratio: 0, built: true,
+                    measurement_status: "insufficient_data", reason: "no_opportunities",
+                    measurement_version: 2,
+                },
+            }),
+            measuredCheckpoint({
+                measured: { opportunities: 12, addressed: 8, ratio: 8 / 12, built: true },
+            }),
+        ]) {
+            expect(verdictCards([acceptedWithExperiment(true, {
+                latest_checkpoint: checkpoint,
+            })])).toEqual([]);
+        }
+    });
+
+    test("no card for a malformed or missing measurement status", () => {
+        for (const measured of [
+            // no status at all
+            { opportunities: 12, addressed: 8, ratio: 8 / 12, built: true, measurement_version: 2 },
+            // a status nothing writes
+            {
+                opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+                measurement_status: "estimated", measurement_version: 2,
+            },
+            // measured, but with no usable count behind it
+            {
+                addressed: 8, ratio: 8 / 12, built: true,
+                measurement_status: "measured", measurement_version: 2,
+            },
+            {
+                opportunities: -4, addressed: 8, ratio: 8 / 12, built: true,
+                measurement_status: "measured", measurement_version: 2,
+            },
+            {
+                opportunities: 0, addressed: 0, ratio: 0, built: true,
+                measurement_status: "measured", measurement_version: 2,
+            },
+        ]) {
+            expect(verdictCards([acceptedWithExperiment(true, {
+                latest_checkpoint: measuredCheckpoint({ measured }),
+            })])).toEqual([]);
+        }
+    });
+
+    test("no card for an unbuilt, retired or regressed experiment", () => {
+        for (const overrides of [
+            { status: "task_emitted" },
+            { status: "retired" },
+            { status: "regressed" },
+            { artifact_path: null },
+            { scaffolded_at: null },
+        ]) {
+            expect(verdictCards([acceptedWithExperiment(true, overrides)])).toEqual([]);
+        }
+    });
+
+    test("brief mentions the suggested verdict", () => {
         const cards = verdictCards([acceptedWithExperiment(true)]);
         expect(cards[0]!.brief).toContain("adopted");
     });
 
-    test("link is null", () => {
-        const cards = verdictCards([acceptedWithExperiment(false)]);
+    test("link is null and the title says Lock verdict", () => {
+        const cards = verdictCards([acceptedWithExperiment(true)]);
         expect(cards[0]!.link).toBeNull();
-    });
-
-    test("title contains 'Lock verdict'", () => {
-        const cards = verdictCards([acceptedWithExperiment(false)]);
         expect(cards[0]!.title).toMatch(/^Lock verdict:/);
     });
 });

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -26,6 +26,7 @@ import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import type { SkillHygieneRow } from "../queries/skill-hygiene.ts";
 import { fetchSkillHygiene } from "../queries/skill-hygiene.ts";
 import { fetchImproveProposals, proposalReviewBrief } from "./improve-proposals.ts";
+import { currentCheckpointProjection } from "../improve/measurement.ts";
 import { findStaleOpenProposals, type StaleProposalRow } from "../improve/housekeep.ts";
 import { interventionFormSpec } from "../improve/intervention-forms.ts";
 import { fetchToolFailures } from "./tool-failures.ts";
@@ -141,29 +142,51 @@ export const proposalCards = (
 // ---------------------------------------------------------------------------
 
 /**
- * Cards for accepted proposals whose experiment needs a verdict locked.
- * Only includes proposals where:
- * - status === "accepted"
- * - experiment exists
- * - experiment.locked_verdict is null/undefined (not yet decided)
+ * Cards for accepted proposals whose experiment has a MEASURED verdict waiting.
+ *
+ * A next action has to be actionable, and "lock a verdict" is not - it is a
+ * one-click decision - unless a current measurement supports it. So the card
+ * appears only when the experiment is eligible today (installed, not retired,
+ * not locked) AND its newest window carries a real suggestion under the current
+ * measurement rules (#1134). An unbuilt, retired, unrefreshed or
+ * nothing-to-measure experiment stays visible in the ordinary experiment lists,
+ * where its state is described, rather than being surfaced here as a decision
+ * the user could take on no evidence.
  */
 export const verdictCards = (
     proposals: ReadonlyArray<ProposalDto>,
 ): NextActionCard[] =>
     capByImpact(
         proposals
-            .filter(
-                (p) =>
-                    p.status === "accepted" &&
-                    p.experiment != null &&
-                    (p.experiment.locked_verdict == null),
-            )
+            .filter((p) => {
+                const experiment = p.experiment;
+                if (experiment == null) return false;
+                // A locked experiment is decided, so it gets no card at all -
+                // the projection deliberately keeps showing its verdict, which
+                // is right for a display and wrong for an action.
+                if (experiment.locked_verdict != null) return false;
+                // Everything else is the SHARED projection, not a second copy
+                // of the version/status/count rules: an action offered on
+                // evidence the read surfaces refuse to present would be exactly
+                // the one-click null verdict #1134 removes.
+                return currentCheckpointProjection({
+                    proposalStatus: p.status,
+                    experimentStatus: experiment.status ?? "",
+                    lockedVerdict: null,
+                    artifactPath: experiment.artifact_path,
+                    scaffoldedAt: experiment.scaffolded_at,
+                }, experiment.latest_checkpoint === null || experiment.latest_checkpoint === undefined
+                    ? null
+                    : {
+                        suggested: experiment.latest_checkpoint.suggested,
+                        user_verdict: experiment.latest_checkpoint.user_verdict,
+                        measured: experiment.latest_checkpoint.measured,
+                    }).suggested !== null;
+            })
             .map((p): NextActionCard => {
                 const experiment = p.experiment!;
                 const suggested = experiment.latest_checkpoint?.suggested ?? null;
-                const evidenceLine = suggested != null
-                    ? `experiment scaffolded, suggested verdict: ${suggested}`
-                    : "experiment scaffolded, no checkpoint yet";
+                const evidenceLine = `experiment scaffolded, suggested verdict: ${suggested}`;
 
                 return {
                     id: `verdict:${p.dedupe_sig}`,

--- a/apps/axctl/src/improve/measurement.test.ts
+++ b/apps/axctl/src/improve/measurement.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test";
+import {
+    currentCheckpointProjection,
+    detectorSupport,
+    measurementEligibility,
+    parseSkillTriggerTool,
+    readMeasurementVersion,
+} from "./measurement.ts";
+
+const subject = (overrides: Record<string, unknown> = {}) => ({
+    proposalStatus: "accepted",
+    experimentStatus: "scaffolded",
+    lockedVerdict: null,
+    artifactPath: "/tmp/CLAUDE.md",
+    scaffoldedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+}) as Parameters<typeof measurementEligibility>[0];
+
+describe("measurementEligibility", () => {
+    test("accepted + scaffolded + unlocked + installed artifact is eligible", () => {
+        expect(measurementEligibility(subject())).toEqual({ eligible: true });
+    });
+
+    test("a rejected or open proposal is excluded", () => {
+        expect(measurementEligibility(subject({ proposalStatus: "open" })))
+            .toEqual({ eligible: false, reason: "not_accepted" });
+        expect(measurementEligibility(subject({ proposalStatus: "rejected" })))
+            .toEqual({ eligible: false, reason: "not_accepted" });
+    });
+
+    test("task_emitted, retired and regressed experiments are excluded by lifecycle", () => {
+        expect(measurementEligibility(subject({ experimentStatus: "task_emitted" })))
+            .toEqual({ eligible: false, reason: "not_started" });
+        expect(measurementEligibility(subject({ experimentStatus: "retired" })))
+            .toEqual({ eligible: false, reason: "retired" });
+        expect(measurementEligibility(subject({ experimentStatus: "regressed" })))
+            .toEqual({ eligible: false, reason: "regressed" });
+    });
+
+    test("a locked verdict outranks every other reason", () => {
+        expect(measurementEligibility(subject({ lockedVerdict: "adopted", experimentStatus: "retired" })))
+            .toEqual({ eligible: false, reason: "locked" });
+    });
+
+    test("a missing artifact path or install time is unavailable evidence, not a verdict", () => {
+        expect(measurementEligibility(subject({ artifactPath: null })))
+            .toEqual({ eligible: false, reason: "artifact_unavailable" });
+        expect(measurementEligibility(subject({ artifactPath: "   " })))
+            .toEqual({ eligible: false, reason: "artifact_unavailable" });
+        expect(measurementEligibility(subject({ scaffoldedAt: null })))
+            .toEqual({ eligible: false, reason: "artifact_unavailable" });
+    });
+
+    test("accepts a Date install time as well as an ISO string", () => {
+        expect(measurementEligibility(subject({ scaffoldedAt: new Date("2026-01-01T00:00:00Z") })))
+            .toEqual({ eligible: true });
+    });
+});
+
+describe("parseSkillTriggerTool", () => {
+    test("reads the supported tool=<name> form only", () => {
+        expect(parseSkillTriggerTool("tool=Bash")).toBe("Bash");
+        expect(parseSkillTriggerTool("  tool=Edit  ")).toBe("Edit");
+        expect(parseSkillTriggerTool("when the agent edits schema")).toBeNull();
+        expect(parseSkillTriggerTool("tool=")).toBeNull();
+    });
+});
+
+describe("detectorSupport", () => {
+    const detector = (overrides: Record<string, unknown> = {}) => ({
+        form: "guidance",
+        skillTrigger: null,
+        hasSkillCandidate: false,
+        hookTargetTool: null,
+        hookEventName: null,
+        dedupeSig: "74da7418",
+        artifactPath: "/tmp/CLAUDE.md",
+        ...overrides,
+    }) as Parameters<typeof detectorSupport>[0];
+
+    test("guidance is supported by its reconciled artifact path", () => {
+        expect(detectorSupport(detector())).toEqual({ supported: true });
+        expect(detectorSupport(detector({ artifactPath: null })))
+            .toEqual({ supported: false, reason: "artifact_unavailable" });
+    });
+
+    test("hooks need target tool, event name and a usable marker identity", () => {
+        const hook = { form: "hook", hookTargetTool: "Bash", hookEventName: "PreToolUse" };
+        expect(detectorSupport(detector(hook))).toEqual({ supported: true });
+        expect(detectorSupport(detector({ ...hook, hookTargetTool: null })))
+            .toEqual({ supported: false, reason: "detector_unavailable" });
+        expect(detectorSupport(detector({ ...hook, hookEventName: null })))
+            .toEqual({ supported: false, reason: "detector_unavailable" });
+        expect(detectorSupport(detector({ ...hook, dedupeSig: "" })))
+            .toEqual({ supported: false, reason: "detector_unavailable" });
+    });
+
+    test("skills need a resolvable candidate or the tool=<name> trigger", () => {
+        expect(detectorSupport(detector({ form: "skill", hasSkillCandidate: true })))
+            .toEqual({ supported: true });
+        expect(detectorSupport(detector({ form: "skill", skillTrigger: "tool=Bash" })))
+            .toEqual({ supported: true });
+        expect(detectorSupport(detector({ form: "skill", skillTrigger: "agent edits schema files" })))
+            .toEqual({ supported: false, reason: "detector_unavailable" });
+        expect(detectorSupport(detector({ form: "skill" })))
+            .toEqual({ supported: false, reason: "detector_unavailable" });
+    });
+
+    test("automation, subagent and harness_check forms have no detector", () => {
+        for (const form of ["automation", "subagent", "harness_check"]) {
+            expect(detectorSupport(detector({ form }))).toEqual({
+                supported: false,
+                reason: "detector_unavailable",
+            });
+        }
+    });
+});
+
+describe("readMeasurementVersion", () => {
+    test("reads the numeric version, or null when absent or malformed", () => {
+        expect(readMeasurementVersion({ measurement_version: 2 })).toBe(2);
+        expect(readMeasurementVersion({ opportunities: 3 })).toBeNull();
+        expect(readMeasurementVersion({ measurement_version: "2" })).toBeNull();
+        expect(readMeasurementVersion(null)).toBeNull();
+    });
+});
+
+describe("currentCheckpointProjection", () => {
+    const measured = (overrides: Record<string, unknown> = {}) => ({
+        opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+        measurement_status: "measured", measurement_version: 2,
+        ...overrides,
+    });
+
+    test("a current measured suggestion is the recommendation", () => {
+        expect(currentCheckpointProjection(subject(), {
+            suggested: "adopted", user_verdict: null, measured: measured(),
+        })).toEqual({ suggested: "adopted", reason: null });
+    });
+
+    test("no checkpoint yet reports no_checkpoint, not a verdict", () => {
+        expect(currentCheckpointProjection(subject(), null))
+            .toEqual({ suggested: null, reason: "no_checkpoint" });
+    });
+
+    test("an ineligible experiment reports its lifecycle state, never an old suggestion", () => {
+        expect(currentCheckpointProjection(subject({ experimentStatus: "retired" }), {
+            suggested: "adopted", user_verdict: null, measured: measured(),
+        })).toEqual({ suggested: null, reason: "retired" });
+        expect(currentCheckpointProjection(subject({ experimentStatus: "task_emitted" }), {
+            suggested: "adopted", user_verdict: null, measured: measured(),
+        })).toEqual({ suggested: null, reason: "not_started" });
+    });
+
+    test("a locked experiment keeps the human decision visible", () => {
+        expect(currentCheckpointProjection(subject({ lockedVerdict: "adopted" }), {
+            suggested: "adopted", user_verdict: "adopted", measured: measured(),
+        })).toEqual({ suggested: "adopted", reason: null });
+    });
+
+    test("an insufficient-data row surfaces its own reason", () => {
+        expect(currentCheckpointProjection(subject(), {
+            suggested: null,
+            user_verdict: null,
+            measured: measured({
+                opportunities: 0, addressed: 0, ratio: 0,
+                measurement_status: "insufficient_data", reason: "no_opportunities",
+            }),
+        })).toEqual({ suggested: null, reason: "no_opportunities" });
+    });
+
+    test("a pre-version-2 row awaits explicit refresh instead of reporting its suggestion", () => {
+        expect(currentCheckpointProjection(subject(), {
+            suggested: "adopted",
+            user_verdict: null,
+            measured: { opportunities: 12, addressed: 8, ratio: 8 / 12, built: true },
+        })).toEqual({ suggested: null, reason: "refresh_required" });
+    });
+
+    test("a missing or unknown measurement status never authorizes a suggestion", () => {
+        for (const status of [undefined, "estimated", "insufficient_data", 2]) {
+            expect(currentCheckpointProjection(subject(), {
+                suggested: "adopted",
+                user_verdict: null,
+                measured: {
+                    opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+                    measurement_version: 2,
+                    ...(status === undefined ? {} : { measurement_status: status }),
+                },
+            })).toEqual({ suggested: null, reason: "refresh_required" });
+        }
+    });
+
+    test("a missing or malformed opportunity count asks for a refresh, not a verdict", () => {
+        for (const opportunities of [undefined, "12", null, Number.NaN, Number.POSITIVE_INFINITY, -3]) {
+            expect(currentCheckpointProjection(subject(), {
+                suggested: "adopted",
+                user_verdict: null,
+                measured: {
+                    addressed: 8, ratio: 8 / 12, built: true,
+                    measurement_status: "measured", measurement_version: 2,
+                    ...(opportunities === undefined ? {} : { opportunities }),
+                },
+            })).toEqual({ suggested: null, reason: "refresh_required" });
+        }
+    });
+
+    test("an insufficient-data row keeps its own reason ahead of the status gate", () => {
+        expect(currentCheckpointProjection(subject(), {
+            suggested: null,
+            user_verdict: null,
+            measured: measured({
+                opportunities: 12,
+                measurement_status: "insufficient_data", reason: "detector_unavailable",
+            }),
+        })).toEqual({ suggested: null, reason: "detector_unavailable" });
+    });
+
+    test("zero opportunities never reads as a substantive verdict", () => {
+        expect(currentCheckpointProjection(subject(), {
+            suggested: "no_longer_needed",
+            user_verdict: null,
+            measured: measured({ opportunities: 0, addressed: 0, ratio: 0 }),
+        })).toEqual({ suggested: null, reason: "no_opportunities" });
+    });
+});

--- a/apps/axctl/src/improve/measurement.ts
+++ b/apps/axctl/src/improve/measurement.ts
@@ -1,0 +1,258 @@
+/**
+ * Measurement eligibility - the one place that answers "may this experiment
+ * receive a new measurement, and can anything actually detect its artifact?"
+ * (#1134).
+ *
+ * Two readers share it: the opportunities derive stage (which evidence to
+ * collect, and from when) and the checkpoint stage (which windows to measure).
+ * They used to disagree - opportunities windowed hooks/guidance on the OBSERVED
+ * install while checkpoints counted sessions from acceptance, and neither
+ * checked the experiment's lifecycle - so a retired or never-installed
+ * experiment could still acquire a confident-looking verdict.
+ *
+ * The distinction this module exists to keep is between a MEASUREMENT and an
+ * ABSENCE OF DATA. "No opportunities" is not "the pattern went away", and "no
+ * detector for this form" is not "the artifact was ignored". Both are
+ * insufficient data, and they are reported as such rather than resolved into
+ * one of the five human verdicts.
+ *
+ * Pure by contract: plain values in, a verdict-shaped record out. It opens no
+ * store, reads no filesystem, and introduces no service - the data-dependent
+ * part (does a skill proposal cite a resolvable candidate?) is passed IN as a
+ * boolean by whichever caller already did that cache lookup.
+ */
+
+/** Why an experiment cannot be measured right now - a lifecycle/identity fact,
+ *  never a judgment about the artifact. */
+export type IneligibleReason =
+    | "not_accepted"
+    | "not_started"
+    | "retired"
+    | "regressed"
+    | "locked"
+    | "artifact_unavailable";
+
+/** Why a due window produced no suggested verdict. Mirrors the optional
+ *  `reason` field written into `checkpoint.measured`. */
+export type MeasurementReason =
+    | "no_opportunities"
+    | "detector_unavailable"
+    | "artifact_unavailable"
+    | "refresh_required";
+
+/** The measured-JSON status flag. `measured` means a real ratio was computed
+ *  over positive opportunities; everything else is absence of data. */
+export type MeasurementStatus = "measured" | "insufficient_data";
+
+/** The measured-JSON format version this chunk writes. Bumped together with the
+ *  fields below; the opportunity DERIVATION version is a separate token
+ *  (`opportunity-cache-version.ts`) because it certifies different facts. */
+export const MEASUREMENT_VERSION = 2;
+
+/** The additive fields written alongside the existing measured numbers. */
+export interface MeasurementFields {
+    readonly measurement_status: MeasurementStatus;
+    readonly reason?: MeasurementReason;
+    readonly measurement_version: number;
+}
+
+export interface MeasurementSubject {
+    readonly proposalStatus: string;
+    readonly experimentStatus: string;
+    readonly lockedVerdict: string | null;
+    readonly artifactPath: string | null;
+    /** When `improve lint` OBSERVED the artifact installed. */
+    readonly scaffoldedAt: Date | string | null;
+}
+
+export type Eligibility =
+    | { readonly eligible: true }
+    | { readonly eligible: false; readonly reason: IneligibleReason };
+
+const ELIGIBLE: Eligibility = { eligible: true };
+
+/** The install instant, or `null` when nothing usable was recorded. Accepts the
+ *  sidecar's decoded `Date` and the ISO string every projection carries. */
+export const installationTime = (value: Date | string | null | undefined): Date | null => {
+    if (value === null || value === undefined) return null;
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isFinite(date.getTime()) ? date : null;
+};
+
+/**
+ * May this experiment receive a new measurement?
+ *
+ * All four conditions hold or none of it counts: the proposal is accepted, the
+ * experiment reached `scaffolded` (`task_emitted` never installed anything,
+ * `retired`/`regressed` are past their measurement life), no verdict is locked,
+ * and lint reconciled BOTH an artifact path and an install time. `locked` is
+ * checked first on purpose: a locked experiment is finished, and reporting its
+ * lifecycle state as "retired" would invite a caller to rewrite settled history.
+ */
+export const measurementEligibility = (subject: MeasurementSubject): Eligibility => {
+    if (subject.lockedVerdict !== null) return { eligible: false, reason: "locked" };
+    if (subject.proposalStatus !== "accepted") return { eligible: false, reason: "not_accepted" };
+    switch (subject.experimentStatus) {
+        case "scaffolded":
+            break;
+        case "retired":
+            return { eligible: false, reason: "retired" };
+        case "regressed":
+            return { eligible: false, reason: "regressed" };
+        default:
+            return { eligible: false, reason: "not_started" };
+    }
+    if ((subject.artifactPath?.trim() ?? "").length === 0) {
+        return { eligible: false, reason: "artifact_unavailable" };
+    }
+    if (installationTime(subject.scaffoldedAt) === null) {
+        return { eligible: false, reason: "artifact_unavailable" };
+    }
+    return ELIGIBLE;
+};
+
+/**
+ * Parse a skill_proposal.trigger_pattern of the form `tool=<Name>` and return
+ * the tool name. Returns null for any other shape - a prose trigger has no
+ * detector, and guessing one from the words would manufacture evidence.
+ */
+export const parseSkillTriggerTool = (pattern: string): string | null => {
+    const m = /^tool=(.+)$/.exec(pattern.trim());
+    return m && m[1] ? m[1].trim() : null;
+};
+
+export interface DetectorSubject {
+    readonly form: string;
+    /** skill_proposal.trigger_pattern, when the proposal carries one. */
+    readonly skillTrigger: string | null;
+    /** Did the caller RESOLVE a cited `skill_candidate` ROW? A dangling
+     *  `cites_evidence` edge is not a detector - the legacy skill detector
+     *  derives its match tokens from the candidate itself. */
+    readonly hasSkillCandidate: boolean;
+    readonly hookTargetTool: string | null;
+    readonly hookEventName: string | null;
+    /** The `ax:<dedupe_sig>` marker identity installed in the hook command. */
+    readonly dedupeSig: string;
+    readonly artifactPath: string | null;
+}
+
+export type DetectorSupport =
+    | { readonly supported: true }
+    | { readonly supported: false; readonly reason: "detector_unavailable" | "artifact_unavailable" };
+
+const SUPPORTED: DetectorSupport = { supported: true };
+const NO_DETECTOR: DetectorSupport = { supported: false, reason: "detector_unavailable" };
+
+/**
+ * Can anything in this codebase observe whether this artifact did its job?
+ *
+ * The answer follows the detectors that EXIST in `derive-opportunities.ts`, not
+ * the forms the proposal vocabulary can express. Automation, subagent and
+ * harness-check proposals have no detector at all; a skill proposal needs
+ * either a cited candidate or the one supported `tool=<name>` trigger; a hook
+ * needs the three identity fields its correlation matches on; guidance needs
+ * the file lint actually reconciled.
+ */
+export const detectorSupport = (subject: DetectorSubject): DetectorSupport => {
+    switch (subject.form) {
+        case "guidance":
+            return (subject.artifactPath?.trim() ?? "").length > 0
+                ? SUPPORTED
+                : { supported: false, reason: "artifact_unavailable" };
+        case "hook":
+            return (subject.hookTargetTool?.trim() ?? "").length > 0
+                && (subject.hookEventName?.trim() ?? "").length > 0
+                && subject.dedupeSig.length > 0
+                ? SUPPORTED
+                : NO_DETECTOR;
+        case "skill":
+            if (subject.hasSkillCandidate) return SUPPORTED;
+            return subject.skillTrigger !== null && parseSkillTriggerTool(subject.skillTrigger) !== null
+                ? SUPPORTED
+                : NO_DETECTOR;
+        default:
+            return NO_DETECTOR;
+    }
+};
+
+/** The stored measured-JSON version, or null when the row predates it (or
+ *  carries a non-numeric value a JSON blob can always contain). */
+export const readMeasurementVersion = (
+    measured: Readonly<Record<string, unknown>> | null | undefined,
+): number | null => {
+    const raw = measured?.measurement_version;
+    return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+};
+
+/** The stored opportunity count, or null when the blob carries no usable one -
+ *  absent, non-numeric, non-finite, or negative. A count you cannot read is not
+ *  a count of zero, and neither one may authorize a suggestion. */
+const readOpportunities = (measured: Readonly<Record<string, unknown>> | null | undefined): number | null => {
+    const raw = measured?.opportunities;
+    return typeof raw === "number" && Number.isFinite(raw) && raw >= 0 ? raw : null;
+};
+
+const readReason = (
+    measured: Readonly<Record<string, unknown>> | null | undefined,
+): MeasurementReason | null => {
+    const raw = measured?.reason;
+    return raw === "no_opportunities" || raw === "detector_unavailable"
+        || raw === "artifact_unavailable" || raw === "refresh_required"
+        ? raw
+        : null;
+};
+
+/** The newest checkpoint row, as every projection sees it. */
+export interface CheckpointView {
+    readonly suggested: string | null;
+    readonly user_verdict: string | null;
+    readonly measured: Readonly<Record<string, unknown>> | null;
+}
+
+export interface CurrentProjection {
+    /** The suggestion safe to present as a CURRENT recommendation, or null. */
+    readonly suggested: string | null;
+    /** Why there is none. Null when `suggested` stands on its own. */
+    readonly reason: IneligibleReason | MeasurementReason | "no_checkpoint" | null;
+}
+
+/**
+ * The CURRENT recommendation for one experiment - a projection over its newest
+ * stored row plus today's eligibility, never a search back through history for
+ * the last positive answer.
+ *
+ * Stored checkpoints stay exactly as written (they are the evidence trail).
+ * What this suppresses is the claim that an old row still recommends something:
+ * a retired experiment, a row measured before the corrected rules, a window
+ * that found nothing to measure. A LOCKED experiment is exempt - the human
+ * already decided, and that decision is displayed as-is.
+ */
+export const currentCheckpointProjection = (
+    subject: MeasurementSubject,
+    latest: CheckpointView | null,
+): CurrentProjection => {
+    if (subject.lockedVerdict !== null) {
+        return { suggested: latest?.suggested ?? null, reason: null };
+    }
+    const eligibility = measurementEligibility(subject);
+    if (!eligibility.eligible) return { suggested: null, reason: eligibility.reason };
+    if (latest === null) return { suggested: null, reason: "no_checkpoint" };
+    // Every gate below is a POSITIVE requirement, checked against the stored
+    // blob rather than inferred from what is missing. A row has to carry the
+    // current format version, an explicit `measured` status, and a usable
+    // positive count before its suggestion can be presented as advice; absent
+    // or unrecognized values ask for an explicit refresh instead of passing.
+    if (readMeasurementVersion(latest.measured) !== MEASUREMENT_VERSION) {
+        return { suggested: null, reason: "refresh_required" };
+    }
+    if (latest.suggested === null) {
+        return { suggested: null, reason: readReason(latest.measured) ?? "refresh_required" };
+    }
+    if (latest.measured?.measurement_status !== "measured") {
+        return { suggested: null, reason: readReason(latest.measured) ?? "refresh_required" };
+    }
+    const opportunities = readOpportunities(latest.measured);
+    if (opportunities === null) return { suggested: null, reason: "refresh_required" };
+    if (opportunities === 0) return { suggested: null, reason: "no_opportunities" };
+    return { suggested: latest.suggested, reason: null };
+};

--- a/apps/axctl/src/improve/retro-skill.test.ts
+++ b/apps/axctl/src/improve/retro-skill.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A narrow contract over the SHIPPED retro skill (`skills/retro/SKILL.md`).
+ *
+ * The retro is the workflow that reads verdicts, so its ordering is part of
+ * #1134: the checkpoint measurement has to run, and finish, before any verdict
+ * read - otherwise the retro presents the previous run's suggestions as fresh
+ * ones. This inspects the command ORDER and the flags in the workflow, not the
+ * prose around them.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_PATH = join(import.meta.dir, "../../../../skills/retro/SKILL.md");
+const skill = readFileSync(SKILL_PATH, "utf8");
+
+/** Every ```bash fence in the document, in order. */
+const bashBlocks = (markdown: string): string[] =>
+    [...markdown.matchAll(/```bash\n([\s\S]*?)```/g)].map((m) => m[1] ?? "");
+
+/** The commands of the workflow steps, in document order - the CLI reference
+ *  section at the end is a lookup table, not a sequence. */
+const workflowCommands = (): string[] => {
+    const workflow = skill.slice(
+        skill.indexOf("## Workflow"),
+        skill.indexOf("## CLI reference"),
+    );
+    return bashBlocks(workflow)
+        .flatMap((block) => block.split("\n"))
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith("#"));
+};
+
+describe("shipped retro skill", () => {
+    test("the checkpoint prerequisite precedes every verdict read", () => {
+        const commands = workflowCommands();
+        const checkpoint = commands.findIndex((c) => c.includes("ax improve checkpoint"));
+        const verdictReads = commands
+            .map((c, i) => ({ c, i }))
+            .filter(({ c }) => c.includes("ax improve verdict"));
+        expect(checkpoint).toBeGreaterThanOrEqual(0);
+        expect(verdictReads.length).toBeGreaterThan(0);
+        for (const { i } of verdictReads) expect(i).toBeGreaterThan(checkpoint);
+    });
+
+    test("no workflow command runs checkpoint with --force", () => {
+        for (const command of workflowCommands()) {
+            if (command.includes("ax improve checkpoint")) {
+                expect(command).not.toContain("--force");
+            }
+        }
+    });
+
+    test("every workflow read disables the automatic freshness drive", () => {
+        // A prefix on the first command does not carry to the next one, so each
+        // ax command in the snapshot step needs its own.
+        const snapshot = skill.slice(skill.indexOf("### Step 1 - Snapshot"), skill.indexOf("### Step 2"));
+        const commands = bashBlocks(snapshot)
+            .flatMap((block) => block.split("\n"))
+            .map((line) => line.trim())
+            .filter((line) => line.startsWith("ax ") || line.includes(" ax "));
+        expect(commands.length).toBeGreaterThan(0);
+        for (const command of commands) expect(command).toStartWith("AX_NO_AUTO_INGEST=1 ax ");
+    });
+});

--- a/apps/axctl/src/improve/verdicts.test.ts
+++ b/apps/axctl/src/improve/verdicts.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The verdict read model over a REAL temporary sidecar built from the
+ * production DDL: history stays, unsafe current recommendations do not.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { Judgment, JudgmentLayer } from "@ax/lib/sqlite";
+import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
+import { listVerdicts, showVerdict } from "./verdicts.ts";
+
+const CREATED_AT = new Date("2026-01-01T00:00:00Z");
+const INSTALLED_AT = new Date("2026-01-10T00:00:00Z");
+
+const measured = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+    opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+    measurement_status: "measured", measurement_version: 2,
+    ...overrides,
+});
+
+interface Seed {
+    readonly sig: string;
+    readonly status?: string;
+    readonly experimentStatus?: string;
+    readonly lockedVerdict?: string | null;
+    readonly checkpoints?: ReadonlyArray<{
+        readonly kind: string;
+        readonly suggested: string | null;
+        readonly measured: string;
+        readonly userVerdict?: string | null;
+        readonly observedAt: Date;
+    }>;
+}
+
+const withSidecar = <A>(seeds: ReadonlyArray<Seed>, body: Effect.Effect<A, unknown, Judgment>) => {
+    const sidecarPath = join(mkdtempSync(join(tmpdir(), "ax-verdicts-")), "judgment.sqlite");
+    return Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        for (const seed of seeds) {
+            yield* judgment.put("proposal", {
+                id: `proposal-${seed.sig}`, form: "guidance", title: `T-${seed.sig}`,
+                hypothesis: "H", dedupe_sig: seed.sig, frequency: 3, confidence: "high",
+                status: seed.status ?? "accepted", origin: "agent", hypothesis_template: null,
+                evidence_query: null, reject_reason: null, baseline: null,
+                created_at: CREATED_AT, updated_at: CREATED_AT,
+            });
+            yield* judgment.put("experiment", {
+                id: `experiment-${seed.sig}`, proposal: `proposal-${seed.sig}`, artifact: null,
+                artifact_path: "/repo/CLAUDE.md", scaffolded_at: INSTALLED_AT, created_at: CREATED_AT,
+                locked_verdict: seed.lockedVerdict ?? null,
+                status: seed.experimentStatus ?? "scaffolded", task_path: null,
+            });
+            for (const checkpoint of seed.checkpoints ?? []) {
+                yield* judgment.put("checkpoint", {
+                    id: `checkpoint-${seed.sig}-${checkpoint.kind}`, experiment: `experiment-${seed.sig}`,
+                    kind: checkpoint.kind, measured: checkpoint.measured, suggested: checkpoint.suggested,
+                    user_verdict: checkpoint.userVerdict ?? null, observed_at: checkpoint.observedAt,
+                });
+            }
+        }
+        return yield* body;
+    }).pipe(
+        Effect.provide(JudgmentLayer({ sidecarPath, schemaSql: SIDECAR_SCHEMA_SQL })),
+        Effect.scoped,
+    ) as Effect.Effect<A, unknown, never>);
+};
+
+const history = [
+    {
+        kind: "+3s", suggested: "adopted", measured: measured(),
+        observedAt: new Date("2026-01-20T00:00:00Z"),
+    },
+    {
+        kind: "+10s", suggested: null,
+        measured: measured({
+            opportunities: 0, addressed: 0, ratio: 0,
+            measurement_status: "insufficient_data", reason: "no_opportunities",
+        }),
+        observedAt: new Date("2026-01-25T00:00:00Z"),
+    },
+] as const;
+
+describe("listVerdicts", () => {
+    test("projects the newest row, never an older positive suggestion", async () => {
+        const rows = await withSidecar([{ sig: "sig-a", checkpoints: history }], listVerdicts());
+        const row = rows[0] as Record<string, unknown>;
+        const latest = row.latest_checkpoint as Record<string, unknown>;
+        expect(latest.kind).toBe("+10s");
+        expect(latest.suggested).toBeNull();
+        expect(row.current_reason).toBe("no_opportunities");
+    });
+
+    test("suppresses the suggestion of an ineligible experiment and names its state", async () => {
+        const rows = await withSidecar(
+            [{ sig: "sig-b", experimentStatus: "retired", checkpoints: [history[0]] }],
+            listVerdicts(),
+        );
+        const row = rows[0] as Record<string, unknown>;
+        expect((row.latest_checkpoint as Record<string, unknown>).suggested).toBeNull();
+        expect(row.current_reason).toBe("retired");
+    });
+
+    test("a locked experiment keeps the decision the human made", async () => {
+        const rows = await withSidecar([{
+            sig: "sig-c",
+            lockedVerdict: "adopted",
+            checkpoints: [{ ...history[0], userVerdict: "adopted" }],
+        }], listVerdicts());
+        const row = rows[0] as Record<string, unknown>;
+        expect(row.locked_verdict).toBe("adopted");
+        expect((row.latest_checkpoint as Record<string, unknown>).suggested).toBe("adopted");
+        expect(row.current_reason).toBeNull();
+    });
+
+    test("no checkpoint yet reads as no_checkpoint", async () => {
+        const rows = await withSidecar([{ sig: "sig-d" }], listVerdicts());
+        const row = rows[0] as Record<string, unknown>;
+        expect(row.latest_checkpoint).toBeNull();
+        expect(row.current_reason).toBe("no_checkpoint");
+    });
+});
+
+describe("showVerdict", () => {
+    test("keeps the full history newest-first while the current view stays safe", async () => {
+        const row = await withSidecar(
+            [{ sig: "sig-a", checkpoints: history }],
+            showVerdict("sig-a"),
+        ) as Record<string, unknown>;
+        const checkpoints = row.checkpoints as Array<Record<string, unknown>>;
+        expect(checkpoints.map((c) => c.kind)).toEqual(["+10s", "+3s"]);
+        // The stored history is untouched - the +3s row still reports what it
+        // measured, and only the CURRENT projection withholds it.
+        expect(checkpoints[1]!.suggested).toBe("adopted");
+        expect((row.latest_checkpoint as Record<string, unknown>).suggested).toBeNull();
+        expect(row.current_reason).toBe("no_opportunities");
+    });
+
+    test("a pre-version-2 row awaits refresh rather than recommending itself", async () => {
+        const row = await withSidecar([{
+            sig: "sig-legacy",
+            checkpoints: [{
+                kind: "+3s", suggested: "adopted",
+                measured: JSON.stringify({ opportunities: 40, addressed: 39, ratio: 0.975, built: true }),
+                observedAt: new Date("2026-01-20T00:00:00Z"),
+            }],
+        }], showVerdict("sig-legacy")) as Record<string, unknown>;
+        expect((row.latest_checkpoint as Record<string, unknown>).suggested).toBeNull();
+        expect(row.current_reason).toBe("refresh_required");
+        expect((row.checkpoints as Array<Record<string, unknown>>)[0]!.suggested).toBe("adopted");
+    });
+});

--- a/apps/axctl/src/improve/verdicts.ts
+++ b/apps/axctl/src/improve/verdicts.ts
@@ -20,6 +20,7 @@ import {
     type StoredCheckpoint,
     type StoredProposal,
 } from "./judgment-proposals.ts";
+import { currentCheckpointProjection, type CurrentProjection } from "./measurement.ts";
 
 /** One experiment row in the verdict listing, with its newest checkpoint
  *  inlined as `latest_checkpoint` (or `null` when none exists yet). */
@@ -68,9 +69,45 @@ const checkpointRow = (checkpoint: StoredCheckpoint) => ({
     observed_at: checkpoint.observed_at.toISOString(),
 });
 
+/**
+ * History versus recommendation (#1134).
+ *
+ * `checkpoints` is the stored evidence trail and is returned verbatim - a row
+ * that once suggested `adopted` keeps saying so. `latest_checkpoint` is the
+ * CURRENT recommendation, and it carries the newest row's suggestion only when
+ * that suggestion still stands: the experiment is eligible today, the row was
+ * measured under the current rules, and it had something to measure. Otherwise
+ * the suggestion reads null and `current_reason` names why, so a retired or
+ * unrefreshed experiment can never present an old positive answer as advice.
+ */
+const currentView = (proposal: StoredProposal): {
+    readonly latest: ReturnType<typeof checkpointRow> | null;
+    readonly projection: CurrentProjection;
+} => {
+    const experiment = proposal.experiment!;
+    const newest = experiment.checkpoints.at(-1);
+    const projection = currentCheckpointProjection({
+        proposalStatus: proposal.status,
+        experimentStatus: experiment.status,
+        lockedVerdict: experiment.locked_verdict,
+        artifactPath: experiment.artifact_path,
+        scaffoldedAt: experiment.scaffolded_at,
+    }, newest === undefined ? null : {
+        suggested: newest.suggested,
+        user_verdict: newest.user_verdict,
+        measured: newest.measured,
+    });
+    return {
+        latest: newest === undefined
+            ? null
+            : { ...checkpointRow(newest), suggested: projection.suggested },
+        projection,
+    };
+};
+
 const toVerdictListRow = (proposal: StoredProposal): VerdictListRow => {
     const experiment = proposal.experiment!;
-    const latest = experiment.checkpoints.at(-1);
+    const current = currentView(proposal);
     return {
         title: proposal.title,
         dedupe_sig: proposal.dedupe_sig,
@@ -78,21 +115,26 @@ const toVerdictListRow = (proposal: StoredProposal): VerdictListRow => {
         created_at: experiment.created_at.toISOString(),
         scaffolded_at: experiment.scaffolded_at?.toISOString() ?? null,
         locked_verdict: experiment.locked_verdict,
-        latest_checkpoint: latest ? checkpointRow(latest) : null,
+        latest_checkpoint: current.latest,
+        current_reason: current.projection.reason,
     };
 };
 
 const toVerdictShowRow = (proposal: StoredProposal): VerdictShowRow => {
     const experiment = proposal.experiment!;
+    const current = currentView(proposal);
     return {
         id: experiment.id,
         title: proposal.title,
         dedupe_sig: proposal.dedupe_sig,
         proposal_status: proposal.status,
+        experiment_status: experiment.status,
         artifact_path: experiment.artifact_path,
         created_at: experiment.created_at.toISOString(),
         scaffolded_at: experiment.scaffolded_at?.toISOString() ?? null,
         locked_verdict: experiment.locked_verdict,
+        latest_checkpoint: current.latest,
+        current_reason: current.projection.reason,
         checkpoints: experiment.checkpoints.toReversed().map(checkpointRow),
     };
 };

--- a/apps/axctl/src/ingest/derive-checkpoints.test.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { CacheReadLayer, withCacheWrite } from "@ax/lib/duckdb/seam";
 import { withIngestLock } from "@ax/lib/ingest-lock";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
-import { Judgment, JudgmentLayer, TextColumn } from "@ax/lib/sqlite";
+import { Judgment, JudgmentLayer, TextColumn, TimestampColumn } from "@ax/lib/sqlite";
+import CACHE_DDL from "@ax/schema/schema.duckdb.sql" with { type: "text" };
 import { SIDECAR_SCHEMA_SQL } from "@ax/schema/sidecar-ddl";
 import {
     checkpointKey,
@@ -16,10 +17,6 @@ import {
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("derive checkpoints");
 const Platform = Layer.merge(BunFileSystem.layer, BunPath.layer);
-const CACHE_DDL = `
-CREATE TABLE opportunity (id VARCHAR PRIMARY KEY, in_id VARCHAR NOT NULL, was_addressed BOOLEAN NOT NULL);
-CREATE TABLE session (id VARCHAR PRIMARY KEY, created_at TIMESTAMP);
-`;
 
 describe("computeSuggestedVerdict", () => {
     test("opportunities=0 + no frequency info -> no_longer_needed", () => {
@@ -104,11 +101,11 @@ describe("checkpointKey", () => {
     });
 });
 
-dtest("deriveCheckpoints uses DuckDB facts and SQLite judgments", async () => {
+dtest("deriveCheckpoints counts subsequent sessions against production DDL and persists SQLite checkpoints", async () => {
     const root = tempDir("ax-checkpoint-sidecar-");
     const lockPath = join(root, "ingest.lock");
     const snapshotPath = join(root, "snapshot.duckdb");
-    const publish = withIngestLock({
+    const publish = (sessionCount: number, addressed = true) => withIngestLock({
         lockPath,
         command: "derive-checkpoints-test",
         staleMs: 60_000,
@@ -120,23 +117,34 @@ dtest("deriveCheckpoints uses DuckDB facts and SQLite judgments", async () => {
         schemaSql: CACHE_DDL,
         ...(dylibPath === null ? {} : { assetPath: dylibPath }),
     }, (write) => Effect.gen(function* () {
-        yield* write.putMany("session", [1, 2, 3].map((n) => ({
-            id: `session-${n}`,
-            created_at: new Date(`2026-01-0${n + 1}T00:00:00Z`),
-        })));
-        yield* write.putMany("opportunity", [
-            { id: "o1", in_id: "experiment-one", was_addressed: true },
-            { id: "o2", in_id: "experiment-one", was_addressed: true },
-            { id: "o3", in_id: "experiment-one", was_addressed: false },
+        yield* write.putMany("session", [
+            // Neither an earlier start nor an exact boundary start counts,
+            // even when the session ends after the experiment starts.
+            { id: "older", started_at: new Date("2025-12-31T23:59:59.999Z"), ended_at: new Date("2026-02-01T00:00:00Z") },
+            { id: "boundary", started_at: new Date("2026-01-01T00:00:00Z"), ended_at: new Date("2026-02-01T00:00:00Z") },
+            { id: "unknown", started_at: null, ended_at: new Date("2026-02-01T00:00:00Z") },
+            ...Array.from({ length: sessionCount }, (_, n) => ({
+                id: `session-${n + 1}`,
+                started_at: new Date(Date.parse("2026-01-01T00:00:00Z") + n + 1),
+                ended_at: null,
+            })),
         ]);
+        yield* write.putMany("opportunity", [
+            { id: "o1", in_id: "experiment-one", was_addressed: addressed },
+            { id: "o2", in_id: "experiment-one", was_addressed: addressed },
+            { id: "o3", in_id: "experiment-one", was_addressed: false },
+        ].map((row) => ({
+            ...row, out_id: "session-1", out_table: "session",
+            matched_at: new Date("2026-01-02T00:00:00Z"),
+        })));
     })));
-    await Effect.runPromise(publish.pipe(Effect.provide(Platform)));
+    await Effect.runPromise(publish(0).pipe(Effect.provide(Platform)));
 
-    const layer = Layer.mergeAll(
+    const layer = () => Layer.mergeAll(
         CacheReadLayer({ snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) }),
         JudgmentLayer({ sidecarPath: join(root, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
     );
-    const result = await Effect.runPromise(Effect.gen(function* () {
+    await Effect.runPromise(Effect.gen(function* () {
         const judgment = yield* Judgment;
         const now = new Date("2026-01-01T00:00:00Z");
         yield* judgment.put("proposal", {
@@ -147,16 +155,72 @@ dtest("deriveCheckpoints uses DuckDB facts and SQLite judgments", async () => {
         });
         yield* judgment.put("experiment", {
             id: "experiment-one", proposal: "proposal-one", artifact: null,
-            artifact_path: "/tmp/plan.md", scaffolded_at: now, created_at: now,
+            artifact_path: join(root, "plan.md"), scaffolded_at: now, created_at: now,
             locked_verdict: null, status: "scaffolded", task_path: null,
         });
-        const stats = yield* deriveCheckpoints({ now: new Date("2026-02-01T00:00:00Z") });
+    }).pipe(Effect.provide(layer()), Effect.scoped));
+
+    const observe = (now: Date, force = false) => Effect.runPromise(Effect.gen(function* () {
+        const stats = yield* deriveCheckpoints({ now, force });
+        const judgment = yield* Judgment;
         const rows = yield* judgment.rows(
-            Schema.Struct({ kind: TextColumn, suggested: TextColumn }),
-            "SELECT kind, suggested FROM checkpoint ORDER BY kind",
+            Schema.Struct({
+                id: TextColumn, kind: TextColumn, suggested: TextColumn,
+                measured: TextColumn, observed_at: TimestampColumn,
+            }),
+            "SELECT id, kind, suggested, measured, observed_at FROM checkpoint ORDER BY kind",
         );
         return { stats, rows };
-    }).pipe(Effect.provide(layer), Effect.scoped));
-    expect(result.stats.checkpointsInserted).toBe(1);
-    expect(result.rows).toEqual([{ kind: "+3s", suggested: "adopted" }]);
+    }).pipe(Effect.provide(layer()), Effect.scoped));
+
+    const now = new Date("2026-02-01T00:00:00Z");
+    const later = new Date("2026-02-02T00:00:00Z");
+    const cases = [
+        { count: 0, inserted: 0, kinds: [] },
+        { count: 2, inserted: 0, kinds: [] },
+        { count: 3, inserted: 1, kinds: ["+3s"] },
+        { count: 9, inserted: 0, kinds: ["+3s"] },
+        { count: 10, inserted: 1, kinds: ["+10s", "+3s"] },
+        { count: 29, inserted: 0, kinds: ["+10s", "+3s"] },
+        { count: 30, inserted: 1, kinds: ["+10s", "+30s", "+3s"] },
+    ];
+    for (const { count, inserted, kinds } of cases) {
+        await Effect.runPromise(publish(count).pipe(Effect.provide(Platform)));
+        const result = await observe(now);
+        expect(result.stats.experimentsScanned).toBe(1);
+        expect(result.stats.checkpointsInserted).toBe(inserted);
+        expect(result.rows.map((row) => row.kind)).toEqual(kinds);
+        for (const row of result.rows) {
+            expect(row.suggested).toBe("adopted");
+            expect(JSON.parse(row.measured)).toEqual({
+                opportunities: 3, addressed: 2, ratio: 2 / 3, built: true,
+                current_frequency: 3, baseline_frequency: 3,
+            });
+        }
+        const repeated = await observe(later);
+        expect(repeated.stats.checkpointsInserted).toBe(0);
+        expect(repeated.rows).toEqual(result.rows);
+    }
+
+    const before = await observe(now);
+    await Effect.runPromise(publish(30, false).pipe(Effect.provide(Platform)));
+    const unchanged = await observe(later);
+    expect(unchanged.stats.checkpointsInserted).toBe(0);
+    expect(unchanged.rows).toEqual(before.rows);
+
+    const forced = await observe(later, true);
+    expect(forced.stats.checkpointsInserted).toBe(3);
+    expect(forced.rows.map((row) => row.id)).toEqual(before.rows.map((row) => row.id));
+    expect(forced.rows.map((row) => row.kind)).toEqual(["+10s", "+30s", "+3s"]);
+    for (const row of forced.rows) {
+        expect(row.observed_at).toEqual(later);
+        expect(row.suggested).toBe("ignored");
+        expect(JSON.parse(row.measured)).toEqual({
+            opportunities: 3, addressed: 0, ratio: 0, built: true,
+            current_frequency: 3, baseline_frequency: 3,
+        });
+    }
+    const after = await observe(now);
+    expect(after.stats.checkpointsInserted).toBe(0);
+    expect(after.rows).toEqual(forced.rows);
 });

--- a/apps/axctl/src/ingest/derive-checkpoints.test.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.test.ts
@@ -223,4 +223,4 @@ dtest("deriveCheckpoints counts subsequent sessions against production DDL and p
     const after = await observe(now);
     expect(after.stats.checkpointsInserted).toBe(0);
     expect(after.rows).toEqual(forced.rows);
-}, 90_000); // Production DDL setup publishes 11 snapshots and derives 17 times.
+}, 90_000); // Multiple production snapshots and checkpoint refreshes share this budget.

--- a/apps/axctl/src/ingest/derive-checkpoints.test.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.test.ts
@@ -223,4 +223,4 @@ dtest("deriveCheckpoints counts subsequent sessions against production DDL and p
     const after = await observe(now);
     expect(after.stats.checkpointsInserted).toBe(0);
     expect(after.rows).toEqual(forced.rows);
-});
+}, 90_000); // Production DDL setup publishes 11 snapshots and derives 17 times.

--- a/apps/axctl/src/ingest/derive-checkpoints.test.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, Schema } from "effect";
 import { join } from "node:path";
 import { CacheReadLayer, withCacheWrite } from "@ax/lib/duckdb/seam";
 import { withIngestLock } from "@ax/lib/ingest-lock";
+import { WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
 import { duckdbTestSetup } from "@ax/lib/testing/duckdb-dylib";
 import { Judgment, JudgmentLayer, TextColumn, TimestampColumn } from "@ax/lib/sqlite";
 import CACHE_DDL from "@ax/schema/schema.duckdb.sql" with { type: "text" };
@@ -14,35 +15,29 @@ import {
     deriveCheckpoints,
     dueCheckpointKinds,
 } from "./derive-checkpoints.ts";
+import {
+    OPPORTUNITY_VERSION,
+    OPPORTUNITY_VERSION_PATH,
+    OPPORTUNITY_VERSION_SOURCE,
+} from "./opportunity-cache-version.ts";
 
 const { dylibPath, dtest, tempDir } = await duckdbTestSetup("derive checkpoints");
 const Platform = Layer.merge(BunFileSystem.layer, BunPath.layer);
 
 describe("computeSuggestedVerdict", () => {
-    test("opportunities=0 + no frequency info -> no_longer_needed", () => {
-        expect(computeSuggestedVerdict({ opportunities: 0, addressed: 0, ratio: 0, built: true })).toBe("no_longer_needed");
-    });
-
-    test("opportunities=0 + current==baseline -> no_longer_needed (pattern self-resolved)", () => {
-        expect(computeSuggestedVerdict({
-            opportunities: 0,
-            addressed: 0,
-            ratio: 0,
-            built: true,
-            currentFrequency: 5,
-            baselineFrequency: 5,
-        })).toBe("no_longer_needed");
-    });
-
-    test("opportunities=0 + current > baseline -> ignored (artifact exists but pattern still firing)", () => {
-        expect(computeSuggestedVerdict({
-            opportunities: 0,
-            addressed: 0,
-            ratio: 0,
-            built: true,
-            currentFrequency: 9,
-            baselineFrequency: 5,
-        })).toBe("ignored");
+    test("zero opportunities is insufficient data, whatever the frequency delta says", () => {
+        // Frequency equality never proved a pattern disappeared, and a rising
+        // counter never proved the artifact was ignored (#1134).
+        for (const frequencies of [
+            {},
+            { currentFrequency: 5, baselineFrequency: 5 },
+            { currentFrequency: 9, baselineFrequency: 5 },
+            { currentFrequency: 1, baselineFrequency: 9 },
+        ]) {
+            expect(computeSuggestedVerdict({
+                opportunities: 0, addressed: 0, ratio: 0, built: true, ...frequencies,
+            })).toBeNull();
+        }
     });
 
     test("ratio > 0.6 -> adopted", () => {
@@ -60,31 +55,20 @@ describe("computeSuggestedVerdict", () => {
 
 describe("dueCheckpointKinds", () => {
     test("nothing due at 2 sessions", () => {
-        expect(dueCheckpointKinds(2, new Set()).length).toBe(0);
+        expect(dueCheckpointKinds(2).length).toBe(0);
     });
 
     test("+3s due at exactly 3 sessions", () => {
-        expect(dueCheckpointKinds(3, new Set())).toEqual(["+3s"]);
+        expect(dueCheckpointKinds(3)).toEqual(["+3s"]);
     });
 
     test("+3s and +10s due at 11 sessions", () => {
-        expect(dueCheckpointKinds(11, new Set())).toEqual(["+3s", "+10s"]);
+        expect(dueCheckpointKinds(11)).toEqual(["+3s", "+10s"]);
     });
 
     test("all three due at 30+ sessions", () => {
-        expect(dueCheckpointKinds(30, new Set())).toEqual(["+3s", "+10s", "+30s"]);
-        expect(dueCheckpointKinds(42, new Set())).toEqual(["+3s", "+10s", "+30s"]);
-    });
-
-    test("skips kinds already present in existing", () => {
-        expect(dueCheckpointKinds(40, new Set(["+3s", "+10s"]))).toEqual(["+30s"]);
-    });
-
-    test("legacy day-based kinds in existing are not treated as the new session-based ones", () => {
-        // A migrated experiment may have legacy t+7/t+30/t+90 rows. Those
-        // don't satisfy the new windows; they're separate kinds. The new
-        // session-based checkpoints should still emit.
-        expect(dueCheckpointKinds(40, new Set(["t+7", "t+30", "t+90"]))).toEqual(["+3s", "+10s", "+30s"]);
+        expect(dueCheckpointKinds(30)).toEqual(["+3s", "+10s", "+30s"]);
+        expect(dueCheckpointKinds(42)).toEqual(["+3s", "+10s", "+30s"]);
     });
 });
 
@@ -101,11 +85,53 @@ describe("checkpointKey", () => {
     });
 });
 
-dtest("deriveCheckpoints counts subsequent sessions against production DDL and persists SQLite checkpoints", async () => {
-    const root = tempDir("ax-checkpoint-sidecar-");
+// ---------------------------------------------------------------------------
+// Production-DDL integration
+// ---------------------------------------------------------------------------
+
+const INSTALLED_AT = new Date("2026-01-10T00:00:00Z");
+const CREATED_AT = new Date("2026-01-01T00:00:00Z");
+
+interface PublishOpts {
+    /** Sessions started AFTER the install; each counts toward a window. */
+    readonly sessions?: number;
+    /** Sessions started after ACCEPTANCE but before the install - never counted. */
+    readonly preInstallSessions?: number;
+    /** Subagent-source sessions after the install - never counted. */
+    readonly subagentSessions?: number;
+    readonly opportunities?: number;
+    readonly addressed?: number;
+    /** The derivation-version sentinel to publish, or null for none. */
+    readonly marker?: string | null;
+    /** `source_kind` for the sentinel row, to test a foreign marker. */
+    readonly markerSource?: string;
+    readonly experimentKey?: string;
+    /** Base instant for the post-install sessions (default: the install). */
+    readonly sessionsFrom?: Date;
+    /** `matched_at` for the opportunity rows (default: just after the install). */
+    readonly matchedAt?: Date;
+    /** `cites_evidence` edges to publish: proposal -> skill_candidate. */
+    readonly candidateEdges?: ReadonlyArray<{
+        readonly proposal: string;
+        readonly candidate: string;
+        /** Write the `skill_candidate` row too (false = a dangling edge). */
+        readonly resolvable: boolean;
+    }>;
+}
+
+/** One published snapshot, built through the production cache DDL. */
+const publishSnapshot = (root: string, opts: PublishOpts = {}) => {
+    const sessions = opts.sessions ?? 0;
+    const preInstall = opts.preInstallSessions ?? 0;
+    const subagents = opts.subagentSessions ?? 0;
+    const opportunities = opts.opportunities ?? 0;
+    const addressed = opts.addressed ?? 0;
+    const marker = opts.marker === undefined ? OPPORTUNITY_VERSION : opts.marker;
+    const experimentKey = opts.experimentKey ?? "experiment-one";
+    const sessionsFrom = opts.sessionsFrom ?? INSTALLED_AT;
+    const matchedAt = opts.matchedAt ?? new Date(INSTALLED_AT.getTime() + 1000);
     const lockPath = join(root, "ingest.lock");
-    const snapshotPath = join(root, "snapshot.duckdb");
-    const publish = (sessionCount: number, addressed = true) => withIngestLock({
+    return Effect.runPromise(withIngestLock({
         lockPath,
         command: "derive-checkpoints-test",
         staleMs: 60_000,
@@ -113,114 +139,567 @@ dtest("deriveCheckpoints counts subsequent sessions against production DDL and p
     }, withCacheWrite({
         livePath: join(root, "live.duckdb"),
         lockPath,
-        snapshotPath,
+        snapshotPath: join(root, "snapshot.duckdb"),
         schemaSql: CACHE_DDL,
         ...(dylibPath === null ? {} : { assetPath: dylibPath }),
     }, (write) => Effect.gen(function* () {
+        yield* write.exec("DELETE FROM session");
+        yield* write.exec("DELETE FROM opportunity");
+        yield* write.exec("DELETE FROM cites_evidence");
+        yield* write.exec("DELETE FROM skill_candidate");
+        yield* write.exec(`DELETE FROM ${WATERMARK_TABLE}`);
         yield* write.putMany("session", [
-            // Neither an earlier start nor an exact boundary start counts,
-            // even when the session ends after the experiment starts.
-            { id: "older", started_at: new Date("2025-12-31T23:59:59.999Z"), ended_at: new Date("2026-02-01T00:00:00Z") },
-            { id: "boundary", started_at: new Date("2026-01-01T00:00:00Z"), ended_at: new Date("2026-02-01T00:00:00Z") },
-            { id: "unknown", started_at: null, ended_at: new Date("2026-02-01T00:00:00Z") },
-            ...Array.from({ length: sessionCount }, (_, n) => ({
-                id: `session-${n + 1}`,
-                started_at: new Date(Date.parse("2026-01-01T00:00:00Z") + n + 1),
-                ended_at: null,
+            // Accepted-but-not-installed exposure: after created_at, before the
+            // observed install, so it can say nothing about the artifact.
+            ...Array.from({ length: preInstall }, (_, n) => ({
+                id: `pre-${n + 1}`, source: "claude",
+                started_at: new Date(CREATED_AT.getTime() + n + 1), ended_at: null,
+            })),
+            ...Array.from({ length: subagents }, (_, n) => ({
+                id: `sub-${n + 1}`, source: n % 2 === 0 ? "claude-subagent" : "codex-subagent",
+                started_at: new Date(sessionsFrom.getTime() + n + 1), ended_at: null,
+            })),
+            ...Array.from({ length: sessions }, (_, n) => ({
+                id: `session-${n + 1}`, source: "claude",
+                started_at: new Date(sessionsFrom.getTime() + n + 1), ended_at: null,
             })),
         ]);
-        yield* write.putMany("opportunity", [
-            { id: "o1", in_id: "experiment-one", was_addressed: addressed },
-            { id: "o2", in_id: "experiment-one", was_addressed: addressed },
-            { id: "o3", in_id: "experiment-one", was_addressed: false },
-        ].map((row) => ({
-            ...row, out_id: "session-1", out_table: "session",
-            matched_at: new Date("2026-01-02T00:00:00Z"),
+        yield* write.putMany("opportunity", Array.from({ length: opportunities }, (_, n) => ({
+            id: `o${n + 1}`,
+            in_id: experimentKey,
+            out_id: "session-1",
+            out_table: "session",
+            matched_at: matchedAt,
+            was_addressed: n < addressed,
         })));
-    })));
-    await Effect.runPromise(publish(0).pipe(Effect.provide(Platform)));
-
-    const layer = () => Layer.mergeAll(
-        CacheReadLayer({ snapshotPath, ...(dylibPath === null ? {} : { assetPath: dylibPath }) }),
-        JudgmentLayer({ sidecarPath: join(root, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
-    );
-    await Effect.runPromise(Effect.gen(function* () {
-        const judgment = yield* Judgment;
-        const now = new Date("2026-01-01T00:00:00Z");
-        yield* judgment.put("proposal", {
-            id: "proposal-one", form: "guidance", title: "T", hypothesis: "H", dedupe_sig: "sig",
-            frequency: 3, confidence: "high", status: "accepted", origin: "agent",
-            hypothesis_template: null, evidence_query: null, reject_reason: null,
-            baseline: JSON.stringify({ frequency: 3 }), created_at: now, updated_at: now,
-        });
-        yield* judgment.put("experiment", {
-            id: "experiment-one", proposal: "proposal-one", artifact: null,
-            artifact_path: join(root, "plan.md"), scaffolded_at: now, created_at: now,
-            locked_verdict: null, status: "scaffolded", task_path: null,
-        });
-    }).pipe(Effect.provide(layer()), Effect.scoped));
-
-    const observe = (now: Date, force = false) => Effect.runPromise(Effect.gen(function* () {
-        const stats = yield* deriveCheckpoints({ now, force });
-        const judgment = yield* Judgment;
-        const rows = yield* judgment.rows(
-            Schema.Struct({
-                id: TextColumn, kind: TextColumn, suggested: TextColumn,
-                measured: TextColumn, observed_at: TimestampColumn,
-            }),
-            "SELECT id, kind, suggested, measured, observed_at FROM checkpoint ORDER BY kind",
-        );
-        return { stats, rows };
-    }).pipe(Effect.provide(layer()), Effect.scoped));
-
-    const now = new Date("2026-02-01T00:00:00Z");
-    const later = new Date("2026-02-02T00:00:00Z");
-    const cases = [
-        { count: 0, inserted: 0, kinds: [] },
-        { count: 2, inserted: 0, kinds: [] },
-        { count: 3, inserted: 1, kinds: ["+3s"] },
-        { count: 9, inserted: 0, kinds: ["+3s"] },
-        { count: 10, inserted: 1, kinds: ["+10s", "+3s"] },
-        { count: 29, inserted: 0, kinds: ["+10s", "+3s"] },
-        { count: 30, inserted: 1, kinds: ["+10s", "+30s", "+3s"] },
-    ];
-    for (const { count, inserted, kinds } of cases) {
-        await Effect.runPromise(publish(count).pipe(Effect.provide(Platform)));
-        const result = await observe(now);
-        expect(result.stats.experimentsScanned).toBe(1);
-        expect(result.stats.checkpointsInserted).toBe(inserted);
-        expect(result.rows.map((row) => row.kind)).toEqual(kinds);
-        for (const row of result.rows) {
-            expect(row.suggested).toBe("adopted");
-            expect(JSON.parse(row.measured)).toEqual({
-                opportunities: 3, addressed: 2, ratio: 2 / 3, built: true,
-                current_frequency: 3, baseline_frequency: 3,
+        for (const edge of opts.candidateEdges ?? []) {
+            if (edge.resolvable) {
+                yield* write.put("skill_candidate", {
+                    id: edge.candidate, name: edge.candidate, trigger_pattern: "schema edits",
+                    suspected_gap: "gap", proposed_behavior: "behavior", confidence: "high",
+                    expected_impact: null, status: "candidate", labels: null, metrics: null,
+                    created_at: CREATED_AT,
+                });
+            }
+            yield* write.put("cites_evidence", {
+                id: `cites-${edge.proposal}-${edge.candidate}`,
+                in_id: edge.proposal, out_id: edge.candidate,
+                in_table: "proposal", out_table: "skill_candidate",
+                count: 1, kind: null, ts: CREATED_AT,
             });
         }
-        const repeated = await observe(later);
-        expect(repeated.stats.checkpointsInserted).toBe(0);
-        expect(repeated.rows).toEqual(result.rows);
-    }
+        if (marker !== null) {
+            yield* write.put(
+                WATERMARK_TABLE,
+                watermarkRow(opts.markerSource ?? OPPORTUNITY_VERSION_SOURCE, OPPORTUNITY_VERSION_PATH, {
+                    sha: marker,
+                }),
+            );
+        }
+    }))).pipe(Effect.provide(Platform)));
+};
 
-    const before = await observe(now);
-    await Effect.runPromise(publish(30, false).pipe(Effect.provide(Platform)));
-    const unchanged = await observe(later);
-    expect(unchanged.stats.checkpointsInserted).toBe(0);
-    expect(unchanged.rows).toEqual(before.rows);
+const CheckpointRow = Schema.Struct({
+    id: TextColumn,
+    experiment: TextColumn,
+    kind: TextColumn,
+    suggested: Schema.NullOr(TextColumn),
+    user_verdict: Schema.NullOr(TextColumn),
+    measured: TextColumn,
+    observed_at: TimestampColumn,
+});
 
-    const forced = await observe(later, true);
-    expect(forced.stats.checkpointsInserted).toBe(3);
-    expect(forced.rows.map((row) => row.id)).toEqual(before.rows.map((row) => row.id));
-    expect(forced.rows.map((row) => row.kind)).toEqual(["+10s", "+30s", "+3s"]);
-    for (const row of forced.rows) {
-        expect(row.observed_at).toEqual(later);
-        expect(row.suggested).toBe("ignored");
-        expect(JSON.parse(row.measured)).toEqual({
-            opportunities: 3, addressed: 0, ratio: 0, built: true,
+interface ProposalSeed {
+    readonly id: string;
+    readonly form?: string;
+    /** skill_proposal.trigger_pattern for skill-form seeds. */
+    readonly skillTrigger?: string;
+    readonly status?: string;
+    readonly frequency?: number;
+    readonly baseline?: string | null;
+    readonly experiment?: {
+        readonly id: string;
+        readonly status?: string;
+        readonly locked_verdict?: string | null;
+        readonly artifact_path?: string | null;
+        readonly scaffolded_at?: Date | null;
+    };
+}
+
+const stores = (root: string) => Layer.mergeAll(
+    CacheReadLayer({
+        snapshotPath: join(root, "snapshot.duckdb"),
+        ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+    }),
+    JudgmentLayer({ sidecarPath: join(root, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
+);
+
+const seed = (root: string, proposals: ReadonlyArray<ProposalSeed>) =>
+    Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        for (const p of proposals) {
+            yield* judgment.put("proposal", {
+                id: p.id, form: p.form ?? "guidance", title: `T-${p.id}`, hypothesis: "H",
+                dedupe_sig: `sig-${p.id}`, frequency: p.frequency ?? 3, confidence: "high",
+                status: p.status ?? "accepted", origin: "agent",
+                hypothesis_template: null, evidence_query: null, reject_reason: null,
+                baseline: p.baseline === undefined ? JSON.stringify({ frequency: 3 }) : p.baseline,
+                created_at: CREATED_AT, updated_at: CREATED_AT,
+            });
+            if (p.form === "guidance" || p.form === undefined) {
+                yield* judgment.put("guidance_proposal", {
+                    id: `guidance-${p.id}`, proposal: p.id, file_target: "CLAUDE.md",
+                    section: null, suggested_text: "do the thing",
+                });
+            }
+            if (p.form === "skill") {
+                yield* judgment.put("skill_proposal", {
+                    id: `skill-${p.id}`, proposal: p.id,
+                    trigger_pattern: p.skillTrigger ?? "the agent edits schema files",
+                    suspected_gap: "gap", proposed_behavior: "behavior", expected_impact: null,
+                });
+            }
+            if (p.experiment) {
+                yield* judgment.put("experiment", {
+                    id: p.experiment.id, proposal: p.id, artifact: null,
+                    artifact_path: p.experiment.artifact_path === undefined
+                        ? join(root, "CLAUDE.md")
+                        : p.experiment.artifact_path,
+                    scaffolded_at: p.experiment.scaffolded_at === undefined
+                        ? INSTALLED_AT
+                        : p.experiment.scaffolded_at,
+                    created_at: CREATED_AT,
+                    locked_verdict: p.experiment.locked_verdict ?? null,
+                    status: p.experiment.status ?? "scaffolded",
+                    task_path: null,
+                });
+            }
+        }
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+const run = (
+    root: string,
+    opts: { readonly now?: Date; readonly force?: boolean; readonly beforeWrite?: Effect.Effect<void> } = {},
+) => Effect.runPromise(Effect.gen(function* () {
+    const stats = yield* deriveCheckpoints({ now: opts.now ?? new Date("2026-02-01T00:00:00Z"), ...opts });
+    const judgment = yield* Judgment;
+    const rows = yield* judgment.rows(
+        CheckpointRow,
+        "SELECT id, experiment, kind, suggested, user_verdict, measured, observed_at FROM checkpoint ORDER BY experiment, kind",
+    );
+    return { stats, rows: rows.map((row) => ({ ...row, measured: JSON.parse(row.measured) as Record<string, unknown> })) };
+}).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+const lockVerdict = (root: string, checkpointId: string, verdict: string) =>
+    Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        yield* judgment.exec("UPDATE checkpoint SET user_verdict = ? WHERE id = ?", [verdict, checkpointId]);
+        yield* judgment.exec(
+            "UPDATE experiment SET locked_verdict = ? WHERE id = (SELECT experiment FROM checkpoint WHERE id = ?)",
+            [verdict, checkpointId],
+        );
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+dtest("measures only eligible experiments, windowed on the observed install", async () => {
+    const root = tempDir("ax-checkpoint-eligibility-");
+    await publishSnapshot(root, {
+        sessions: 30, preInstallSessions: 30, subagentSessions: 30,
+        opportunities: 12, addressed: 8,
+    });
+    await seed(root, [
+        { id: "p-ok", experiment: { id: "experiment-one" } },
+        { id: "p-open", status: "open", experiment: { id: "exp-open" } },
+        { id: "p-emitted", experiment: { id: "exp-emitted", status: "task_emitted" } },
+        { id: "p-retired", experiment: { id: "exp-retired", status: "retired" } },
+        { id: "p-regressed", experiment: { id: "exp-regressed", status: "regressed" } },
+        { id: "p-locked", experiment: { id: "exp-locked", locked_verdict: "adopted" } },
+        { id: "p-nopath", experiment: { id: "exp-nopath", artifact_path: null } },
+        { id: "p-noinstall", experiment: { id: "exp-noinstall", scaffolded_at: null } },
+    ]);
+
+    const result = await run(root);
+    expect(result.stats.experimentsScanned).toBe(1);
+    expect(result.stats.experimentsExcluded).toBe(7);
+    expect(result.stats.checkpointsInserted).toBe(3);
+    expect(result.rows.map((row) => row.experiment)).toEqual(["experiment-one", "experiment-one", "experiment-one"]);
+    for (const row of result.rows) {
+        expect(row.suggested).toBe("adopted");
+        expect(row.measured).toEqual({
+            opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
             current_frequency: 3, baseline_frequency: 3,
+            measurement_status: "measured", measurement_version: 2,
         });
     }
-    const after = await observe(now);
-    expect(after.stats.checkpointsInserted).toBe(0);
-    expect(after.rows).toEqual(forced.rows);
-}, 90_000); // Multiple production snapshots and checkpoint refreshes share this budget.
+}, 120_000); // Production DDL snapshot + sidecar seeding share this budget.
+
+dtest("pre-install and subagent sessions never satisfy a window", async () => {
+    const root = tempDir("ax-checkpoint-denominator-");
+    // 2 real post-install sessions is below +3s; the 40 pre-install + 40
+    // subagent sessions must not push it over the line.
+    await publishSnapshot(root, {
+        sessions: 2, preInstallSessions: 40, subagentSessions: 40, opportunities: 5, addressed: 4,
+    });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+
+    expect((await run(root)).rows).toEqual([]);
+
+    await publishSnapshot(root, {
+        sessions: 3, preInstallSessions: 40, subagentSessions: 40, opportunities: 5, addressed: 4,
+    });
+    const due = await run(root);
+    expect(due.rows.map((row) => row.kind)).toEqual(["+3s"]);
+    expect(due.stats.checkpointsInserted).toBe(1);
+}, 120_000); // Two production snapshots.
+
+dtest("reports a needed derivation even when no window is due", async () => {
+    const root = tempDir("ax-checkpoint-marker-idle-");
+    // Nothing is due (0 sessions), but the snapshot still carries no corrected
+    // derivation certificate - and the user has to hear that before the first
+    // window arrives, not after it lands as insufficient data.
+    await publishSnapshot(root, { sessions: 0, opportunities: 12, addressed: 8, marker: null });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+
+    const result = await run(root);
+    expect(result.stats.cacheRefreshRequired).toBe(1);
+    expect(result.stats.checkpointsInserted).toBe(0);
+    expect(result.rows).toEqual([]);
+}, 120_000); // One production snapshot.
+
+dtest("a failed cache read propagates instead of writing refresh-required rows", async () => {
+    const root = tempDir("ax-checkpoint-readfail-");
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 8 });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+
+    // A reader pointed at a snapshot that is not there. Under the strict-read
+    // contract that is an ERROR - never "the marker is missing", which would
+    // stamp every due window insufficient on the strength of a failed open.
+    const failure = await Effect.runPromise(
+        deriveCheckpoints({ now: new Date("2026-02-01T00:00:00Z") }).pipe(
+            Effect.map(() => "unexpected success"),
+            Effect.catchCause((cause) => Effect.succeed(cause.toString())),
+            Effect.provide(Layer.mergeAll(
+                CacheReadLayer({
+                    snapshotPath: join(root, "absent.duckdb"),
+                    ...(dylibPath === null ? {} : { assetPath: dylibPath }),
+                }),
+                JudgmentLayer({ sidecarPath: join(root, "judgment.sqlite"), schemaSql: SIDECAR_SCHEMA_SQL }),
+            )),
+            Effect.scoped,
+        ),
+    );
+    expect(failure).not.toBe("unexpected success");
+    const stored = await Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        return yield* judgment.rows(CheckpointRow, "SELECT id, experiment, kind, suggested, user_verdict, measured, observed_at FROM checkpoint");
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+    expect(stored).toEqual([]);
+    // The same sidecar measures normally once a reachable snapshot is used.
+    expect((await run(root)).rows.length).toBe(3);
+}, 120_000); // One production snapshot plus a deliberate read failure.
+
+dtest("zero opportunities and unsupported detectors are insufficient data, not verdicts", async () => {
+    const root = tempDir("ax-checkpoint-insufficient-");
+    await publishSnapshot(root, { sessions: 3, opportunities: 0 });
+    await seed(root, [
+        // Zero opportunities, with a baseline that used to decide the verdict.
+        { id: "p-zero", frequency: 9, experiment: { id: "experiment-one" } },
+        { id: "p-zero-equal", frequency: 3, experiment: { id: "exp-equal" } },
+        { id: "p-zero-nobaseline", baseline: null, experiment: { id: "exp-nobaseline" } },
+        { id: "p-zero-badbaseline", baseline: "not json", experiment: { id: "exp-badbaseline" } },
+        // No detector exists for the automation form.
+        { id: "p-automation", form: "automation", experiment: { id: "exp-automation" } },
+    ]);
+
+    const result = await run(root);
+    expect(result.stats.experimentsScanned).toBe(5);
+    expect(result.stats.checkpointsInserted).toBe(5);
+    expect(result.stats.insufficientData).toBe(5);
+    const byExperiment = new Map(result.rows.map((row) => [row.experiment, row]));
+    for (const id of ["experiment-one", "exp-equal", "exp-nobaseline", "exp-badbaseline"]) {
+        const row = byExperiment.get(id)!;
+        expect(row.suggested).toBeNull();
+        expect(row.measured.measurement_status).toBe("insufficient_data");
+        expect(row.measured.reason).toBe("no_opportunities");
+        expect(row.measured.opportunities).toBe(0);
+        expect(row.measured.measurement_version).toBe(2);
+    }
+    const automation = byExperiment.get("exp-automation")!;
+    expect(automation.suggested).toBeNull();
+    expect(automation.measured.reason).toBe("detector_unavailable");
+}, 120_000); // Five experiments over one production snapshot.
+
+dtest("opportunity rows cached before the recorded installation never count", async () => {
+    const root = tempDir("ax-checkpoint-reinstall-");
+    const reinstalledAt = new Date(INSTALLED_AT.getTime() + 3_600_000);
+    // The snapshot is valid by every other measure: corrected marker, positive
+    // addressed rows. They were matched against the PREVIOUS installation, and
+    // the sidecar recorded the new one before this command started - so the
+    // write-transaction guard, which only sees changes DURING the command,
+    // cannot catch it.
+    await publishSnapshot(root, {
+        sessions: 30,
+        sessionsFrom: reinstalledAt,
+        opportunities: 12,
+        addressed: 12,
+        matchedAt: new Date(INSTALLED_AT.getTime() + 1000),
+    });
+    await seed(root, [{
+        id: "p-ok",
+        experiment: { id: "experiment-one", scaffolded_at: reinstalledAt },
+    }]);
+
+    const result = await run(root);
+    expect(result.stats.insufficientData).toBe(3);
+    for (const row of result.rows) {
+        expect(row.suggested).toBeNull();
+        expect(row.measured.opportunities).toBe(0);
+        expect(row.measured.addressed).toBe(0);
+        expect(row.measured.reason).toBe("no_opportunities");
+    }
+
+    // Evidence matched against the CURRENT installation measures normally.
+    await publishSnapshot(root, {
+        sessions: 30,
+        sessionsFrom: reinstalledAt,
+        opportunities: 12,
+        addressed: 12,
+        matchedAt: new Date(reinstalledAt.getTime() + 1000),
+    });
+    const measured = await run(root, { now: new Date("2026-02-09T00:00:00Z") });
+    expect(measured.stats.checkpointsRefreshed).toBe(3);
+    for (const row of measured.rows) {
+        expect(row.suggested).toBe("adopted");
+        expect(row.measured.opportunities).toBe(12);
+    }
+}, 180_000); // Two production snapshots plus a recorded reinstallation.
+
+dtest("a skill candidate must resolve to a row, not just a cites_evidence edge", async () => {
+    const root = tempDir("ax-checkpoint-candidate-");
+    await publishSnapshot(root, {
+        sessions: 3, opportunities: 12, addressed: 8,
+        candidateEdges: [
+            { proposal: "p-dangling", candidate: "candidate-gone", resolvable: false },
+            { proposal: "p-prose", candidate: "candidate-gone-2", resolvable: false },
+            { proposal: "p-resolved", candidate: "candidate-live", resolvable: true },
+        ],
+    });
+    await seed(root, [
+        // A dangling edge with a prose trigger: nothing can detect this skill.
+        { id: "p-dangling", form: "skill", experiment: { id: "experiment-one" } },
+        // A dangling edge, but the supported tool trigger still detects it.
+        { id: "p-prose", form: "skill", skillTrigger: "tool=Bash", experiment: { id: "exp-prose" } },
+        // The cited candidate is really there.
+        { id: "p-resolved", form: "skill", experiment: { id: "exp-resolved" } },
+    ]);
+
+    const rows = new Map((await run(root)).rows.map((row) => [row.experiment, row]));
+    expect(rows.get("experiment-one")!.suggested).toBeNull();
+    expect(rows.get("experiment-one")!.measured.reason).toBe("detector_unavailable");
+    // Both of these HAVE a detector, so their windows report the measurement
+    // gap (no opportunity rows were seeded for them) rather than the absence of
+    // any way to detect the artifact.
+    expect(rows.get("exp-prose")!.measured.reason).toBe("no_opportunities");
+    expect(rows.get("exp-resolved")!.measured.reason).toBe("no_opportunities");
+}, 120_000); // One production snapshot with three skill-form experiments.
+
+dtest("a refresh updates the stored row, whatever id it carries", async () => {
+    const root = tempDir("ax-checkpoint-noncanonical-");
+    await publishSnapshot(root, { sessions: 10, opportunities: 12, addressed: 8 });
+    await seed(root, [
+        { id: "p-refresh", experiment: { id: "experiment-one" } },
+        { id: "p-reviewed", experiment: { id: "exp-reviewed" } },
+    ]);
+    // Rows keyed by something other than `checkpointKey` - older history, or a
+    // producer that keyed them differently. Both are the canonical row for
+    // their window as far as the reader is concerned.
+    await Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        yield* judgment.put("checkpoint", {
+            id: "legacy-noncanonical-refresh", experiment: "experiment-one", kind: "+3s",
+            measured: JSON.stringify({ opportunities: 40, addressed: 39, ratio: 0.975, built: true }),
+            suggested: "adopted", user_verdict: null, observed_at: new Date("2026-01-20T00:00:00Z"),
+        });
+        yield* judgment.put("checkpoint", {
+            id: "legacy-noncanonical-reviewed", experiment: "exp-reviewed", kind: "+3s",
+            measured: JSON.stringify({ opportunities: 40, addressed: 39, ratio: 0.975, built: true }),
+            suggested: "adopted", user_verdict: "partial", observed_at: new Date("2026-01-20T00:00:00Z"),
+        });
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+    const result = await run(root);
+    const refreshed = result.rows.filter((row) => row.experiment === "experiment-one" && row.kind === "+3s");
+    expect(refreshed.map((row) => row.id)).toEqual(["legacy-noncanonical-refresh"]);
+    expect(refreshed[0]!.measured.opportunities).toBe(12);
+    expect(refreshed[0]!.measured.measurement_version).toBe(2);
+    // No second row for the same window under the canonical id.
+    expect(result.rows.some((row) => row.id === checkpointKey("experiment-one", "+3s"))).toBe(false);
+
+    // The reviewed noncanonical row keeps the human's answer, unduplicated.
+    const reviewed = result.rows.filter((row) => row.experiment === "exp-reviewed" && row.kind === "+3s");
+    expect(reviewed.map((row) => row.id)).toEqual(["legacy-noncanonical-reviewed"]);
+    expect(reviewed[0]!.user_verdict).toBe("partial");
+    expect(reviewed[0]!.suggested).toBe("adopted");
+    expect(reviewed[0]!.observed_at).toEqual(new Date("2026-01-20T00:00:00Z"));
+}, 120_000); // One production snapshot plus two seeded noncanonical rows.
+
+dtest("a missing or foreign derivation marker forces refresh instead of measuring old rows", async () => {
+    const root = tempDir("ax-checkpoint-marker-");
+    const invalidMarkers: ReadonlyArray<PublishOpts> = [
+        { marker: null },
+        { marker: "" },
+        { marker: "artifact-identity-v2" },
+        { marker: "who-knows" },
+        { marker: OPPORTUNITY_VERSION, markerSource: "some_other_stage" },
+    ];
+    await publishSnapshot(root, { sessions: 3, opportunities: 12, addressed: 8, ...invalidMarkers[0] });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+
+    for (const marker of invalidMarkers) {
+        await publishSnapshot(root, { sessions: 3, opportunities: 12, addressed: 8, ...marker });
+        const result = await run(root);
+        expect(result.stats.cacheRefreshRequired).toBe(1);
+        expect(result.rows.length).toBe(1);
+        const row = result.rows[0]!;
+        expect(row.suggested).toBeNull();
+        expect(row.measured.measurement_status).toBe("insufficient_data");
+        expect(row.measured.reason).toBe("refresh_required");
+    }
+
+    // The corrected derivation lands: the same ordinary (unforced) run now
+    // measures the window that had been left null.
+    await publishSnapshot(root, { sessions: 3, opportunities: 12, addressed: 8 });
+    const measured = await run(root, { now: new Date("2026-02-02T00:00:00Z") });
+    expect(measured.stats.cacheRefreshRequired).toBe(0);
+    expect(measured.stats.checkpointsRefreshed).toBe(1);
+    expect(measured.rows[0]!.suggested).toBe("adopted");
+    expect(measured.rows[0]!.measured.measurement_status).toBe("measured");
+
+    // A measured window is stable across ordinary reruns...
+    const rerun = await run(root, { now: new Date("2026-02-03T00:00:00Z") });
+    expect(rerun.stats.checkpointsRefreshed).toBe(0);
+    expect(rerun.rows).toEqual(measured.rows);
+
+    // ...but an invalid marker must not leave an old positive answer standing.
+    await publishSnapshot(root, { sessions: 3, opportunities: 12, addressed: 8, marker: null });
+    const invalidated = await run(root, { now: new Date("2026-02-04T00:00:00Z") });
+    expect(invalidated.stats.checkpointsRefreshed).toBe(1);
+    expect(invalidated.rows[0]!.suggested).toBeNull();
+    expect(invalidated.rows[0]!.measured.reason).toBe("refresh_required");
+}, 180_000); // Eight production snapshots, one per marker case.
+
+dtest("refresh preserves reviewed rows, locked experiments and unchanged measured windows", async () => {
+    const root = tempDir("ax-checkpoint-refresh-");
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 8 });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+    const first = await run(root);
+    expect(first.stats.checkpointsInserted).toBe(3);
+
+    // A human reviews the +3s window. Nothing may touch it again - not an
+    // ordinary run, not --force.
+    const reviewed = first.rows.find((row) => row.kind === "+3s")!;
+    await Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        yield* judgment.exec("UPDATE checkpoint SET user_verdict = ? WHERE id = ?", ["partial", reviewed.id]);
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 0 });
+    const ordinary = await run(root, { now: new Date("2026-02-05T00:00:00Z") });
+    expect(ordinary.stats.checkpointsRefreshed).toBe(0);
+    expect(ordinary.rows.find((row) => row.kind === "+3s")).toEqual({
+        ...reviewed, user_verdict: "partial",
+    });
+
+    const forced = await run(root, { now: new Date("2026-02-06T00:00:00Z"), force: true });
+    expect(forced.stats.checkpointsRefreshed).toBe(2);
+    expect(forced.rows.find((row) => row.kind === "+3s")).toEqual({
+        ...reviewed, user_verdict: "partial",
+    });
+    for (const kind of ["+10s", "+30s"]) {
+        const row = forced.rows.find((r) => r.kind === kind)!;
+        expect(row.suggested).toBe("ignored");
+        expect(row.observed_at).toEqual(new Date("2026-02-06T00:00:00Z"));
+    }
+
+    // Locking the experiment freezes every remaining row, even under --force.
+    await lockVerdict(root, forced.rows.find((row) => row.kind === "+10s")!.id, "ignored");
+    const afterLock = await run(root, { now: new Date("2026-02-07T00:00:00Z"), force: true });
+    expect(afterLock.stats.experimentsScanned).toBe(0);
+    expect(afterLock.stats.experimentsExcluded).toBe(1);
+    expect(afterLock.rows.map((row) => row.measured)).toEqual(
+        forced.rows.map((row) => row.measured),
+    );
+}, 180_000); // Four production snapshots plus repeated refresh passes.
+
+dtest("an old unreviewed row without the current measurement version is refreshed", async () => {
+    const root = tempDir("ax-checkpoint-legacy-");
+    await publishSnapshot(root, { sessions: 3, opportunities: 12, addressed: 8 });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+    const legacyId = checkpointKey("experiment-one", "+3s");
+    await Effect.runPromise(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        yield* judgment.put("checkpoint", {
+            id: legacyId, experiment: "experiment-one", kind: "+3s",
+            // A pre-#1134 positive row: no measurement_version, and its
+            // opportunities came from the uncorrected derivation.
+            measured: JSON.stringify({ opportunities: 40, addressed: 39, ratio: 0.975, built: true }),
+            suggested: "adopted", user_verdict: null, observed_at: new Date("2026-01-20T00:00:00Z"),
+        });
+    }).pipe(Effect.provide(stores(root)), Effect.scoped));
+
+    const result = await run(root);
+    expect(result.stats.checkpointsRefreshed).toBe(1);
+    expect(result.stats.checkpointsInserted).toBe(0);
+    const row = result.rows[0]!;
+    expect(row.id).toBe(legacyId);
+    expect(row.measured.opportunities).toBe(12);
+    expect(row.measured.measurement_version).toBe(2);
+}, 120_000); // One production snapshot plus a seeded legacy row.
+
+dtest("a verdict or lifecycle change during the cache read cancels that write", async () => {
+    const root = tempDir("ax-checkpoint-race-");
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 8 });
+    await seed(root, [
+        { id: "p-race", experiment: { id: "experiment-one" } },
+        { id: "p-retire", experiment: { id: "exp-two" } },
+    ]);
+    const first = await run(root);
+    expect(first.stats.checkpointsInserted).toBe(6);
+
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 0 });
+    const raced = await run(root, {
+        now: new Date("2026-02-08T00:00:00Z"),
+        force: true,
+        // Between the cache read and the sidecar write: a human locks one
+        // experiment, and the other retires. Neither may be overwritten.
+        beforeWrite: Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            yield* judgment.exec("UPDATE checkpoint SET user_verdict = ? WHERE experiment = ?", ["adopted", "experiment-one"]);
+            yield* judgment.exec("UPDATE experiment SET locked_verdict = ? WHERE id = ?", ["adopted", "experiment-one"]);
+            yield* judgment.exec("UPDATE experiment SET status = ? WHERE id = ?", ["retired", "exp-two"]);
+        }).pipe(Effect.provide(stores(root)), Effect.scoped, Effect.orDie),
+    });
+    expect(raced.stats.checkpointsRefreshed).toBe(0);
+    // Byte-for-byte: the locked row keeps its answer and the retired
+    // experiment's history keeps its timestamps.
+    expect(raced.rows).toEqual(first.rows.map((row) => ({
+        ...row,
+        ...(row.experiment === "experiment-one" ? { user_verdict: "adopted" } : {}),
+    })));
+}, 180_000); // Two production snapshots plus a concurrent-write simulation.
+
+dtest("a changed installation timestamp cancels the stale write", async () => {
+    const root = tempDir("ax-checkpoint-install-");
+    await publishSnapshot(root, { sessions: 30, opportunities: 12, addressed: 8 });
+    await seed(root, [{ id: "p-ok", experiment: { id: "experiment-one" } }]);
+
+    const result = await run(root, {
+        beforeWrite: Effect.gen(function* () {
+            const judgment = yield* Judgment;
+            yield* judgment.exec("UPDATE experiment SET scaffolded_at = ? WHERE id = ?", [
+                new Date("2026-01-25T00:00:00Z").toISOString(), "experiment-one",
+            ]);
+        }).pipe(Effect.provide(stores(root)), Effect.scoped, Effect.orDie),
+    });
+    expect(result.stats.checkpointsInserted).toBe(0);
+    expect(result.rows).toEqual([]);
+}, 120_000); // One production snapshot plus a concurrent reinstall.

--- a/apps/axctl/src/ingest/derive-checkpoints.test.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.test.ts
@@ -547,7 +547,10 @@ dtest("a missing or foreign derivation marker forces refresh instead of measurin
     const invalidMarkers: ReadonlyArray<PublishOpts> = [
         { marker: null },
         { marker: "" },
+        // Every superseded token: rows they certified answer a different
+        // question (#1133 identity rules, pre-UTC matched_at) than this reader asks.
         { marker: "artifact-identity-v2" },
+        { marker: "eligible-install-v3" },
         { marker: "who-knows" },
         { marker: OPPORTUNITY_VERSION, markerSource: "some_other_stage" },
     ];

--- a/apps/axctl/src/ingest/derive-checkpoints.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.ts
@@ -2,7 +2,7 @@
  * Derive-Checkpoints Stage (Phase C6).
  *
  * For each active experiment, at the +3 / +10 / +30 session marks measured
- * by count of sessions created after experiment.created_at, emit one
+ * by count of sessions started after experiment.created_at, emit one
  * `checkpoint` row carrying:
  *  - measured  : { opportunities, addressed, ratio, built }
  *  - suggested : adopted | ignored | regressed | no_longer_needed | partial
@@ -12,7 +12,7 @@
  * may ship eight sessions in a day or none in a weekend. The verdict should
  * ride exposure to the pattern, not the wall clock. See issue #83.
  *
- * v1 exposure definition: count of sessions whose `created_at` is after
+ * v1 exposure definition: count of sessions whose `started_at` is after
  * `experiment.created_at`. (Refinements to narrow this to "sessions that
  * touched the artifact file" or "sessions that fired the trigger pattern"
  * are tracked in follow-ups.)
@@ -137,7 +137,7 @@ export const deriveCheckpoints = (
             const [opportunityRows, addressedRows, sessionRows] = yield* Effect.all([
                 cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM opportunity WHERE in_id = ?", [experimentKey]),
                 cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM opportunity WHERE in_id = ? AND was_addressed = true", [experimentKey]),
-                cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM session WHERE created_at > ?", [exp.created_at]),
+                cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM session WHERE started_at > ?", [exp.created_at]),
             ], { concurrency: 3 });
             const sessionsSince = sessionRows[0]?.count ?? 0;
             const due = dueCheckpointKinds(sessionsSince, existing);

--- a/apps/axctl/src/ingest/derive-checkpoints.ts
+++ b/apps/axctl/src/ingest/derive-checkpoints.ts
@@ -1,49 +1,77 @@
 /**
  * Derive-Checkpoints Stage (Phase C6).
  *
- * For each active experiment, at the +3 / +10 / +30 session marks measured
- * by count of sessions started after experiment.created_at, emit one
- * `checkpoint` row carrying:
- *  - measured  : { opportunities, addressed, ratio, built }
+ * For each ELIGIBLE experiment, at the +3 / +10 / +30 session marks measured by
+ * count of sessions started after the OBSERVED INSTALL
+ * (`experiment.scaffolded_at`), emit one `checkpoint` row carrying:
+ *  - measured  : { opportunities, addressed, ratio, built, measurement_status,
+ *                  reason?, measurement_version }
  *  - suggested : adopted | ignored | regressed | no_longer_needed | partial
+ *                | NULL when the window has no measurement to report
  *  - user_verdict : NULL - the human confirms via `axctl improve verdict`.
  *
  * Windows are session-count, not calendar days, because an AI-coding agent
  * may ship eight sessions in a day or none in a weekend. The verdict should
  * ride exposure to the pattern, not the wall clock. See issue #83.
  *
- * v1 exposure definition: count of sessions whose `started_at` is after
- * `experiment.created_at`. (Refinements to narrow this to "sessions that
- * touched the artifact file" or "sessions that fired the trigger pattern"
- * are tracked in follow-ups.)
+ * Exposure definition: sessions whose `started_at` is after the install, minus
+ * the recognized `*-subagent` sources (a subagent run is not an independent
+ * exposure of the user's rig). Acceptance can precede installation by days, and
+ * sessions in that gap could not have met the artifact at all.
  *
- * Verdict math (suggested only - the human still confirms):
- *   if opportunities == 0:
- *       if currentFrequency > baselineFrequency  -> ignored (pattern still
- *           firing post-accept, artifact not preventing the trigger)
- *       else                                     -> no_longer_needed
- *   if ratio > 0.6                 -> adopted
- *   if ratio < 0.1                 -> ignored
- *   otherwise                      -> partial
+ * WHAT A CHECKPOINT MAY AND MAY NOT SAY (#1134). Three distinct states used to
+ * collapse into one confident verdict:
+ *  - measured           : positive opportunities, corrected evidence, a real
+ *                         ratio. Reported as OBSERVED USE - the artifact was
+ *                         present when the trigger fired - never as proven
+ *                         causal improvement.
+ *  - insufficient data  : zero opportunities, no detector for this form, or
+ *                         opportunity rows that predate the corrected
+ *                         derivation. `suggested` is NULL with a `reason`.
+ *  - not measurable     : the experiment is not eligible at all (never
+ *                         installed, retired, regressed, locked, or lint never
+ *                         reconciled an artifact). Nothing is written, and its
+ *                         existing rows are left exactly as they are.
+ * `no_longer_needed` survives only as a HUMAN verdict: frequency equality never
+ * proved a pattern disappeared, so the algorithm no longer suggests it.
  *
- * Idempotency: a (experiment, kind) checkpoint is only inserted once.
- * Re-derive passes that hit the same window skip. If the underlying
- * opportunity count changes the suggested verdict, the user can re-run
- * `axctl improve checkpoint --force` (Phase C7) to refresh - that path
- * deletes the existing checkpoint and re-inserts.
+ * Verdict math for a supported measurement with positive opportunities:
+ *   ratio > 0.6  -> adopted
+ *   ratio < 0.1  -> ignored
+ *   otherwise    -> partial
+ *
+ * Refresh: an unreviewed window is recomputed when its last run left no
+ * suggestion, when it predates {@link MEASUREMENT_VERSION}, when the snapshot
+ * lost its corrected-derivation certificate, or under `--force`. A row a human
+ * has answered (`user_verdict`) is never touched, by any path, and no row of a
+ * locked experiment is either. Both protections are re-checked INSIDE the write
+ * transaction, so a verdict locked while the cache was being read cannot be
+ * overwritten by a measurement computed before it.
  *
  * Legacy `t+7` / `t+30` / `t+90` checkpoint rows from the calendar-day era
- * remain valid in the DB (kind is a free-form string). New experiments
- * emit the session-based kinds. The two are non-conflicting because the
- * (experiment, kind) unique index keys on the kind string.
+ * remain valid in the DB (kind is a free-form string) and are left alone.
  */
 
 import { Effect, Schema } from "effect";
 import { CacheRead, type CacheReadError } from "@ax/lib/duckdb/seam";
-import { Judgment, NumberColumn, type JudgmentError, type SidecarParam } from "@ax/lib/sqlite";
+import { Judgment, NumberColumn, TextColumn, TimestampColumn, type JudgmentError, type JudgmentTransaction, type SidecarParam } from "@ax/lib/sqlite";
 import { stableId } from "@ax/lib/stable-id";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
-import { listStoredProposals } from "../improve/judgment-proposals.ts";
+import { listStoredProposals, type StoredCheckpoint } from "../improve/judgment-proposals.ts";
+import {
+    MEASUREMENT_VERSION,
+    detectorSupport,
+    installationTime,
+    measurementEligibility,
+    readMeasurementVersion,
+    type MeasurementReason,
+} from "../improve/measurement.ts";
+import { SUBAGENT_SOURCES_SQL } from "./source-origin.ts";
+import {
+    OPPORTUNITY_VERSION,
+    OPPORTUNITY_VERSION_PATH,
+    OPPORTUNITY_VERSION_SOURCE,
+} from "./opportunity-cache-version.ts";
 
 export type CheckpointKind = "+3s" | "+10s" | "+30s";
 export type CheckpointVerdict =
@@ -54,14 +82,33 @@ export type CheckpointVerdict =
     | "partial";
 
 export interface DeriveCheckpointsStats {
+    /** Eligible experiments this run measured. */
     readonly experimentsScanned: number;
+    /** Experiments skipped by the eligibility rules - never measured, never
+     *  rewritten. Distinct from a measurement that found nothing. */
+    readonly experimentsExcluded: number;
     readonly checkpointsInserted: number;
+    /** Existing unreviewed windows recomputed this run. */
+    readonly checkpointsRefreshed: number;
+    /** Windows of eligible experiments left alone (not due, reviewed, or still
+     *  current). */
     readonly checkpointsSkipped: number;
+    /** Written windows that carry no suggestion - the absence-of-data count. */
+    readonly insufficientData: number;
+    /** Eligible experiments whose published snapshot carries no valid
+     *  opportunity-derivation certificate. Reported even when nothing is due. */
+    readonly cacheRefreshRequired: number;
 }
 
 export interface DeriveCheckpointsOpts {
     readonly now?: Date;
     readonly force?: boolean;
+    /**
+     * TEST SEAM: runs after the cache reads and before the sidecar write
+     * transaction. Exists so the concurrent-verdict protection can be exercised
+     * at the real boundary it guards; production callers never pass it.
+     */
+    readonly beforeWrite?: Effect.Effect<void>;
 }
 
 export interface CheckpointMeasured {
@@ -71,11 +118,7 @@ export interface CheckpointMeasured {
     readonly built: boolean;
     /** proposal.frequency as of this checkpoint pass (live counter). */
     readonly currentFrequency?: number;
-    /**
-     * proposal.baseline.frequency at proposal-creation time (snapshot).
-     * Used to disambiguate `no_longer_needed` (pattern resolved) from
-     * `ignored` (artifact exists but doesn't fire).
-     */
+    /** proposal.baseline.frequency at proposal-creation time (snapshot). */
     readonly baselineFrequency?: number;
 }
 
@@ -85,35 +128,140 @@ export const CHECKPOINT_WINDOWS_SESSIONS: ReadonlyArray<readonly [CheckpointKind
     ["+30s", 30],
 ];
 
-export const computeSuggestedVerdict = (measured: CheckpointMeasured): CheckpointVerdict => {
-    if (measured.opportunities === 0) {
-        // Disambiguate via frequency delta. If the cluster has kept growing
-        // post-accept, the trigger pattern is still firing and the artifact
-        // is being ignored. Otherwise, the underlying pattern self-resolved.
-        const base = measured.baselineFrequency ?? 0;
-        const curr = measured.currentFrequency ?? 0;
-        if (curr > base) return "ignored";
-        return "no_longer_needed";
-    }
+/**
+ * The suggested verdict for a SUPPORTED measurement, or `null` when there is
+ * nothing to suggest.
+ *
+ * Zero opportunities returns null unconditionally. The old code disambiguated
+ * it with the proposal's frequency counters - `current > baseline` read as
+ * "ignored", anything else as "no_longer_needed" - which turned the absence of
+ * evidence into two confident verdicts. Frequency equality does not prove a
+ * pattern disappeared; it is just as consistent with a detector that never ran.
+ */
+export const computeSuggestedVerdict = (measured: CheckpointMeasured): CheckpointVerdict | null => {
+    if (measured.opportunities === 0) return null;
     const ratio = measured.ratio;
     if (ratio > 0.6) return "adopted";
     if (ratio < 0.1) return "ignored";
     return "partial";
 };
 
-export const dueCheckpointKinds = (
-    sessionsSinceCreated: number,
-    existing: ReadonlySet<string>,
-): CheckpointKind[] => {
-    const threshold = (kind: CheckpointKind) =>
-        CHECKPOINT_WINDOWS_SESSIONS.find(([k]) => k === kind)?.[1] ?? 0;
-    return CHECKPOINT_WINDOWS_SESSIONS
-        .map(([k]) => k)
-        .filter((k) => sessionsSinceCreated >= threshold(k) && !existing.has(k));
-};
+/** Every window whose session threshold this exposure count has reached. */
+export const dueCheckpointKinds = (sessionsSinceInstall: number): CheckpointKind[] =>
+    CHECKPOINT_WINDOWS_SESSIONS
+        .filter(([, threshold]) => sessionsSinceInstall >= threshold)
+        .map(([kind]) => kind);
 
 export const checkpointKey = (experimentKey: string, kind: CheckpointKind): string =>
     stableId("checkpoint", [experimentKey, kind]);
+
+/**
+ * ONE statement per experiment: both opportunity counts, the exposure count,
+ * the resolvable skill candidate, and the derivation-version certificate.
+ *
+ * They travel together on purpose. Split across statements, a publication
+ * landing mid-read could hand this stage counts from the corrected derivation
+ * and a certificate from the previous snapshot (or the reverse), and the
+ * measurement would describe a cache state that never existed.
+ *
+ * Both opportunity counts are windowed on the OBSERVED INSTALL, and that
+ * predicate is load-bearing rather than belt-and-braces. The certificate says
+ * the rows came from the corrected derivation; it does NOT say they came from
+ * the CURRENT installation. An experiment reinstalled since the last ingest
+ * carries cached rows matched against its previous install, and without this
+ * window they would be counted - a positive verdict for an artifact this
+ * installation was never present for. The write-transaction guard cannot catch
+ * it either: that detects a change DURING the command, and this one happened
+ * before it started.
+ *
+ * The candidate arm RESOLVES the cited row rather than counting the edge. A
+ * `cites_evidence` edge whose `skill_candidate` is gone (a rebuilt cache, a
+ * retired candidate) leaves the legacy skill detector with no match tokens to
+ * derive, so it detects nothing - and the supported `tool=<name>` trigger, when
+ * the proposal has one, is what the caller falls back to.
+ */
+const MEASUREMENT_SQL = `
+SELECT
+    (SELECT CAST(count(*) AS INTEGER) FROM opportunity
+      WHERE in_id = ? AND matched_at > ?) AS opportunities,
+    (SELECT CAST(count(*) AS INTEGER) FROM opportunity
+      WHERE in_id = ? AND matched_at > ? AND was_addressed = true) AS addressed,
+    (SELECT CAST(count(*) AS INTEGER) FROM session
+      WHERE started_at > ?
+        AND (source IS NULL OR source NOT IN ${SUBAGENT_SOURCES_SQL})) AS sessions,
+    (SELECT CAST(count(*) AS INTEGER) FROM cites_evidence AS ce
+       JOIN skill_candidate AS sc ON sc.id = ce.out_id
+      WHERE ce.in_id = ? AND ce.out_table = 'skill_candidate') AS resolved_candidates,
+    (SELECT sha FROM ingest_file_state WHERE source_kind = ? AND path = ? LIMIT 1) AS cache_version
+`;
+
+const MeasurementRow = Schema.Struct({
+    opportunities: NumberColumn,
+    addressed: NumberColumn,
+    sessions: NumberColumn,
+    resolved_candidates: NumberColumn,
+    cache_version: Schema.NullOr(Schema.String),
+});
+
+/** The sidecar state a pending write is re-checked against inside the
+ *  transaction. */
+const GuardRow = Schema.Struct({
+    id: TextColumn,
+    status: TextColumn,
+    locked_verdict: Schema.NullOr(TextColumn),
+    artifact_path: Schema.NullOr(TextColumn),
+    scaffolded_at: Schema.NullOr(TimestampColumn),
+    proposal_status: TextColumn,
+});
+
+const ReviewRow = Schema.Struct({
+    id: TextColumn,
+    user_verdict: Schema.NullOr(TextColumn),
+});
+
+interface PendingWrite {
+    readonly experimentId: string;
+    readonly kind: CheckpointKind;
+    /** The install this measurement describes; a changed one voids it. */
+    readonly installedAtMs: number;
+    readonly artifactPath: string;
+    readonly refresh: boolean;
+    readonly insufficient: boolean;
+    readonly row: Readonly<Record<string, SidecarParam>>;
+}
+
+/** The newest stored row for a window, keyed by kind. */
+const byKind = (checkpoints: ReadonlyArray<StoredCheckpoint>): Map<string, StoredCheckpoint> => {
+    const map = new Map<string, StoredCheckpoint>();
+    for (const checkpoint of checkpoints) map.set(checkpoint.kind, checkpoint);
+    return map;
+};
+
+/**
+ * May this run write over an existing window?
+ *
+ * A reviewed row is never rewritten, whatever else is true - that answer is the
+ * judgment the sidecar exists to keep. Everything else is recomputed when the
+ * stored result is not a current measurement: no suggestion, an older measured
+ * format, or a snapshot that lost its corrected-derivation certificate (an old
+ * positive answer must not outlive the evidence it was computed from).
+ */
+export const shouldRefreshCheckpoint = (input: {
+    readonly existing: StoredCheckpoint | undefined;
+    readonly force: boolean;
+    readonly correctedEvidence: boolean;
+}): "insert" | "refresh" | "preserve" => {
+    const existing = input.existing;
+    if (existing === undefined) return "insert";
+    if (existing.user_verdict !== null) return "preserve";
+    if (existing.suggested === null) return "refresh";
+    if (readMeasurementVersion(existing.measured) !== MEASUREMENT_VERSION) return "refresh";
+    if (!input.correctedEvidence) return "refresh";
+    return input.force ? "refresh" : "preserve";
+};
+
+const numberOrUndefined = (value: unknown): number | undefined =>
+    typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
 export const deriveCheckpoints = (
     opts: DeriveCheckpointsOpts = {},
@@ -122,84 +270,215 @@ export const deriveCheckpoints = (
         const cache = yield* CacheRead;
         const judgment = yield* Judgment;
         const now = opts.now ?? new Date();
+        const force = opts.force ?? false;
         const proposals = yield* listStoredProposals(100_000);
-        const experiments = proposals.filter((proposal) =>
-            proposal.experiment !== null && proposal.experiment.locked_verdict === null);
-        const CountRow = Schema.Struct({ count: NumberColumn });
 
-        let inserted = 0;
-        let skipped = 0;
-        const writes: Array<Readonly<Record<string, SidecarParam>>> = [];
-        for (const proposal of experiments) {
-            const exp = proposal.experiment!;
+        let scanned = 0;
+        let excluded = 0;
+        let cacheRefreshRequired = 0;
+        const pending: PendingWrite[] = [];
+
+        for (const proposal of proposals) {
+            const exp = proposal.experiment;
+            if (exp === null) continue;
+            const subject = {
+                proposalStatus: proposal.status,
+                experimentStatus: exp.status,
+                lockedVerdict: exp.locked_verdict,
+                artifactPath: exp.artifact_path,
+                scaffoldedAt: exp.scaffolded_at,
+            };
+            const eligibility = measurementEligibility(subject);
+            if (!eligibility.eligible) {
+                excluded += 1;
+                continue;
+            }
+            scanned += 1;
+            const installedAt = installationTime(exp.scaffolded_at)!;
+            const artifactPath = exp.artifact_path!;
             const experimentKey = exp.id;
-            const existing = new Set(opts.force ? [] : exp.checkpoints.map((checkpoint) => checkpoint.kind));
-            const [opportunityRows, addressedRows, sessionRows] = yield* Effect.all([
-                cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM opportunity WHERE in_id = ?", [experimentKey]),
-                cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM opportunity WHERE in_id = ? AND was_addressed = true", [experimentKey]),
-                cache.rows(CountRow, "SELECT count(*)::INTEGER AS count FROM session WHERE started_at > ?", [exp.created_at]),
-            ], { concurrency: 3 });
-            const sessionsSince = sessionRows[0]?.count ?? 0;
-            const due = dueCheckpointKinds(sessionsSince, existing);
-            if (due.length === 0) continue;
 
-            const opportunities = opportunityRows[0]?.count ?? 0;
-            const addressed = addressedRows[0]?.count ?? 0;
+            const rows = yield* cache.rows(MeasurementRow, MEASUREMENT_SQL, [
+                experimentKey,
+                installedAt,
+                experimentKey,
+                installedAt,
+                installedAt,
+                proposal.id,
+                OPPORTUNITY_VERSION_SOURCE,
+                OPPORTUNITY_VERSION_PATH,
+            ]);
+            const facts = rows[0];
+            if (facts === undefined) continue;
+
+            // Algorithm compatibility, not freshness: the certificate says the
+            // published opportunity rows came from the corrected derivation.
+            // Missing, null, old or unknown all mean the same thing here.
+            const correctedEvidence = facts.cache_version === OPPORTUNITY_VERSION;
+            if (!correctedEvidence) cacheRefreshRequired += 1;
+
+            const support = detectorSupport({
+                form: proposal.form,
+                skillTrigger: proposal.skill_payload?.trigger_pattern ?? null,
+                hasSkillCandidate: facts.resolved_candidates > 0,
+                hookTargetTool: proposal.hook_payload?.target_tool ?? null,
+                hookEventName: proposal.hook_payload?.event_name ?? null,
+                dedupeSig: proposal.dedupe_sig,
+                artifactPath,
+            });
+
+            const opportunities = facts.opportunities;
+            const addressed = facts.addressed;
             const ratio = opportunities === 0 ? 0 : addressed / opportunities;
 
-            // proposal.baseline is stored as a JSON string (schema rule:
-            // SCHEMAFULL v3 has no flexible<object>). Parse defensively -
+            // proposal.baseline is stored as a JSON string. Parse defensively -
             // older proposals predating the frequency snapshot won't have
-            // baseline.frequency and we just leave it undefined.
-            let baselineFrequency: number | undefined;
-            const rawBaseline = proposal.baseline;
-            if (typeof rawBaseline === "string" && rawBaseline.length > 0) {
-                const parsed = safeJsonParse<{ frequency?: number }>(rawBaseline);
-                if (parsed && typeof parsed.frequency === "number") baselineFrequency = parsed.frequency;
-                // non-JSON baseline (legacy) - null parse is ignored.
-            }
-            const rawCurrent = proposal.frequency;
-            const currentFrequency =
-                typeof rawCurrent === "number" && Number.isFinite(rawCurrent)
-                    ? rawCurrent
-                    : undefined;
+            // baseline.frequency. Both counters ride along for compatibility;
+            // neither decides a verdict any more.
+            const parsedBaseline = typeof proposal.baseline === "string" && proposal.baseline.length > 0
+                ? safeJsonParse<{ frequency?: number }>(proposal.baseline)
+                : null;
+            const baselineFrequency = numberOrUndefined(parsedBaseline?.frequency);
+            const currentFrequency = numberOrUndefined(proposal.frequency);
 
             const measured: CheckpointMeasured = {
                 opportunities,
                 addressed,
                 ratio,
-                built: exp.artifact_path !== null,
-                ...(currentFrequency !== undefined ? { currentFrequency } : {}),
-                ...(baselineFrequency !== undefined ? { baselineFrequency } : {}),
+                built: true,
+                ...(currentFrequency === undefined ? {} : { currentFrequency }),
+                ...(baselineFrequency === undefined ? {} : { baselineFrequency }),
             };
-            const suggested = computeSuggestedVerdict(measured);
 
-            for (const kind of due) {
-                writes.push({
-                    id: checkpointKey(experimentKey, kind),
-                    experiment: experimentKey,
+            // Order matters: uncorrected evidence outranks everything, because
+            // the counts themselves cannot be trusted yet.
+            const reason: MeasurementReason | null = !correctedEvidence
+                ? "refresh_required"
+                : !support.supported
+                    ? support.reason
+                    : opportunities === 0
+                        ? "no_opportunities"
+                        : null;
+            const suggested = reason === null ? computeSuggestedVerdict(measured) : null;
+            const measuredJson = JSON.stringify({
+                opportunities: measured.opportunities,
+                addressed: measured.addressed,
+                ratio: measured.ratio,
+                built: measured.built,
+                ...(measured.currentFrequency === undefined ? {} : { current_frequency: measured.currentFrequency }),
+                ...(measured.baselineFrequency === undefined ? {} : { baseline_frequency: measured.baselineFrequency }),
+                measurement_status: suggested === null ? "insufficient_data" : "measured",
+                ...(reason === null ? {} : { reason }),
+                measurement_version: MEASUREMENT_VERSION,
+            });
+
+            const existingByKind = byKind(exp.checkpoints);
+            for (const kind of dueCheckpointKinds(facts.sessions)) {
+                const existing = existingByKind.get(kind);
+                const action = shouldRefreshCheckpoint({ existing, force, correctedEvidence });
+                if (action === "preserve") continue;
+                pending.push({
+                    experimentId: experimentKey,
                     kind,
-                    measured: JSON.stringify({
-                        opportunities: measured.opportunities,
-                        addressed: measured.addressed,
-                        ratio: measured.ratio,
-                        built: measured.built,
-                        ...(measured.currentFrequency === undefined ? {} : { current_frequency: measured.currentFrequency }),
-                        ...(measured.baselineFrequency === undefined ? {} : { baseline_frequency: measured.baselineFrequency }),
-                    }),
-                    suggested,
-                    user_verdict: null,
-                    observed_at: now,
+                    installedAtMs: installedAt.getTime(),
+                    artifactPath,
+                    refresh: action === "refresh",
+                    insufficient: suggested === null,
+                    row: {
+                        // A REFRESH updates the row it read, whatever its id.
+                        // History predating `checkpointKey` (and any row written
+                        // by another producer) is keyed differently, and writing
+                        // the canonical id instead would leave the old row in
+                        // place as a second, contradicting checkpoint for the
+                        // same window - and would send the transaction's
+                        // user_verdict re-check at a row nobody reviewed.
+                        id: action === "refresh" && existing !== undefined
+                            ? existing.id
+                            : checkpointKey(experimentKey, kind),
+                        experiment: experimentKey,
+                        kind,
+                        measured: measuredJson,
+                        suggested,
+                        user_verdict: null,
+                        observed_at: now,
+                    },
                 });
-                inserted += 1;
             }
-            skipped += (CHECKPOINT_WINDOWS_SESSIONS.length - due.length);
         }
 
-        yield* judgment.transaction((transaction) => transaction.putMany("checkpoint", writes));
+        if (opts.beforeWrite !== undefined) yield* opts.beforeWrite;
+
+        const landed = pending.length === 0
+            ? []
+            : yield* judgment.transaction((transaction) => commitCheckpoints(transaction, pending));
+
         return {
-            experimentsScanned: experiments.length,
-            checkpointsInserted: inserted,
-            checkpointsSkipped: skipped,
+            experimentsScanned: scanned,
+            experimentsExcluded: excluded,
+            checkpointsInserted: landed.filter((write) => !write.refresh).length,
+            checkpointsRefreshed: landed.filter((write) => write.refresh).length,
+            checkpointsSkipped: scanned * CHECKPOINT_WINDOWS_SESSIONS.length - landed.length,
+            insufficientData: landed.filter((write) => write.insufficient).length,
+            cacheRefreshRequired,
         };
+    });
+
+/**
+ * Write the selected windows, re-checking every protection first.
+ *
+ * The cache read above is not instantaneous, and a human can lock a verdict or
+ * retire an experiment while it runs. Re-reading eligibility and `user_verdict`
+ * HERE - inside the same transaction as the write - is what stops a measurement
+ * computed against the previous state from landing on top of a decision made
+ * since. A changed install (or artifact) is treated the same way: the
+ * measurement describes an installation that is no longer the current one, so
+ * it is dropped rather than published, and the next explicit run measures the
+ * new one.
+ */
+const commitCheckpoints = (
+    transaction: JudgmentTransaction,
+    pending: ReadonlyArray<PendingWrite>,
+): Effect.Effect<ReadonlyArray<PendingWrite>, JudgmentError> =>
+    Effect.gen(function* () {
+        const experimentIds = [...new Set(pending.map((write) => write.experimentId))];
+        const guards = yield* transaction.rows(
+            GuardRow,
+            `SELECT e.id AS id, e.status AS status, e.locked_verdict AS locked_verdict,
+                    e.artifact_path AS artifact_path, e.scaffolded_at AS scaffolded_at,
+                    p.status AS proposal_status
+             FROM experiment e JOIN proposal p ON p.id = e.proposal
+             WHERE e.id IN (${experimentIds.map(() => "?").join(", ")})`,
+            experimentIds,
+        );
+        const guardById = new Map(guards.map((guard) => [guard.id, guard]));
+
+        const checkpointIds = pending.map((write) => String(write.row.id));
+        const reviews = yield* transaction.rows(
+            ReviewRow,
+            `SELECT id, user_verdict FROM checkpoint WHERE id IN (${checkpointIds.map(() => "?").join(", ")})`,
+            checkpointIds,
+        );
+        const reviewedIds = new Set(
+            reviews.filter((review) => review.user_verdict !== null).map((review) => review.id),
+        );
+
+        const selected = pending.filter((write) => {
+            if (reviewedIds.has(String(write.row.id))) return false;
+            const guard = guardById.get(write.experimentId);
+            if (guard === undefined) return false;
+            const eligibility = measurementEligibility({
+                proposalStatus: guard.proposal_status,
+                experimentStatus: guard.status,
+                lockedVerdict: guard.locked_verdict,
+                artifactPath: guard.artifact_path,
+                scaffoldedAt: guard.scaffolded_at,
+            });
+            if (!eligibility.eligible) return false;
+            if (guard.artifact_path !== write.artifactPath) return false;
+            return installationTime(guard.scaffolded_at)?.getTime() === write.installedAtMs;
+        });
+        if (selected.length > 0) {
+            yield* transaction.putMany("checkpoint", selected.map((write) => write.row));
+        }
+        return selected;
     });

--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -809,6 +809,45 @@ describe("guidance form: a failed stat is unavailable evidence", () => {
     });
 });
 
+describe("timestamp projections carry an explicit zone", () => {
+    dtest("a correction keeps its instant on a UTC+8 host", async () => {
+        const harness = makeHarness("ax-opp-identity-tz-");
+        const guidancePath = join(harness.root, "CLAUDE.md");
+        const experimentKey = await installGuidanceExperiment(harness, { sig: "use-rg", guidancePath });
+        // A whole number of milliseconds, so the round-trip is exact rather
+        // than "close enough" - the shift this guards against is 8 HOURS.
+        const correctionAt = new Date(Math.floor((Date.now() + 60_000) / 1000) * 1000 + 541);
+        await utimes(guidancePath, correctionAt, correctionAt);
+
+        const previousTz = process.env.TZ;
+        // The host offset is the whole bug: DuckDB stores UTC, and a zone-less
+        // projection came back through `new Date(...)` as LOCAL time, moving
+        // every matched_at by the offset - out of its own install window.
+        process.env.TZ = "Asia/Singapore";
+        let stored: ReadonlyArray<{ readonly in_id: string; readonly matched_at: string }>;
+        try {
+            stored = await inCache(harness, (session) =>
+                Effect.gen(function* () {
+                    yield* session.write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);
+                    yield* session.derive;
+                    const read = yield* session.write.raw(
+                        `SELECT in_id, strftime(matched_at, '%Y-%m-%dT%H:%M:%S.%gZ') AS matched_at
+                         FROM opportunity`,
+                    );
+                    return read.rows as unknown as ReadonlyArray<{ in_id: string; matched_at: string }>;
+                }));
+        } finally {
+            if (previousTz === undefined) delete process.env.TZ;
+            else process.env.TZ = previousTz;
+        }
+
+        expect(stored).toHaveLength(1);
+        expect(stored[0]!.in_id).toBe(experimentKey);
+        // EXACT, not "within a window": an offset-shifted row differs by hours.
+        expect(stored[0]!.matched_at).toBe(correctionAt.toISOString());
+    });
+});
+
 describe("skill form: the cited candidate has to exist", () => {
     /** Seed one accepted+installed skill experiment straight into the real
      *  sidecar. The install path itself is covered by the hook/guidance cases

--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -820,6 +820,16 @@ describe("timestamp projections carry an explicit zone", () => {
         await utimes(guidancePath, correctionAt, correctionAt);
 
         const previousTz = process.env.TZ;
+        // Deleting TZ does NOT put the runtime back: bun keeps resolving the
+        // last zone it was ASSIGNED, so an unset variable leaves Asia/Singapore
+        // in force for every later test in this process (root saw the
+        // run-evidence SQL/TS parity case fail behind exactly that leak). The
+        // effective zone therefore has to be captured and re-ASSIGNED, not
+        // merely unset. The offset probe is a FIXED instant so the before/after
+        // comparison cannot move for a DST reason.
+        const priorZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const OFFSET_PROBE = new Date("2026-09-05T00:00:00Z");
+        const priorOffset = OFFSET_PROBE.getTimezoneOffset();
         // The host offset is the whole bug: DuckDB stores UTC, and a zone-less
         // projection came back through `new Date(...)` as LOCAL time, moving
         // every matched_at by the offset - out of its own install window.
@@ -842,14 +852,21 @@ describe("timestamp projections carry an explicit zone", () => {
                     return read.rows as unknown as ReadonlyArray<{ in_id: string; matched_at: string }>;
                 }));
         } finally {
+            // ASSIGN first - that is what makes the runtime re-resolve - and
+            // only then restore the variable's original shape.
+            process.env.TZ = previousTz ?? priorZone;
             if (previousTz === undefined) delete process.env.TZ;
-            else process.env.TZ = previousTz;
         }
 
         expect(stored).toHaveLength(1);
         expect(stored[0]!.in_id).toBe(experimentKey);
         // EXACT, not "within a window": an offset-shifted row differs by hours.
         expect(stored[0]!.matched_at).toBe(correctionAt.toISOString());
+        // Isolation is part of the contract: this case mutates process-wide
+        // state, and the next test in this process must not inherit it.
+        expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(priorZone);
+        expect(OFFSET_PROBE.getTimezoneOffset()).toBe(priorOffset);
+        expect(process.env.TZ).toBe(previousTz);
     });
 });
 

--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -809,6 +809,79 @@ describe("guidance form: a failed stat is unavailable evidence", () => {
     });
 });
 
+describe("skill form: the cited candidate has to exist", () => {
+    /** Seed one accepted+installed skill experiment straight into the real
+     *  sidecar. The install path itself is covered by the hook/guidance cases
+     *  above; what this case is about is which DETECTOR the cache-side lookup
+     *  selects. */
+    const installSkillExperiment = (harness: Harness, opts: {
+        readonly sig: string;
+        readonly trigger: string;
+        readonly installedAt: Date;
+    }) => harness.judgment(Effect.gen(function* () {
+        const judgment = yield* Judgment;
+        yield* judgment.put("proposal", {
+            id: `proposal-${opts.sig}`, form: "skill", title: "Guard schema edits",
+            hypothesis: "schema edits keep failing", dedupe_sig: opts.sig, frequency: 3,
+            confidence: "high", status: "accepted", origin: "agent", hypothesis_template: null,
+            evidence_query: null, reject_reason: null, baseline: null,
+            created_at: opts.installedAt, updated_at: opts.installedAt,
+        });
+        yield* judgment.put("skill_proposal", {
+            id: `skill-${opts.sig}`, proposal: `proposal-${opts.sig}`,
+            trigger_pattern: opts.trigger, suspected_gap: "gap",
+            proposed_behavior: "behavior", expected_impact: null,
+        });
+        yield* judgment.put("experiment", {
+            id: `experiment-${opts.sig}`, proposal: `proposal-${opts.sig}`, artifact: null,
+            artifact_path: join(harness.root, "skills", opts.sig, "SKILL.md"),
+            scaffolded_at: opts.installedAt, created_at: opts.installedAt,
+            locked_verdict: null, status: "scaffolded", task_path: null,
+        });
+    }));
+
+    dtest("a dangling cites_evidence edge falls through to the tool trigger", async () => {
+        const harness = makeHarness("ax-opp-identity-candidate-");
+        const installedAt = new Date(Date.now() - 60_000);
+        await installSkillExperiment(harness, {
+            sig: "guard-schema",
+            trigger: "tool=Bash",
+            installedAt,
+        });
+
+        const result = await inCache(harness, (session) =>
+            Effect.gen(function* () {
+                // The proposal cites a candidate that is no longer in the cache
+                // (retired, or dropped by a rebuild). The old lookup trusted the
+                // edge, chose the legacy candidate detector, and derived its
+                // match tokens from a row it could not read - so the experiment
+                // produced nothing at all.
+                yield* session.write.put("cites_evidence", {
+                    id: "cites-dangling", in_id: "proposal-guard-schema", out_id: "skill_candidate-gone",
+                    in_table: "proposal", out_table: "skill_candidate", count: 1, kind: null,
+                    ts: installedAt,
+                });
+                yield* session.write.put("session", {
+                    id: "skill-session", source: "claude",
+                    started_at: installedAt, ended_at: null,
+                });
+                yield* session.write.put("tool_call", {
+                    id: "failing-bash", session: "skill-session", agent_event: null, turn: null,
+                    tool: null, name: "Bash", ts: new Date(installedAt.getTime() + 30_000),
+                    status: "error", input_json: null, output_json: null, raw: null,
+                    duration_ms: null, seq: 1, call_id: null, cwd: null, command_text: null,
+                    command_norm: null, command_tool: null, output_excerpt: null,
+                    error_text: "boom", exit_code: 1, has_error: true,
+                });
+                const stats = yield* session.derive;
+                return { stats, rows: yield* session.rows };
+            }));
+
+        expect(result.rows.map((row) => row.out_id)).toEqual(["failing-bash"]);
+        expect(result.stats.bySkillForm).toBe(1);
+    });
+});
+
 describe("derivation-version sentinel", () => {
     dtest("stamps a complete pass, and a later failed pass revokes it", async () => {
         const harness = makeHarness("ax-opp-identity-sentinel-");

--- a/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.identity.test.ts
@@ -826,6 +826,11 @@ describe("timestamp projections carry an explicit zone", () => {
         process.env.TZ = "Asia/Singapore";
         let stored: ReadonlyArray<{ readonly in_id: string; readonly matched_at: string }>;
         try {
+            // The regression is only a regression if the host really is on a
+            // non-UTC clock while the derivation runs. `getTimezoneOffset` is
+            // evaluated now, against the TZ just set, so this fails loudly on a
+            // runner that ignores the variable rather than passing vacuously.
+            expect(correctionAt.getTimezoneOffset()).toBe(-480);
             stored = await inCache(harness, (session) =>
                 Effect.gen(function* () {
                     yield* session.write.putMany("friction_event", [correctionRow("friction-1", correctionAt)]);

--- a/apps/axctl/src/ingest/derive-opportunities.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.ts
@@ -1,10 +1,12 @@
 /**
  * Derive-Opportunities Stage (Phase C5 + form-aware extension).
  *
- * Each active experiment (proposal.status='accepted', locked_verdict
- * IS NONE) collects `opportunity` rows for every new piece of trigger-
- * matching evidence after experiment.created_at. C6 then aggregates the
- * count + addressed ratio into a `checkpoint` row at t+7/t+30/t+90.
+ * Each ELIGIBLE experiment collects `opportunity` rows for every new piece of
+ * trigger-matching evidence after its OBSERVED INSTALL. C6 then aggregates the
+ * count + addressed ratio into a `checkpoint` row at +3/+10/+30 sessions.
+ * Eligibility is the shared rule in `improve/measurement.ts` (#1134): accepted
+ * proposal, `scaffolded` experiment, no locked verdict, a recorded artifact and
+ * install time. Anything else has no measurable installation.
  *
  * Form coverage:
  *  - skill (closure-derived, cites skill_candidate): legacy detector via
@@ -26,8 +28,9 @@
  * install time has UNAVAILABLE evidence: it contributes no rows, and its stale
  * ones are cleared rather than left to read as "not addressed".
  *
- * Measurement starts at `experiment.scaffolded_at` (the observed install),
- * because acceptance can precede installation by days.
+ * Measurement starts at `experiment.scaffolded_at` (the observed install) for
+ * EVERY form, because acceptance can precede installation by days and evidence
+ * from that gap could not have met the artifact.
  *
  * The opportunity row is a RELATION (in=experiment, out=evidence record).
  * Edge id = sha-style key over (experimentKey, evidenceKey) so re-derive
@@ -46,6 +49,11 @@ import { tsParam } from "@ax/lib/duckdb/row";
 import type { CacheReadError, CacheWriteError, CacheWriteService } from "@ax/lib/duckdb/seam";
 import type { Judgment, JudgmentError } from "@ax/lib/sqlite";
 import { listStoredProposals } from "../improve/judgment-proposals.ts";
+import {
+    detectorSupport,
+    measurementEligibility,
+    parseSkillTriggerTool,
+} from "../improve/measurement.ts";
 import { parseHookCommandMarkers } from "../improve/markers.ts";
 import { REAL_HOOK_EFFECTS, isRealHookEffect } from "@ax/lib/shared/hook-effects";
 import { WATERMARK_TABLE, watermarkRow } from "@ax/lib/duckdb/watermark";
@@ -192,18 +200,15 @@ export const hookOpportunityAddressed = (
     });
 };
 
-/**
- * Parse a skill_proposal.trigger_pattern of the form `tool=<Name>` and
- * return the tool name. Returns null for any other shape.
- */
-export const parseSkillTriggerTool = (pattern: string): string | null => {
-    const m = /^tool=(.+)$/.exec(pattern.trim());
-    return m && m[1] ? m[1].trim() : null;
-};
+/** Re-exported from the shared measurement helper, which owns the one
+ *  definition of "a skill trigger this codebase can detect" (#1134). */
+export { parseSkillTriggerTool } from "../improve/measurement.ts";
 
 interface ActiveExperimentRow {
     readonly id: string | { tb: string; id: string };
     readonly created_at: string;
+    /** experiment lifecycle: task_emitted | scaffolded | regressed | retired. */
+    readonly status: string;
     /** When `improve lint` OBSERVED the artifact installed - the earliest time a
      *  measurement can mean anything. Null until lint has reconciled the marker
      *  (acceptance can precede installation by days). */
@@ -462,12 +467,22 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
         // The one field that has to cross: `cites_evidence` is a MINED edge and
         // stays in the cache, so the skill_candidate a proposal cites is looked
         // up here and matched to its (sidecar) proposal id in JS.
+        //
+        // The join RESOLVES the candidate rather than trusting the edge. A
+        // dangling edge - the candidate was retired, or a rebuilt cache dropped
+        // it - would otherwise select the legacy detector, whose match tokens
+        // are derived from the candidate name it cannot read; the experiment
+        // would silently produce no rows instead of falling through to the
+        // supported `tool=<name>` trigger the proposal may still carry.
         const candidateByProposal = new Map<string, string>();
         if (active.length > 0) {
             const proposalIds = active.map((proposal) => proposal.id);
             const citesRaw = yield* write.raw(
-                `SELECT in_id, out_id FROM cites_evidence
-                 WHERE out_table = 'skill_candidate' AND in_id IN (${proposalIds.map(() => "?").join(", ")})`,
+                `SELECT ce.in_id AS in_id, ce.out_id AS out_id
+                 FROM cites_evidence AS ce
+                 JOIN skill_candidate AS sc ON sc.id = ce.out_id
+                 WHERE ce.out_table = 'skill_candidate'
+                   AND ce.in_id IN (${proposalIds.map(() => "?").join(", ")})`,
                 proposalIds,
             );
             for (const row of citesRaw.rows as Array<Record<string, unknown>>) {
@@ -484,6 +499,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             return {
                 id: experiment.id,
                 created_at: experiment.created_at.toISOString(),
+                status: experiment.status,
                 scaffolded_at: experiment.scaffolded_at?.toISOString() ?? null,
                 form: proposal.form,
                 dedupe_sig: proposal.dedupe_sig,
@@ -519,9 +535,46 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
             if (!experimentKey) continue;
             rebuiltExperimentKeys.push(experimentKey);
             const form = exp.form;
+            const candidateKey = exp.candidate_id ? recordKeyPart(exp.candidate_id, "skill_candidate") : null;
+
+            // Eligibility first, and it is the SAME rule the checkpoint reader
+            // applies (`improve/measurement.ts`). An experiment that never
+            // reached `scaffolded`, or has retired, has no measurable
+            // installation - so it collects no rows, and the replacement below
+            // clears any it still carries rather than leaving them to read as
+            // "not addressed". `active` already pinned accepted + unlocked.
+            const eligibility = measurementEligibility({
+                proposalStatus: "accepted",
+                experimentStatus: exp.status,
+                lockedVerdict: null,
+                artifactPath: exp.artifact_path,
+                scaffoldedAt: exp.scaffolded_at,
+            });
+            if (!eligibility.eligible) {
+                if (eligibility.reason === "artifact_unavailable" || eligibility.reason === "not_started") {
+                    artifactUnavailable += 1;
+                }
+                continue;
+            }
+            // Every form's evidence window starts at the OBSERVED install, not
+            // at acceptance: a failure, correction or fix-chain from the gap
+            // between the two could not have met the artifact.
+            const installedAt = new Date(exp.scaffolded_at!);
+            const support = detectorSupport({
+                form,
+                skillTrigger: exp.skill_trigger,
+                hasSkillCandidate: candidateKey !== null,
+                hookTargetTool: exp.hook_payload?.target_tool ?? null,
+                hookEventName: exp.hook_payload?.event_name ?? null,
+                dedupeSig: exp.dedupe_sig,
+                artifactPath: exp.artifact_path,
+            });
+            if (!support.supported) {
+                if (support.reason === "artifact_unavailable") artifactUnavailable += 1;
+                continue;
+            }
 
             // -------- skill form (legacy: closure-derived via skill_candidate) --------
-            const candidateKey = exp.candidate_id ? recordKeyPart(exp.candidate_id, "skill_candidate") : null;
             if (form === "skill" && candidateKey) {
                 const tokens = triggerTokensFromCandidate(candidateKey);
                 if (tokens.length === 0) continue;
@@ -529,7 +582,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 const fixesResult = yield* write.raw(`
                     SELECT id, CAST(ts AS VARCHAR) AS ts, overlap_files
                     FROM later_fixed_by
-                    WHERE ts > ?`, [new Date(exp.created_at)]);
+                    WHERE ts > ?`, [installedAt]);
                 const fixes = fixesResult.rows as unknown as LaterFixedByRow[];
                 const matches: Array<{ evidenceTable: string; evidenceKey: string; ts: string }> = [];
                 for (const fix of fixes) {
@@ -550,7 +603,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     if (skillRow?.id) {
                         const skillKey = recordKeyPart(skillRow.id, "skill");
                         if (skillKey) {
-                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, new Date(exp.created_at)]);
+                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, installedAt]);
                             invokedTimestamps = (invokedResult.rows as unknown as InvokedTsRow[])
                                 .map((r) => new Date(r.ts).getTime())
                                 .filter((t) => Number.isFinite(t));
@@ -580,7 +633,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 const callsResult = yield* write.raw(`
                     SELECT id, CAST(ts AS VARCHAR) AS ts
                     FROM tool_call
-                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, new Date(exp.created_at)]);
+                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, installedAt]);
                 const calls = callsResult.rows as unknown as ToolCallRow[];
                 const matches: Array<{ evidenceTable: string; evidenceKey: string; ts: string }> = [];
                 for (const c of calls) {
@@ -602,7 +655,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     if (skillRow?.id) {
                         const skillKey = recordKeyPart(skillRow.id, "skill");
                         if (skillKey) {
-                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, new Date(exp.created_at)]);
+                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, installedAt]);
                             invokedTimestamps = (invokedResult.rows as unknown as InvokedTsRow[])
                                 .map((r) => new Date(r.ts).getTime())
                                 .filter((t) => Number.isFinite(t));
@@ -626,22 +679,16 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
 
             // -------- hook form --------
             if (form === "hook") {
-                const tool = exp.hook_payload?.target_tool ?? null;
-                const eventName = exp.hook_payload?.event_name ?? null;
-                if (!tool) continue;
-
-                // The identity a fire has to carry to be THIS hook. Without an
-                // installed marker + a configured event + an observed install
-                // time there is nothing to match on: the hook is UNMEASURED, not
-                // unaddressed, so its stale rows go and no new ones land. The
-                // executable is never guessed from the proposal - a wrapper, a
-                // python/node/bun script and an inline command all look the same
-                // from here, and only the marker distinguishes them.
-                const installedAt = exp.scaffolded_at;
-                if (!eventName || exp.dedupe_sig.length === 0 || installedAt === null) {
-                    artifactUnavailable += 1;
-                    continue;
-                }
+                // The identity a fire has to carry to be THIS hook: the target
+                // tool, the configured event, and the installed marker. The
+                // detector gate above already refused the hook without all
+                // three - it is UNMEASURED, not unaddressed, so its stale rows
+                // go and no new ones land. The executable is never guessed from
+                // the proposal: a wrapper, a python/node/bun script and an
+                // inline command all look the same from here, and only the
+                // marker distinguishes them.
+                const tool = exp.hook_payload!.target_tool!;
+                const eventName = exp.hook_payload!.event_name!;
 
                 // Both sides of the match are windowed on the OBSERVED install:
                 // a call that failed before the hook existed was never an
@@ -650,7 +697,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 const callsResult = yield* write.raw(`
                     SELECT id, session, call_id, CAST(ts AS VARCHAR) AS ts
                     FROM tool_call
-                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, new Date(installedAt)]);
+                    WHERE name = ? AND has_error = true AND ts > ?`, [tool, installedAt]);
                 const calls = callsResult.rows as unknown as HookToolCallRow[];
                 const matches: Array<{
                     evidenceTable: string;
@@ -682,7 +729,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     FROM hook_command_invocation
                     WHERE ts > ? AND event_name = ? AND provider_status <> 'progress_only'
                       AND effect IN (${REAL_HOOK_EFFECTS.map(() => "?").join(", ")})`,
-                    [new Date(installedAt), eventName, ...REAL_HOOK_EFFECTS]);
+                    [installedAt, eventName, ...REAL_HOOK_EFFECTS]);
                 const fires = (invResult.rows as unknown as HookInvocationFact[]).filter(
                     (invocation) => isCreditableHookInvocation(invocation, {
                         dedupeSig: exp.dedupe_sig,
@@ -710,19 +757,14 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 // this experiment. No recorded path (or no observed install
                 // time) = unavailable artifact evidence; the user has to run
                 // `ax improve lint` in the target repository first.
-                const artifactPath = installedArtifactPath(exp.artifact_path);
-                const installedAt = exp.scaffolded_at;
-                if (artifactPath === null || installedAt === null) {
-                    artifactUnavailable += 1;
-                    continue;
-                }
+                const artifactPath = installedArtifactPath(exp.artifact_path)!;
 
                 // Cheap initial wedge: every correction friction_event AFTER the
                 // install is one opportunity for the guidance to have prevented.
                 const frictionResult = yield* write.raw(`
                     SELECT id, CAST(ts AS VARCHAR) AS ts
                     FROM friction_event
-                    WHERE kind = 'correction' AND ts > ?`, [new Date(installedAt)]);
+                    WHERE kind = 'correction' AND ts > ?`, [installedAt]);
                 const events = frictionResult.rows as unknown as FrictionEventRow[];
                 const matches: Array<{ evidenceTable: string; evidenceKey: string; ts: string }> = [];
                 for (const ev of events) {

--- a/apps/axctl/src/ingest/derive-opportunities.ts
+++ b/apps/axctl/src/ingest/derive-opportunities.ts
@@ -32,6 +32,10 @@
  * EVERY form, because acceptance can precede installation by days and evidence
  * from that gap could not have met the artifact.
  *
+ * Every timestamp this stage reads back is projected as an explicit UTC instant
+ * ({@link utcTs}); a bare `CAST(ts AS VARCHAR)` is a zone-less string that JS
+ * silently reads as host-local time.
+ *
  * The opportunity row is a RELATION (in=experiment, out=evidence record).
  * Edge id = sha-style key over (experimentKey, evidenceKey) so re-derive
  * passes are idempotent; every selected experiment's rows are REBUILT each run
@@ -250,6 +254,25 @@ interface FrictionEventRow {
     readonly id: string | { tb: string; id: string };
     readonly ts: string;
 }
+
+/**
+ * Project a TIMESTAMP column as an EXPLICIT UTC instant (#1134).
+ *
+ * `CAST(ts AS VARCHAR)` yields `2026-09-05 17:32:41.541` - a naive local-looking
+ * string with no zone. The DuckDB side is fine (the seam pins every connection
+ * to UTC), but `new Date(...)`/`tsParam` then read that string as HOST-LOCAL
+ * time, so on a UTC+8 machine a correction recorded at 17:32Z came back as
+ * 09:32Z. Every consumer of these rows inherited the shift: `matched_at` landed
+ * eight hours early, the install window then excluded the very evidence it was
+ * meant to admit, and the ±window hook/skill correlations compared instants
+ * that were never on the same clock.
+ *
+ * `%g` is DuckDB's millisecond specifier, so this is the ISO-8601 `Z` form JS
+ * parses unambiguously - matching the precision `Date` keeps. The fix stays
+ * local to this file's projections: `tsParam` is a shared seam helper and does
+ * not get to guess a zone the query failed to state.
+ */
+const utcTs = (column: string): string => `strftime(${column}, '%Y-%m-%dT%H:%M:%S.%gZ')`;
 
 export const opportunityKey = (experimentKey: string, evidenceKey: string): string =>
     `${safeKeyPart(experimentKey).slice(0, 48)}__${safeKeyPart(evidenceKey).slice(0, 48)}__${Bun.hash(`${experimentKey}:${evidenceKey}`).toString(16).slice(0, 12)}`;
@@ -580,7 +603,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 if (tokens.length === 0) continue;
 
                 const fixesResult = yield* write.raw(`
-                    SELECT id, CAST(ts AS VARCHAR) AS ts, overlap_files
+                    SELECT id, ${utcTs("ts")} AS ts, overlap_files
                     FROM later_fixed_by
                     WHERE ts > ?`, [installedAt]);
                 const fixes = fixesResult.rows as unknown as LaterFixedByRow[];
@@ -603,7 +626,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     if (skillRow?.id) {
                         const skillKey = recordKeyPart(skillRow.id, "skill");
                         if (skillKey) {
-                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, installedAt]);
+                            const invokedResult = yield* write.raw(`SELECT ${utcTs("ts")} AS ts FROM invoked WHERE out_id = ? AND ts > ?`, [skillKey, installedAt]);
                             invokedTimestamps = (invokedResult.rows as unknown as InvokedTsRow[])
                                 .map((r) => new Date(r.ts).getTime())
                                 .filter((t) => Number.isFinite(t));
@@ -631,7 +654,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 if (!tool) continue;
 
                 const callsResult = yield* write.raw(`
-                    SELECT id, CAST(ts AS VARCHAR) AS ts
+                    SELECT id, ${utcTs("ts")} AS ts
                     FROM tool_call
                     WHERE name = ? AND has_error = true AND ts > ?`, [tool, installedAt]);
                 const calls = callsResult.rows as unknown as ToolCallRow[];
@@ -655,7 +678,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                     if (skillRow?.id) {
                         const skillKey = recordKeyPart(skillRow.id, "skill");
                         if (skillKey) {
-                            const invokedResult = yield* write.raw("SELECT CAST(ts AS VARCHAR) AS ts FROM invoked WHERE out_id = ? AND ts > ?", [skillKey, installedAt]);
+                            const invokedResult = yield* write.raw(`SELECT ${utcTs("ts")} AS ts FROM invoked WHERE out_id = ? AND ts > ?`, [skillKey, installedAt]);
                             invokedTimestamps = (invokedResult.rows as unknown as InvokedTsRow[])
                                 .map((r) => new Date(r.ts).getTime())
                                 .filter((t) => Number.isFinite(t));
@@ -695,7 +718,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 // opportunity for it, and counting it would dilute the ratio
                 // with failures the hook could not have been present for.
                 const callsResult = yield* write.raw(`
-                    SELECT id, session, call_id, CAST(ts AS VARCHAR) AS ts
+                    SELECT id, session, call_id, ${utcTs("ts")} AS ts
                     FROM tool_call
                     WHERE name = ? AND has_error = true AND ts > ?`, [tool, installedAt]);
                 const calls = callsResult.rows as unknown as HookToolCallRow[];
@@ -724,7 +747,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 // credit a prefix collision or a filename that merely contains
                 // the signature.
                 const invResult = yield* write.raw(`
-                    SELECT session, CAST(ts AS VARCHAR) AS ts, command, event_name,
+                    SELECT session, ${utcTs("ts")} AS ts, command, event_name,
                            tool_call, tool_call_id, effect, provider_status
                     FROM hook_command_invocation
                     WHERE ts > ? AND event_name = ? AND provider_status <> 'progress_only'
@@ -762,7 +785,7 @@ export const deriveOpportunities = (write: CacheWriteService): Effect.Effect<
                 // Cheap initial wedge: every correction friction_event AFTER the
                 // install is one opportunity for the guidance to have prevented.
                 const frictionResult = yield* write.raw(`
-                    SELECT id, CAST(ts AS VARCHAR) AS ts
+                    SELECT id, ${utcTs("ts")} AS ts
                     FROM friction_event
                     WHERE kind = 'correction' AND ts > ?`, [installedAt]);
                 const events = frictionResult.rows as unknown as FrictionEventRow[];

--- a/apps/axctl/src/ingest/opportunity-cache-version.ts
+++ b/apps/axctl/src/ingest/opportunity-cache-version.ts
@@ -24,5 +24,13 @@ export const OPPORTUNITY_VERSION_SOURCE = "opportunity_derivation";
  *  file, and deliberately not shared with a transcript or content-hash mark. */
 export const OPPORTUNITY_VERSION_PATH = "__opportunity_derivation__";
 
-/** The token stored in `sha`. Bump it when matching semantics change again. */
-export const OPPORTUNITY_VERSION = "artifact-identity-v2";
+/**
+ * The token stored in `sha`. Bump it when matching semantics change again.
+ *
+ * `artifact-identity-v2` (#1133) certified the artifact-identity rules only.
+ * `eligible-install-v3` (#1134) adds the eligibility gate and moves EVERY
+ * form's evidence window to the observed install, so rows a v2 pass produced
+ * describe a different question and cannot certify a v3 measurement - a
+ * checkpoint reader that finds the old token asks for derivation instead.
+ */
+export const OPPORTUNITY_VERSION = "eligible-install-v3";

--- a/apps/axctl/src/ingest/opportunity-cache-version.ts
+++ b/apps/axctl/src/ingest/opportunity-cache-version.ts
@@ -28,9 +28,13 @@ export const OPPORTUNITY_VERSION_PATH = "__opportunity_derivation__";
  * The token stored in `sha`. Bump it when matching semantics change again.
  *
  * `artifact-identity-v2` (#1133) certified the artifact-identity rules only.
- * `eligible-install-v3` (#1134) adds the eligibility gate and moves EVERY
- * form's evidence window to the observed install, so rows a v2 pass produced
- * describe a different question and cannot certify a v3 measurement - a
- * checkpoint reader that finds the old token asks for derivation instead.
+ * `eligible-install-v3` (#1134) added the eligibility gate and moved EVERY
+ * form's evidence window to the observed install.
+ * `utc-matched-at-v4` (#1134) fixes the timestamp projections: rows derived
+ * before it carry a `matched_at` shifted by the host's UTC offset, so on any
+ * non-UTC machine they sit outside their own install window and read as absent
+ * evidence. Those rows are not repairable in place - only a re-derivation can
+ * restore the instants - so a checkpoint reader that finds an older token asks
+ * for derivation rather than measuring them.
  */
-export const OPPORTUNITY_VERSION = "eligible-install-v3";
+export const OPPORTUNITY_VERSION = "utc-matched-at-v4";

--- a/apps/studio/src/components/experiments-section.test.ts
+++ b/apps/studio/src/components/experiments-section.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
-import { experimentDisplayState } from "./experiments-section.tsx";
+import { ExperimentsSection, experimentDisplayState } from "./experiments-section.tsx";
 
 const proposal = (experiment: Record<string, unknown>): ProposalDto => ({
     id: "proposal:abc",
@@ -104,5 +106,39 @@ describe("experimentDisplayState", () => {
         }));
         expect(state.badge).toBe("normalized");
         expect(state.note).toBe("pattern resolved · no longer firing");
+    });
+});
+
+describe("the rendered trace strip", () => {
+    const render = (p: ProposalDto): string =>
+        renderToStaticMarkup(
+            createElement(ExperimentsSection, { proposals: [p], onOpen: () => undefined }),
+        );
+
+    test("a window that measured nothing is never marked a win", () => {
+        const empty = checkpoint({
+            suggested: null,
+            measured: {
+                opportunities: 0, addressed: 0, ratio: 0, built: true,
+                measurement_status: "insufficient_data", reason: "no_opportunities",
+            },
+        });
+        const markup = render(proposal({
+            latest_checkpoint: empty,
+            checkpoints: [checkpoint(), empty],
+            current_reason: "no_opportunities",
+        }));
+        expect(markup).toContain('class="experiment-trace"');
+        expect(markup).not.toContain("is-win");
+    });
+
+    test("the human's locked verdict still colours the strip", () => {
+        const markup = render(proposal({
+            locked_verdict: "adopted",
+            latest_checkpoint: checkpoint({ user_verdict: "adopted" }),
+            checkpoints: [checkpoint({ user_verdict: "adopted" })],
+        }));
+        expect(markup).toContain("experiment-trace-addr accent-green");
+        expect(markup).not.toContain("is-win");
     });
 });

--- a/apps/studio/src/components/experiments-section.test.ts
+++ b/apps/studio/src/components/experiments-section.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
+import { experimentDisplayState } from "./experiments-section.tsx";
+
+const proposal = (experiment: Record<string, unknown>): ProposalDto => ({
+    id: "proposal:abc",
+    form: "guidance",
+    title: "Always read CLAUDE.md",
+    hypothesis: "H",
+    dedupe_sig: "abc123",
+    frequency: 9,
+    confidence: "high",
+    status: "accepted",
+    reject_reason: null,
+    created_at: "2026-01-01T00:00:00Z",
+    experiment: {
+        id: "exp:1",
+        artifact_path: "/repo/CLAUDE.md",
+        status: "scaffolded",
+        task_path: null,
+        locked_verdict: null,
+        created_at: "2026-01-01T00:00:00Z",
+        scaffolded_at: "2026-01-10T00:00:00Z",
+        latest_checkpoint: null,
+        checkpoints: [],
+        ...experiment,
+    },
+} as ProposalDto);
+
+const checkpoint = (overrides: Record<string, unknown> = {}) => ({
+    kind: "+3s",
+    suggested: "adopted" as string | null,
+    user_verdict: null,
+    measured: {
+        opportunities: 12, addressed: 8, ratio: 8 / 12, built: true,
+        measurement_status: "measured", measurement_version: 2,
+    },
+    observed_at: "2026-01-20T00:00:00Z",
+    ...overrides,
+});
+
+describe("experimentDisplayState", () => {
+    test("a measured suggestion is described as observed use", () => {
+        const state = experimentDisplayState(proposal({
+            latest_checkpoint: checkpoint(),
+            checkpoints: [checkpoint()],
+        }));
+        expect(state.note).toBe("suggested: adopted · observed use");
+        expect(state.badge).toBe("1/3 checkpoints");
+    });
+
+    test("an insufficient-data window says so, never `measuring…`", () => {
+        const insufficient = checkpoint({
+            suggested: null,
+            measured: {
+                opportunities: 0, addressed: 0, ratio: 0, built: true,
+                measurement_status: "insufficient_data", reason: "no_opportunities",
+            },
+        });
+        const state = experimentDisplayState(proposal({
+            latest_checkpoint: insufficient,
+            checkpoints: [insufficient],
+            current_reason: "no_opportunities",
+        }));
+        expect(state.note).toBe("insufficient data · no opportunities in the window");
+        expect(state.accent).toBe("muted");
+    });
+
+    test("an unavailable detector is named, not read as a pending measurement", () => {
+        const state = experimentDisplayState(proposal({
+            latest_checkpoint: checkpoint({ suggested: null }),
+            checkpoints: [checkpoint({ suggested: null })],
+            current_reason: "detector_unavailable",
+        }));
+        expect(state.note).toBe("detector unavailable");
+        expect(state.note).not.toContain("measuring");
+    });
+
+    test("a lifecycle state replaces the measurement note", () => {
+        for (const [reason, note] of [
+            ["retired", "retired"],
+            ["not_started", "artifact not installed yet"],
+            ["refresh_required", "insufficient data · evidence needs derivation"],
+        ] as const) {
+            const state = experimentDisplayState(proposal({
+                latest_checkpoint: checkpoint({ suggested: null }),
+                checkpoints: [checkpoint({ suggested: null })],
+                current_reason: reason,
+            }));
+            expect(state.note).toBe(note);
+        }
+    });
+
+    test("an experiment with no checkpoint at all still waits for sessions", () => {
+        const state = experimentDisplayState(proposal({ current_reason: "no_checkpoint" }));
+        expect(state).toEqual({ accent: "blue", badge: "pending", note: "waiting for sessions…" });
+    });
+
+    test("a locked verdict keeps its own rendering", () => {
+        const state = experimentDisplayState(proposal({
+            locked_verdict: "no_longer_needed",
+            latest_checkpoint: checkpoint({ suggested: "adopted", user_verdict: "no_longer_needed" }),
+            checkpoints: [checkpoint()],
+        }));
+        expect(state.badge).toBe("normalized");
+        expect(state.note).toBe("pattern resolved · no longer firing");
+    });
+});

--- a/apps/studio/src/components/experiments-section.tsx
+++ b/apps/studio/src/components/experiments-section.tsx
@@ -48,12 +48,20 @@ const tracePoints = (p: ProposalDto): TracePoint[] => {
     return points;
 };
 
+/**
+ * The strip carries the counts and nothing else (#1134).
+ *
+ * It used to add `is-win` whenever the last bar sat at zero, celebrating the
+ * one reading that is NOT a result: zero opportunities means the window had
+ * nothing to measure - no trigger fired, or no detector watched for one - and
+ * that is insufficient data, not a confirmed win. The only verdict styling left
+ * is the human's: `accent` carries the locked verdict's colour.
+ */
 function TraceStrip({ points, accent }: { readonly points: TracePoint[]; readonly accent: string }) {
     const max = Math.max(...points.map((pt) => pt.opportunities), 1);
-    const lastIsZero = points.length > 1 && points[points.length - 1]!.opportunities === 0;
     return (
         <span
-            className={`experiment-trace${lastIsZero ? " is-win" : ""}`}
+            className="experiment-trace"
             title={points.map((pt) => `${pt.label}: ${pt.opportunities} opportunities, ${pt.addressed} addressed`).join(" · ")}
         >
             {points.map((pt, i) => {

--- a/apps/studio/src/components/experiments-section.tsx
+++ b/apps/studio/src/components/experiments-section.tsx
@@ -5,7 +5,8 @@ import { fmtTs } from "@ax/lib/shared/formatters";
  * Experiments - past bets paying off. The deck above is futures; this is
  * the ledger of accepted improvements with their measured effect. The
  * trace strip is the argument: baseline frequency, then opportunities at
- * +3/+10/+30 sessions. A bar shrinking to zero is a confirmed win.
+ * +3/+10/+30 sessions. A bar at zero means the window had nothing to measure -
+ * insufficient data, not a confirmed win (#1134); the human places the verdict.
  */
 
 const VERDICT_ACCENT: Record<string, string> = {
@@ -75,7 +76,30 @@ function TraceStrip({ points, accent }: { readonly points: TracePoint[]; readonl
     );
 }
 
-const stateOf = (p: ProposalDto): { accent: string; badge: string; note: string } => {
+/**
+ * Why the current recommendation is missing, in the user's words (#1134).
+ *
+ * `measuring…` used to cover all of these, which read as "give it time" for
+ * states time cannot fix: a form with no detector, an experiment that retired,
+ * evidence that has to be re-derived. The DTO's `current_reason` distinguishes
+ * them, and each gets its own line here.
+ */
+const REASON_NOTE: Record<string, string> = {
+    no_opportunities: "insufficient data · no opportunities in the window",
+    detector_unavailable: "detector unavailable",
+    artifact_unavailable: "insufficient data · no installed artifact recorded",
+    refresh_required: "insufficient data · evidence needs derivation",
+    not_started: "artifact not installed yet",
+    retired: "retired",
+    regressed: "marked regressed",
+    not_accepted: "proposal not accepted",
+};
+
+/** The badge/note/accent one experiment card renders. Exported as a pure
+ *  function so the state machine is testable without a DOM. */
+export const experimentDisplayState = (
+    p: ProposalDto,
+): { accent: string; badge: string; note: string } => {
     const exp = p.experiment;
     const verdict = exp?.locked_verdict ?? null;
     const checkpoints = (exp?.checkpoints ?? []).filter((c) => c.measured);
@@ -93,13 +117,29 @@ const stateOf = (p: ProposalDto): { accent: string; badge: string; note: string 
         return { accent, badge: VERDICT_LABEL[verdict] ?? verdict, note };
     }
     if (checkpoints.length === 0) {
-        return { accent: "blue", badge: "pending", note: "waiting for sessions…" };
+        const reason = exp?.current_reason ?? null;
+        const pending = reason === null || reason === "no_checkpoint"
+            ? "waiting for sessions…"
+            : REASON_NOTE[reason] ?? "insufficient data";
+        return { accent: "blue", badge: "pending", note: pending };
     }
-    const suggested = exp?.latest_checkpoint?.suggested;
+    const suggested = exp?.latest_checkpoint?.suggested ?? null;
+    const badge = `${checkpoints.length}/3 checkpoints`;
+    if (suggested === null) {
+        // Neutral styling: an unavailable measurement is not a bad result.
+        const reason = exp?.current_reason ?? null;
+        return {
+            accent: "muted",
+            badge,
+            note: reason === null ? "insufficient data" : REASON_NOTE[reason] ?? "insufficient data",
+        };
+    }
     return {
         accent: suggested === "regressed" ? "rose" : "blue",
-        badge: `${checkpoints.length}/3 checkpoints`,
-        note: suggested ? `suggested: ${suggested}` : "measuring…",
+        badge,
+        // Invocation counts show the artifact was PRESENT when the trigger
+        // fired. They do not show that the work got better.
+        note: `suggested: ${suggested} · observed use`,
     };
 };
 
@@ -132,15 +172,16 @@ export function ExperimentsSection({
                 <div className="experiments-empty">
                     <p className="experiments-empty-head">No bets placed yet.</p>
                     <p className="proposal-prose" style={{ color: "var(--muted)" }}>
-                        Accept an improvement from the deck above - ax measures whether the
-                        fix actually changed your sessions over the next 30. A trace bar
-                        that shrinks to zero is a confirmed win.
+                        Accept an improvement from the deck above - ax tracks how often
+                        the artifact was there when its trigger fired, over the next 30
+                        sessions. A window with nothing to measure reports insufficient
+                        data; you place the verdict.
                     </p>
                 </div>
             ) : (
                 <div className="experiments-list">
                     {experiments.map((p) => {
-                        const st = stateOf(p);
+                        const st = experimentDisplayState(p);
                         const exp = p.experiment!;
                         const artifact = exp.artifact_path?.split("/").pop() ?? null;
                         return (

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -851,6 +851,14 @@ export interface CheckpointSnapshotDto {
         readonly addressed: number;
         readonly ratio: number;
         readonly built: boolean;
+        /** #1134: whether this window measured anything at all. Absent on rows
+         *  written before the corrected rules. */
+        readonly measurement_status?: "measured" | "insufficient_data" | string;
+        /** Why there is no suggestion: no_opportunities | detector_unavailable
+         *  | artifact_unavailable | refresh_required. */
+        readonly reason?: string;
+        /** Format version of this measured blob (2 = the corrected rules). */
+        readonly measurement_version?: number;
     } | null;
     readonly observed_at: string;
 }
@@ -869,8 +877,16 @@ export interface ExperimentDto {
     readonly locked_verdict: CheckpointVerdictDto | string | null;
     readonly created_at: string;
     readonly scaffolded_at: string | null;
+    /** The CURRENT recommendation: the newest row, with `suggested` withheld
+     *  when today's eligibility or measurement no longer supports it (#1134). */
     readonly latest_checkpoint: CheckpointSnapshotDto | null;
-    /** full +3s/+10s/+30s series, observed_at ASC - drives the trace strip */
+    /** Why `latest_checkpoint.suggested` is null - a lifecycle state
+     *  (`not_started`, `retired`, ...) or a measurement gap
+     *  (`no_opportunities`, `detector_unavailable`, `refresh_required`,
+     *  `no_checkpoint`). Null when the suggestion stands on its own. */
+    readonly current_reason?: string | null;
+    /** full +3s/+10s/+30s series, observed_at ASC - drives the trace strip.
+     *  HISTORY: rows keep the suggestion they were written with. */
     readonly checkpoints?: ReadonlyArray<CheckpointSnapshotDto>;
 }
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -30,8 +30,8 @@ unrelated context into the loop.
 - Window for hook signals: last 7 days. Widen to 30 if evidence is sparse.
 - Don't apply changes silently. Every accept/reject/verdict gets the
   user's explicit yes per row.
-- The retro is read-mostly. Skill scaffolds + verdict locks are the only
-  side-effects.
+- The retro is read-mostly. Its side-effects are the Step 1 checkpoint
+  measurements, the task briefs `accept` emits, and verdict locks.
 
 ## Workflow
 
@@ -91,15 +91,43 @@ picks it up.
 
 ### Step 1 - Snapshot
 
-Run silently (parallel where possible):
+Measure first, then read. The checkpoint pass is what turns due windows
+into current ones; a verdict read taken before it reports whatever the
+last run happened to leave behind.
 
-```bash
-ax improve list --status=open --json
-ax improve list --status=accepted --json
-ax improve verdict --json
-ax retro list --since=7 --json         # cluster-derived friction summary
-ax hooks summary --since=7 --tail=20   # optional; tolerate failure
-```
+1. Run the prerequisite ALONE and wait for it:
+
+   ```bash
+   AX_NO_AUTO_INGEST=1 ax improve checkpoint --json
+   ```
+
+   It reads the published snapshot and writes checkpoint judgments only -
+   no transcript parsing, no guidance edits, no verdict locks. Leave
+   `--force` out of an ordinary retro; it rewrites unreviewed windows that
+   are already current.
+
+2. On success, run the reads (parallel is fine). Prefix EVERY command -
+   a prefix on the first one leaves the freshness drive on for the rest:
+
+   ```bash
+   AX_NO_AUTO_INGEST=1 ax improve list --status=open --json
+   AX_NO_AUTO_INGEST=1 ax improve list --status=accepted --json
+   AX_NO_AUTO_INGEST=1 ax improve verdict --json
+   AX_NO_AUTO_INGEST=1 ax retro list --since=7 --json        # cluster-derived friction summary
+   AX_NO_AUTO_INGEST=1 ax hooks summary --since=7 --tail=20  # optional; tolerate failure
+   ```
+
+3. If the checkpoint run fails, tell the user measurement is unavailable
+   and continue with proposal review only. Any suggestion already stored
+   belongs to an earlier run - report it as that, and skip the verdict
+   step.
+
+4. If the checkpoint result reports `cacheRefreshRequired` above zero, the
+   opportunity evidence needs deriving; say so, and treat those
+   experiments as unmeasured. When the user asks for current evidence, run
+   three operations in order, each awaited on its own: `ax ingest` (wait
+   for successful publication), the checkpoint prerequisite, then the
+   reads.
 
 `ax retro list` reflects three pattern types now:
 - **tool failures** (skill form) -> `Pre-<Tool> guard` proposals
@@ -112,8 +140,9 @@ If any of those surfaced, mention them so the user knows to triage in
 Step 2.
 
 Compute counts: open proposals (by form), accepted experiments with
-`locked_verdict IS NONE`, checkpoints due since last lock. Then render
-to the user as 2-4 lines, e.g.:
+`locked_verdict IS NONE`, and - separately - experiments whose current
+view carries a `current_reason` (insufficient data or a lifecycle state).
+Then render to the user as 2-4 lines, e.g.:
 
 > 7 open proposals (3 skill, 4 guidance). 2 accepted experiments are
 > waiting on a verdict. Hook activity last 7d: 142 invocations, 3
@@ -140,9 +169,12 @@ Order open proposals by `frequency` desc. For each, in turn:
 
 4. Branch:
    - **accept** → run `ax improve accept <dedupe_sig>`.
-     Tell the user where the SKILL.md was scaffolded.
-     Offer: *"Want to refine the scaffolded SKILL.md right now?"*
-     If yes: read the file, propose edits, write them back.
+     By default this emits a TASK BRIEF and returns its `task_path`; it
+     does not install the artifact. Report that path.
+     Offer: *"Want me to implement the brief now?"*
+     If yes: implement it, then run `ax improve lint` so ax reconciles the
+     marker it finds on disk and records the installed artifact. Until
+     lint records one, the experiment has no measurable installation.
    - **reject** → ask for a short reason (≤80 chars).
      Run `ax improve reject <dedupe_sig> --reason "<reason>"`.
    - **skip** → no command. Move on; the proposal stays open for the
@@ -155,22 +187,31 @@ After the loop, summarize: *"Accepted 3, rejected 1, skipped 2."*
 For each experiment whose latest checkpoint is unlocked
 (`locked_verdict IS NONE`), in age order:
 
-1. Run `ax improve verdict <dedupe_sig>` to fetch the experiment +
-   checkpoint history.
+1. Run `AX_NO_AUTO_INGEST=1 ax improve verdict <dedupe_sig>` to fetch the
+   experiment + checkpoint history.
 
-2. Render the most recent checkpoint as 2-3 lines:
+2. When the current view carries a `current_reason`, there is no
+   suggestion to confirm. Report the reason as it is - `no opportunities
+   in the window`, `no detector for this form`, `retired` - and move to
+   the next experiment. A suggestion in the `checkpoints` history is
+   history, not a recommendation.
 
-   > **Schema change guardrail** - t+30 checkpoint
-   > 12 opportunities in window, 8 addressed (66%). Suggested: **adopted**.
+3. Otherwise render the current checkpoint as 2-3 lines:
 
-3. Ask the user to confirm the suggested verdict OR override:
+   > **Schema change guardrail** - +30s checkpoint
+   > 12 opportunities in window, 8 addressed (66%) - observed use.
+   > Suggested: **adopted**.
+
+4. Ask the user to confirm the suggested verdict OR override:
    - `adopted` (artifact is doing real work)
    - `ignored` (user wrote it but never invoked it)
    - `regressed` (it made things worse)
    - `partial` (mixed signal)
    - `no_longer_needed` (pattern self-resolved; trigger stopped firing)
 
-4. Run `ax improve verdict <dedupe_sig> --set <verdict>` to lock it.
+5. Run `ax improve verdict <dedupe_sig> --set <verdict>` to lock it. All
+   five values stay available to the user by hand, including
+   `no_longer_needed`, which the algorithm never suggests on its own.
 
 ### Step 4 - Hook effectiveness pass (optional)
 
@@ -251,7 +292,7 @@ ax improve show <dedupe_sig> [--json]
 ax improve accept <dedupe_sig> [--force]
 ax improve reject <dedupe_sig> --reason "<text>"
 ax improve verdict [<dedupe_sig>] [--set <verdict>] [--json]
-ax improve checkpoint [--force]
+ax improve checkpoint [--force]            # Step 1 prerequisite; --force only on request
 ax improve reset --yes                     # destructive; only when user requests
 
 ax retro pending [--since=N] [--idle-min=N] [--json]   # Step 0 backlog
@@ -278,6 +319,8 @@ without explicit user confirmation in this session.
   want `--force` or to abandon.
 - `ax improve verdict --set` reports `verdict_locked` → that experiment
   is already finalized; show the locked value and move on.
+- `ax improve checkpoint` fails → measurement is unavailable for this
+  retro. Say so, skip Step 3, and keep Step 2 going.
 - `ax hooks summary` returns nothing → retry with `--since=30`; if
   still empty, the hook telemetry pipeline is idle, surface as a TODO.
 - Read/query error → tell the user to check `docs/development.md#setup`


### PR DESCRIPTION
A checkpoint previously treated zero opportunities as a resolved problem. Uninstalled, retired, and unsupported experiments could also receive a suggested verdict.

This change requires an accepted proposal, an installed artifact, and usable evidence. Zero opportunities and unavailable detectors produce a null suggestion with an explicit reason. Measurements use the installation time. Ordinary refresh repairs old unreviewed windows. Reviewed checkpoints and user verdicts remain protected inside the SQLite write transaction.

CLI and Studio separate current advice from historical checkpoints. Suggested actions require the same evidence checks. The retro skill measures before it reads verdicts and disables automatic ingest during those reads. Artifact use remains an observation, not proof of improved outcomes.

Stack: this PR targets the artifact-identity branch in #1139. It also contains the three checkpoint-schema commits from #1135. Merge those dependencies before this correction.

Validation: 301 affected tests pass with 843 assertions. The UTC correction passes 83 focused tests and a regression that confirms a UTC+8 host. The compiler passes. Independent review confirms all requested corrections. A complete cycle over temporary production-schema stores passes: acceptance, task publication, marker reconciliation, evidence derivation, checkpoint refresh, and preservation of the user verdict. Browser checks confirm six display states and no automatic success marker for zero evidence. The timezone regression also restores the effective process clock. Identity and SQL/TypeScript parity suites pass together: 22 tests. Final combined verification passes at integration commit 0e7c4d4a: 6,848 tests pass, 14 skip, zero fail. Root, Studio, and site type checks pass. The CLI and Studio build passes. Four compiled-hook tests pass. All required CI checks pass on this PR. Merge awaits an authenticated Fleetboard main-merge claim.

The complete-cycle test also finds and fixes a timestamp defect: zone-less DuckDB strings shift evidence eight hours earlier on a UTC+8 host. All affected projections now preserve UTC. A new derivation token requires old evidence to be rebuilt.

Closes #1134

---

_Generated with [ax](https://github.com/Necmttn/ax)._
