### PR TITLE
fix(ingest): reduce OpenCode memory use and update Bun

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       # The suite imports workspace packages (@ax/lib/testing/gated-test since
       # #863); without an install, bun cannot resolve them and the job fails.

--- a/.github/workflows/build-duckdb.yml
+++ b/.github/workflows/build-duckdb.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       # The dynamic library smoke (both here and in the isolated re-smoke
       # below) imports @ax/lib through the workspace link.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       # The dynamic library smoke imports @ax/lib through the workspace link.
       # Install before both the build path and the cache-hit smoke path.
@@ -124,7 +124,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/community-nightly.yml
+++ b/.github/workflows/community-nightly.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/community-users.yml
+++ b/.github/workflows/community-users.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: steps.scope.outputs.mode == 'users-clean' || steps.scope.outputs.mode == 'patterns-clean'
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Validate registrations
         if: steps.scope.outputs.mode == 'users-clean'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       # The dynamic library smoke imports @ax/lib through the workspace link.
       # Install before both a cache-hit smoke and a cache-miss build.
@@ -122,7 +122,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - name: Install ripgrep (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/studio-desktop-release.yml
+++ b/.github/workflows/studio-desktop-release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.14"
 
       - run: bun install --frozen-lockfile
 

--- a/apps/axctl/src/ingest/opencode-memory.test.ts
+++ b/apps/axctl/src/ingest/opencode-memory.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// A large snapshot part is representative of OpenCode stores, but contributes
+// no transcript text. Holding every raw part used to cost ~700 MiB here (#1148).
+test("OpenCode extraction does not retain the database's raw part payloads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ax-opencode-memory-"));
+    const path = join(dir, "opencode.db");
+    try {
+        const db = new Database(path);
+        try {
+            db.run("CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER)");
+            db.run("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)");
+            db.run("CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)");
+            db.run("CREATE INDEX message_session ON message(session_id)");
+            db.run("CREATE INDEX part_message ON part(message_id)");
+            const session = db.query("INSERT INTO session VALUES (?, '/tmp/acme-app', 'memory', 1, 2)");
+            const message = db.query("INSERT INTO message VALUES (?, ?, 1, ?)");
+            const part = db.query("INSERT INTO part VALUES (?, ?, ?, 1, ?)");
+            const payload = JSON.stringify({ type: "step-start", snapshot: "x".repeat(32768) });
+            db.transaction(() => {
+                for (let i = 0; i < 8192; i++) {
+                    const id = `session-${Math.floor(i / 128)}`;
+                    if (i % 128 === 0) session.run(id);
+                    message.run(`message-${i}`, id, '{"role":"assistant"}');
+                    part.run(`part-${i}`, `message-${i}`, id, payload);
+                }
+            })();
+        } finally {
+            db.close();
+        }
+        // Isolate RSS from other tests and fixture creation. No forced GC:
+        // production extraction must also release raw rows without it.
+        const child = Bun.spawn([process.execPath, "--eval", `
+            import { extractOpenCodeDatabase } from ${JSON.stringify(new URL("./opencode.ts", import.meta.url).pathname)};
+            const result = extractOpenCodeDatabase(${JSON.stringify(path)});
+            console.log(JSON.stringify({sessions: result.sessions.length, turns: result.turns.length,
+                warnings: result.warnings, rss: process.memoryUsage().rss}));
+        `], { stdout: "pipe", stderr: "pipe" });
+        const [stdout, stderr, code] = await Promise.all([
+            new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited,
+        ]);
+        expect({ code, stderr }).toEqual({ code: 0, stderr: "" });
+        const result = JSON.parse(stdout);
+        expect(result).toMatchObject({ sessions: 64, turns: 8192, warnings: [] });
+        expect(result.rss).toBeLessThan(384 * 1024 * 1024);
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+}, 30_000);

--- a/apps/axctl/src/ingest/opencode.test.ts
+++ b/apps/axctl/src/ingest/opencode.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { Effect, Layer, Option } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
@@ -10,6 +10,8 @@ import {
     __testFindOpenCodeDbCandidates,
     __testIncludeOpenCodeByMtime,
     extractOpenCodeDatabase,
+    streamOpenCodeDatabase,
+    __testSliceOpenCodeExtractForSession,
 } from "./opencode.ts";
 import { turnRecordKey } from "./record-keys.ts";
 
