### PR TITLE
docs: link the website and documentation from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 **Make your agent learn.**
 Turn every agent session into a better next run.
 
+[Website](https://ax.necmttn.com) · [Documentation](https://ax.necmttn.com/docs)
+
 ---
 
 Every sub-agent you spawn finishes its work and disappears. Whatever it


### PR DESCRIPTION
The README now links to the website and documentation below the introduction.

Both addresses return HTTP 200. The README mirror test and `git diff --check` pass.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
