### PR TITLE
fix(cost): price gpt-6-astra so ax cost stops showing UNPRICED

### DIFF
--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -148,6 +148,21 @@ describe("model pricing", () => {
             inputAbove200kPerMillionUsd: 0.4,
             outputAbove200kPerMillionUsd: 1.8,
         });
+        // gpt-6-astra rates verified 2026-09-06 against openai.com/api/pricing
+        // and models.dev's `openai` provider entry (exact agreement).
+        expect(pricingForModel("gpt-6-astra", catalog)).toMatchObject({
+            inputPerMillionUsd: 10,
+            outputPerMillionUsd: 50,
+            cacheCreationPerMillionUsd: 12.5,
+            cacheReadPerMillionUsd: 1,
+            inputAbove200kPerMillionUsd: 20,
+            outputAbove200kPerMillionUsd: 75,
+        });
+        // Suffixed variants (pro/fast) route to the same base tier.
+        expect(pricingForModel("gpt-6-astra-pro", catalog)).toMatchObject({
+            inputPerMillionUsd: 10,
+            outputPerMillionUsd: 50,
+        });
     });
 
     it("bills at base rates by default and at the fast tier only when asked", () => {

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -219,6 +219,25 @@ const RAW_BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing>> 
         contextWindow: 1_050_000,
         pricingSource: MODEL_PRICING_SOURCE,
     },
+    // Verified 2026-09-06 against openai.com/api/pricing (raw HTML table,
+    // "standard"/"context_over_200k" rows) and models.dev's `openai` provider
+    // entry - both agree exactly. Same shape as the gpt-5.6 tiers above: own
+    // >200k context tier, fastMultiplier:1 (fast-tier pricing isn't modeled
+    // separately for this family, matching sol/terra/luna above).
+    "gpt-6-astra": {
+        provider: "openai",
+        inputPerMillionUsd: 10,
+        outputPerMillionUsd: 50,
+        cacheCreationPerMillionUsd: 12.5,
+        cacheReadPerMillionUsd: 1,
+        inputAbove200kPerMillionUsd: 20,
+        outputAbove200kPerMillionUsd: 75,
+        cacheCreationAbove200kPerMillionUsd: 25,
+        cacheReadAbove200kPerMillionUsd: 2,
+        fastMultiplier: 1,
+        contextWindow: 1_050_000,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
     "gpt-5-mini": {
         provider: "openai",
         inputPerMillionUsd: 0.25,
@@ -527,6 +546,9 @@ export function pricingForModel(
     if (modelKey.startsWith("gpt-5.6-terra")) return catalog.get("gpt-5.6-terra") ?? null;
     if (modelKey.startsWith("gpt-5.6-luna")) return catalog.get("gpt-5.6-luna") ?? null;
     if (/^gpt-5\.6(?:-|$)/i.test(modelKey)) return catalog.get("gpt-5.5") ?? catalog.get("gpt-5") ?? null;
+    // Dated/suffixed gpt-6-astra variants (e.g. gpt-6-astra-pro, gpt-6-astra-fast)
+    // price at the same tier as the base entry above.
+    if (modelKey.startsWith("gpt-6-astra")) return catalog.get("gpt-6-astra") ?? null;
     if (/^gpt-5(?:\.\d+)?$/i.test(modelKey)) return catalog.get("gpt-5") ?? null;
     if (modelKey.startsWith("claude-fable-5")) return catalog.get("claude-fable-5") ?? null;
     if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;


### PR DESCRIPTION
## Summary
- `ax cost models`/`split`/`sessions` rendered `gpt-6-astra` as `UNPRICED` - no built-in catalog entry existed for it, and no prefix rule routed suffixed variants (`gpt-6-astra-pro`, `gpt-6-astra-fast`).
- Added a `gpt-6-astra` entry to `RAW_BUILTIN_MODEL_PRICING_CATALOG` in `apps/axctl/src/ingest/model-pricing.ts`, following the same shape as the existing `gpt-5.6-sol`/`terra`/`luna` entries (own >200k context tier, `fastMultiplier: 1`).
- Added a `pricingForModel` prefix rule (`modelKey.startsWith("gpt-6-astra")`) so dated/suffixed variants resolve to the base entry, same pattern as the gpt-5.6 family.

## Price + source
Per 1M tokens (input / output / cache-write / cache-read):
- Standard: **$10 / $50 / $12.5 / $1**
- Above 200k context: **$20 / $75 / $25 / $2**

Verified 2026-09-06 by cross-checking two independent sources, both in exact agreement:
- https://openai.com/api/pricing/ (raw HTML pricing table, `standard` tier row for `gpt-6-astra`)
- https://models.dev/api.json - the canonical `openai` provider's `gpt-6-astra` entry (`cost` + `context_over_200k` fields)

Not provisional - both sources matched exactly, so no need to fall back to copying gpt-5.6-sol's rate.

## Test plan
- [x] `bun test apps/axctl/src/ingest/model-pricing.test.ts apps/axctl/src/cli/commands/ax-cost.test.ts` - 33 pass, 0 fail
- [x] `bun test` (full repo) - 6685 pass / 4 fail / 4 errors, all 4 failures pre-existing and unrelated (Electron install issue in `apps/studio-desktop`, reproduced identically on a stash of this change reverted)
- [x] `bun run typecheck` - exit 0, no errors touching `model-pricing.ts`
- [x] `ax cost models --days=2` (run from source):
  - before: `gpt-6-astra    31  1,151,332,449  3,308,440  1,119,422,848  0  UNPRICED`
  - after:  `gpt-6-astra    31  1,151,332,449  3,308,440  1,119,422,848  0  $1603.9409`

🤖 Generated with [Claude Code](https://claude.com/claude-code)