@@ -479,6 +481,9 @@ describe("OpenCode SQLite extraction", () => {
             expect(extracted.warnings.join("\n")).toContain("invalid timestamp");
             expect(extracted.warnings.join("\n")).toContain("invalid message JSON");
             expect(extracted.warnings.join("\n")).toContain("missing session");
+            const streamed = [...streamOpenCodeDatabase(dbPath)];
+            expect(streamed.reduce((sum, batch) => sum + batch.skipped, 0)).toBe(extracted.skipped);
+            expect(streamed.flatMap((batch) => batch.warnings).sort()).toEqual([...extracted.warnings].sort());
         });
     });
 
@@ -493,6 +498,7 @@ describe("OpenCode SQLite extraction", () => {
             expect(extracted.providerEvents).toHaveLength(0);
             expect(extracted.turns).toHaveLength(0);
             expect(extracted.warnings.join("\n")).toContain("unsupported OpenCode schema");
+            expect([...streamOpenCodeDatabase(dbPath)]).toEqual([extracted]);
         });
     });
 
@@ -547,5 +553,57 @@ describe("OpenCode SQLite extraction", () => {
             false,
         );
         expect(__testIncludeOpenCodeByMtime(Option.none(), cutoffMs)).toBe(true);
+    });
+});
+
+
+describe("OpenCode session streaming", () => {
+    test("streams complete sessions without reading later session payloads", async () => {
+        await withTempOpenCodeDb((db, dbPath) => {
+            db.run("CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER)");
+            db.run("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)");
+            db.run("CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)");
+            for (const id of ["a", "b"]) {
+                db.query("INSERT INTO session VALUES (?, '/tmp/acme-app', 'stream', 1, 2)").run(id);
+                db.query("INSERT INTO message VALUES (?, ?, 1, ?)").run(id, id, '{"role":"assistant"}');
+                db.query("INSERT INTO part VALUES (?, ?, ?, 1, ?)").run(id, id, id, JSON.stringify({
+                    type: "tool", tool: "bash", callID: id,
+                    state: { status: "completed", input: { command: "pwd" }, output: id },
+                }));
+            }
+            const aggregate = extractOpenCodeDatabase(dbPath);
+            const extracts = streamOpenCodeDatabase(dbPath);
+            try {
+                expect(extracts.next().value).toEqual(__testSliceOpenCodeExtractForSession(aggregate, "a"));
+                // A later session must be read only after the consumer finishes
+                // the first write. A whole-store extract would return stale data.
+                db.query("UPDATE part SET data = ? WHERE id = 'b'").run(JSON.stringify({ type: "text", text: "later" }));
+                const second = extracts.next();
+                expect(second.done).toBe(false);
+                expect(second.value).toMatchObject({ sessions: [{ id: "b" }], turns: [{ seq: 1, text: "later" }], toolCalls: [] });
+                expect(extracts.next().done).toBe(true);
+            } finally {
+                extracts.return();
+            }
+        });
+    });
+
+    test("closes the SQLite connection when the consumer stops early", async () => {
+        await withTempOpenCodeDb((db, dbPath) => {
+            db.run("CREATE TABLE session (id TEXT PRIMARY KEY, cwd TEXT, title TEXT, created_at TEXT, updated_at TEXT)");
+            db.run("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, created_at TEXT)");
+            db.run("INSERT INTO session VALUES ('a', '/tmp/acme-app', 'stream', '2026-01-01', '2026-01-01')");
+            const close = spyOn(Database.prototype, "close");
+            const extracts = streamOpenCodeDatabase(dbPath);
+            try {
+                expect(extracts.next().done).toBe(false);
+                expect(close).not.toHaveBeenCalled();
+                extracts.return();
+                expect(close).toHaveBeenCalledTimes(1);
+            } finally {
+                extracts.return();
+                close.mockRestore();
+            }
+        });
     });
 });

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -482,36 +482,37 @@ function processStepFinishCompactions(input: {
     }
 }
 
