### PR TITLE
docs: publish the 0.44.1 release announcement

### DIFF
--- a/docs/releases/v0.44.1.md
+++ b/docs/releases/v0.44.1.md
@@ -1,0 +1,39 @@
+---
+version: "0.44.1"
+date: "2026-09-08"
+title: "Safer package checks and ingestion"
+summary: "Version 0.44.1 keeps verification inside the changed package and preserves live ingest locks."
+---
+
+Version 0.44.1 corrects the ingestion and project verification problems reviewed in [PR #1124](https://github.com/Necmttn/ax/pull/1124).
+
+The review reproduces incorrect package commands and incomplete test recommendations. It also identifies unsafe installer files and premature replacement of live ingest locks. Regression tests cover these cases.
+
+* **Package verification:** Checks use the Git root and the nearest package manifest. Each changed package receives its own test recommendation. New packages are included.
+* **Command safety:** Package paths receive shell quotation. Unknown package managers produce no executable guess. Compiler fallbacks use local files, including hoisted installations, without registry downloads.
+* **Discovery boundaries:** Package discovery rejects paths and symbolic links that lead outside the checkout.
+* **Ingestion:** Derive-only runs have no implicit shared deadline. Explicit timeout settings retain precedence. A live process keeps its ingest lock regardless of age.
+* **Setup:** The installer uses a private temporary directory. Download failure, review failure, declined approval, or end of input stops installation.
+* **Skills and documentation:** Dojo frontmatter parses correctly and no longer requires the retired database daemon. The command reference documents the tools option for weighted skill results.
+
+For an npm package in frontend/, verification can recommend:
+
+```bash
+npm --prefix frontend run typecheck
+npm --prefix frontend run test
+```
+
+To update an existing installation:
+
+```bash
+ax update
+ax --version
+```
+
+A timed-out ingest in another live process continues to hold its lock. That process must exit before another process can take the lock. The existing check/remove race remains tracked in [issue #789](https://github.com/Necmttn/ax/issues/789).
+
+[The release range](https://github.com/Necmttn/ax/compare/v0.44.0...v0.44.1) contains the reviewed correction and the version update. The release PR passes CI, including tests, TypeScript checks, the build, and compiled CLI smoke checks.
+
+---
+
+_Generated with [ax](https://github.com/Necmttn/ax)._


### PR DESCRIPTION
Add the website release note for v0.44.1. It explains the package verification fixes, installer safeguards, and live ingest lock behavior from PR #1124.

Validation: TypeScript checks and the site build pass. Browser inspection confirms the release page and command examples.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