-function syntheticRows(db: Database): {
+// Only session metadata is materialized. Raw messages are streamed and parts
+// are fetched for one message, so snapshot/tool payloads cannot accumulate for
+// the entire SQLite store (#1148). Parameters also serve the ingest session seam.
+function syntheticRows(db: Database, sessionId?: string): {
     sessions: SyntheticSessionRow[];
-    messages: SyntheticMessageRow[];
+    messages: Iterable<SyntheticMessageRow>;
 } {
+    const args: [string] | [] = sessionId === undefined ? [] : [sessionId];
     return {
-        sessions: db.query<SyntheticSessionRow, []>(
-            "SELECT id, cwd, title, created_at, updated_at FROM session ORDER BY created_at, id",
-        ).all(),
-        messages: db.query<SyntheticMessageRow, []>(
-            "SELECT id, session_id, role, content, created_at FROM message ORDER BY created_at, id",
-        ).all(),
+        sessions: db.query<SyntheticSessionRow, typeof args>(
+            `SELECT id, cwd, title, created_at, updated_at FROM session ${sessionId === undefined ? "" : "WHERE id = ?"} ORDER BY created_at, id`,
+        ).all(...args),
+        messages: db.query<SyntheticMessageRow, typeof args>(
+            `SELECT id, session_id, role, content, created_at FROM message ${sessionId === undefined ? "" : "WHERE session_id = ?"} ORDER BY created_at, id`,
+        ).iterate(...args),
     };
 }
 
-function observedRows(db: Database, hasModelColumn: boolean): {
+function observedRows(db: Database, hasModelColumn: boolean, sessionId?: string): {
     sessions: ObservedSessionRow[];
-    messages: ObservedMessageRow[];
-    parts: ObservedPartRow[];
+    messages: Iterable<ObservedMessageRow>;
 } {
     const modelSelect = hasModelColumn ? "model" : "NULL AS model";
+    const args: [string] | [] = sessionId === undefined ? [] : [sessionId];
     return {
-        sessions: db.query<ObservedSessionRow, []>(
-            `SELECT id, directory, title, ${modelSelect}, time_created, time_updated FROM session ORDER BY time_created, id`,
-        ).all(),
-        messages: db.query<ObservedMessageRow, []>(
-            "SELECT id, session_id, time_created, data FROM message ORDER BY time_created, id",
-        ).all(),
-        parts: db.query<ObservedPartRow, []>(
-            "SELECT id, message_id, session_id, time_created, data FROM part ORDER BY time_created, id",
-        ).all(),
+        sessions: db.query<ObservedSessionRow, typeof args>(
+            `SELECT id, directory, title, ${modelSelect}, time_created, time_updated FROM session ${sessionId === undefined ? "" : "WHERE id = ?"} ORDER BY time_created, id`,
+        ).all(...args),
+        messages: db.query<ObservedMessageRow, typeof args>(
+            `SELECT id, session_id, time_created, data FROM message ${sessionId === undefined ? "" : "WHERE session_id = ?"} ORDER BY time_created, id`,
+        ).iterate(...args),
     };
 }
 
@@ -729,19 +730,30 @@ function processToolPart(input: {
 export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
     const db = new Database(dbPath, { readonly: true });
     try {
-        const tables = tableNames(db);
-        if (!tables.has("session") || !tables.has("message")) {
-            return emptyExtract();
-        }
+        return extractOpenCodeConnection(db, dbPath);
+    } finally {
+        db.close();
+    }
+}
 
-        const sessionColumns = columnNames(db, "session");
-        const messageColumns = columnNames(db, "message");
-        const partColumns = tables.has("part") ? columnNames(db, "part") : new Set<string>();
-        const isSynthetic = hasColumns(sessionColumns, ["id", "cwd", "title", "created_at", "updated_at"]) &&
-            hasColumns(messageColumns, ["id", "session_id", "role", "content", "created_at"]);
-        const isObserved = hasColumns(sessionColumns, ["id", "directory", "title", "time_created", "time_updated"]) &&
-            hasColumns(messageColumns, ["id", "session_id", "time_created", "data"]) &&
-            hasColumns(partColumns, ["id", "message_id", "session_id", "time_created", "data"]);
+function openCodeSchema(db: Database) {
+    const tables = tableNames(db);
+    const sessionColumns = columnNames(db, "session");
+    const messageColumns = columnNames(db, "message");
+    const partColumns = tables.has("part") ? columnNames(db, "part") : new Set<string>();
+    const isSynthetic = hasColumns(sessionColumns, ["id", "cwd", "title", "created_at", "updated_at"]) &&
+        hasColumns(messageColumns, ["id", "session_id", "role", "content", "created_at"]);
+    const isObserved = hasColumns(sessionColumns, ["id", "directory", "title", "time_created", "time_updated"]) &&
+        hasColumns(messageColumns, ["id", "session_id", "time_created", "data"]) &&
+        hasColumns(partColumns, ["id", "message_id", "session_id", "time_created", "data"]);
+
+    return { sessionColumns, isSynthetic, isObserved, hasCoreTables: tables.has("session") && tables.has("message") };
+}
+
+function extractOpenCodeConnection(db: Database, dbPath: string, sessionId?: string): OpenCodeExtract {
+    try {
+        const { sessionColumns, isSynthetic, isObserved, hasCoreTables } = openCodeSchema(db);
+        if (!hasCoreTables) return emptyExtract();
 
         if (!isSynthetic && !isObserved) {
             return emptyExtract(["unsupported OpenCode schema: missing required session/message columns"]);
@@ -761,7 +773,7 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
         const compactionSeqBySession = new Map<string, number>();
 
         if (isSynthetic) {
-            const { sessions: sessionRows, messages: messageRows } = syntheticRows(db);
+            const { sessions: sessionRows, messages: messageRows } = syntheticRows(db, sessionId);
             for (const row of sessionRows) {
                 if (typeof row.id !== "string" || row.id.length === 0) {
                     skipped += 1;
@@ -816,9 +828,10 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
                 });
             }
         } else {
-            const { sessions: sessionRows, messages: messageRows, parts } = observedRows(
+            const { sessions: sessionRows, messages: messageRows } = observedRows(
                 db,
                 sessionColumns.has("model"),
+                sessionId,
             );
             for (const row of sessionRows) {
                 if (typeof row.id !== "string" || row.id.length === 0) {
@@ -840,17 +853,17 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
                 });
             }
 
-            const partsByMessage = new Map<string, ObservedPartRow[]>();
-            for (const part of parts) {
-                if (typeof part.message_id !== "string" || part.message_id.length === 0) {
-                    skipped += 1;
-                    warnings.push("skipped part row with missing message_id");
-                    continue;
-                }
-                const bucket = partsByMessage.get(part.message_id) ?? [];
-                bucket.push(part);
-                partsByMessage.set(part.message_id, bucket);
+            // Store-level malformed parts are counted once, not by rescanning
+            // the part table for every session in the production stream.
+            if (sessionId === undefined) {
+                const invalidParts = countInvalidOpenCodeParts(db);
+                skipped += invalidParts;
+                for (let i = 0; i < invalidParts; i++) warnings.push("skipped part row with missing message_id");
             }
+
+            const messageParts = db.query<ObservedPartRow, [string]>(
+                "SELECT id, message_id, session_id, time_created, data FROM part WHERE message_id = ? ORDER BY time_created, id",
+            );
 
             for (const row of messageRows) {
                 if (
@@ -875,7 +888,7 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
                 }
                 const parsedParts: ParsedObservedPart[] = [];
                 const texts: string[] = [];
-                for (const part of partsByMessage.get(row.id) ?? []) {
+                for (const part of messageParts.iterate(row.id)) {
                     const partData = parseJsonRecord(part.data, `part ${part.id}`, warnings);
                     if (!partData) {
                         skipped += 1;
@@ -963,8 +976,60 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
             [`failed to extract OpenCode database ${dbPath}: ${error instanceof Error ? error.message : String(error)}`],
             1,
         );
+    }
+}
+
+function countInvalidOpenCodeParts(db: Database): number {
+    return db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM part WHERE message_id IS NULL OR message_id = ''",
+    ).get()?.count ?? 0;
+}
+
+/**
+ * Production extraction retains one normalized session at a time. The aggregate
+ * extractor above remains for fixture/analysis callers that need a whole batch.
+ * Closing the iterator releases SQLite even after cancellation or a write error.
+ */
+export function* streamOpenCodeDatabase(dbPath: string): Generator<OpenCodeExtract, void> {
+    let db: Database | undefined;
+    try {
+        db = new Database(dbPath, { readonly: true });
+        const schema = openCodeSchema(db);
+        if (!schema.hasCoreTables || (!schema.isSynthetic && !schema.isObserved)) {
+            yield extractOpenCodeConnection(db, dbPath);
+            return;
+        }
+        // IDs only: never retain transcript payloads between yields.
+        const sessions = db.query<{ id: string }, []>("SELECT id FROM session ORDER BY id").all();
+        for (const { id } of sessions) {
+            if (typeof id !== "string" || id.length === 0) {
+                yield emptyExtract(["skipped session row with missing id"], 1);
+                continue;
+            }
+            yield extractOpenCodeConnection(db, dbPath, id);
+        }
+        // Session-scoped reads exclude orphan messages. Preserve their existing
+        // diagnostics without reading their JSON/text payloads.
+        const tables = tableNames(db);
+        if (tables.has("message") && hasColumns(columnNames(db, "message"), ["id", "session_id"])) {
+            const warnings: string[] = [];
+            for (const row of db.query<{ id: string | null; session_id: string | null }, []>(
+                "SELECT id, session_id FROM message WHERE session_id IS NULL OR session_id = '' OR session_id NOT IN (SELECT id FROM session WHERE id IS NOT NULL AND id != '')",
+            ).iterate()) {
+                warnings.push(!row.id || !row.session_id
+                    ? "skipped message row with missing id or session_id"
+                    : `skipped message ${row.id}: missing session ${row.session_id}`);
+            }
+            if (tables.has("part") && columnNames(db, "part").has("message_id")) {
+                const invalidParts = countInvalidOpenCodeParts(db);
+                for (let i = 0; i < invalidParts; i++) warnings.push("skipped part row with missing message_id");
+            }
+            if (warnings.length > 0) yield emptyExtract(warnings, warnings.length);
+        }
+    } catch (error) {
+        yield failedExtract(dbPath, error);
     } finally {
-        db.close();
+        db?.close();
     }
 }
 
@@ -1192,27 +1257,6 @@ export const ingestOpenCode = Effect.fn("opencode.ingest")(
         }
 
         const dbPath = dbPaths[0]!;
-        const extract = yield* Effect.sync(() => {
-            try {
-                return extractOpenCodeDatabase(dbPath);
-            } catch (error) {
-                return failedExtract(dbPath, error);
-            }
-        }).pipe(Effect.withSpan("opencode.extract", {
-            attributes: { "file.name": dbPath.slice(dbPath.lastIndexOf("/") + 1) },
-        }));
-
-        if (extract.sessions.length === 0) {
-            return {
-                sessions: 0,
-                turns: 0,
-                toolCalls: 0,
-                skipped: extract.skipped,
-                warnings: extract.warnings.length,
-                failedFiles: 0,
-            };
-        }
-
         // Snapshot the real skill catalog once (the skills stage is a declared
         // dep, so it is complete). A `skill` tool call records the name the
         // model typed - bare - while a project- or plugin-scoped skill is
@@ -1233,29 +1277,44 @@ export const ingestOpenCode = Effect.fn("opencode.ingest")(
         let sessionCount = 0;
         let turnCount = 0;
         let toolCallCount = 0;
-        for (const session of extract.sessions) {
-            const slice = resolveOpenCodeCatalogSkills(
-                sliceOpenCodeExtractForSession(extract, session.id),
-                skillCatalog,
-            );
-            // Per-session failure isolation (#261): one undecodable / rejected
-            // session skips THIS session - the store is re-read next run -
-            // instead of aborting the whole stage (see file-isolation.ts).
-            yield* failures.isolate(`${dbPath}#${session.id}`, Effect.gen(function* () {
-                yield* writeNormalizedTranscriptBatch(write, toOpenCodeNormalizedBatch(slice, dbPath));
-                sessionCount += 1;
-                turnCount += slice.turns.length;
-                toolCallCount += slice.toolCalls.length;
-            }));
-        }
+        let skipped = 0;
+        let warnings = 0;
+        yield* Effect.acquireUseRelease(
+            Effect.sync(() => streamOpenCodeDatabase(dbPath)),
+            (extracts) => Effect.gen(function* () {
+                while (true) {
+                    const next = yield* Effect.sync(() => extracts.next()).pipe(
+                        Effect.withSpan("opencode.extract", {
+                            attributes: { "file.name": dbPath.slice(dbPath.lastIndexOf("/") + 1) },
+                        }),
+                    );
+                    if (next.done) break;
+                    const extract = next.value;
+                    skipped += extract.skipped;
+                    warnings += extract.warnings.length;
+                    const session = extract.sessions[0];
+                    if (!session) continue;
+                    const slice = resolveOpenCodeCatalogSkills(extract, skillCatalog);
+                    // Each session is written before reading the next one. A
+                    // rejected session is naturally retried on the next run.
+                    yield* failures.isolate(`${dbPath}#${session.id}`, Effect.gen(function* () {
+                        yield* writeNormalizedTranscriptBatch(write, toOpenCodeNormalizedBatch(slice, dbPath));
+                        sessionCount += 1;
+                        turnCount += slice.turns.length;
+                        toolCallCount += slice.toolCalls.length;
+                    }));
+                }
+            }),
+            (extracts) => Effect.sync(() => extracts.return()),
+        );
         yield* failures.report;
 
         return {
             sessions: sessionCount,
             turns: turnCount,
             toolCalls: toolCallCount,
-            skipped: extract.skipped,
-            warnings: extract.warnings.length,
+            skipped,
+            warnings,
             failedFiles: failures.count(),
         } satisfies OpenCodeStats;
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "description": "ax monorepo root - workspace orchestration for the axctl CLI (apps/axctl), landing site (apps/site), and shared packages (@ax/lib, @ax/schema).",
   "type": "module",
-  "packageManager": "bun@1.3.10",
+  "packageManager": "bun@1.3.14",
   "workspaces": {
     "packages": [
       "apps/*",


### PR DESCRIPTION
OpenCode ingestion now reads raw messages incrementally, reads parts for one message, and writes each session before reading the next session. This removes the whole-database raw arrays and normalized output from the production ingest path. SQLite connections close when a consumer stops or a write fails. CI and release builds use Bun 1.3.14.

Related to #1148. This change addresses the measured memory growth. It does not close the issue because the reporter's database is unavailable.

Validation:

- `bun test`: 6,877 pass, 13 skip, 0 fail.
- `bun run typecheck` and `bun run build` pass. The build uses the existing custom DuckDB library.
- The memory regression test fails before the change at 735 MB RSS and passes after it.
- A compiled reader processes a 4.1 GiB fixture containing 1,024 sessions and 131,072 messages/parts. Peak memory with Bun 1.3.10 decreases from 8,830 MiB to 360 MiB. The changed reader with Bun 1.3.14 uses 342 MiB. All records remain present.
- Streaming matches aggregate extraction on the available local OpenCode database: 3 sessions, 177 turns, and 176 tool calls.
- Tests cover deferred reads, connection closure, malformed-row diagnostics, stable sequences, and failed-session isolation.

Limits:

- The controlled fixture reproduces memory growth, but does not reproduce the reported native SIGSEGV. The original 4.5 GB database remains unavailable.
- Memory still depends on the largest normalized session and individual message. This change does not establish crash recovery for DuckDB indexes.
- The current default ingest deadline is already 900 seconds. `--derive-only` has no shared deadline unless an explicit override sets one. The reported 109-second timeout needs the original run configuration and logs.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
